### PR TITLE
fix(admin): complete auth record for admin creation + email_confirmed_at

### DIFF
--- a/supabase/migrations/028_create_admin_confirm_email.sql
+++ b/supabase/migrations/028_create_admin_confirm_email.sql
@@ -1,0 +1,62 @@
+-- ============================================
+-- create_admin 함수 강화: 이메일 인증 보장
+-- 작성일: 2026-04-14
+-- 배경: 과거 create_admin으로 생성된 관리자 중 일부 email_confirmed_at NULL 사례 발견
+-- ============================================
+
+-- 1. 함수 재정의 — INSERT 후 email_confirmed_at 강제 확인 처리
+CREATE OR REPLACE FUNCTION create_admin(admin_email text, admin_password text, admin_name text, admin_role text)
+RETURNS uuid
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  new_user_id uuid;
+BEGIN
+  -- 슈퍼관리자만 실행 가능
+  IF NOT EXISTS (SELECT 1 FROM public.admins WHERE auth_id = auth.uid() AND role = 'super_admin') THEN
+    RAISE EXCEPTION 'Permission denied: super_admin only';
+  END IF;
+
+  -- Auth 계정 생성 (이메일 인증 완료 상태)
+  INSERT INTO auth.users (
+    instance_id, id, aud, role, email,
+    encrypted_password, email_confirmed_at,
+    created_at, updated_at, confirmation_token
+  ) VALUES (
+    '00000000-0000-0000-0000-000000000000',
+    gen_random_uuid(), 'authenticated', 'authenticated', admin_email,
+    crypt(admin_password, gen_salt('bf')), now(),
+    now(), now(), ''
+  ) RETURNING id INTO new_user_id;
+
+  -- 안전망: 혹시라도 email_confirmed_at 누락된 경우 보정
+  UPDATE auth.users
+     SET email_confirmed_at = COALESCE(email_confirmed_at, now())
+   WHERE id = new_user_id;
+
+  -- admins 테이블에 등록
+  INSERT INTO public.admins (auth_id, email, name, role)
+  VALUES (new_user_id, admin_email, admin_name, admin_role);
+
+  RETURN new_user_id;
+END;
+$$;
+
+-- 2. 기존 관리자 중 email_confirmed_at NULL인 경우 일괄 보정
+UPDATE auth.users u
+   SET email_confirmed_at = now()
+  FROM public.admins a
+ WHERE u.id = a.auth_id
+   AND u.email_confirmed_at IS NULL;
+
+-- 3. 검증
+SELECT
+  a.email,
+  a.role,
+  u.email_confirmed_at,
+  CASE WHEN u.email_confirmed_at IS NOT NULL THEN '✓' ELSE '✗' END AS confirmed
+FROM public.admins a
+JOIN auth.users u ON u.id = a.auth_id
+ORDER BY u.email_confirmed_at NULLS FIRST;

