### PR TITLE
feat(admin): invite flow + delete options + PKCE auth

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -1332,7 +1332,18 @@ const ADMIN_EMAIL = 'admin@kemo.jp';
 window.__REVERB_ENV__ = SUPABASE_ENV;
 
 let db = null;
-try { if (window.supabase) db = window.supabase.createClient(SUPABASE_URL, SUPABASE_ANON_KEY); } catch(e) {}
+try {
+  if (window.supabase) {
+    db = window.supabase.createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
+      auth: {
+        flowType: 'pkce',
+        detectSessionInUrl: true,
+        persistSession: true,
+        autoRefreshToken: true
+      }
+    });
+  }
+} catch(e) {}
 // ══════════════════════════════════════
 // SHARED — 클라이언트/관리자 공유 변수
 // ══════════════════════════════════════

--- a/admin/index.html
+++ b/admin/index.html
@@ -1077,10 +1077,6 @@ textarea.form-input{resize:vertical;min-height:80px}
         <label class="form-label">이메일</label>
         <input type="email" id="adminFormEmail" class="form-input" placeholder="admin@example.com">
       </div>
-      <div class="form-group" id="adminFormPwGroup">
-        <label class="form-label">비밀번호 (8자 이상)</label>
-        <input type="password" id="adminFormPw" class="form-input" placeholder="비밀번호 입력">
-      </div>
       <div class="form-group">
         <label class="form-label">이름</label>
         <input type="text" id="adminFormName" class="form-input" placeholder="홍길동">
@@ -1092,6 +1088,9 @@ textarea.form-input{resize:vertical;min-height:80px}
           <option value="campaign_admin">캠페인 관리자</option>
           <option value="super_admin">슈퍼관리자</option>
         </select>
+      </div>
+      <div id="adminFormInviteNotice" style="background:#FDF0F7;border:1px solid rgba(200,120,163,.25);border-radius:10px;padding:10px 12px;font-size:11px;color:#7D4A6A;line-height:1.6;margin-bottom:10px">
+        추가 시 초대 이메일이 발송됩니다. 받는 분이 이메일 링크로 직접 비밀번호를 설정해야 로그인 가능합니다.
       </div>
       <div id="adminFormError" class="form-error" style="display:none;margin-bottom:10px"></div>
       <div style="display:flex;gap:10px;margin-top:16px">
@@ -1125,6 +1124,37 @@ textarea.form-input{resize:vertical;min-height:80px}
       </div>
       <div style="margin-top:12px;text-align:center">
         <button class="btn btn-ghost btn-xs" onclick="sendResetEmail()" style="font-size:11px;color:var(--muted)"><span class="material-icons-round notranslate" translate="no" style="font-size:14px;vertical-align:-2px">email</span> 이메일로 재설정 링크 보내기</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- 관리자 삭제 옵션 모달 -->
+<div class="modal-overlay" id="deleteAdminModal">
+  <div class="modal" style="max-width:420px;border-radius:24px;margin:auto">
+    <div class="modal-header">
+      <div class="modal-title">관리자 삭제</div>
+      <div class="modal-close" onclick="closeDeleteAdminModal()"><span class="material-icons-round notranslate" translate="no" style="font-size:18px">close</span></div>
+    </div>
+    <div class="modal-body">
+      <input type="hidden" id="deleteAdminAuthId">
+      <input type="hidden" id="deleteAdminAdminId">
+      <div style="font-size:13px;color:var(--muted);margin-bottom:16px">
+        <strong id="deleteAdminEmail"></strong> 계정을 어떻게 처리할까요?
+      </div>
+
+      <button class="btn btn-ghost btn-block" onclick="executeRemoveRole()" style="text-align:left;padding:14px;margin-bottom:10px">
+        <div style="font-weight:700;font-size:13px;margin-bottom:4px">권한만 해제</div>
+        <div style="font-size:11px;color:var(--muted);white-space:normal">관리자 권한 제거. 인플루언서 계정 및 데이터는 유지됩니다.</div>
+      </button>
+
+      <button class="btn btn-ghost btn-block" onclick="executeDeleteCompletely()" style="text-align:left;padding:14px;border-color:#B3261E">
+        <div style="font-weight:700;font-size:13px;color:#B3261E;margin-bottom:4px">계정 완전 삭제</div>
+        <div style="font-size:11px;color:var(--muted);white-space:normal">auth, 인플루언서 프로필, 응모, 영수증 전부 삭제. 복구 불가.</div>
+      </button>
+
+      <div style="display:flex;gap:10px;margin-top:16px">
+        <button class="btn btn-ghost" onclick="closeDeleteAdminModal()" style="flex:1">취소</button>
       </div>
     </div>
   </div>
