### PR TITLE
feat: split Supabase env by domain (staging/production)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+# Supabase CLI cache & local bundles
+supabase/.temp/
+supabase/bundle/
+
+# macOS
+.DS_Store
+
+# Editor
+.vscode/
+.idea/
+
+# Node
+node_modules/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,11 +13,20 @@
 ## Key URLs
 - 운영 (인플루언서): https://globalreverb.com
 - 운영 (관리자): https://globalreverb.com/admin/
-- 백업 URL (Vercel 기본): https://kemo-liart.vercel.app
+- 스테이징 (인플루언서): https://dev.globalreverb.com
+- 스테이징 (관리자): https://dev.globalreverb.com/admin/ (admin@kemo.jp / admin1234)
 - GitHub: github.com/jfun-reverb/kemo
-- Supabase: https://twofagomeizrtkwlhsuv.supabase.co
-- Admin: admin@kemo.jp / admin1234
+- Supabase (production): https://twofagomeizrtkwlhsuv.supabase.co (🇦🇺 Sydney)
+- Supabase (staging): https://qysmxtipobomefudyixw.supabase.co (🇯🇵 Tokyo)
 - LINE: @586mnjoc
+
+## Environments
+- **도메인 기반 자동 분기**: `dev/lib/supabase.js`의 `resolveSupabaseEnv()`가 `location.hostname` 을 판별
+  - `globalreverb.com`, `www.globalreverb.com` → production Supabase
+  - 그 외 (dev.globalreverb.com, localhost 등) → staging Supabase
+- Supabase URL/Key는 `SUPABASE_ENVS` 객체에서만 관리 (다른 파일 하드코딩 금지)
+- 관리자 페이지 헤더에 staging 환경에서만 주황색 `STAGING` 배지 표시
+- 운영 배포 시 반드시 staging에서 검증 후 main merge
 
 ## Architecture
 - 인플루언서 앱: dev/index.html (모바일 480px, 바텀탭바)

--- a/admin/index.html
+++ b/admin/index.html
@@ -1275,6 +1275,8 @@ const SUPABASE_ENVS = {
   }
 };
 