--- a/supabase/migrations/029_fix_create_admin_complete.sql
+++ b/supabase/migrations/029_fix_create_admin_complete.sql
@@ -1,0 +1,120 @@
+-- ============================================
+-- create_admin 전면 수정: auth.identities + metadata 완비
+-- 작성일: 2026-04-14
+-- 배경: 기존 함수가 auth.identities와 raw_app_meta_data/raw_user_meta_data를
+--       설정하지 않아 생성된 관리자 계정이 로그인 불가한 상태였음
+-- ============================================
+
+CREATE OR REPLACE FUNCTION create_admin(admin_email text, admin_password text, admin_name text, admin_role text)
+RETURNS uuid
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  new_user_id uuid;
+BEGIN
+  -- 슈퍼관리자만 실행 가능
+  IF NOT EXISTS (SELECT 1 FROM public.admins WHERE auth_id = auth.uid() AND role = 'super_admin') THEN
+    RAISE EXCEPTION 'Permission denied: super_admin only';
+  END IF;
+
+  new_user_id := gen_random_uuid();
+
+  -- Auth 계정 생성 (완전한 Supabase Auth 스펙)
+  INSERT INTO auth.users (
+    instance_id, id, aud, role, email,
+    encrypted_password, email_confirmed_at,
+    created_at, updated_at,
+    confirmation_token, recovery_token,
+    email_change_token_new, email_change_token_current,
+    phone_change_token, reauthentication_token,
+    raw_app_meta_data, raw_user_meta_data
+  ) VALUES (
+    '00000000-0000-0000-0000-000000000000',
+    new_user_id, 'authenticated', 'authenticated', admin_email,
+    extensions.crypt(admin_password, extensions.gen_salt('bf', 10)),
+    now(),
+    now(), now(),
+    '', '', '', '', '', '',
+    jsonb_build_object('provider', 'email', 'providers', jsonb_build_array('email')),
+    jsonb_build_object(
+      'sub', new_user_id::text,
+      'email', admin_email,
+      'email_verified', true,
+      'phone_verified', false
+    )
+  );
+
+  -- auth.identities 생성 (로그인에 필수)
+  INSERT INTO auth.identities (
+    id, user_id, identity_data, provider, provider_id, created_at, updated_at
+  ) VALUES (
+    gen_random_uuid(),
+    new_user_id,
+    jsonb_build_object(
+      'sub', new_user_id::text,
+      'email', admin_email,
+      'email_verified', true
+    ),
+    'email',
+    new_user_id::text,
+    now(), now()
+  );
+
+  -- admins 테이블 등록
+  INSERT INTO public.admins (auth_id, email, name, role)
+  VALUES (new_user_id, admin_email, admin_name, admin_role);
+
+  RETURN new_user_id;
+END;
+$$;
+
+-- ============================================
+-- 기존 관리자 중 누락된 필드 일괄 보정
+-- ============================================
+
+-- raw_app_meta_data / raw_user_meta_data 누락분 채우기
+UPDATE auth.users u
+   SET
+     raw_app_meta_data = COALESCE(raw_app_meta_data, jsonb_build_object('provider', 'email', 'providers', jsonb_build_array('email'))),
+     raw_user_meta_data = COALESCE(raw_user_meta_data, jsonb_build_object(
+       'sub', u.id::text,
+       'email', u.email,
+       'email_verified', true,
+       'phone_verified', false
+     )),
+     recovery_token = COALESCE(recovery_token, ''),
+     email_change_token_new = COALESCE(email_change_token_new, ''),
+     email_change_token_current = COALESCE(email_change_token_current, ''),
+     phone_change_token = COALESCE(phone_change_token, ''),
+     reauthentication_token = COALESCE(reauthentication_token, '')
+  FROM public.admins a
+ WHERE a.auth_id = u.id;
+
+-- auth.identities 누락분 채우기
+INSERT INTO auth.identities (id, user_id, identity_data, provider, provider_id, created_at, updated_at)
+SELECT
+  gen_random_uuid(),
+  u.id,
+  jsonb_build_object('sub', u.id::text, 'email', u.email, 'email_verified', true),
+  'email',
+  u.id::text,
+  now(), now()
+FROM auth.users u
+JOIN public.admins a ON a.auth_id = u.id
+LEFT JOIN auth.identities i ON i.user_id = u.id AND i.provider = 'email'
+WHERE i.id IS NULL;
+
+-- ============================================
+-- 검증
+-- ============================================
+SELECT
+  a.email,
+  a.role,
+  CASE WHEN u.raw_app_meta_data IS NOT NULL THEN '✓' ELSE '✗' END AS app_meta,
+  CASE WHEN u.raw_user_meta_data IS NOT NULL THEN '✓' ELSE '✗' END AS user_meta,
+  CASE WHEN EXISTS (SELECT 1 FROM auth.identities i WHERE i.user_id = u.id AND i.provider = 'email') THEN '✓' ELSE '✗' END AS has_identity
+FROM public.admins a
+JOIN auth.users u ON u.id = a.auth_id
+ORDER BY a.email;

--- a/supabase/migrations/029_fix_create_admin_complete.sql
+++ b/supabase/migrations/029_fix_create_admin_complete.sql
@@ -88,7 +88,9 @@ UPDATE auth.users u
      email_change_token_new = COALESCE(email_change_token_new, ''),
      email_change_token_current = COALESCE(email_change_token_current, ''),
      phone_change_token = COALESCE(phone_change_token, ''),
-     reauthentication_token = COALESCE(reauthentication_token, '')
+     reauthentication_token = COALESCE(reauthentication_token, ''),
+     email_change = COALESCE(email_change, ''),
+     phone_change = COALESCE(phone_change, '')
   FROM public.admins a
  WHERE a.auth_id = u.id;
 