@@ -3641,7 +3671,7 @@ async function loadAdminAccounts() {
     <td><div style="display:flex;gap:5px">
       <button class="btn btn-ghost btn-xs" data-email="${esc(a.email)}" data-name="${esc(a.name||'')}" onclick="openEditAdmin('${a.id}',this.dataset.email,this.dataset.name,'${a.role}')">수정</button>
       <button class="btn btn-ghost btn-xs" data-email="${esc(a.email)}" onclick="openResetPwModal('${a.auth_id}',this.dataset.email)">비밀번호</button>
-      ${a.role !== 'super_admin' ? `<button class="btn btn-ghost btn-xs" style="color:#B3261E" data-email="${esc(a.email)}" onclick="deleteAdmin('${a.id}',this.dataset.email)">삭제</button>` : ''}
+      ${a.role !== 'super_admin' ? `<button class="btn btn-ghost btn-xs" style="color:#B3261E" data-email="${esc(a.email)}" data-auth-id="${a.auth_id}" onclick="openDeleteAdminModal('${a.id}',this.dataset.authId,this.dataset.email)">삭제</button>` : ''}
     </div></td>
   </tr>`).join('') : '<tr><td colspan="5" style="text-align:center;color:var(--muted);padding:24px">데이터 없음</td></tr>';
 
@@ -4078,19 +4108,25 @@ async function saveAdmin() {
       err.textContent = '수정 오류: ' + friendlyError(e.message); err.style.display = 'block';
     }
   } else {
-    // 추가 모드
+    // 추가 모드 (초대 플로우)
     const email = $('adminFormEmail').value.trim();
-    const pw = $('adminFormPw').value;
     const name = $('adminFormName').value.trim();
     const role = $('adminFormRole').value;
-    if (!email || !pw || !name) { err.textContent = '모든 항목을 입력해주세요'; err.style.display = 'block'; return; }
-    if (pw.length < 8) { err.textContent = '비밀번호는 8자 이상이어야 합니다'; err.style.display = 'block'; return; }
+    if (!email || !name) { err.textContent = '모든 항목을 입력해주세요'; err.style.display = 'block'; return; }
     try {
-      const {data, error} = await db.rpc('create_admin', {
-        admin_email: email, admin_password: pw, admin_name: name, admin_role: role
+      const {data, error} = await db.rpc('invite_admin', {
+        admin_email: email, admin_name: name, admin_role: role
       });
       if (error) throw error;
-      toast('관리자가 추가되었습니다','success');
+
+      // 초대 메일 발송 (비밀번호 설정 링크)
+      const redirectUrl = location.origin + '/#reset-pw';
+      const {error: mailErr} = await db.auth.resetPasswordForEmail(email, {redirectTo: redirectUrl});
+      if (mailErr) {
+        toast('관리자 등록 성공. 단 초대 메일 발송 실패: ' + friendlyError(mailErr.message), 'error');
+      } else {
+        toast('관리자가 추가되었습니다. 초대 이메일이 발송되었습니다.', 'success');
+      }
       closeModal('addAdminModal');
       loadAdminAccounts();
     } catch(e) {
@@ -4099,14 +4135,46 @@ async function saveAdmin() {
   }
 }
 
-async function deleteAdmin(id, email) {
-  if (!confirm(`${email} 관리자를 삭제하시겠습니까?`)) return;
+function openDeleteAdminModal(adminId, authId, email) {
+  const modal = document.getElementById('deleteAdminModal');
+  if (!modal) return;
+  document.getElementById('deleteAdminEmail').textContent = email;
+  document.getElementById('deleteAdminAuthId').value = authId;
+  document.getElementById('deleteAdminAdminId').value = adminId;
+  modal.classList.add('open');
+}
+
+function closeDeleteAdminModal() {
+  document.getElementById('deleteAdminModal')?.classList.remove('open');
+}
+
+async function executeRemoveRole() {
+  const authId = document.getElementById('deleteAdminAuthId').value;
+  if (!authId) return;
   try {
-    await db.from('admins').delete().eq('id', id);
-    toast('관리자가 삭제되었습니다','success');
+    const { error } = await db.rpc('remove_admin_role', { target_auth_id: authId });
+    if (error) throw error;
+    toast('관리자 권한이 해제되었습니다 (인플루언서 계정은 유지)', 'success');
+    closeDeleteAdminModal();
     loadAdminAccounts();
   } catch(e) {
-    toast('삭제 오류: ' + friendlyError(e.message),'error');
+    toast('권한 해제 오류: ' + friendlyError(e.message), 'error');
+  }
+}
+
+async function executeDeleteCompletely() {
+  const email = document.getElementById('deleteAdminEmail').textContent;
+  if (!confirm(`정말 ${email} 계정을 완전 삭제합니까? 인플루언서 데이터, 응모 이력 등 모두 삭제되며 복구 불가합니다.`)) return;
+  const authId = document.getElementById('deleteAdminAuthId').value;
+  if (!authId) return;
+  try {
+    const { error } = await db.rpc('delete_admin_completely', { target_auth_id: authId });
+    if (error) throw error;
+    toast('계정이 완전 삭제되었습니다', 'success');
+    closeDeleteAdminModal();
+    loadAdminAccounts();
+  } catch(e) {
+    toast('삭제 오류: ' + friendlyError(e.message), 'error');
   }
 }
 

--- a/admin/index.html
+++ b/admin/index.html
@@ -4068,12 +4068,12 @@ function openAddAdminModal() {
   $('editAdminId').value = '';
   $('adminFormEmail').value = '';
   $('adminFormEmail').disabled = false;
-  $('adminFormPw').value = '';
-  $('adminFormPwGroup').style.display = '';
   $('adminFormName').value = '';
   $('adminFormRole').value = 'campaign_admin';
   $('adminFormBtn').textContent = '추가';
   $('adminFormError').style.display = 'none';
+  const inviteNotice = document.getElementById('adminFormInviteNotice');
+  if (inviteNotice) inviteNotice.style.display = '';
   $('addAdminModal').classList.add('open');
 }
 
@@ -4082,11 +4082,12 @@ function openEditAdmin(id, email, name, role) {
   $('editAdminId').value = id;
   $('adminFormEmail').value = email;
   $('adminFormEmail').disabled = true;
-  $('adminFormPwGroup').style.display = 'none';
   $('adminFormName').value = name;
   $('adminFormRole').value = role;
   $('adminFormBtn').textContent = '저장';
   $('adminFormError').style.display = 'none';
+  const inviteNotice = document.getElementById('adminFormInviteNotice');
+  if (inviteNotice) inviteNotice.style.display = 'none';
   $('addAdminModal').classList.add('open');
 }
 

--- a/dev/admin/index.html
+++ b/dev/admin/index.html
@@ -760,10 +760,6 @@
         <label class="form-label">이메일</label>
         <input type="email" id="adminFormEmail" class="form-input" placeholder="admin@example.com">
       </div>
-      <div class="form-group" id="adminFormPwGroup">
-        <label class="form-label">비밀번호 (8자 이상)</label>
-        <input type="password" id="adminFormPw" class="form-input" placeholder="비밀번호 입력">
-      </div>
       <div class="form-group">
         <label class="form-label">이름</label>
         <input type="text" id="adminFormName" class="form-input" placeholder="홍길동">
@@ -775,6 +771,9 @@
           <option value="campaign_admin">캠페인 관리자</option>
           <option value="super_admin">슈퍼관리자</option>
         </select>
+      </div>
+      <div id="adminFormInviteNotice" style="background:#FDF0F7;border:1px solid rgba(200,120,163,.25);border-radius:10px;padding:10px 12px;font-size:11px;color:#7D4A6A;line-height:1.6;margin-bottom:10px">
+        추가 시 초대 이메일이 발송됩니다. 받는 분이 이메일 링크로 직접 비밀번호를 설정해야 로그인 가능합니다.
       </div>
       <div id="adminFormError" class="form-error" style="display:none;margin-bottom:10px"></div>
       <div style="display:flex;gap:10px;margin-top:16px">
@@ -808,6 +807,37 @@
       </div>
       <div style="margin-top:12px;text-align:center">
         <button class="btn btn-ghost btn-xs" onclick="sendResetEmail()" style="font-size:11px;color:var(--muted)"><span class="material-icons-round notranslate" translate="no" style="font-size:14px;vertical-align:-2px">email</span> 이메일로 재설정 링크 보내기</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- 관리자 삭제 옵션 모달 -->
+<div class="modal-overlay" id="deleteAdminModal">
+  <div class="modal" style="max-width:420px;border-radius:24px;margin:auto">
+    <div class="modal-header">
+      <div class="modal-title">관리자 삭제</div>
+      <div class="modal-close" onclick="closeDeleteAdminModal()"><span class="material-icons-round notranslate" translate="no" style="font-size:18px">close</span></div>
+    </div>
+    <div class="modal-body">
+      <input type="hidden" id="deleteAdminAuthId">
+      <input type="hidden" id="deleteAdminAdminId">
+      <div style="font-size:13px;color:var(--muted);margin-bottom:16px">
+        <strong id="deleteAdminEmail"></strong> 계정을 어떻게 처리할까요?
+      </div>
+
+      <button class="btn btn-ghost btn-block" onclick="executeRemoveRole()" style="text-align:left;padding:14px;margin-bottom:10px">
+        <div style="font-weight:700;font-size:13px;margin-bottom:4px">권한만 해제</div>
+        <div style="font-size:11px;color:var(--muted);white-space:normal">관리자 권한 제거. 인플루언서 계정 및 데이터는 유지됩니다.</div>
+      </button>
+
+      <button class="btn btn-ghost btn-block" onclick="executeDeleteCompletely()" style="text-align:left;padding:14px;border-color:#B3261E">
+        <div style="font-weight:700;font-size:13px;color:#B3261E;margin-bottom:4px">계정 완전 삭제</div>
+        <div style="font-size:11px;color:var(--muted);white-space:normal">auth, 인플루언서 프로필, 응모, 영수증 전부 삭제. 복구 불가.</div>
+      </button>
+
+      <div style="display:flex;gap:10px;margin-top:16px">
+        <button class="btn btn-ghost" onclick="closeDeleteAdminModal()" style="flex:1">취소</button>
       </div>
     </div>
   </div>

--- a/dev/js/admin.js
+++ b/dev/js/admin.js
@@ -1838,12 +1838,12 @@ function openAddAdminModal() {
   $('editAdminId').value = '';
   $('adminFormEmail').value = '';
   $('adminFormEmail').disabled = false;
-  $('adminFormPw').value = '';
-  $('adminFormPwGroup').style.display = '';
   $('adminFormName').value = '';
   $('adminFormRole').value = 'campaign_admin';
   $('adminFormBtn').textContent = '추가';
   $('adminFormError').style.display = 'none';
+  const inviteNotice = document.getElementById('adminFormInviteNotice');
+  if (inviteNotice) inviteNotice.style.display = '';
   $('addAdminModal').classList.add('open');
 }
 
@@ -1852,11 +1852,12 @@ function openEditAdmin(id, email, name, role) {
   $('editAdminId').value = id;
   $('adminFormEmail').value = email;
   $('adminFormEmail').disabled = true;
-  $('adminFormPwGroup').style.display = 'none';
   $('adminFormName').value = name;
   $('adminFormRole').value = role;
   $('adminFormBtn').textContent = '저장';
   $('adminFormError').style.display = 'none';
+  const inviteNotice = document.getElementById('adminFormInviteNotice');
+  if (inviteNotice) inviteNotice.style.display = 'none';
   $('addAdminModal').classList.add('open');
 }
 

--- a/dev/js/admin.js
+++ b/dev/js/admin.js
@@ -1441,7 +1441,7 @@ async function loadAdminAccounts() {
     <td><div style="display:flex;gap:5px">
       <button class="btn btn-ghost btn-xs" data-email="${esc(a.email)}" data-name="${esc(a.name||'')}" onclick="openEditAdmin('${a.id}',this.dataset.email,this.dataset.name,'${a.role}')">수정</button>
       <button class="btn btn-ghost btn-xs" data-email="${esc(a.email)}" onclick="openResetPwModal('${a.auth_id}',this.dataset.email)">비밀번호</button>
-      ${a.role !== 'super_admin' ? `<button class="btn btn-ghost btn-xs" style="color:#B3261E" data-email="${esc(a.email)}" onclick="deleteAdmin('${a.id}',this.dataset.email)">삭제</button>` : ''}
+      ${a.role !== 'super_admin' ? `<button class="btn btn-ghost btn-xs" style="color:#B3261E" data-email="${esc(a.email)}" data-auth-id="${a.auth_id}" onclick="openDeleteAdminModal('${a.id}',this.dataset.authId,this.dataset.email)">삭제</button>` : ''}
     </div></td>
   </tr>`).join('') : '<tr><td colspan="5" style="text-align:center;color:var(--muted);padding:24px">데이터 없음</td></tr>';
 