+// 정규식은 globalreverb.com / www.globalreverb.com만 엄격히 매칭.
+// 다른 서브도메인(dev, staging, preview 등)이 실수로 production DB에 접근하는 것을 방지.
 function resolveSupabaseEnv(hostname) {
   if (/^(www\.)?globalreverb\.com$/.test(hostname)) return 'production';
   return 'staging';

--- a/admin/index.html
+++ b/admin/index.html
@@ -364,7 +364,10 @@ textarea.form-input{resize:vertical;min-height:80px}
   <!-- 관리자 전용 상단 헤더 -->
   <div style="background:#2D1F2B;height:56px;display:flex;align-items:center;position:sticky;top:0;z-index:100;width:100%">
     <div style="display:flex;align-items:center;justify-content:space-between;width:100%;padding:0 24px">
-      <span style="font-family:'Sora',sans-serif;font-weight:800;font-size:17px;color:#fff;cursor:pointer" onclick="switchAdminPane('dashboard',document.querySelector('.admin-si'))">Reverb</span>
+      <div style="display:flex;align-items:center;gap:10px">
+        <span style="font-family:'Sora',sans-serif;font-weight:800;font-size:17px;color:#fff;cursor:pointer" onclick="switchAdminPane('dashboard',document.querySelector('.admin-si'))">Reverb</span>
+        <span id="stagingBadge" style="display:none;background:#f59e0b;color:#fff;font-size:11px;font-weight:700;padding:3px 8px;border-radius:4px;letter-spacing:.5px">STAGING</span>
+      </div>
       <div style="display:flex;align-items:center;gap:10px">
         <div id="adminGnbInfo" style="display:flex;align-items:center;gap:8px;color:rgba(255,255,255,.7);font-size:13px">
           <div style="width:28px;height:28px;border-radius:50%;background:var(--pink);display:flex;align-items:center;justify-content:center;font-size:11px;font-weight:700;color:#fff">A</div>
@@ -1257,11 +1260,34 @@ textarea.form-input{resize:vertical;min-height:80px}
 
 <script>
 // ══════════════════════════════════════
-// CONFIG — Supabase 연결 설정
+// CONFIG — Supabase 연결 설정 (환경별 자동 분기)
 // ══════════════════════════════════════
-const SUPABASE_URL = 'https://twofagomeizrtkwlhsuv.supabase.co';
-const SUPABASE_ANON_KEY = 'sb_publishable_3KgWYIf5w5J727Q2g3Cl7Q_ETD1Swps';
+// production: globalreverb.com / www.globalreverb.com
+// staging:    dev.globalreverb.com, *.vercel.app, localhost, 127.0.0.1, file://
+const SUPABASE_ENVS = {
+  production: {
+    url: 'https://twofagomeizrtkwlhsuv.supabase.co',
+    key: 'sb_publishable_3KgWYIf5w5J727Q2g3Cl7Q_ETD1Swps'
+  },
+  staging: {
+    url: 'https://qysmxtipobomefudyixw.supabase.co',
+    key: 'sb_publishable_WTxFsvQFllOPIdQ8MDNwCw_e0qBlYTv'
+  }
+};
+
+function resolveSupabaseEnv(hostname) {
+  if (/^(www\.)?globalreverb\.com$/.test(hostname)) return 'production';
+  return 'staging';
+}
+
+const SUPABASE_ENV = resolveSupabaseEnv(location.hostname);
+const SUPABASE_URL = SUPABASE_ENVS[SUPABASE_ENV].url;
+const SUPABASE_ANON_KEY = SUPABASE_ENVS[SUPABASE_ENV].key;
+const IS_STAGING = SUPABASE_ENV === 'staging';
 const ADMIN_EMAIL = 'admin@kemo.jp';
+
+// 디버깅용 전역 노출
+window.__REVERB_ENV__ = SUPABASE_ENV;
 
 let db = null;
 try { if (window.supabase) db = window.supabase.createClient(SUPABASE_URL, SUPABASE_ANON_KEY); } catch(e) {}
@@ -4320,6 +4346,14 @@ async function init() {
 }
 
 document.addEventListener('DOMContentLoaded', function() {
+  // STAGING 환경 배지 표시
+  try {
+    if (typeof IS_STAGING !== 'undefined' && IS_STAGING) {
+      var badge = document.getElementById('stagingBadge');
+      if (badge) badge.style.display = 'inline-block';
+    }
+  } catch(e) {}
+
   // 데이터 컨텍스트가 필요한 하위 패널은 부모 패널로 리다이렉트
   var initHash = location.hash.replace('#','') || 'dashboard';
   var subToParent = {'edit-campaign':'campaigns','camp-applicants':'campaigns','influencer-detail':'influencers'};

--- a/dev/admin/app.js
+++ b/dev/admin/app.js
@@ -90,6 +90,14 @@ async function init() {
 }
 
 document.addEventListener('DOMContentLoaded', function() {
+  // STAGING 환경 배지 표시
+  try {
+    if (typeof IS_STAGING !== 'undefined' && IS_STAGING) {
+      var badge = document.getElementById('stagingBadge');
+      if (badge) badge.style.display = 'inline-block';
+    }
+  } catch(e) {}
+
   // 데이터 컨텍스트가 필요한 하위 패널은 부모 패널로 리다이렉트
   var initHash = location.hash.replace('#','') || 'dashboard';
   var subToParent = {'edit-campaign':'campaigns','camp-applicants':'campaigns','influencer-detail':'influencers'};

--- a/dev/admin/index.html
+++ b/dev/admin/index.html
@@ -47,7 +47,10 @@
   <!-- 관리자 전용 상단 헤더 -->
   <div style="background:#2D1F2B;height:56px;display:flex;align-items:center;position:sticky;top:0;z-index:100;width:100%">
     <div style="display:flex;align-items:center;justify-content:space-between;width:100%;padding:0 24px">
-      <span style="font-family:'Sora',sans-serif;font-weight:800;font-size:17px;color:#fff;cursor:pointer" onclick="switchAdminPane('dashboard',document.querySelector('.admin-si'))">Reverb</span>
+      <div style="display:flex;align-items:center;gap:10px">
+        <span style="font-family:'Sora',sans-serif;font-weight:800;font-size:17px;color:#fff;cursor:pointer" onclick="switchAdminPane('dashboard',document.querySelector('.admin-si'))">Reverb</span>
+        <span id="stagingBadge" style="display:none;background:#f59e0b;color:#fff;font-size:11px;font-weight:700;padding:3px 8px;border-radius:4px;letter-spacing:.5px">STAGING</span>
+      </div>
       <div style="display:flex;align-items:center;gap:10px">
         <div id="adminGnbInfo" style="display:flex;align-items:center;gap:8px;color:rgba(255,255,255,.7);font-size:13px">
           <div style="width:28px;height:28px;border-radius:50%;background:var(--pink);display:flex;align-items:center;justify-content:center;font-size:11px;font-weight:700;color:#fff">A</div>

--- a/dev/lib/supabase.js
+++ b/dev/lib/supabase.js
@@ -1,9 +1,32 @@
 // ══════════════════════════════════════
-// CONFIG — Supabase 연결 설정
+// CONFIG — Supabase 연결 설정 (환경별 자동 분기)
 // ══════════════════════════════════════
-const SUPABASE_URL = 'https://twofagomeizrtkwlhsuv.supabase.co';
-const SUPABASE_ANON_KEY = 'sb_publishable_3KgWYIf5w5J727Q2g3Cl7Q_ETD1Swps';
+// production: globalreverb.com / www.globalreverb.com
+// staging:    dev.globalreverb.com, *.vercel.app, localhost, 127.0.0.1, file://
+const SUPABASE_ENVS = {
+  production: {
+    url: 'https://twofagomeizrtkwlhsuv.supabase.co',
+    key: 'sb_publishable_3KgWYIf5w5J727Q2g3Cl7Q_ETD1Swps'
+  },
+  staging: {
+    url: 'https://qysmxtipobomefudyixw.supabase.co',
+    key: 'sb_publishable_WTxFsvQFllOPIdQ8MDNwCw_e0qBlYTv'
+  }
+};
+
+function resolveSupabaseEnv(hostname) {
+  if (/^(www\.)?globalreverb\.com$/.test(hostname)) return 'production';
+  return 'staging';
+}
+
+const SUPABASE_ENV = resolveSupabaseEnv(location.hostname);
+const SUPABASE_URL = SUPABASE_ENVS[SUPABASE_ENV].url;
+const SUPABASE_ANON_KEY = SUPABASE_ENVS[SUPABASE_ENV].key;
+const IS_STAGING = SUPABASE_ENV === 'staging';
 const ADMIN_EMAIL = 'admin@kemo.jp';
+
+// 디버깅용 전역 노출
+window.__REVERB_ENV__ = SUPABASE_ENV;
 
 let db = null;
 try { if (window.supabase) db = window.supabase.createClient(SUPABASE_URL, SUPABASE_ANON_KEY); } catch(e) {}

--- a/dev/lib/supabase.js
+++ b/dev/lib/supabase.js
@@ -14,6 +14,8 @@ const SUPABASE_ENVS = {
   }
 };
 
+// 정규식은 globalreverb.com / www.globalreverb.com만 엄격히 매칭.
+// 다른 서브도메인(dev, staging, preview 등)이 실수로 production DB에 접근하는 것을 방지.
 function resolveSupabaseEnv(hostname) {
   if (/^(www\.)?globalreverb\.com$/.test(hostname)) return 'production';
   return 'staging';

--- a/docs/plans/2026-04-14_supabase-env-separation.md
+++ b/docs/plans/2026-04-14_supabase-env-separation.md
@@ -1,0 +1,136 @@
+# Supabase 환경 분리 (staging / production) 실행 계획
+
+**작성일**: 2026-04-14
+**상태**: 확정 (사용자 승인 완료)
+
+---
+
+## 배경
+- 현재 dev 서버(`kemo-liart.vercel.app`)와 운영(`globalreverb.com`)이 단일 Supabase 프로젝트(`twofagomeizrtkwlhsuv`)를 공유.
+- 대중 오픈을 앞두고, 테스트 행위(캠페인 CRUD, lookup_values 변경, 테스트 신청 등)가 운영 데이터에 즉시 반영되는 리스크 제거 필요.
+- **목표**: Supabase를 staging/production 2개 프로젝트로 분리하고, 도메인 기반 자동 분기 로직 구현.
+
+---
+
+## 확정 사항 (사용자 결정)
+
+| # | 항목 | 결정 |
+|---|------|------|
+| 1 | 분리 방향 | 현 프로젝트 = production 승격 + staging 신규 생성 |
+| 2 | 운영 초기 데이터 | 실제 파트너 캠페인만 유지 (lookup_values, 관리자 포함) |
+| 3 | 테스트 계정 | staging 이전 후 production에서 삭제 |
+| 4 | 관리자 | production은 실제 사용자 super_admin (설정 완료), `admin@kemo.jp`는 staging에만 |
+| 5 | Vercel | 프로젝트 1개 유지, 도메인 분기만 |
+| 6-1 | staging 도메인 | `dev.globalreverb.com` |
+| 6-2 | `kemo-liart.vercel.app` | 제거 |
+| 7 | Supabase 플랜 | staging Free로 시작, 필요 시 Pro 승급 |
+| 8 | STAGING 배지 | 관리자 페이지에만 표시 |
+| 9 | lookup_values seed | 현 데이터 dump → 양쪽 적용 |
+| 10 | 마이그레이션 점검 | 파일 vs 실제 DB 대조 검증 필요 |
+
+---
+
+## 영향 파일 / 범위
+- `dev/lib/supabase.js` — URL/KEY 하드코딩 → 도메인 분기 로직
+- `dev/build.sh` — 빌드 산출물 확인
+- `dev/index.html`, `dev/admin/index.html` 및 루트 산출물
+- `supabase/migrations/*.sql` — 새 프로젝트 순차 적용
+- `supabase/seed/lookup_values.sql` 신규
+- `CLAUDE.md` Key URLs 업데이트
+- `.claude/rules/supabase.md` 환경 분리 원칙 추가
+- Vercel 도메인 설정, Supabase Auth(양쪽) 설정
+
+---
+
+## 실행 단계
+
+### Phase 0: 사전 준비
+- [ ] 현 Supabase DB 풀 백업 (pg_dump + Storage 목록)
+- [ ] **마이그레이션 점검**: 현 production DB `pg_dump --schema-only` vs `supabase/migrations/` 적용 결과 비교
+  - 차이 발견 시 `028_*.sql` 형태로 복구 마이그레이션 작성
+- [ ] `supabase/seed/lookup_values.sql` 추출 및 커밋
+
+### Phase 1: Supabase 프로젝트 작업
+- [ ] **현 프로젝트 → production으로 rename** (`reverb-jp-production`)
+- [ ] **staging 신규 프로젝트 생성** (`reverb-jp-staging`, Free 플랜, 일본 리전)
+- [ ] staging에 마이그레이션 순차 적용 (001~최신)
+- [ ] staging에 `campaign-images` Storage 버킷 생성 + RLS 복제
+- [ ] staging에 lookup_values seed 적용
+- [ ] staging 관리자 계정 생성: `admin@kemo.jp / admin1234`
+- [ ] staging Auth 설정
+  - Site URL: `https://dev.globalreverb.com`
+  - Redirect URLs: `https://dev.globalreverb.com/**`, `http://localhost:*`, `file://`
+- [ ] production 클린업
+  - 테스트 인플루언서(`*.test@reverb.jp`) 삭제
+  - 테스트 캠페인/applications/receipts 삭제
+  - `admin@kemo.jp` 계정 삭제
+  - view_count 리셋 여부 결정
+- [ ] production Auth 재확인
+  - Site URL: `https://globalreverb.com`
+  - Redirect URLs: `https://globalreverb.com/**`, `https://www.globalreverb.com/**`
+
+### Phase 2: Vercel 도메인 작업
+- [ ] `dev.globalreverb.com` 도메인 추가 + dev 브랜치에 연결
+- [ ] `kemo-liart.vercel.app` 제거
+- [ ] production(main 브랜치) 도메인 확인: `globalreverb.com`, `www.globalreverb.com`
+
+### Phase 3: 코드 변경
+- [ ] **커밋 C** (dev): `dev/lib/supabase.js`에 도메인 분기 로직 추가
+  ```js
+  const isProd = /^(www\.)?globalreverb\.com$/.test(location.hostname);
+  const CONFIG = {
+    production: { url: 'PROD_URL', key: 'PROD_ANON_KEY' },
+    staging:    { url: 'STAGING_URL', key: 'STAGING_ANON_KEY' }
+  };
+  const { url: SUPABASE_URL, key: SUPABASE_ANON_KEY } = CONFIG[isProd ? 'production' : 'staging'];
+  ```
+- [ ] 관리자 페이지에 `[STAGING]` 배지 (staging 환경에서만 표시)
+- [ ] `cd dev && bash build.sh` 실행하여 루트 산출물 갱신
+- [ ] **커밋 D**: `CLAUDE.md` Key URLs 업데이트, `.claude/rules/supabase.md`에 환경 분리 원칙 추가
+
+### Phase 4: 검증 (staging)
+- [ ] dev 브랜치 push → `dev.globalreverb.com` 배포 확인
+- [ ] Network 탭에서 staging Supabase URL로 요청 가는지 확인
+- [ ] 회원가입 + 이메일 확인 링크 → staging URL 리다이렉트
+- [ ] 로그인/로그아웃/세션 갱신
+- [ ] 비밀번호 재설정 메일 링크 올바른지
+- [ ] 캠페인 목록/상세/신청 정상 동작
+- [ ] 관리자 CRUD, lookup_values CRUD 정상
+- [ ] 이미지 업로드(Storage) 동작 (transform은 Free라 제한 있음 — 원본 폴백 확인)
+- [ ] **데이터 격리 확인**: staging에서 캠페인 생성 → production에 노출 안 됨
+
+### Phase 5: production 배포
+- [ ] PR dev → main 생성
+- [ ] PR 리뷰 (reverb-reviewer 호출)
+- [ ] main merge + push → `globalreverb.com` 배포
+- [ ] production Network 탭에서 production Supabase URL 확인
+- [ ] production 기능 E2E 재검증
+- [ ] **데이터 격리 역방향 확인**: production에서 lookup_values 수정 → staging 영향 없음
+
+### Phase 6: 모니터링 (72시간)
+- [ ] Supabase 로그 확인 (staging/production 각각)
+- [ ] 실사용자 신청 플로우 샘플 확인
+- [ ] 에러 리포트 모니터링
+
+---
+
+## 롤백 계획
+- 전환 직전 `pg_dump` 풀백업 (로컬 + 원격 2곳)
+- 분기 로직 문제 시: `git revert` → `build.sh` → `main` push (단일 커밋 rollback)
+- production 데이터 손상 시: dump restore
+
+---
+
+## 리스크 체크리스트
+- [ ] anon key 노출 → RLS 감사 완료
+- [ ] Email confirm redirect 꼬임 위험 → Site URL 명확 분리
+- [ ] **build.sh 미실행 시 치명적 사고** (production이 잘못된 DB로 붙음) → 배포 전 빌드 필수
+- [ ] 현 운영에 수동 SQL 적용분 → Phase 0 점검에서 확인
+- [ ] STAGING 배지 누락 → 환경 착각 가능
+
+---
+
+## 참고
+- Supabase URL: 현 `twofagomeizrtkwlhsuv` → production
+- Storage 버킷: `campaign-images`
+- 주요 테이블: campaigns, influencers, applications, admins, receipts, lookup_values

--- a/index.html
+++ b/index.html
@@ -1172,6 +1172,8 @@ const SUPABASE_ENVS = {
   }
 };
 
+// 정규식은 globalreverb.com / www.globalreverb.com만 엄격히 매칭.
+// 다른 서브도메인(dev, staging, preview 등)이 실수로 production DB에 접근하는 것을 방지.
 function resolveSupabaseEnv(hostname) {
   if (/^(www\.)?globalreverb\.com$/.test(hostname)) return 'production';
   return 'staging';

--- a/index.html
+++ b/index.html
@@ -1157,11 +1157,34 @@ textarea.form-input{resize:vertical;min-height:80px}
 
 <script>
 // ══════════════════════════════════════
-// CONFIG — Supabase 연결 설정
+// CONFIG — Supabase 연결 설정 (환경별 자동 분기)
 // ══════════════════════════════════════
-const SUPABASE_URL = 'https://twofagomeizrtkwlhsuv.supabase.co';
-const SUPABASE_ANON_KEY = 'sb_publishable_3KgWYIf5w5J727Q2g3Cl7Q_ETD1Swps';
+// production: globalreverb.com / www.globalreverb.com
+// staging:    dev.globalreverb.com, *.vercel.app, localhost, 127.0.0.1, file://
+const SUPABASE_ENVS = {
+  production: {
+    url: 'https://twofagomeizrtkwlhsuv.supabase.co',
+    key: 'sb_publishable_3KgWYIf5w5J727Q2g3Cl7Q_ETD1Swps'
+  },
+  staging: {
+    url: 'https://qysmxtipobomefudyixw.supabase.co',
+    key: 'sb_publishable_WTxFsvQFllOPIdQ8MDNwCw_e0qBlYTv'
+  }
+};
+
+function resolveSupabaseEnv(hostname) {
+  if (/^(www\.)?globalreverb\.com$/.test(hostname)) return 'production';
+  return 'staging';
+}
+
+const SUPABASE_ENV = resolveSupabaseEnv(location.hostname);
+const SUPABASE_URL = SUPABASE_ENVS[SUPABASE_ENV].url;
+const SUPABASE_ANON_KEY = SUPABASE_ENVS[SUPABASE_ENV].key;
+const IS_STAGING = SUPABASE_ENV === 'staging';
 const ADMIN_EMAIL = 'admin@kemo.jp';
+
+// 디버깅용 전역 노출
+window.__REVERB_ENV__ = SUPABASE_ENV;
 
 let db = null;
 try { if (window.supabase) db = window.supabase.createClient(SUPABASE_URL, SUPABASE_ANON_KEY); } catch(e) {}

--- a/supabase/patches/2026-04-14_apply_missing_022_026.sql
+++ b/supabase/patches/2026-04-14_apply_missing_022_026.sql
@@ -1,0 +1,41 @@
+-- ============================================
+-- 누락된 마이그레이션 022, 026 복구 적용
+-- 대상: production DB
+-- 작성일: 2026-04-14
+-- 안전성: 모든 컬럼이 IF NOT EXISTS로 작성되어 재실행 안전
+-- ============================================
+
+-- ---- 022_add_consent_fields ----
+ALTER TABLE influencers
+  ADD COLUMN IF NOT EXISTS terms_agreed_at TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS privacy_agreed_at TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS marketing_opt_in BOOLEAN DEFAULT FALSE,
+  ADD COLUMN IF NOT EXISTS marketing_agreed_at TIMESTAMPTZ;
+
+COMMENT ON COLUMN influencers.terms_agreed_at IS '서비스 이용약관 동의 시점';
+COMMENT ON COLUMN influencers.privacy_agreed_at IS '개인정보 처리방침 동의 시점';
+COMMENT ON COLUMN influencers.marketing_opt_in IS '마케팅 정보 수신 동의 여부 (선택)';
+COMMENT ON COLUMN influencers.marketing_agreed_at IS '마케팅 정보 수신 동의 시점 (opt-in 시 기록)';
+
+-- ---- 026_campaigns_primary_channel ----
+ALTER TABLE campaigns
+  ADD COLUMN IF NOT EXISTS primary_channel text;
+
+COMMENT ON COLUMN campaigns.primary_channel IS
+  '최소 팔로워수 검증 기준 채널 코드 (channel 컬럼에 포함된 값 중 하나). NULL이면 첫 번째 채널로 폴백';
+
+-- 기존 캠페인: min_followers > 0 인 경우 첫 번째 채널을 기준으로 자동 지정
+UPDATE campaigns
+   SET primary_channel = split_part(channel, ',', 1)
+ WHERE primary_channel IS NULL
+   AND channel IS NOT NULL
+   AND channel <> ''
+   AND COALESCE(min_followers, 0) > 0;
+
+-- ============================================
+-- 검증: 아래 쿼리로 결과 확인
+-- ============================================
+-- SELECT column_name FROM information_schema.columns
+-- WHERE table_schema='public'
+--   AND ((table_name='influencers' AND column_name IN ('terms_agreed_at','privacy_agreed_at','marketing_opt_in','marketing_agreed_at'))
+--     OR (table_name='campaigns' AND column_name='primary_channel'));

--- a/supabase/seed/lookup_values.sql
+++ b/supabase/seed/lookup_values.sql
@@ -1,0 +1,49 @@
+-- ============================================
+-- lookup_values 초기 시드
+-- 추출 시점: 2026-04-14 (production 기준)
+-- 용도: 신규 환경(staging/production) 초기 데이터 투입
+-- 재실행: (kind, code) 기준 UPSERT - 안전
+-- ============================================
+
+INSERT INTO lookup_values (kind, code, name_ko, name_ja, sort_order, active, recruit_types) VALUES
+  -- category
+  ('category', 'beauty',           '뷰티/코스메',                                  'ビューティ',                            10, true, '{}'),
+  ('category', 'food',             '푸드/그르메',                                  'フード',                               20, true, '{}'),
+  ('category', 'fashion',          '패션/라이프',                                  'ファッション',                          30, true, '{}'),
+  ('category', 'health',           '헬스/웰니스',                                  'ヘルスケア',                            40, true, '{}'),
+  ('category', 'other',            '기타',                                        'その他',                                50, true, '{}'),
+
+  -- channel (recruit_types 사용)
+  ('channel',  'instagram',        'Instagram',                                  'Instagram',                            10, true, '{gifting,visit}'),
+  ('channel',  'x',                'X(Twitter)',                                 'X(Twitter)',                           20, true, '{gifting,visit}'),
+  ('channel',  'tiktok',           'TikTok',                                     'TikTok',                               30, true, '{gifting,visit}'),
+  ('channel',  'youtube',          'YouTube',                                    'YouTube',                              40, true, '{gifting,visit}'),
+  ('channel',  'qoo10',            'Qoo10',                                      'Qoo10',                                50, true, '{monitor}'),
+  ('channel',  'channel-96r9y3',   '엣코스메',                                     '@Cosme',                               60, true, '{monitor}'),
+
+  -- content_type
+  ('content_type', 'feed',         '피드',                                        'フィード',                              10, true, '{}'),
+  ('content_type', 'reels',        '릴스',                                        'リール',                                20, true, '{}'),
+  ('content_type', 'story',        '스토리',                                      'ストーリー',                            30, true, '{}'),
+  ('content_type', 'short',        '쇼츠',                                        'ショート動画',                          40, true, '{}'),
+  ('content_type', 'video',        '동영상',                                      '動画',                                  50, true, '{}'),
+  ('content_type', 'image',        '이미지',                                      '画像',                                  60, true, '{}'),
+
+  -- ng_item
+  ('ng_item', 'competitor_brand',  '경쟁사 기업명·상품명·상품 노출 금지',                      '競合他社の企業名・商品名・商品の露出 NG',           10, true, '{}'),
+  ('ng_item', 'dark_lighting',     '어두운 장소에서 촬영해 상품이 잘 보이지 않는 사진 금지',           '暗い場所での撮影により商品が見えにくいもの NG',       20, true, '{}'),
+  ('ng_item', 'logo_reverse',      '로고가 뒤집힌 사진 금지',                               'ロゴが逆向きになっているもの NG',                30, true, '{}'),
+  ('ng_item', 'unclear_brand',     '브랜드명·상품명·패키지·상품의 색감이 잘 보이지 않는 사진 금지',        'ブランド名・商品名・パッケージ・商品の発色が見えにくいもの NG', 40, true, '{}'),
+  ('ng_item', 'negative',          '본 상품/서비스에 대한 부정적인 표현 금지',                    '本商品／サービスに対するネガティブな表現 NG',         50, true, '{}'),
+  ('ng_item', 'swatch_only',       '상품을 실제로 사용하지 않고 스와치 게시물만 등록 금지',              '商品を実際に使用せずスウォッチ投稿のみ NG',          60, true, '{}')
+ON CONFLICT (kind, code) DO UPDATE SET
+  name_ko = EXCLUDED.name_ko,
+  name_ja = EXCLUDED.name_ja,
+  sort_order = EXCLUDED.sort_order,
+  active = EXCLUDED.active,
+  recruit_types = EXCLUDED.recruit_types,
+  updated_at = now();
+
+-- 검증:
+-- SELECT kind, COUNT(*) FROM lookup_values GROUP BY kind ORDER BY kind;
+-- 예상: category=5, channel=6, content_type=6, ng_item=6 (총 23)


### PR DESCRIPTION
## Summary
- 도메인 기반 Supabase 자동 분기 (globalreverb.com=production, 그 외=staging)
- staging 환경 신규 구축 (🇯🇵 Tokyo) — 검증 완료
- production 테스트 데이터 클린업 완료

## Changes
- `dev/lib/supabase.js` — 환경 분기 로직 (`resolveSupabaseEnv`)
- `dev/admin/` — STAGING 배지 (staging 환경에서만 표시)
- `supabase/patches/` — 022, 026 누락 마이그레이션 복구
- `supabase/seed/lookup_values.sql` — 시드 데이터
- `CLAUDE.md` — Key URLs + Environments 섹션 업데이트
- `docs/plans/2026-04-14_supabase-env-separation.md` — 실행 계획서

## Verification
- ✅ staging (dev.globalreverb.com) 접속, STAGING 배지 표시, 로그인 동작
- ✅ window.__REVERB_ENV__ === "staging"
- ✅ 데이터 격리: staging 캠페인이 production에 노출 안 됨
- ✅ production 클린업: 테스트 인플루언서 3명 + admin@kemo.jp 제거

## Test plan
- [ ] main merge 후 globalreverb.com 접속 → production Supabase 사용 확인
- [ ] 관리자 로그인 정상 동작
- [ ] STAGING 배지 **미표시** 확인 (production이므로)
- [ ] 네트워크 탭에서 `twofagomeizrtkwlhsuv.supabase.co`로 요청 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)