--- a/supabase/seed/test_influencers_staging.sql
+++ b/supabase/seed/test_influencers_staging.sql
@@ -1,0 +1,82 @@
+-- ============================================
+-- 개발서버(staging) 테스트 인플루언서 3명 생성
+-- 비밀번호: 모두 test1234
+-- 이메일: 모두 이메일 확인 완료 처리
+-- 주의: staging 전용 — 운영서버에 실행 금지
+-- ============================================
+
+-- ── 1. 사쿠라 (뷰티/Instagram 메인) ──
+INSERT INTO auth.users (instance_id, id, aud, role, email, encrypted_password, email_confirmed_at, created_at, updated_at, confirmation_token)
+VALUES ('00000000-0000-0000-0000-000000000000', gen_random_uuid(), 'authenticated', 'authenticated',
+  'sakura.test@reverb.jp', crypt('test1234', gen_salt('bf')), now(), now(), now(), '');
+
+UPDATE influencers SET
+  name = '佐藤さくら',
+  name_kanji = '佐藤さくら',
+  name_kana = 'さとうさくら',
+  ig = 'sakura_beauty', ig_followers = 12500,
+  x = 'sakura_x', x_followers = 3200,
+  tiktok = 'sakura_tt', tiktok_followers = 8900,
+  category = 'beauty',
+  primary_sns = 'instagram',
+  bio = 'K-Beautyが大好き！毎日のスキンケアを発信中 🌸',
+  line_id = 'sakura_line',
+  zip = '150-0001', prefecture = '東京都', city = '渋谷区神宮前3-15-8', building = 'サクラマンション 301',
+  phone = '090-1234-5678',
+  paypal_email = 'sakura.paypal@example.com',
+  terms_agreed_at = now(),
+  privacy_agreed_at = now(),
+  marketing_opt_in = true,
+  marketing_agreed_at = now()
+WHERE email = 'sakura.test@reverb.jp';
+
+-- ── 2. 유이 (푸드/TikTok 메인) ──
+INSERT INTO auth.users (instance_id, id, aud, role, email, encrypted_password, email_confirmed_at, created_at, updated_at, confirmation_token)
+VALUES ('00000000-0000-0000-0000-000000000000', gen_random_uuid(), 'authenticated', 'authenticated',
+  'yui.test@reverb.jp', crypt('test1234', gen_salt('bf')), now(), now(), now(), '');
+
+UPDATE influencers SET
+  name = '田中ゆい',
+  name_kanji = '田中ゆい',
+  name_kana = 'たなかゆい',
+  ig = 'yui_foodie', ig_followers = 8300,
+  tiktok = 'yui_tiktok', tiktok_followers = 45000,
+  youtube = 'yui_yt', youtube_followers = 2100,
+  category = 'food',
+  primary_sns = 'tiktok',
+  bio = '韓国料理とK-Foodのレビュー🍜 TikTokメイン',
+  line_id = 'yui_line',
+  zip = '530-0001', prefecture = '大阪府', city = '大阪市北区梅田1-2-3', building = 'グランフロント 1205',
+  phone = '080-9876-5432',
+  paypal_email = 'yui.paypal@example.com',
+  terms_agreed_at = now(),
+  privacy_agreed_at = now(),
+  marketing_opt_in = false
+WHERE email = 'yui.test@reverb.jp';
+
+-- ── 3. 하루카 (패션/Instagram+X) ──
+INSERT INTO auth.users (instance_id, id, aud, role, email, encrypted_password, email_confirmed_at, created_at, updated_at, confirmation_token)
+VALUES ('00000000-0000-0000-0000-000000000000', gen_random_uuid(), 'authenticated', 'authenticated',
+  'haruka.test@reverb.jp', crypt('test1234', gen_salt('bf')), now(), now(), now(), '');
+
+UPDATE influencers SET
+  name = '鈴木はるか',
+  name_kanji = '鈴木はるか',
+  name_kana = 'すずきはるか',
+  ig = 'haruka_style', ig_followers = 22000,
+  x = 'haruka_fashion', x_followers = 15000,
+  category = 'fashion',
+  primary_sns = 'instagram',
+  bio = 'K-Fashionコーデを毎日投稿👗 Instagram+X',
+  line_id = 'haruka_line',
+  zip = '460-0008', prefecture = '愛知県', city = '名古屋市中区栄4-5-6', building = '',
+  phone = '070-5555-1234',
+  paypal_email = 'haruka.paypal@example.com',
+  terms_agreed_at = now(),
+  privacy_agreed_at = now(),
+  marketing_opt_in = true,
+  marketing_agreed_at = now()
+WHERE email = 'haruka.test@reverb.jp';
+
+-- 결과 확인
+SELECT email, name, primary_sns, category, ig_followers, tiktok_followers FROM influencers WHERE email LIKE '%.test@reverb.jp' ORDER BY email;


### PR DESCRIPTION
## Summary
Applies admin-related DB migrations already executed on production, plus staging test seed file.

Excludes i18n work (staging only, per separate decision).

## Migrations included
- 028: ensure email_confirmed_at on create_admin
- 029: create complete Supabase Auth record (identities + metadata + email_change/phone_change)

## Seed file
- supabase/seed/test_influencers_staging.sql (staging-only test accounts)

## Already applied to
- Production DB: 2026-04-14 (SQL Editor)
- Staging DB: 2026-04-14

This PR only preserves migration history in main branch.
🤖 Generated with [Claude Code](https://claude.com/claude-code)