@@ -1878,19 +1878,25 @@ async function saveAdmin() {
       err.textContent = '수정 오류: ' + friendlyError(e.message); err.style.display = 'block';
     }
   } else {
-    // 추가 모드
+    // 추가 모드 (초대 플로우)
     const email = $('adminFormEmail').value.trim();
-    const pw = $('adminFormPw').value;
     const name = $('adminFormName').value.trim();
     const role = $('adminFormRole').value;
-    if (!email || !pw || !name) { err.textContent = '모든 항목을 입력해주세요'; err.style.display = 'block'; return; }
-    if (pw.length < 8) { err.textContent = '비밀번호는 8자 이상이어야 합니다'; err.style.display = 'block'; return; }
+    if (!email || !name) { err.textContent = '모든 항목을 입력해주세요'; err.style.display = 'block'; return; }
     try {
-      const {data, error} = await db.rpc('create_admin', {
-        admin_email: email, admin_password: pw, admin_name: name, admin_role: role
+      const {data, error} = await db.rpc('invite_admin', {
+        admin_email: email, admin_name: name, admin_role: role
       });
       if (error) throw error;
-      toast('관리자가 추가되었습니다','success');
+
+      // 초대 메일 발송 (비밀번호 설정 링크)
+      const redirectUrl = location.origin + '/#reset-pw';
+      const {error: mailErr} = await db.auth.resetPasswordForEmail(email, {redirectTo: redirectUrl});
+      if (mailErr) {
+        toast('관리자 등록 성공. 단 초대 메일 발송 실패: ' + friendlyError(mailErr.message), 'error');
+      } else {
+        toast('관리자가 추가되었습니다. 초대 이메일이 발송되었습니다.', 'success');
+      }
       closeModal('addAdminModal');
       loadAdminAccounts();
     } catch(e) {
@@ -1899,14 +1905,46 @@ async function saveAdmin() {
   }
 }
 
-async function deleteAdmin(id, email) {
-  if (!confirm(`${email} 관리자를 삭제하시겠습니까?`)) return;
+function openDeleteAdminModal(adminId, authId, email) {
+  const modal = document.getElementById('deleteAdminModal');
+  if (!modal) return;
+  document.getElementById('deleteAdminEmail').textContent = email;
+  document.getElementById('deleteAdminAuthId').value = authId;
+  document.getElementById('deleteAdminAdminId').value = adminId;
+  modal.classList.add('open');
+}
+
+function closeDeleteAdminModal() {
+  document.getElementById('deleteAdminModal')?.classList.remove('open');
+}
+
+async function executeRemoveRole() {
+  const authId = document.getElementById('deleteAdminAuthId').value;
+  if (!authId) return;
   try {
-    await db.from('admins').delete().eq('id', id);
-    toast('관리자가 삭제되었습니다','success');
+    const { error } = await db.rpc('remove_admin_role', { target_auth_id: authId });
+    if (error) throw error;
+    toast('관리자 권한이 해제되었습니다 (인플루언서 계정은 유지)', 'success');
+    closeDeleteAdminModal();
     loadAdminAccounts();
   } catch(e) {
-    toast('삭제 오류: ' + friendlyError(e.message),'error');
+    toast('권한 해제 오류: ' + friendlyError(e.message), 'error');
+  }
+}
+
+async function executeDeleteCompletely() {
+  const email = document.getElementById('deleteAdminEmail').textContent;
+  if (!confirm(`정말 ${email} 계정을 완전 삭제합니까? 인플루언서 데이터, 응모 이력 등 모두 삭제되며 복구 불가합니다.`)) return;
+  const authId = document.getElementById('deleteAdminAuthId').value;
+  if (!authId) return;
+  try {
+    const { error } = await db.rpc('delete_admin_completely', { target_auth_id: authId });
+    if (error) throw error;
+    toast('계정이 완전 삭제되었습니다', 'success');
+    closeDeleteAdminModal();
+    loadAdminAccounts();
+  } catch(e) {
+    toast('삭제 오류: ' + friendlyError(e.message), 'error');
   }
 }
 

--- a/dev/js/app.js
+++ b/dev/js/app.js
@@ -170,8 +170,8 @@ async function init() {
         updateGnb();
       }
     });
-    // URL에 복구 토큰이 포함된 경우 즉시 reset-pw로
-    if (isRecoveryUrl || hasAccessToken) {
+    // 초기 URL이 명시적 recovery인 경우에만 즉시 이동 (access_token만 있을 때는 이벤트 기다림)
+    if (isRecoveryUrl) {
       navigate('reset-pw');
     }
     // 링크 만료/에러 감지

--- a/dev/lib/supabase.js
+++ b/dev/lib/supabase.js
@@ -31,4 +31,15 @@ const ADMIN_EMAIL = 'admin@kemo.jp';
 window.__REVERB_ENV__ = SUPABASE_ENV;
 
 let db = null;
-try { if (window.supabase) db = window.supabase.createClient(SUPABASE_URL, SUPABASE_ANON_KEY); } catch(e) {}
+try {
+  if (window.supabase) {
+    db = window.supabase.createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
+      auth: {
+        flowType: 'pkce',
+        detectSessionInUrl: true,
+        persistSession: true,
+        autoRefreshToken: true
+      }
+    });
+  }
+} catch(e) {}

--- a/index.html
+++ b/index.html
@@ -3539,8 +3539,8 @@ async function init() {
         updateGnb();
       }
     });
-    // URL에 복구 토큰이 포함된 경우 즉시 reset-pw로
-    if (isRecoveryUrl || hasAccessToken) {
+    // 초기 URL이 명시적 recovery인 경우에만 즉시 이동 (access_token만 있을 때는 이벤트 기다림)
+    if (isRecoveryUrl) {
       navigate('reset-pw');
     }
     // 링크 만료/에러 감지

--- a/index.html
+++ b/index.html
@@ -1199,7 +1199,18 @@ const ADMIN_EMAIL = 'admin@kemo.jp';
 window.__REVERB_ENV__ = SUPABASE_ENV;
 
 let db = null;
-try { if (window.supabase) db = window.supabase.createClient(SUPABASE_URL, SUPABASE_ANON_KEY); } catch(e) {}
+try {
+  if (window.supabase) {
+    db = window.supabase.createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
+      auth: {
+        flowType: 'pkce',
+        detectSessionInUrl: true,
+        persistSession: true,
+        autoRefreshToken: true
+      }
+    });
+  }
+} catch(e) {}
 // ══════════════════════════════════════
 // SHARED — 클라이언트/관리자 공유 변수
 // ══════════════════════════════════════

--- a/supabase/migrations/031_admin_invite_and_delete.sql
+++ b/supabase/migrations/031_admin_invite_and_delete.sql
@@ -1,0 +1,120 @@
+-- ============================================
+-- 관리자 초대 방식 + 삭제 옵션 2종
+-- 작성일: 2026-04-14
+-- ============================================
+
+-- 1) invite_admin: 이메일+이름+역할만 받고 랜덤 임시비번 생성. 호출 후 클라이언트가 resetPasswordForEmail로 초대 메일 발송.
+CREATE OR REPLACE FUNCTION invite_admin(admin_email text, admin_name text, admin_role text)
+RETURNS uuid
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  existing_user_id uuid;
+  new_user_id uuid;
+  target_user_id uuid;
+  temp_password text;
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM public.admins WHERE auth_id = auth.uid() AND role = 'super_admin') THEN
+    RAISE EXCEPTION 'Permission denied: super_admin only';
+  END IF;
+
+  IF EXISTS (SELECT 1 FROM public.admins WHERE email = admin_email) THEN
+    RAISE EXCEPTION 'Admin with this email already exists';
+  END IF;
+
+  -- 임시 32자 랜덤 비번 (받는 사람은 메일 링크로만 로그인 가능)
+  temp_password := encode(extensions.gen_random_bytes(24), 'base64');
+
+  SELECT id INTO existing_user_id FROM auth.users WHERE email = admin_email LIMIT 1;
+
+  IF existing_user_id IS NOT NULL THEN
+    -- 기존 인플루언서 계정을 관리자로 승격. 비번은 덮어쓰기(재설정 메일 필수).
+    UPDATE auth.users
+       SET encrypted_password = extensions.crypt(temp_password, extensions.gen_salt('bf', 10)),
+           email_confirmed_at = COALESCE(email_confirmed_at, now()),
+           email_change = COALESCE(email_change, ''),
+           raw_app_meta_data = COALESCE(raw_app_meta_data, jsonb_build_object('provider', 'email', 'providers', jsonb_build_array('email')))
+     WHERE id = existing_user_id;
+    target_user_id := existing_user_id;
+  ELSE
+    new_user_id := gen_random_uuid();
+    INSERT INTO auth.users (
+      instance_id, id, aud, role, email,
+      encrypted_password, email_confirmed_at,
+      created_at, updated_at,
+      confirmation_token, recovery_token,
+      email_change, email_change_token_new, email_change_token_current,
+      phone_change, phone_change_token, reauthentication_token,
+      raw_app_meta_data, raw_user_meta_data
+    ) VALUES (
+      '00000000-0000-0000-0000-000000000000',
+      new_user_id, 'authenticated', 'authenticated', admin_email,
+      extensions.crypt(temp_password, extensions.gen_salt('bf', 10)),
+      now(), now(), now(),
+      '', '', '', '', '', '', '', '',
+      jsonb_build_object('provider', 'email', 'providers', jsonb_build_array('email')),
+      jsonb_build_object('sub', new_user_id::text, 'email', admin_email, 'email_verified', true, 'phone_verified', false)
+    );
+    INSERT INTO auth.identities (id, user_id, identity_data, provider, provider_id, created_at, updated_at)
+    VALUES (
+      gen_random_uuid(), new_user_id,
+      jsonb_build_object('sub', new_user_id::text, 'email', admin_email, 'email_verified', true),
+      'email', new_user_id::text, now(), now()
+    );
+    target_user_id := new_user_id;
+  END IF;
+
+  INSERT INTO public.admins (auth_id, email, name, role)
+  VALUES (target_user_id, admin_email, admin_name, admin_role);
+
+  RETURN target_user_id;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.invite_admin(text, text, text) TO authenticated;
+
+-- 2) 관리자 권한만 해제
+CREATE OR REPLACE FUNCTION remove_admin_role(target_auth_id uuid)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM public.admins WHERE auth_id = auth.uid() AND role = 'super_admin') THEN
+    RAISE EXCEPTION 'Permission denied: super_admin only';
+  END IF;
+  IF target_auth_id = auth.uid() THEN
+    RAISE EXCEPTION 'Cannot remove own admin role';
+  END IF;
+  DELETE FROM public.admins WHERE auth_id = target_auth_id;
+END;
+$$;
+GRANT EXECUTE ON FUNCTION public.remove_admin_role(uuid) TO authenticated;
+
+-- 3) 계정 완전 삭제
+CREATE OR REPLACE FUNCTION delete_admin_completely(target_auth_id uuid)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM public.admins WHERE auth_id = auth.uid() AND role = 'super_admin') THEN
+    RAISE EXCEPTION 'Permission denied: super_admin only';
+  END IF;
+  IF target_auth_id = auth.uid() THEN
+    RAISE EXCEPTION 'Cannot delete own account';
+  END IF;
+
+  DELETE FROM public.applications WHERE user_id = target_auth_id;
+  DELETE FROM public.receipts WHERE user_id = target_auth_id;
+  DELETE FROM public.admins WHERE auth_id = target_auth_id;
+  DELETE FROM public.influencers WHERE id = target_auth_id;
+  DELETE FROM auth.identities WHERE user_id = target_auth_id;
+  DELETE FROM auth.users WHERE id = target_auth_id;
+END;
+$$;
+GRANT EXECUTE ON FUNCTION public.delete_admin_completely(uuid) TO authenticated;


### PR DESCRIPTION
Production deploy of admin management improvements validated on staging.

## Changes
- invite_admin RPC replaces direct password entry (email validation via invite)
- Admin delete offers 권한만 해제 vs 계정 완전 삭제
- PKCE flow enabled on Supabase client (fixes recovery link session issues)
- Recovery flow no longer navigates before SDK processes URL

## Requires
- Migration 031 (invite_admin, remove_admin_role, delete_admin_completely) applied on production DB

## Excluded
- i18n (staging only)

🤖 Generated with Claude Code