### PR TITLE
fix(mobile): various bugs + image aspect + reorder save + drag upload

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -2638,7 +2638,7 @@ function previewSlideImgs() {
   if (!preview) return;
   preview.innerHTML = campImgData.map((img,i)=>`
     <div style="position:relative;width:68px;height:68px;border-radius:8px;overflow:hidden;border:2px solid ${i===0?'var(--pink)':'var(--line)'}">
-      <img src="${img.data}" style="width:100%;height:100%;object-fit:cover">
+      <img src="${img.data}" style="width:100%;height:100%;object-fit:contain;background:#f5f5f5">
       ${i===0?'<div style="position:absolute;bottom:0;left:0;right:0;background:var(--pink);color:#fff;font-size:9px;font-weight:700;text-align:center;padding:1px">MAIN</div>':''}
     </div>`).join('');
 }

--- a/admin/index.html
+++ b/admin/index.html
@@ -2795,6 +2795,10 @@ document.addEventListener('drop', function(e) {
   if (files.length) {
     var wrapId = listName === 'campImgData' ? 'campImgPreviewWrap' : 'editCampImgPreviewWrap';
     var counterId = listName === 'campImgData' ? 'campImgCounter' : 'editCampImgCounter';
+    // editCampImgChanged 플래그 세팅 (편집 폼 저장 로직이 이 플래그로 업로드 판단)
+    if (listName === 'editCampImgData' && typeof editCampImgChanged !== 'undefined') {
+      editCampImgChanged = true;
+    }
     addImagesToList(files, list, wrapId, counterId, listName);
   }
 });

--- a/admin/index.html
+++ b/admin/index.html
@@ -2895,6 +2895,10 @@ function imgDrop(e, targetIdx, listName, wrapId, counterId) {
   var item = list.splice(_dragSrcIdx, 1)[0];
   list.splice(targetIdx, 0, item);
   _dragSrcIdx = null;
+  // 편집 폼 저장 플래그 세팅 (순서만 바뀌어도 DB 재업로드 필요)
+  if (listName === 'editCampImgData' && typeof editCampImgChanged !== 'undefined') {
+    editCampImgChanged = true;
+  }
   renderImgPreview(list, wrapId, counterId, listName);
 }
 

--- a/admin/index.html
+++ b/admin/index.html
@@ -2522,24 +2522,13 @@ function imgThumb(url, width, quality) {
   return url.replace('/storage/v1/object/public/', '/storage/v1/render/image/public/') + `?width=${w}&quality=${q}&resize=cover`;
 }
 
-// 비파괴 크롭 렌더 — background-image 방식 (퍼센트 해석 이슈 회피)
-// crop = {x,y,w,h} 0~1 정규화. opts: {thumb, quality, lazy, class, style}
-// **중요**: 반환 HTML은 단독 div (부모에 aspect-ratio 지정은 호출부 책임)
-function renderCroppedImg(url, crop, opts) {
+// 이미지 렌더 — 가로세로 비율 유지 (object-fit:contain, 레터박스)
+// opts: {thumb, quality, lazy}. crop 인자는 하위호환으로 받지만 무시
+function renderCroppedImg(url, _ignoredCrop, opts) {
   opts = opts || {};
   const thumb = opts.thumb ? imgThumb(url, opts.thumb, opts.quality||80) : url;
-  if (!crop || typeof crop.w !== 'number' || crop.w <= 0) {
-    // 크롭 정보 없음 — 기존 방식: img + object-fit:cover (fallback)
-    const lazy = opts.lazy ? 'loading="lazy" decoding="async"' : '';
-    return `<img src="${esc(thumb)}" data-orig="${esc(url)}" ${lazy} style="width:100%;height:100%;object-fit:cover;display:block" onerror="if(this.src!==this.dataset.orig){this.src=this.dataset.orig}">`;
-  }
-  // 크롭 있음 — background-image로 렌더
-  const bgSizeW = (100 / crop.w).toFixed(4);
-  const bgSizeH = (100 / crop.h).toFixed(4);
-  const bgPosX = crop.w >= 1 ? 0 : (crop.x / (1 - crop.w) * 100).toFixed(4);
-  const bgPosY = crop.h >= 1 ? 0 : (crop.y / (1 - crop.h) * 100).toFixed(4);
-  const extra = opts.style || '';
-  return `<div style="width:100%;height:100%;background-image:url('${esc(thumb)}');background-size:${bgSizeW}% ${bgSizeH}%;background-position:${bgPosX}% ${bgPosY}%;background-repeat:no-repeat;${extra}"></div>`;
+  const lazy = opts.lazy ? 'loading="lazy" decoding="async"' : '';
+  return `<img src="${esc(thumb)}" data-orig="${esc(url)}" ${lazy} style="width:100%;height:100%;object-fit:contain;display:block;background:#f5f5f5" onerror="if(this.src!==this.dataset.orig){this.src=this.dataset.orig}">`;
 }
 
 // lookup_values 캐시에서 라벨 우선 조회, 없으면 하드코딩 폴백
@@ -2853,15 +2842,10 @@ function renderImgPreview(imgList, wrapId, counterId, listName) {
       ' ondragleave="this.style.outline=\'none\'"' +
       ' ondrop="imgDrop(event,'+i+',\''+listName+'\',\''+wrapId+'\',\''+counterId+'\')"' +
       ' style="position:relative;width:88px;height:88px;flex-shrink:0;cursor:grab">' +
-      (img.crop
-        ? '<div style="width:88px;height:88px;border-radius:10px;border:2px solid '+(i===0?'var(--pink)':'var(--line)')+';background-image:url(\''+img.data+'\');background-size:'+((100/img.crop.w).toFixed(4))+'% '+((100/img.crop.h).toFixed(4))+'%;background-position:'+(img.crop.w>=1?0:(img.crop.x/(1-img.crop.w)*100).toFixed(4))+'% '+(img.crop.h>=1?0:(img.crop.y/(1-img.crop.h)*100).toFixed(4))+'%;background-repeat:no-repeat;pointer-events:none"></div>'
-        : '<img src="'+img.data+'" draggable="false" style="width:88px;height:88px;object-fit:cover;border-radius:10px;border:2px solid '+(i===0?'var(--pink)':'var(--line)')+';pointer-events:none">') +
+      '<img src="'+img.data+'" draggable="false" style="width:88px;height:88px;object-fit:contain;border-radius:10px;border:2px solid '+(i===0?'var(--pink)':'var(--line)')+';background:#f5f5f5;pointer-events:none">' +
       (i===0?'<div style="position:absolute;bottom:0;left:0;right:0;background:var(--pink);color:#fff;font-size:9px;font-weight:700;text-align:center;border-radius:0 0 8px 8px;padding:2px">MAIN</div>':'') +
-      (img.crop||img.original?'<div style="position:absolute;top:2px;left:2px;background:var(--pink);color:#fff;font-size:8px;font-weight:700;padding:1px 5px;border-radius:4px;z-index:2">CROP</div>':'') +
       '<button data-action="remove" data-i="'+i+'" data-remove-fn="'+removeFn+'" style="position:absolute;top:-4px;right:-4px;width:22px;height:22px;background:#333;color:#fff;border-radius:50%;font-size:12px;display:flex;align-items:center;justify-content:center;border:none;cursor:pointer;z-index:2" title="삭제"><span class="material-icons-round notranslate" translate="no" style="font-size:14px">close</span></button>' +
       '<div style="position:absolute;bottom:'+(i===0?'20px':'2px')+';right:2px;display:flex;gap:3px;z-index:2">' +
-        (img.crop||img.original?'<button data-action="restore" data-i="'+i+'" data-list="'+listName+'" data-wrap="'+wrapId+'" data-counter="'+counterId+'" style="width:26px;height:26px;background:rgba(0,0,0,.7);color:#fff;border-radius:6px;display:flex;align-items:center;justify-content:center;border:none;cursor:pointer" title="크롭 취소"><span class="material-icons-round" style="font-size:16px">undo</span></button>':'') +
-        '<button data-action="crop" data-i="'+i+'" data-list="'+listName+'" data-wrap="'+wrapId+'" data-counter="'+counterId+'" style="width:26px;height:26px;background:rgba(0,0,0,.7);color:#fff;border-radius:6px;display:flex;align-items:center;justify-content:center;border:none;cursor:pointer" title="1:1 크롭"><span class="material-icons-round" style="font-size:16px">crop</span></button>' +
         '<button data-action="download" data-i="'+i+'" data-list="'+listName+'" style="width:26px;height:26px;background:rgba(0,0,0,.7);color:#fff;border-radius:6px;display:flex;align-items:center;justify-content:center;border:none;cursor:pointer" title="다운로드"><span class="material-icons-round" style="font-size:16px">download</span></button>' +
       '</div>' +
     '</div>';

--- a/admin/index.html
+++ b/admin/index.html
@@ -2519,7 +2519,8 @@ function imgThumb(url, width, quality) {
   if (!url.includes('/storage/v1/object/public/')) return url;
   const q = quality || 70;
   const w = width || 400;
-  return url.replace('/storage/v1/object/public/', '/storage/v1/render/image/public/') + `?width=${w}&quality=${q}&resize=cover`;
+  // resize=contain: 비율 유지 (cover는 크롭됨)
+  return url.replace('/storage/v1/object/public/', '/storage/v1/render/image/public/') + `?width=${w}&quality=${q}&resize=contain`;
 }
 
 // 이미지 렌더 — 가로세로 비율 유지 (object-fit:contain, 레터박스)

--- a/admin/index.html
+++ b/admin/index.html
@@ -2853,7 +2853,9 @@ function renderImgPreview(imgList, wrapId, counterId, listName) {
       ' ondragleave="this.style.outline=\'none\'"' +
       ' ondrop="imgDrop(event,'+i+',\''+listName+'\',\''+wrapId+'\',\''+counterId+'\')"' +
       ' style="position:relative;width:88px;height:88px;flex-shrink:0;cursor:grab">' +
-      '<img src="'+img.data+'" draggable="false" style="width:88px;height:88px;object-fit:cover;border-radius:10px;border:2px solid '+(i===0?'var(--pink)':'var(--line)')+';pointer-events:none">' +
+      (img.crop
+        ? '<div style="width:88px;height:88px;border-radius:10px;border:2px solid '+(i===0?'var(--pink)':'var(--line)')+';background-image:url(\''+img.data+'\');background-size:'+((100/img.crop.w).toFixed(4))+'% '+((100/img.crop.h).toFixed(4))+'%;background-position:'+(img.crop.w>=1?0:(img.crop.x/(1-img.crop.w)*100).toFixed(4))+'% '+(img.crop.h>=1?0:(img.crop.y/(1-img.crop.h)*100).toFixed(4))+'%;background-repeat:no-repeat;pointer-events:none"></div>'
+        : '<img src="'+img.data+'" draggable="false" style="width:88px;height:88px;object-fit:cover;border-radius:10px;border:2px solid '+(i===0?'var(--pink)':'var(--line)')+';pointer-events:none">') +
       (i===0?'<div style="position:absolute;bottom:0;left:0;right:0;background:var(--pink);color:#fff;font-size:9px;font-weight:700;text-align:center;border-radius:0 0 8px 8px;padding:2px">MAIN</div>':'') +
       (img.crop||img.original?'<div style="position:absolute;top:2px;left:2px;background:var(--pink);color:#fff;font-size:8px;font-weight:700;padding:1px 5px;border-radius:4px;z-index:2">CROP</div>':'') +
       '<button data-action="remove" data-i="'+i+'" data-remove-fn="'+removeFn+'" style="position:absolute;top:-4px;right:-4px;width:22px;height:22px;background:#333;color:#fff;border-radius:50%;font-size:12px;display:flex;align-items:center;justify-content:center;border:none;cursor:pointer;z-index:2" title="삭제"><span class="material-icons-round notranslate" translate="no" style="font-size:14px">close</span></button>' +

--- a/admin/index.html
+++ b/admin/index.html
@@ -2522,6 +2522,24 @@ function imgThumb(url, width, quality) {
   return url.replace('/storage/v1/object/public/', '/storage/v1/render/image/public/') + `?width=${w}&quality=${q}&resize=cover`;
 }
 
+// 비파괴 크롭 렌더 — 원본 이미지에서 특정 영역만 노출 (aspect 컨테이너 안)
+// crop = {x,y,w,h} 0~1 정규화. 없으면 단순 object-fit:cover
+function renderCroppedImg(url, crop, opts) {
+  opts = opts || {};
+  const alt = opts.alt || '';
+  const thumb = opts.thumb ? imgThumb(url, opts.thumb, opts.quality||80) : url;
+  const imgAttrs = `src="${esc(thumb)}" data-orig="${esc(url)}" alt="${esc(alt)}" onerror="if(this.src!==this.dataset.orig){this.src=this.dataset.orig}"`;
+  const lazy = opts.lazy ? 'loading="lazy" decoding="async"' : '';
+  if (!crop || typeof crop.w !== 'number' || crop.w <= 0) {
+    return `<img ${imgAttrs} ${lazy} style="width:100%;height:100%;object-fit:cover;display:block">`;
+  }
+  const scaleW = 100 / crop.w;
+  const scaleH = 100 / crop.h;
+  const offsetX = -crop.x * scaleW;
+  const offsetY = -crop.y * scaleH;
+  return `<img ${imgAttrs} ${lazy} style="position:absolute;left:${offsetX}%;top:${offsetY}%;width:${scaleW}%;height:${scaleH}%;max-width:none;display:block">`;
+}
+
 // lookup_values 캐시에서 라벨 우선 조회, 없으면 하드코딩 폴백
 const CHANNEL_LABEL_FALLBACK = {instagram:'Instagram',x:'X(Twitter)',qoo10:'Qoo10',tiktok:'TikTok',youtube:'YouTube'};
 function _currentLookupLang(lang) {
@@ -2835,10 +2853,10 @@ function renderImgPreview(imgList, wrapId, counterId, listName) {
       ' style="position:relative;width:88px;height:88px;flex-shrink:0;cursor:grab">' +
       '<img src="'+img.data+'" draggable="false" style="width:88px;height:88px;object-fit:cover;border-radius:10px;border:2px solid '+(i===0?'var(--pink)':'var(--line)')+';pointer-events:none">' +
       (i===0?'<div style="position:absolute;bottom:0;left:0;right:0;background:var(--pink);color:#fff;font-size:9px;font-weight:700;text-align:center;border-radius:0 0 8px 8px;padding:2px">MAIN</div>':'') +
-      (img.original?'<div style="position:absolute;top:2px;left:2px;background:var(--pink);color:#fff;font-size:8px;font-weight:700;padding:1px 5px;border-radius:4px;z-index:2">CROP</div>':'') +
+      (img.crop||img.original?'<div style="position:absolute;top:2px;left:2px;background:var(--pink);color:#fff;font-size:8px;font-weight:700;padding:1px 5px;border-radius:4px;z-index:2">CROP</div>':'') +
       '<button data-action="remove" data-i="'+i+'" data-remove-fn="'+removeFn+'" style="position:absolute;top:-4px;right:-4px;width:22px;height:22px;background:#333;color:#fff;border-radius:50%;font-size:12px;display:flex;align-items:center;justify-content:center;border:none;cursor:pointer;z-index:2" title="삭제"><span class="material-icons-round notranslate" translate="no" style="font-size:14px">close</span></button>' +
       '<div style="position:absolute;bottom:'+(i===0?'20px':'2px')+';right:2px;display:flex;gap:3px;z-index:2">' +
-        (img.original?'<button data-action="restore" data-i="'+i+'" data-list="'+listName+'" data-wrap="'+wrapId+'" data-counter="'+counterId+'" style="width:26px;height:26px;background:rgba(0,0,0,.7);color:#fff;border-radius:6px;display:flex;align-items:center;justify-content:center;border:none;cursor:pointer" title="원본 복원"><span class="material-icons-round" style="font-size:16px">undo</span></button>':'') +
+        (img.crop||img.original?'<button data-action="restore" data-i="'+i+'" data-list="'+listName+'" data-wrap="'+wrapId+'" data-counter="'+counterId+'" style="width:26px;height:26px;background:rgba(0,0,0,.7);color:#fff;border-radius:6px;display:flex;align-items:center;justify-content:center;border:none;cursor:pointer" title="크롭 취소"><span class="material-icons-round" style="font-size:16px">undo</span></button>':'') +
         '<button data-action="crop" data-i="'+i+'" data-list="'+listName+'" data-wrap="'+wrapId+'" data-counter="'+counterId+'" style="width:26px;height:26px;background:rgba(0,0,0,.7);color:#fff;border-radius:6px;display:flex;align-items:center;justify-content:center;border:none;cursor:pointer" title="1:1 크롭"><span class="material-icons-round" style="font-size:16px">crop</span></button>' +
         '<button data-action="download" data-i="'+i+'" data-list="'+listName+'" style="width:26px;height:26px;background:rgba(0,0,0,.7);color:#fff;border-radius:6px;display:flex;align-items:center;justify-content:center;border:none;cursor:pointer" title="다운로드"><span class="material-icons-round" style="font-size:16px">download</span></button>' +
       '</div>' +
@@ -2903,11 +2921,16 @@ function downloadImg(idx, listName) {
 // 원본 복원
 function restoreOriginal(idx, listName, wrapId, counterId) {
   var list = getImgList(listName);
-  if (!list || !list[idx] || !list[idx].original) return;
-  list[idx].data = list[idx].original;
-  delete list[idx].original;
+  if (!list || !list[idx]) return;
+  // 비파괴 크롭 좌표 제거
+  if (list[idx].crop) delete list[idx].crop;
+  // 레거시 파괴적 크롭(original 백업) 복원
+  if (list[idx].original) {
+    list[idx].data = list[idx].original;
+    delete list[idx].original;
+  }
   renderImgPreview(list, wrapId, counterId, listName);
-  toast('원본으로 복원됨','success');
+  toast('크롭 영역 해제','success');
 }
 
 // 1:1 크롭 모달
@@ -2973,18 +2996,25 @@ function closeCropModal() {
 
 function applyCrop() {
   if (!_cropperInstance || !_cropTarget) return;
-  var canvas = _cropperInstance.getCroppedCanvas({width:1080, height:1080, imageSmoothingQuality:'high'});
-  var croppedData = canvas.toDataURL('image/jpeg', 0.92);
+  // 비파괴 크롭: 좌표만 0~1로 정규화해서 저장 (원본 이미지 유지)
+  var cropData = _cropperInstance.getData(true);  // {x,y,width,height,rotate,scaleX,scaleY}
+  var imgData = _cropperInstance.getImageData();  // {naturalWidth,naturalHeight,...}
+  var natW = imgData.naturalWidth;
+  var natH = imgData.naturalHeight;
+  var rect = natW && natH ? {
+    x: Math.max(0, cropData.x / natW),
+    y: Math.max(0, cropData.y / natH),
+    w: Math.min(1, cropData.width / natW),
+    h: Math.min(1, cropData.height / natH)
+  } : null;
   var list = getImgList(_cropTarget.listName);
-  if (list) {
+  if (list && rect) {
     var item = list[_cropTarget.idx];
-    // 원본 보존 — 처음 크롭할 때만 원본 저장
-    if (!item.original) item.original = item.data;
-    item.data = croppedData;
+    item.crop = rect;  // 좌표만 저장, item.data는 그대로
     renderImgPreview(list, _cropTarget.wrapId, _cropTarget.counterId, _cropTarget.listName);
   }
   closeCropModal();
-  toast('크롭 완료 (원본 유지됨)','success');
+  toast('크롭 영역 저장 (원본 유지)','success');
 }
 
 // ── 로그인 안내 팝업 ──
@@ -3401,6 +3431,23 @@ function exitReorderMode() {
   if (btn) { btn.textContent = '순서 변경'; btn.onclick = enterReorderMode; btn.classList.remove('btn-primary'); btn.classList.add('btn-ghost'); }
 }
 
+// 이미지 리스트의 crop 정보를 {img1:{x,y,w,h},...} 맵으로 직렬화
+function buildImageCrops(imgList) {
+  const out = {};
+  (imgList || []).forEach((img, i) => {
+    if (i < 8 && img?.crop) out['img' + (i+1)] = img.crop;
+  });
+  return out;
+}
+// 저장된 image_crops를 imgList 항목에 주입 (편집 로드 시)
+function applyImageCropsToList(imgList, cropsMap) {
+  if (!cropsMap || !imgList) return;
+  imgList.forEach((img, i) => {
+    const key = 'img' + (i+1);
+    if (cropsMap[key]) img.crop = cropsMap[key];
+  });
+}
+
 async function loadAdminCampaigns(useCache) {
   let camps = useCache ? allCampaigns.slice() : await fetchCampaigns();
   if (!useCache) allCampaigns = camps.slice();
@@ -3626,6 +3673,8 @@ async function openEditCampaign(campId) {
   editCampImgData.length = 0;
   [camp.img1,camp.img2,camp.img3,camp.img4,camp.img5,camp.img6,camp.img7,camp.img8]
     .filter(Boolean).forEach(url => editCampImgData.push({data: url}));
+  // 저장된 crop 좌표 복원
+  applyImageCropsToList(editCampImgData, camp.image_crops || {});
   renderImgPreview(editCampImgData, 'editCampImgPreviewWrap', 'editCampImgCounter', 'editCampImgData');
 
   // 참여방법 번들 복원 (스냅샷 우선, 번들 드롭다운도 recruit_type 필터로 채움)
@@ -3772,6 +3821,7 @@ async function saveCampaignEdit() {
       updates.img3 = imgUrls[2]; updates.img4 = imgUrls[3];
       updates.img5 = imgUrls[4]; updates.img6 = imgUrls[5];
       updates.img7 = imgUrls[6]; updates.img8 = imgUrls[7];
+      updates.image_crops = buildImageCrops(editCampImgData);
     }
 
     await updateCampaign(campId, updates);
@@ -4608,6 +4658,7 @@ async function addCampaign() {
     img3: imgUrls[2], img4: imgUrls[3],
     img5: imgUrls[4], img6: imgUrls[5],
     img7: imgUrls[6], img8: imgUrls[7],
+    image_crops: buildImageCrops(campImgData),
     product_url: productUrl,
     product_price: parseInt($('newCampProductPrice')?.value)||0,
     reward: parseInt($('newCampReward').value)||0,

--- a/admin/index.html
+++ b/admin/index.html
@@ -2522,22 +2522,24 @@ function imgThumb(url, width, quality) {
   return url.replace('/storage/v1/object/public/', '/storage/v1/render/image/public/') + `?width=${w}&quality=${q}&resize=cover`;
 }
 
-// 비파괴 크롭 렌더 — 원본 이미지에서 특정 영역만 노출 (aspect 컨테이너 안)
-// crop = {x,y,w,h} 0~1 정규화. 없으면 단순 object-fit:cover
+// 비파괴 크롭 렌더 — background-image 방식 (퍼센트 해석 이슈 회피)
+// crop = {x,y,w,h} 0~1 정규화. opts: {thumb, quality, lazy, class, style}
+// **중요**: 반환 HTML은 단독 div (부모에 aspect-ratio 지정은 호출부 책임)
 function renderCroppedImg(url, crop, opts) {
   opts = opts || {};
-  const alt = opts.alt || '';
   const thumb = opts.thumb ? imgThumb(url, opts.thumb, opts.quality||80) : url;
-  const imgAttrs = `src="${esc(thumb)}" data-orig="${esc(url)}" alt="${esc(alt)}" onerror="if(this.src!==this.dataset.orig){this.src=this.dataset.orig}"`;
-  const lazy = opts.lazy ? 'loading="lazy" decoding="async"' : '';
   if (!crop || typeof crop.w !== 'number' || crop.w <= 0) {
-    return `<img ${imgAttrs} ${lazy} style="width:100%;height:100%;object-fit:cover;display:block">`;
+    // 크롭 정보 없음 — 기존 방식: img + object-fit:cover (fallback)
+    const lazy = opts.lazy ? 'loading="lazy" decoding="async"' : '';
+    return `<img src="${esc(thumb)}" data-orig="${esc(url)}" ${lazy} style="width:100%;height:100%;object-fit:cover;display:block" onerror="if(this.src!==this.dataset.orig){this.src=this.dataset.orig}">`;
   }
-  const scaleW = 100 / crop.w;
-  const scaleH = 100 / crop.h;
-  const offsetX = -crop.x * scaleW;
-  const offsetY = -crop.y * scaleH;
-  return `<img ${imgAttrs} ${lazy} style="position:absolute;left:${offsetX}%;top:${offsetY}%;width:${scaleW}%;height:${scaleH}%;max-width:none;display:block">`;
+  // 크롭 있음 — background-image로 렌더
+  const bgSizeW = (100 / crop.w).toFixed(4);
+  const bgSizeH = (100 / crop.h).toFixed(4);
+  const bgPosX = crop.w >= 1 ? 0 : (crop.x / (1 - crop.w) * 100).toFixed(4);
+  const bgPosY = crop.h >= 1 ? 0 : (crop.y / (1 - crop.h) * 100).toFixed(4);
+  const extra = opts.style || '';
+  return `<div style="width:100%;height:100%;background-image:url('${esc(thumb)}');background-size:${bgSizeW}% ${bgSizeH}%;background-position:${bgPosX}% ${bgPosY}%;background-repeat:no-repeat;${extra}"></div>`;
 }
 
 // lookup_values 캐시에서 라벨 우선 조회, 없으면 하드코딩 폴백
@@ -3531,7 +3533,7 @@ async function loadAdminCampaigns(useCache) {
       <td>
         <div style="display:flex;align-items:center;gap:10px">
           <div style="position:relative;width:44px;height:44px;flex-shrink:0;border-radius:8px;overflow:hidden;background:var(--surface-dim)">
-            ${thumbUrl ? `<img src="${imgThumb(thumbUrl,160)}" data-orig="${thumbUrl}" loading="lazy" decoding="async" onerror="if(this.src!==this.dataset.orig){this.src=this.dataset.orig}" style="width:100%;height:100%;object-fit:cover">` : `<span style="display:flex;align-items:center;justify-content:center;width:100%;height:100%;font-size:20px">${esc(c.emoji)||'<span class="material-icons-round notranslate" translate="no" style="font-size:20px;color:var(--muted)">inventory_2</span>'}</span>`}
+            ${thumbUrl ? renderCroppedImg(thumbUrl, (c.image_crops||{}).img1, {thumb:160, lazy:true}) : `<span style="display:flex;align-items:center;justify-content:center;width:100%;height:100%;font-size:20px">${esc(c.emoji)||'<span class="material-icons-round notranslate" translate="no" style="font-size:20px;color:var(--muted)">inventory_2</span>'}</span>`}
             ${imgCount > 1 ? `<span style="position:absolute;bottom:0;left:0;background:rgba(0,0,0,.65);color:#fff;font-size:9px;font-weight:700;padding:1px 5px;border-radius:0 4px 0 0">+${imgCount}</span>` : ''}
           </div>
           <div style="min-width:0">

--- a/dev/index.html
+++ b/dev/index.html
@@ -682,14 +682,17 @@ window._supabaseLoaded = false;
     </div>
     <div class="container mypage-wrap" style="padding-left:0;padding-right:0">
       <div id="myApplyTabs" class="apply-tabs" style="padding:0 16px"></div>
-      <div style="display:flex;gap:8px;padding:8px 16px;align-items:center">
-        <select id="myApplyCampStatus" class="form-input" style="padding:6px 32px 6px 10px;font-size:12px;border-radius:8px;width:auto;flex:1" onchange="renderMyApplyList()">
+      <div style="display:flex;gap:8px;padding:8px 16px;align-items:center;flex-wrap:wrap">
+        <select id="myApplyCampStatus" class="form-input" style="padding:6px 32px 6px 10px;font-size:12px;border-radius:8px;width:auto;flex:1;min-width:110px" onchange="renderMyApplyList()">
           <option value="" data-i18n="appHistory.campStatus">キャンペーン状態</option>
           <option value="active" data-i18n="status.campaign.active">募集中</option>
           <option value="scheduled" data-i18n="status.campaign.scheduled">近日公開</option>
           <option value="closed" data-i18n="status.campaign.closed">締切</option>
         </select>
-        <select id="myApplySort" class="form-input" style="padding:6px 32px 6px 10px;font-size:12px;border-radius:8px;width:auto;flex:1" onchange="renderMyApplyList()">
+        <select id="myApplyChannel" class="form-input" style="padding:6px 32px 6px 10px;font-size:12px;border-radius:8px;width:auto;flex:1;min-width:100px" onchange="renderMyApplyList()">
+          <option value="" data-i18n="appHistory.allChannels">全チャンネル</option>
+        </select>
+        <select id="myApplySort" class="form-input" style="padding:6px 32px 6px 10px;font-size:12px;border-radius:8px;width:auto;flex:1;min-width:100px" onchange="renderMyApplyList()">
           <option value="newest" data-i18n="appHistory.sortNewest">新しい順</option>
           <option value="oldest" data-i18n="appHistory.sortOldest">古い順</option>
         </select>

--- a/dev/js/admin.js
+++ b/dev/js/admin.js
@@ -352,6 +352,23 @@ function exitReorderMode() {
   if (btn) { btn.textContent = '순서 변경'; btn.onclick = enterReorderMode; btn.classList.remove('btn-primary'); btn.classList.add('btn-ghost'); }
 }
 
+// 이미지 리스트의 crop 정보를 {img1:{x,y,w,h},...} 맵으로 직렬화
+function buildImageCrops(imgList) {
+  const out = {};
+  (imgList || []).forEach((img, i) => {
+    if (i < 8 && img?.crop) out['img' + (i+1)] = img.crop;
+  });
+  return out;
+}
+// 저장된 image_crops를 imgList 항목에 주입 (편집 로드 시)
+function applyImageCropsToList(imgList, cropsMap) {
+  if (!cropsMap || !imgList) return;
+  imgList.forEach((img, i) => {
+    const key = 'img' + (i+1);
+    if (cropsMap[key]) img.crop = cropsMap[key];
+  });
+}
+
 async function loadAdminCampaigns(useCache) {
   let camps = useCache ? allCampaigns.slice() : await fetchCampaigns();
   if (!useCache) allCampaigns = camps.slice();
@@ -577,6 +594,8 @@ async function openEditCampaign(campId) {
   editCampImgData.length = 0;
   [camp.img1,camp.img2,camp.img3,camp.img4,camp.img5,camp.img6,camp.img7,camp.img8]
     .filter(Boolean).forEach(url => editCampImgData.push({data: url}));
+  // 저장된 crop 좌표 복원
+  applyImageCropsToList(editCampImgData, camp.image_crops || {});
   renderImgPreview(editCampImgData, 'editCampImgPreviewWrap', 'editCampImgCounter', 'editCampImgData');
 
   // 참여방법 번들 복원 (스냅샷 우선, 번들 드롭다운도 recruit_type 필터로 채움)
@@ -723,6 +742,7 @@ async function saveCampaignEdit() {
       updates.img3 = imgUrls[2]; updates.img4 = imgUrls[3];
       updates.img5 = imgUrls[4]; updates.img6 = imgUrls[5];
       updates.img7 = imgUrls[6]; updates.img8 = imgUrls[7];
+      updates.image_crops = buildImageCrops(editCampImgData);
     }
 
     await updateCampaign(campId, updates);
@@ -1559,6 +1579,7 @@ async function addCampaign() {
     img3: imgUrls[2], img4: imgUrls[3],
     img5: imgUrls[4], img6: imgUrls[5],
     img7: imgUrls[6], img8: imgUrls[7],
+    image_crops: buildImageCrops(campImgData),
     product_url: productUrl,
     product_price: parseInt($('newCampProductPrice')?.value)||0,
     reward: parseInt($('newCampReward').value)||0,

--- a/dev/js/admin.js
+++ b/dev/js/admin.js
@@ -452,7 +452,7 @@ async function loadAdminCampaigns(useCache) {
       <td>
         <div style="display:flex;align-items:center;gap:10px">
           <div style="position:relative;width:44px;height:44px;flex-shrink:0;border-radius:8px;overflow:hidden;background:var(--surface-dim)">
-            ${thumbUrl ? `<img src="${imgThumb(thumbUrl,160)}" data-orig="${thumbUrl}" loading="lazy" decoding="async" onerror="if(this.src!==this.dataset.orig){this.src=this.dataset.orig}" style="width:100%;height:100%;object-fit:cover">` : `<span style="display:flex;align-items:center;justify-content:center;width:100%;height:100%;font-size:20px">${esc(c.emoji)||'<span class="material-icons-round notranslate" translate="no" style="font-size:20px;color:var(--muted)">inventory_2</span>'}</span>`}
+            ${thumbUrl ? renderCroppedImg(thumbUrl, (c.image_crops||{}).img1, {thumb:160, lazy:true}) : `<span style="display:flex;align-items:center;justify-content:center;width:100%;height:100%;font-size:20px">${esc(c.emoji)||'<span class="material-icons-round notranslate" translate="no" style="font-size:20px;color:var(--muted)">inventory_2</span>'}</span>`}
             ${imgCount > 1 ? `<span style="position:absolute;bottom:0;left:0;background:rgba(0,0,0,.65);color:#fff;font-size:9px;font-weight:700;padding:1px 5px;border-radius:0 4px 0 0">+${imgCount}</span>` : ''}
           </div>
           <div style="min-width:0">

--- a/dev/js/app.js
+++ b/dev/js/app.js
@@ -97,6 +97,8 @@ window.addEventListener('langchange', function() {
   if (page === 'home') { if (typeof loadCampaigns === 'function') loadCampaigns(); }
   else if (page === 'campaigns') { if (typeof loadCampaignsPage === 'function') loadCampaignsPage(); }
   else if (page.startsWith('detail-')) { if (typeof openCampaign === 'function') openCampaign(page.replace('detail-','')); }
+  // 햄버거 메뉴 재렌더 (언어에 따라 라벨 갱신)
+  if (typeof renderNavMenu === 'function') renderNavMenu();
 });
 
 // Step 3: 햄버거 메뉴 활성 페이지 하이라이트

--- a/dev/js/application.js
+++ b/dev/js/application.js
@@ -133,15 +133,19 @@ async function openCampaign(id) {
       <div style="background:#fff;padding:16px;margin-bottom:10px;border-bottom:8px solid var(--bg)">
         <div style="font-size:14px;font-weight:700;margin-bottom:14px;color:var(--ink)">${t('detail.participationTitle')}</div>
         <div style="display:flex;flex-direction:column;gap:14px">
-          ${steps.map((s,i)=>`
+          ${steps.map((s,i)=>{
+            const lang = (typeof getLang === 'function' ? getLang() : 'ja');
+            const title = lang === 'ko' ? (s.title_ko||s.title_ja||'') : (s.title_ja||s.title_ko||'');
+            const desc = lang === 'ko' ? (s.desc_ko||s.desc_ja||'') : (s.desc_ja||s.desc_ko||'');
+            return `
             <div style="display:flex;gap:12px;align-items:flex-start">
               <div style="min-width:50px;height:20px;background:var(--light-pink);border-radius:20px;display:flex;align-items:center;justify-content:center;font-size:10px;font-weight:700;color:var(--pink);flex-shrink:0">STEP ${i+1}</div>
               <div>
-                <div style="font-size:13px;font-weight:700;margin-bottom:2px">${esc(s.title_ja||s.title_ko||'')}</div>
-                ${(s.desc_ja||s.desc_ko) ? `<div style="font-size:12px;color:var(--muted);line-height:1.55">${esc(s.desc_ja||s.desc_ko||'')}</div>` : ''}
+                <div style="font-size:13px;font-weight:700;margin-bottom:2px">${esc(title)}</div>
+                ${desc ? `<div style="font-size:12px;color:var(--muted);line-height:1.55">${esc(desc)}</div>` : ''}
               </div>
-            </div>
-          `).join('')}
+            </div>`;
+          }).join('')}
         </div>
       </div>`;
       })()}

--- a/dev/js/application.js
+++ b/dev/js/application.js
@@ -29,7 +29,7 @@ async function openCampaign(id) {
   const slideHtml = slideImgs.length > 0 ? `
     <div id="campSlider" style="position:relative;overflow:hidden;border-radius:16px;margin-bottom:0;background:${getCampGrad(camp.category)};aspect-ratio:1/1;height:auto">
       <div id="campSlides" style="display:flex;height:100%;transition:transform .32s cubic-bezier(.4,0,.2,1)">
-        ${slideImgs.map((url,idx)=>`<div style="flex:0 0 100%;width:100%;height:100%;background:${getCampGrad(camp.category)}"><img src="${imgThumb(url,960,80)}" data-orig="${url}" ${idx===0?'':'loading="lazy"'} decoding="async" style="width:100%;height:100%;object-fit:contain;display:block" onerror="if(this.src!==this.dataset.orig){this.src=this.dataset.orig}else{this.parentElement.style.background='${getCampGrad(camp.category)}'}"></div>`).join('')}
+        ${slideImgs.map((url,idx)=>`<div style="flex:0 0 100%;width:100%;height:100%;background:${getCampGrad(camp.category)}"><img src="${imgThumb(url,960,80)}" data-orig="${url}" ${idx===0?'':'loading="lazy"'} decoding="async" style="width:100%;height:100%;object-fit:cover;display:block" onerror="if(this.src!==this.dataset.orig){this.src=this.dataset.orig}else{this.parentElement.style.background='${getCampGrad(camp.category)}'}"></div>`).join('')}
       </div>
       ${slideImgs.length>1?`
         <button onclick="slideMove(-1)" style="position:absolute;left:10px;top:50%;transform:translateY(-50%);width:30px;height:30px;background:rgba(255,255,255,.88);border:none;border-radius:50%;cursor:pointer;display:flex;align-items:center;justify-content:center;z-index:5;box-shadow:0 2px 6px rgba(0,0,0,.15)"><span class="material-icons-round" style="font-size:20px;color:#333">chevron_left</span></button>

--- a/dev/js/application.js
+++ b/dev/js/application.js
@@ -22,14 +22,26 @@ async function openCampaign(id) {
   const isFull = camp.recruit_type === 'monitor' && (camp.applied_count||0) >= camp.slots;
   _slideIdx = 0;
 
-  // 슬라이드 이미지
-  const slideImgs = [camp.img1,camp.img2,camp.img3,camp.img4,camp.img5,camp.img6,camp.img7,camp.img8,camp.image_url]
-    .filter(Boolean).filter((v,i,a)=>a.indexOf(v)===i);
+  // 슬라이드 이미지 + 크롭 정보 매핑
+  const crops = camp.image_crops || {};
+  const rawSlides = [
+    {url: camp.img1, key: 'img1'}, {url: camp.img2, key: 'img2'},
+    {url: camp.img3, key: 'img3'}, {url: camp.img4, key: 'img4'},
+    {url: camp.img5, key: 'img5'}, {url: camp.img6, key: 'img6'},
+    {url: camp.img7, key: 'img7'}, {url: camp.img8, key: 'img8'},
+    {url: camp.image_url, key: null}
+  ].filter(s => s.url);
+  const seen = new Set();
+  const slideData = rawSlides.filter(s => seen.has(s.url) ? false : (seen.add(s.url), true));
+  const slideImgs = slideData.map(s => s.url);
 
   const slideHtml = slideImgs.length > 0 ? `
     <div id="campSlider" style="position:relative;overflow:hidden;border-radius:16px;margin-bottom:0;background:${getCampGrad(camp.category)};aspect-ratio:1/1;height:auto">
       <div id="campSlides" style="display:flex;height:100%;transition:transform .32s cubic-bezier(.4,0,.2,1)">
-        ${slideImgs.map((url,idx)=>`<div style="flex:0 0 100%;width:100%;height:100%;background:${getCampGrad(camp.category)}"><img src="${imgThumb(url,960,80)}" data-orig="${url}" ${idx===0?'':'loading="lazy"'} decoding="async" style="width:100%;height:100%;object-fit:cover;display:block" onerror="if(this.src!==this.dataset.orig){this.src=this.dataset.orig}else{this.parentElement.style.background='${getCampGrad(camp.category)}'}"></div>`).join('')}
+        ${slideData.map((s,idx)=>{
+          const crop = s.key ? crops[s.key] : null;
+          return `<div style="flex:0 0 100%;width:100%;height:100%;position:relative;overflow:hidden;background:${getCampGrad(camp.category)}">${renderCroppedImg(s.url, crop, {thumb:960, quality:80, lazy: idx>0})}</div>`;
+        }).join('')}
       </div>
       ${slideImgs.length>1?`
         <button onclick="slideMove(-1)" style="position:absolute;left:10px;top:50%;transform:translateY(-50%);width:30px;height:30px;background:rgba(255,255,255,.88);border:none;border-radius:50%;cursor:pointer;display:flex;align-items:center;justify-content:center;z-index:5;box-shadow:0 2px 6px rgba(0,0,0,.15)"><span class="material-icons-round" style="font-size:20px;color:#333">chevron_left</span></button>

--- a/dev/js/campaign.js
+++ b/dev/js/campaign.js
@@ -139,7 +139,7 @@ function buildCampCards(camps) {
     const dimImage = isFull || isScheduled || isClosed;
     return `<div class="camp-card" onclick="${isClickable?'openCampaign(\''+c.id+'\')':''}" style="${!isClickable?'opacity:.85;cursor:default':''}">
       <div class="camp-img" style="background:${c.image_url?'#f0f0f0':bgGrad};position:relative">
-        ${c.image_url?`<img src="${imgThumb(c.image_url,480)}" data-orig="${c.image_url}" loading="lazy" decoding="async" style="width:100%;height:100%;object-fit:cover;position:absolute;inset:0;${dimImage?'filter:brightness(.5)':''}" onerror="if(this.src!==this.dataset.orig){this.src=this.dataset.orig}else{this.style.display='none'}">`:''}
+        ${c.image_url?`<div style="position:absolute;inset:0;${dimImage?'filter:brightness(.5)':''}">${renderCroppedImg(c.image_url, (c.image_crops||{}).img1, {thumb:480, lazy:true})}</div>`:''}
         <div class="camp-img-overlay"></div>
         ${isScheduled?`<div style="position:absolute;inset:0;display:flex;align-items:center;justify-content:center;z-index:4"><span style="background:rgba(200,120,163,.9);color:#fff;font-size:12px;font-weight:700;padding:7px 18px;border-radius:20px;letter-spacing:.04em">${t('detail.scheduledOverlay')}</span></div>`:''}
         ${isClosed?`<div style="position:absolute;inset:0;display:flex;align-items:center;justify-content:center;z-index:4"><span style="background:rgba(0,0,0,.7);color:#fff;font-size:12px;font-weight:700;padding:7px 18px;border-radius:20px;letter-spacing:.04em">${t('detail.closedOverlay')}</span></div>`:''}

--- a/dev/js/mypage.js
+++ b/dev/js/mypage.js
@@ -113,6 +113,17 @@ async function renderMyApplyList() {
     });
   }
 
+  // 채널 필터 (공용 populateMyApplyChannelOptions에서 드롭다운 채움)
+  populateMyApplyChannelOptions();
+  const channelFilter = $('myApplyChannel')?.value || '';
+  if (channelFilter) {
+    filtered = filtered.filter(a => {
+      const camp = allCampaigns.find(c=>c.id===a.campaign_id);
+      if (!camp?.channel) return false;
+      return camp.channel.split(',').map(s=>s.trim()).includes(channelFilter);
+    });
+  }
+
   // 정렬
   const sortVal = $('myApplySort')?.value || 'newest';
   filtered.sort((a,b) => sortVal === 'oldest'
@@ -252,4 +263,22 @@ function handleWithdraw() {
 document.addEventListener('DOMContentLoaded', updateLangToggleUI);
 window.addEventListener('langchange', updateLangToggleUI);
 
+// 응모이력: 내가 응모한 캠페인에 등장한 모든 채널을 드롭다운에 채움
+function populateMyApplyChannelOptions() {
+  const sel = $('myApplyChannel');
+  if (!sel) return;
+  const prev = sel.value;
+  // 내 응모 캠페인의 채널 집합
+  const chSet = new Set();
+  _myApps.forEach(a => {
+    const camp = allCampaigns.find(c=>c.id===a.campaign_id);
+    if (!camp?.channel) return;
+    camp.channel.split(',').map(s=>s.trim()).filter(Boolean).forEach(c => chSet.add(c));
+  });
+  const channels = Array.from(chSet).sort();
+  const head = `<option value="" data-i18n="appHistory.allChannels">${t('appHistory.allChannels')}</option>`;
+  const options = channels.map(c => `<option value="${esc(c)}">${esc(getChannelLabel(c))}</option>`).join('');
+  sel.innerHTML = head + options;
+  if (prev && channels.includes(prev)) sel.value = prev;
+}
 // Stage 6 알림 로직은 dev/js/notifications.js (햄버거 메뉴 모달)로 이전됨

--- a/dev/js/notifications.js
+++ b/dev/js/notifications.js
@@ -72,6 +72,26 @@ function navItemHtml(it) {
   </button>`;
 }
 
+// ── 배지 자동 갱신 (30초 폴링 + 탭 포커스) ──
+let _notifPollTimer = null;
+function startNotifPolling() {
+  if (_notifPollTimer) return;
+  _notifPollTimer = setInterval(() => {
+    if (currentUser && !document.hidden) refreshNotifBadge();
+  }, 30000);
+  document.addEventListener('visibilitychange', () => {
+    if (!document.hidden && currentUser) refreshNotifBadge();
+  });
+}
+// 앱 초기화 시 시작
+if (typeof window !== 'undefined') {
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', startNotifPolling);
+  } else {
+    startNotifPolling();
+  }
+}
+
 // ── 미읽음 배지 갱신 ──
 async function refreshNotifBadge() {
   const gnbBadge = $('gnbNotifBadge');

--- a/dev/js/ui.js
+++ b/dev/js/ui.js
@@ -124,6 +124,24 @@ function imgThumb(url, width, quality) {
   return url.replace('/storage/v1/object/public/', '/storage/v1/render/image/public/') + `?width=${w}&quality=${q}&resize=cover`;
 }
 
+// 비파괴 크롭 렌더 — 원본 이미지에서 특정 영역만 노출 (aspect 컨테이너 안)
+// crop = {x,y,w,h} 0~1 정규화. 없으면 단순 object-fit:cover
+function renderCroppedImg(url, crop, opts) {
+  opts = opts || {};
+  const alt = opts.alt || '';
+  const thumb = opts.thumb ? imgThumb(url, opts.thumb, opts.quality||80) : url;
+  const imgAttrs = `src="${esc(thumb)}" data-orig="${esc(url)}" alt="${esc(alt)}" onerror="if(this.src!==this.dataset.orig){this.src=this.dataset.orig}"`;
+  const lazy = opts.lazy ? 'loading="lazy" decoding="async"' : '';
+  if (!crop || typeof crop.w !== 'number' || crop.w <= 0) {
+    return `<img ${imgAttrs} ${lazy} style="width:100%;height:100%;object-fit:cover;display:block">`;
+  }
+  const scaleW = 100 / crop.w;
+  const scaleH = 100 / crop.h;
+  const offsetX = -crop.x * scaleW;
+  const offsetY = -crop.y * scaleH;
+  return `<img ${imgAttrs} ${lazy} style="position:absolute;left:${offsetX}%;top:${offsetY}%;width:${scaleW}%;height:${scaleH}%;max-width:none;display:block">`;
+}
+
 // lookup_values 캐시에서 라벨 우선 조회, 없으면 하드코딩 폴백
 const CHANNEL_LABEL_FALLBACK = {instagram:'Instagram',x:'X(Twitter)',qoo10:'Qoo10',tiktok:'TikTok',youtube:'YouTube'};
 function _currentLookupLang(lang) {
@@ -437,10 +455,10 @@ function renderImgPreview(imgList, wrapId, counterId, listName) {
       ' style="position:relative;width:88px;height:88px;flex-shrink:0;cursor:grab">' +
       '<img src="'+img.data+'" draggable="false" style="width:88px;height:88px;object-fit:cover;border-radius:10px;border:2px solid '+(i===0?'var(--pink)':'var(--line)')+';pointer-events:none">' +
       (i===0?'<div style="position:absolute;bottom:0;left:0;right:0;background:var(--pink);color:#fff;font-size:9px;font-weight:700;text-align:center;border-radius:0 0 8px 8px;padding:2px">MAIN</div>':'') +
-      (img.original?'<div style="position:absolute;top:2px;left:2px;background:var(--pink);color:#fff;font-size:8px;font-weight:700;padding:1px 5px;border-radius:4px;z-index:2">CROP</div>':'') +
+      (img.crop||img.original?'<div style="position:absolute;top:2px;left:2px;background:var(--pink);color:#fff;font-size:8px;font-weight:700;padding:1px 5px;border-radius:4px;z-index:2">CROP</div>':'') +
       '<button data-action="remove" data-i="'+i+'" data-remove-fn="'+removeFn+'" style="position:absolute;top:-4px;right:-4px;width:22px;height:22px;background:#333;color:#fff;border-radius:50%;font-size:12px;display:flex;align-items:center;justify-content:center;border:none;cursor:pointer;z-index:2" title="삭제"><span class="material-icons-round notranslate" translate="no" style="font-size:14px">close</span></button>' +
       '<div style="position:absolute;bottom:'+(i===0?'20px':'2px')+';right:2px;display:flex;gap:3px;z-index:2">' +
-        (img.original?'<button data-action="restore" data-i="'+i+'" data-list="'+listName+'" data-wrap="'+wrapId+'" data-counter="'+counterId+'" style="width:26px;height:26px;background:rgba(0,0,0,.7);color:#fff;border-radius:6px;display:flex;align-items:center;justify-content:center;border:none;cursor:pointer" title="원본 복원"><span class="material-icons-round" style="font-size:16px">undo</span></button>':'') +
+        (img.crop||img.original?'<button data-action="restore" data-i="'+i+'" data-list="'+listName+'" data-wrap="'+wrapId+'" data-counter="'+counterId+'" style="width:26px;height:26px;background:rgba(0,0,0,.7);color:#fff;border-radius:6px;display:flex;align-items:center;justify-content:center;border:none;cursor:pointer" title="크롭 취소"><span class="material-icons-round" style="font-size:16px">undo</span></button>':'') +
         '<button data-action="crop" data-i="'+i+'" data-list="'+listName+'" data-wrap="'+wrapId+'" data-counter="'+counterId+'" style="width:26px;height:26px;background:rgba(0,0,0,.7);color:#fff;border-radius:6px;display:flex;align-items:center;justify-content:center;border:none;cursor:pointer" title="1:1 크롭"><span class="material-icons-round" style="font-size:16px">crop</span></button>' +
         '<button data-action="download" data-i="'+i+'" data-list="'+listName+'" style="width:26px;height:26px;background:rgba(0,0,0,.7);color:#fff;border-radius:6px;display:flex;align-items:center;justify-content:center;border:none;cursor:pointer" title="다운로드"><span class="material-icons-round" style="font-size:16px">download</span></button>' +
       '</div>' +
@@ -505,11 +523,16 @@ function downloadImg(idx, listName) {
 // 원본 복원
 function restoreOriginal(idx, listName, wrapId, counterId) {
   var list = getImgList(listName);
-  if (!list || !list[idx] || !list[idx].original) return;
-  list[idx].data = list[idx].original;
-  delete list[idx].original;
+  if (!list || !list[idx]) return;
+  // 비파괴 크롭 좌표 제거
+  if (list[idx].crop) delete list[idx].crop;
+  // 레거시 파괴적 크롭(original 백업) 복원
+  if (list[idx].original) {
+    list[idx].data = list[idx].original;
+    delete list[idx].original;
+  }
   renderImgPreview(list, wrapId, counterId, listName);
-  toast('원본으로 복원됨','success');
+  toast('크롭 영역 해제','success');
 }
 
 // 1:1 크롭 모달
@@ -575,18 +598,25 @@ function closeCropModal() {
 
 function applyCrop() {
   if (!_cropperInstance || !_cropTarget) return;
-  var canvas = _cropperInstance.getCroppedCanvas({width:1080, height:1080, imageSmoothingQuality:'high'});
-  var croppedData = canvas.toDataURL('image/jpeg', 0.92);
+  // 비파괴 크롭: 좌표만 0~1로 정규화해서 저장 (원본 이미지 유지)
+  var cropData = _cropperInstance.getData(true);  // {x,y,width,height,rotate,scaleX,scaleY}
+  var imgData = _cropperInstance.getImageData();  // {naturalWidth,naturalHeight,...}
+  var natW = imgData.naturalWidth;
+  var natH = imgData.naturalHeight;
+  var rect = natW && natH ? {
+    x: Math.max(0, cropData.x / natW),
+    y: Math.max(0, cropData.y / natH),
+    w: Math.min(1, cropData.width / natW),
+    h: Math.min(1, cropData.height / natH)
+  } : null;
   var list = getImgList(_cropTarget.listName);
-  if (list) {
+  if (list && rect) {
     var item = list[_cropTarget.idx];
-    // 원본 보존 — 처음 크롭할 때만 원본 저장
-    if (!item.original) item.original = item.data;
-    item.data = croppedData;
+    item.crop = rect;  // 좌표만 저장, item.data는 그대로
     renderImgPreview(list, _cropTarget.wrapId, _cropTarget.counterId, _cropTarget.listName);
   }
   closeCropModal();
-  toast('크롭 완료 (원본 유지됨)','success');
+  toast('크롭 영역 저장 (원본 유지)','success');
 }
 
 // ── 로그인 안내 팝업 ──

--- a/dev/js/ui.js
+++ b/dev/js/ui.js
@@ -124,24 +124,13 @@ function imgThumb(url, width, quality) {
   return url.replace('/storage/v1/object/public/', '/storage/v1/render/image/public/') + `?width=${w}&quality=${q}&resize=cover`;
 }
 
-// 비파괴 크롭 렌더 — background-image 방식 (퍼센트 해석 이슈 회피)
-// crop = {x,y,w,h} 0~1 정규화. opts: {thumb, quality, lazy, class, style}
-// **중요**: 반환 HTML은 단독 div (부모에 aspect-ratio 지정은 호출부 책임)
-function renderCroppedImg(url, crop, opts) {
+// 이미지 렌더 — 가로세로 비율 유지 (object-fit:contain, 레터박스)
+// opts: {thumb, quality, lazy}. crop 인자는 하위호환으로 받지만 무시
+function renderCroppedImg(url, _ignoredCrop, opts) {
   opts = opts || {};
   const thumb = opts.thumb ? imgThumb(url, opts.thumb, opts.quality||80) : url;
-  if (!crop || typeof crop.w !== 'number' || crop.w <= 0) {
-    // 크롭 정보 없음 — 기존 방식: img + object-fit:cover (fallback)
-    const lazy = opts.lazy ? 'loading="lazy" decoding="async"' : '';
-    return `<img src="${esc(thumb)}" data-orig="${esc(url)}" ${lazy} style="width:100%;height:100%;object-fit:cover;display:block" onerror="if(this.src!==this.dataset.orig){this.src=this.dataset.orig}">`;
-  }
-  // 크롭 있음 — background-image로 렌더
-  const bgSizeW = (100 / crop.w).toFixed(4);
-  const bgSizeH = (100 / crop.h).toFixed(4);
-  const bgPosX = crop.w >= 1 ? 0 : (crop.x / (1 - crop.w) * 100).toFixed(4);
-  const bgPosY = crop.h >= 1 ? 0 : (crop.y / (1 - crop.h) * 100).toFixed(4);
-  const extra = opts.style || '';
-  return `<div style="width:100%;height:100%;background-image:url('${esc(thumb)}');background-size:${bgSizeW}% ${bgSizeH}%;background-position:${bgPosX}% ${bgPosY}%;background-repeat:no-repeat;${extra}"></div>`;
+  const lazy = opts.lazy ? 'loading="lazy" decoding="async"' : '';
+  return `<img src="${esc(thumb)}" data-orig="${esc(url)}" ${lazy} style="width:100%;height:100%;object-fit:contain;display:block;background:#f5f5f5" onerror="if(this.src!==this.dataset.orig){this.src=this.dataset.orig}">`;
 }
 
 // lookup_values 캐시에서 라벨 우선 조회, 없으면 하드코딩 폴백
@@ -455,15 +444,10 @@ function renderImgPreview(imgList, wrapId, counterId, listName) {
       ' ondragleave="this.style.outline=\'none\'"' +
       ' ondrop="imgDrop(event,'+i+',\''+listName+'\',\''+wrapId+'\',\''+counterId+'\')"' +
       ' style="position:relative;width:88px;height:88px;flex-shrink:0;cursor:grab">' +
-      (img.crop
-        ? '<div style="width:88px;height:88px;border-radius:10px;border:2px solid '+(i===0?'var(--pink)':'var(--line)')+';background-image:url(\''+img.data+'\');background-size:'+((100/img.crop.w).toFixed(4))+'% '+((100/img.crop.h).toFixed(4))+'%;background-position:'+(img.crop.w>=1?0:(img.crop.x/(1-img.crop.w)*100).toFixed(4))+'% '+(img.crop.h>=1?0:(img.crop.y/(1-img.crop.h)*100).toFixed(4))+'%;background-repeat:no-repeat;pointer-events:none"></div>'
-        : '<img src="'+img.data+'" draggable="false" style="width:88px;height:88px;object-fit:cover;border-radius:10px;border:2px solid '+(i===0?'var(--pink)':'var(--line)')+';pointer-events:none">') +
+      '<img src="'+img.data+'" draggable="false" style="width:88px;height:88px;object-fit:contain;border-radius:10px;border:2px solid '+(i===0?'var(--pink)':'var(--line)')+';background:#f5f5f5;pointer-events:none">' +
       (i===0?'<div style="position:absolute;bottom:0;left:0;right:0;background:var(--pink);color:#fff;font-size:9px;font-weight:700;text-align:center;border-radius:0 0 8px 8px;padding:2px">MAIN</div>':'') +
-      (img.crop||img.original?'<div style="position:absolute;top:2px;left:2px;background:var(--pink);color:#fff;font-size:8px;font-weight:700;padding:1px 5px;border-radius:4px;z-index:2">CROP</div>':'') +
       '<button data-action="remove" data-i="'+i+'" data-remove-fn="'+removeFn+'" style="position:absolute;top:-4px;right:-4px;width:22px;height:22px;background:#333;color:#fff;border-radius:50%;font-size:12px;display:flex;align-items:center;justify-content:center;border:none;cursor:pointer;z-index:2" title="삭제"><span class="material-icons-round notranslate" translate="no" style="font-size:14px">close</span></button>' +
       '<div style="position:absolute;bottom:'+(i===0?'20px':'2px')+';right:2px;display:flex;gap:3px;z-index:2">' +
-        (img.crop||img.original?'<button data-action="restore" data-i="'+i+'" data-list="'+listName+'" data-wrap="'+wrapId+'" data-counter="'+counterId+'" style="width:26px;height:26px;background:rgba(0,0,0,.7);color:#fff;border-radius:6px;display:flex;align-items:center;justify-content:center;border:none;cursor:pointer" title="크롭 취소"><span class="material-icons-round" style="font-size:16px">undo</span></button>':'') +
-        '<button data-action="crop" data-i="'+i+'" data-list="'+listName+'" data-wrap="'+wrapId+'" data-counter="'+counterId+'" style="width:26px;height:26px;background:rgba(0,0,0,.7);color:#fff;border-radius:6px;display:flex;align-items:center;justify-content:center;border:none;cursor:pointer" title="1:1 크롭"><span class="material-icons-round" style="font-size:16px">crop</span></button>' +
         '<button data-action="download" data-i="'+i+'" data-list="'+listName+'" style="width:26px;height:26px;background:rgba(0,0,0,.7);color:#fff;border-radius:6px;display:flex;align-items:center;justify-content:center;border:none;cursor:pointer" title="다운로드"><span class="material-icons-round" style="font-size:16px">download</span></button>' +
       '</div>' +
     '</div>';

--- a/dev/js/ui.js
+++ b/dev/js/ui.js
@@ -240,7 +240,7 @@ function previewSlideImgs() {
   if (!preview) return;
   preview.innerHTML = campImgData.map((img,i)=>`
     <div style="position:relative;width:68px;height:68px;border-radius:8px;overflow:hidden;border:2px solid ${i===0?'var(--pink)':'var(--line)'}">
-      <img src="${img.data}" style="width:100%;height:100%;object-fit:cover">
+      <img src="${img.data}" style="width:100%;height:100%;object-fit:contain;background:#f5f5f5">
       ${i===0?'<div style="position:absolute;bottom:0;left:0;right:0;background:var(--pink);color:#fff;font-size:9px;font-weight:700;text-align:center;padding:1px">MAIN</div>':''}
     </div>`).join('');
 }

--- a/dev/js/ui.js
+++ b/dev/js/ui.js
@@ -497,6 +497,10 @@ function imgDrop(e, targetIdx, listName, wrapId, counterId) {
   var item = list.splice(_dragSrcIdx, 1)[0];
   list.splice(targetIdx, 0, item);
   _dragSrcIdx = null;
+  // 편집 폼 저장 플래그 세팅 (순서만 바뀌어도 DB 재업로드 필요)
+  if (listName === 'editCampImgData' && typeof editCampImgChanged !== 'undefined') {
+    editCampImgChanged = true;
+  }
   renderImgPreview(list, wrapId, counterId, listName);
 }
 

--- a/dev/js/ui.js
+++ b/dev/js/ui.js
@@ -124,22 +124,24 @@ function imgThumb(url, width, quality) {
   return url.replace('/storage/v1/object/public/', '/storage/v1/render/image/public/') + `?width=${w}&quality=${q}&resize=cover`;
 }
 
-// 비파괴 크롭 렌더 — 원본 이미지에서 특정 영역만 노출 (aspect 컨테이너 안)
-// crop = {x,y,w,h} 0~1 정규화. 없으면 단순 object-fit:cover
+// 비파괴 크롭 렌더 — background-image 방식 (퍼센트 해석 이슈 회피)
+// crop = {x,y,w,h} 0~1 정규화. opts: {thumb, quality, lazy, class, style}
+// **중요**: 반환 HTML은 단독 div (부모에 aspect-ratio 지정은 호출부 책임)
 function renderCroppedImg(url, crop, opts) {
   opts = opts || {};
-  const alt = opts.alt || '';
   const thumb = opts.thumb ? imgThumb(url, opts.thumb, opts.quality||80) : url;
-  const imgAttrs = `src="${esc(thumb)}" data-orig="${esc(url)}" alt="${esc(alt)}" onerror="if(this.src!==this.dataset.orig){this.src=this.dataset.orig}"`;
-  const lazy = opts.lazy ? 'loading="lazy" decoding="async"' : '';
   if (!crop || typeof crop.w !== 'number' || crop.w <= 0) {
-    return `<img ${imgAttrs} ${lazy} style="width:100%;height:100%;object-fit:cover;display:block">`;
+    // 크롭 정보 없음 — 기존 방식: img + object-fit:cover (fallback)
+    const lazy = opts.lazy ? 'loading="lazy" decoding="async"' : '';
+    return `<img src="${esc(thumb)}" data-orig="${esc(url)}" ${lazy} style="width:100%;height:100%;object-fit:cover;display:block" onerror="if(this.src!==this.dataset.orig){this.src=this.dataset.orig}">`;
   }
-  const scaleW = 100 / crop.w;
-  const scaleH = 100 / crop.h;
-  const offsetX = -crop.x * scaleW;
-  const offsetY = -crop.y * scaleH;
-  return `<img ${imgAttrs} ${lazy} style="position:absolute;left:${offsetX}%;top:${offsetY}%;width:${scaleW}%;height:${scaleH}%;max-width:none;display:block">`;
+  // 크롭 있음 — background-image로 렌더
+  const bgSizeW = (100 / crop.w).toFixed(4);
+  const bgSizeH = (100 / crop.h).toFixed(4);
+  const bgPosX = crop.w >= 1 ? 0 : (crop.x / (1 - crop.w) * 100).toFixed(4);
+  const bgPosY = crop.h >= 1 ? 0 : (crop.y / (1 - crop.h) * 100).toFixed(4);
+  const extra = opts.style || '';
+  return `<div style="width:100%;height:100%;background-image:url('${esc(thumb)}');background-size:${bgSizeW}% ${bgSizeH}%;background-position:${bgPosX}% ${bgPosY}%;background-repeat:no-repeat;${extra}"></div>`;
 }
 
 // lookup_values 캐시에서 라벨 우선 조회, 없으면 하드코딩 폴백

--- a/dev/js/ui.js
+++ b/dev/js/ui.js
@@ -121,7 +121,8 @@ function imgThumb(url, width, quality) {
   if (!url.includes('/storage/v1/object/public/')) return url;
   const q = quality || 70;
   const w = width || 400;
-  return url.replace('/storage/v1/object/public/', '/storage/v1/render/image/public/') + `?width=${w}&quality=${q}&resize=cover`;
+  // resize=contain: 비율 유지 (cover는 크롭됨)
+  return url.replace('/storage/v1/object/public/', '/storage/v1/render/image/public/') + `?width=${w}&quality=${q}&resize=contain`;
 }
 
 // 이미지 렌더 — 가로세로 비율 유지 (object-fit:contain, 레터박스)

--- a/dev/js/ui.js
+++ b/dev/js/ui.js
@@ -397,6 +397,10 @@ document.addEventListener('drop', function(e) {
   if (files.length) {
     var wrapId = listName === 'campImgData' ? 'campImgPreviewWrap' : 'editCampImgPreviewWrap';
     var counterId = listName === 'campImgData' ? 'campImgCounter' : 'editCampImgCounter';
+    // editCampImgChanged 플래그 세팅 (편집 폼 저장 로직이 이 플래그로 업로드 판단)
+    if (listName === 'editCampImgData' && typeof editCampImgChanged !== 'undefined') {
+      editCampImgChanged = true;
+    }
     addImagesToList(files, list, wrapId, counterId, listName);
   }
 });

--- a/dev/js/ui.js
+++ b/dev/js/ui.js
@@ -455,7 +455,9 @@ function renderImgPreview(imgList, wrapId, counterId, listName) {
       ' ondragleave="this.style.outline=\'none\'"' +
       ' ondrop="imgDrop(event,'+i+',\''+listName+'\',\''+wrapId+'\',\''+counterId+'\')"' +
       ' style="position:relative;width:88px;height:88px;flex-shrink:0;cursor:grab">' +
-      '<img src="'+img.data+'" draggable="false" style="width:88px;height:88px;object-fit:cover;border-radius:10px;border:2px solid '+(i===0?'var(--pink)':'var(--line)')+';pointer-events:none">' +
+      (img.crop
+        ? '<div style="width:88px;height:88px;border-radius:10px;border:2px solid '+(i===0?'var(--pink)':'var(--line)')+';background-image:url(\''+img.data+'\');background-size:'+((100/img.crop.w).toFixed(4))+'% '+((100/img.crop.h).toFixed(4))+'%;background-position:'+(img.crop.w>=1?0:(img.crop.x/(1-img.crop.w)*100).toFixed(4))+'% '+(img.crop.h>=1?0:(img.crop.y/(1-img.crop.h)*100).toFixed(4))+'%;background-repeat:no-repeat;pointer-events:none"></div>'
+        : '<img src="'+img.data+'" draggable="false" style="width:88px;height:88px;object-fit:cover;border-radius:10px;border:2px solid '+(i===0?'var(--pink)':'var(--line)')+';pointer-events:none">') +
       (i===0?'<div style="position:absolute;bottom:0;left:0;right:0;background:var(--pink);color:#fff;font-size:9px;font-weight:700;text-align:center;border-radius:0 0 8px 8px;padding:2px">MAIN</div>':'') +
       (img.crop||img.original?'<div style="position:absolute;top:2px;left:2px;background:var(--pink);color:#fff;font-size:8px;font-weight:700;padding:1px 5px;border-radius:4px;z-index:2">CROP</div>':'') +
       '<button data-action="remove" data-i="'+i+'" data-remove-fn="'+removeFn+'" style="position:absolute;top:-4px;right:-4px;width:22px;height:22px;background:#333;color:#fff;border-radius:50%;font-size:12px;display:flex;align-items:center;justify-content:center;border:none;cursor:pointer;z-index:2" title="삭제"><span class="material-icons-round notranslate" translate="no" style="font-size:14px">close</span></button>' +

--- a/dev/lib/i18n/ja.js
+++ b/dev/lib/i18n/ja.js
@@ -167,6 +167,7 @@ window.I18N_JA = {
     emptySub: '今すぐKブランド体験団に応募してみましょう！',
     emptyBtn: 'キャンペーンを見る',
     applyDate: '応募日',
+    allChannels: '全チャンネル',
   },
 
   // 햄버거 메뉴

--- a/dev/lib/i18n/ko.js
+++ b/dev/lib/i18n/ko.js
@@ -160,6 +160,7 @@ window.I18N_KO = {
     emptySub: '지금 바로 K브랜드 체험단에 응모해보세요!',
     emptyBtn: '캠페인 보기',
     applyDate: '응모일',
+    allChannels: '전체 채널',
   },
 
   menu: {

--- a/index.html
+++ b/index.html
@@ -3602,6 +3602,10 @@ document.addEventListener('drop', function(e) {
   if (files.length) {
     var wrapId = listName === 'campImgData' ? 'campImgPreviewWrap' : 'editCampImgPreviewWrap';
     var counterId = listName === 'campImgData' ? 'campImgCounter' : 'editCampImgCounter';
+    // editCampImgChanged 플래그 세팅 (편집 폼 저장 로직이 이 플래그로 업로드 판단)
+    if (listName === 'editCampImgData' && typeof editCampImgChanged !== 'undefined') {
+      editCampImgChanged = true;
+    }
     addImagesToList(files, list, wrapId, counterId, listName);
   }
 });

--- a/index.html
+++ b/index.html
@@ -3329,24 +3329,13 @@ function imgThumb(url, width, quality) {
   return url.replace('/storage/v1/object/public/', '/storage/v1/render/image/public/') + `?width=${w}&quality=${q}&resize=cover`;
 }
 
-// 비파괴 크롭 렌더 — background-image 방식 (퍼센트 해석 이슈 회피)
-// crop = {x,y,w,h} 0~1 정규화. opts: {thumb, quality, lazy, class, style}
-// **중요**: 반환 HTML은 단독 div (부모에 aspect-ratio 지정은 호출부 책임)
-function renderCroppedImg(url, crop, opts) {
+// 이미지 렌더 — 가로세로 비율 유지 (object-fit:contain, 레터박스)
+// opts: {thumb, quality, lazy}. crop 인자는 하위호환으로 받지만 무시
+function renderCroppedImg(url, _ignoredCrop, opts) {
   opts = opts || {};
   const thumb = opts.thumb ? imgThumb(url, opts.thumb, opts.quality||80) : url;
-  if (!crop || typeof crop.w !== 'number' || crop.w <= 0) {
-    // 크롭 정보 없음 — 기존 방식: img + object-fit:cover (fallback)
-    const lazy = opts.lazy ? 'loading="lazy" decoding="async"' : '';
-    return `<img src="${esc(thumb)}" data-orig="${esc(url)}" ${lazy} style="width:100%;height:100%;object-fit:cover;display:block" onerror="if(this.src!==this.dataset.orig){this.src=this.dataset.orig}">`;
-  }
-  // 크롭 있음 — background-image로 렌더
-  const bgSizeW = (100 / crop.w).toFixed(4);
-  const bgSizeH = (100 / crop.h).toFixed(4);
-  const bgPosX = crop.w >= 1 ? 0 : (crop.x / (1 - crop.w) * 100).toFixed(4);
-  const bgPosY = crop.h >= 1 ? 0 : (crop.y / (1 - crop.h) * 100).toFixed(4);
-  const extra = opts.style || '';
-  return `<div style="width:100%;height:100%;background-image:url('${esc(thumb)}');background-size:${bgSizeW}% ${bgSizeH}%;background-position:${bgPosX}% ${bgPosY}%;background-repeat:no-repeat;${extra}"></div>`;
+  const lazy = opts.lazy ? 'loading="lazy" decoding="async"' : '';
+  return `<img src="${esc(thumb)}" data-orig="${esc(url)}" ${lazy} style="width:100%;height:100%;object-fit:contain;display:block;background:#f5f5f5" onerror="if(this.src!==this.dataset.orig){this.src=this.dataset.orig}">`;
 }
 
 // lookup_values 캐시에서 라벨 우선 조회, 없으면 하드코딩 폴백
@@ -3660,15 +3649,10 @@ function renderImgPreview(imgList, wrapId, counterId, listName) {
       ' ondragleave="this.style.outline=\'none\'"' +
       ' ondrop="imgDrop(event,'+i+',\''+listName+'\',\''+wrapId+'\',\''+counterId+'\')"' +
       ' style="position:relative;width:88px;height:88px;flex-shrink:0;cursor:grab">' +
-      (img.crop
-        ? '<div style="width:88px;height:88px;border-radius:10px;border:2px solid '+(i===0?'var(--pink)':'var(--line)')+';background-image:url(\''+img.data+'\');background-size:'+((100/img.crop.w).toFixed(4))+'% '+((100/img.crop.h).toFixed(4))+'%;background-position:'+(img.crop.w>=1?0:(img.crop.x/(1-img.crop.w)*100).toFixed(4))+'% '+(img.crop.h>=1?0:(img.crop.y/(1-img.crop.h)*100).toFixed(4))+'%;background-repeat:no-repeat;pointer-events:none"></div>'
-        : '<img src="'+img.data+'" draggable="false" style="width:88px;height:88px;object-fit:cover;border-radius:10px;border:2px solid '+(i===0?'var(--pink)':'var(--line)')+';pointer-events:none">') +
+      '<img src="'+img.data+'" draggable="false" style="width:88px;height:88px;object-fit:contain;border-radius:10px;border:2px solid '+(i===0?'var(--pink)':'var(--line)')+';background:#f5f5f5;pointer-events:none">' +
       (i===0?'<div style="position:absolute;bottom:0;left:0;right:0;background:var(--pink);color:#fff;font-size:9px;font-weight:700;text-align:center;border-radius:0 0 8px 8px;padding:2px">MAIN</div>':'') +
-      (img.crop||img.original?'<div style="position:absolute;top:2px;left:2px;background:var(--pink);color:#fff;font-size:8px;font-weight:700;padding:1px 5px;border-radius:4px;z-index:2">CROP</div>':'') +
       '<button data-action="remove" data-i="'+i+'" data-remove-fn="'+removeFn+'" style="position:absolute;top:-4px;right:-4px;width:22px;height:22px;background:#333;color:#fff;border-radius:50%;font-size:12px;display:flex;align-items:center;justify-content:center;border:none;cursor:pointer;z-index:2" title="삭제"><span class="material-icons-round notranslate" translate="no" style="font-size:14px">close</span></button>' +
       '<div style="position:absolute;bottom:'+(i===0?'20px':'2px')+';right:2px;display:flex;gap:3px;z-index:2">' +
-        (img.crop||img.original?'<button data-action="restore" data-i="'+i+'" data-list="'+listName+'" data-wrap="'+wrapId+'" data-counter="'+counterId+'" style="width:26px;height:26px;background:rgba(0,0,0,.7);color:#fff;border-radius:6px;display:flex;align-items:center;justify-content:center;border:none;cursor:pointer" title="크롭 취소"><span class="material-icons-round" style="font-size:16px">undo</span></button>':'') +
-        '<button data-action="crop" data-i="'+i+'" data-list="'+listName+'" data-wrap="'+wrapId+'" data-counter="'+counterId+'" style="width:26px;height:26px;background:rgba(0,0,0,.7);color:#fff;border-radius:6px;display:flex;align-items:center;justify-content:center;border:none;cursor:pointer" title="1:1 크롭"><span class="material-icons-round" style="font-size:16px">crop</span></button>' +
         '<button data-action="download" data-i="'+i+'" data-list="'+listName+'" style="width:26px;height:26px;background:rgba(0,0,0,.7);color:#fff;border-radius:6px;display:flex;align-items:center;justify-content:center;border:none;cursor:pointer" title="다운로드"><span class="material-icons-round" style="font-size:16px">download</span></button>' +
       '</div>' +
     '</div>';

--- a/index.html
+++ b/index.html
@@ -4342,7 +4342,7 @@ async function openCampaign(id) {
   const slideHtml = slideImgs.length > 0 ? `
     <div id="campSlider" style="position:relative;overflow:hidden;border-radius:16px;margin-bottom:0;background:${getCampGrad(camp.category)};aspect-ratio:1/1;height:auto">
       <div id="campSlides" style="display:flex;height:100%;transition:transform .32s cubic-bezier(.4,0,.2,1)">
-        ${slideImgs.map((url,idx)=>`<div style="flex:0 0 100%;width:100%;height:100%;background:${getCampGrad(camp.category)}"><img src="${imgThumb(url,960,80)}" data-orig="${url}" ${idx===0?'':'loading="lazy"'} decoding="async" style="width:100%;height:100%;object-fit:contain;display:block" onerror="if(this.src!==this.dataset.orig){this.src=this.dataset.orig}else{this.parentElement.style.background='${getCampGrad(camp.category)}'}"></div>`).join('')}
+        ${slideImgs.map((url,idx)=>`<div style="flex:0 0 100%;width:100%;height:100%;background:${getCampGrad(camp.category)}"><img src="${imgThumb(url,960,80)}" data-orig="${url}" ${idx===0?'':'loading="lazy"'} decoding="async" style="width:100%;height:100%;object-fit:cover;display:block" onerror="if(this.src!==this.dataset.orig){this.src=this.dataset.orig}else{this.parentElement.style.background='${getCampGrad(camp.category)}'}"></div>`).join('')}
       </div>
       ${slideImgs.length>1?`
         <button onclick="slideMove(-1)" style="position:absolute;left:10px;top:50%;transform:translateY(-50%);width:30px;height:30px;background:rgba(255,255,255,.88);border:none;border-radius:50%;cursor:pointer;display:flex;align-items:center;justify-content:center;z-index:5;box-shadow:0 2px 6px rgba(0,0,0,.15)"><span class="material-icons-round" style="font-size:20px;color:#333">chevron_left</span></button>

--- a/index.html
+++ b/index.html
@@ -3702,6 +3702,10 @@ function imgDrop(e, targetIdx, listName, wrapId, counterId) {
   var item = list.splice(_dragSrcIdx, 1)[0];
   list.splice(targetIdx, 0, item);
   _dragSrcIdx = null;
+  // 편집 폼 저장 플래그 세팅 (순서만 바뀌어도 DB 재업로드 필요)
+  if (listName === 'editCampImgData' && typeof editCampImgChanged !== 'undefined') {
+    editCampImgChanged = true;
+  }
   renderImgPreview(list, wrapId, counterId, listName);
 }
 

--- a/index.html
+++ b/index.html
@@ -5562,6 +5562,8 @@ window.addEventListener('langchange', function() {
   if (page === 'home') { if (typeof loadCampaigns === 'function') loadCampaigns(); }
   else if (page === 'campaigns') { if (typeof loadCampaignsPage === 'function') loadCampaignsPage(); }
   else if (page.startsWith('detail-')) { if (typeof openCampaign === 'function') openCampaign(page.replace('detail-','')); }
+  // 햄버거 메뉴 재렌더 (언어에 따라 라벨 갱신)
+  if (typeof renderNavMenu === 'function') renderNavMenu();
 });
 
 // Step 3: 햄버거 메뉴 활성 페이지 하이라이트

--- a/index.html
+++ b/index.html
@@ -4446,15 +4446,19 @@ async function openCampaign(id) {
       <div style="background:#fff;padding:16px;margin-bottom:10px;border-bottom:8px solid var(--bg)">
         <div style="font-size:14px;font-weight:700;margin-bottom:14px;color:var(--ink)">${t('detail.participationTitle')}</div>
         <div style="display:flex;flex-direction:column;gap:14px">
-          ${steps.map((s,i)=>`
+          ${steps.map((s,i)=>{
+            const lang = (typeof getLang === 'function' ? getLang() : 'ja');
+            const title = lang === 'ko' ? (s.title_ko||s.title_ja||'') : (s.title_ja||s.title_ko||'');
+            const desc = lang === 'ko' ? (s.desc_ko||s.desc_ja||'') : (s.desc_ja||s.desc_ko||'');
+            return `
             <div style="display:flex;gap:12px;align-items:flex-start">
               <div style="min-width:50px;height:20px;background:var(--light-pink);border-radius:20px;display:flex;align-items:center;justify-content:center;font-size:10px;font-weight:700;color:var(--pink);flex-shrink:0">STEP ${i+1}</div>
               <div>
-                <div style="font-size:13px;font-weight:700;margin-bottom:2px">${esc(s.title_ja||s.title_ko||'')}</div>
-                ${(s.desc_ja||s.desc_ko) ? `<div style="font-size:12px;color:var(--muted);line-height:1.55">${esc(s.desc_ja||s.desc_ko||'')}</div>` : ''}
+                <div style="font-size:13px;font-weight:700;margin-bottom:2px">${esc(title)}</div>
+                ${desc ? `<div style="font-size:12px;color:var(--muted);line-height:1.55">${esc(desc)}</div>` : ''}
               </div>
-            </div>
-          `).join('')}
+            </div>`;
+          }).join('')}
         </div>
       </div>`;
       })()}

--- a/index.html
+++ b/index.html
@@ -3660,7 +3660,9 @@ function renderImgPreview(imgList, wrapId, counterId, listName) {
       ' ondragleave="this.style.outline=\'none\'"' +
       ' ondrop="imgDrop(event,'+i+',\''+listName+'\',\''+wrapId+'\',\''+counterId+'\')"' +
       ' style="position:relative;width:88px;height:88px;flex-shrink:0;cursor:grab">' +
-      '<img src="'+img.data+'" draggable="false" style="width:88px;height:88px;object-fit:cover;border-radius:10px;border:2px solid '+(i===0?'var(--pink)':'var(--line)')+';pointer-events:none">' +
+      (img.crop
+        ? '<div style="width:88px;height:88px;border-radius:10px;border:2px solid '+(i===0?'var(--pink)':'var(--line)')+';background-image:url(\''+img.data+'\');background-size:'+((100/img.crop.w).toFixed(4))+'% '+((100/img.crop.h).toFixed(4))+'%;background-position:'+(img.crop.w>=1?0:(img.crop.x/(1-img.crop.w)*100).toFixed(4))+'% '+(img.crop.h>=1?0:(img.crop.y/(1-img.crop.h)*100).toFixed(4))+'%;background-repeat:no-repeat;pointer-events:none"></div>'
+        : '<img src="'+img.data+'" draggable="false" style="width:88px;height:88px;object-fit:cover;border-radius:10px;border:2px solid '+(i===0?'var(--pink)':'var(--line)')+';pointer-events:none">') +
       (i===0?'<div style="position:absolute;bottom:0;left:0;right:0;background:var(--pink);color:#fff;font-size:9px;font-weight:700;text-align:center;border-radius:0 0 8px 8px;padding:2px">MAIN</div>':'') +
       (img.crop||img.original?'<div style="position:absolute;top:2px;left:2px;background:var(--pink);color:#fff;font-size:8px;font-weight:700;padding:1px 5px;border-radius:4px;z-index:2">CROP</div>':'') +
       '<button data-action="remove" data-i="'+i+'" data-remove-fn="'+removeFn+'" style="position:absolute;top:-4px;right:-4px;width:22px;height:22px;background:#333;color:#fff;border-radius:50%;font-size:12px;display:flex;align-items:center;justify-content:center;border:none;cursor:pointer;z-index:2" title="삭제"><span class="material-icons-round notranslate" translate="no" style="font-size:14px">close</span></button>' +

--- a/index.html
+++ b/index.html
@@ -3326,7 +3326,8 @@ function imgThumb(url, width, quality) {
   if (!url.includes('/storage/v1/object/public/')) return url;
   const q = quality || 70;
   const w = width || 400;
-  return url.replace('/storage/v1/object/public/', '/storage/v1/render/image/public/') + `?width=${w}&quality=${q}&resize=cover`;
+  // resize=contain: 비율 유지 (cover는 크롭됨)
+  return url.replace('/storage/v1/object/public/', '/storage/v1/render/image/public/') + `?width=${w}&quality=${q}&resize=contain`;
 }
 
 // 이미지 렌더 — 가로세로 비율 유지 (object-fit:contain, 레터박스)

--- a/index.html
+++ b/index.html
@@ -3324,6 +3324,24 @@ function imgThumb(url, width, quality) {
   return url.replace('/storage/v1/object/public/', '/storage/v1/render/image/public/') + `?width=${w}&quality=${q}&resize=cover`;
 }
 
+// 비파괴 크롭 렌더 — 원본 이미지에서 특정 영역만 노출 (aspect 컨테이너 안)
+// crop = {x,y,w,h} 0~1 정규화. 없으면 단순 object-fit:cover
+function renderCroppedImg(url, crop, opts) {
+  opts = opts || {};
+  const alt = opts.alt || '';
+  const thumb = opts.thumb ? imgThumb(url, opts.thumb, opts.quality||80) : url;
+  const imgAttrs = `src="${esc(thumb)}" data-orig="${esc(url)}" alt="${esc(alt)}" onerror="if(this.src!==this.dataset.orig){this.src=this.dataset.orig}"`;
+  const lazy = opts.lazy ? 'loading="lazy" decoding="async"' : '';
+  if (!crop || typeof crop.w !== 'number' || crop.w <= 0) {
+    return `<img ${imgAttrs} ${lazy} style="width:100%;height:100%;object-fit:cover;display:block">`;
+  }
+  const scaleW = 100 / crop.w;
+  const scaleH = 100 / crop.h;
+  const offsetX = -crop.x * scaleW;
+  const offsetY = -crop.y * scaleH;
+  return `<img ${imgAttrs} ${lazy} style="position:absolute;left:${offsetX}%;top:${offsetY}%;width:${scaleW}%;height:${scaleH}%;max-width:none;display:block">`;
+}
+
 // lookup_values 캐시에서 라벨 우선 조회, 없으면 하드코딩 폴백
 const CHANNEL_LABEL_FALLBACK = {instagram:'Instagram',x:'X(Twitter)',qoo10:'Qoo10',tiktok:'TikTok',youtube:'YouTube'};
 function _currentLookupLang(lang) {
@@ -3637,10 +3655,10 @@ function renderImgPreview(imgList, wrapId, counterId, listName) {
       ' style="position:relative;width:88px;height:88px;flex-shrink:0;cursor:grab">' +
       '<img src="'+img.data+'" draggable="false" style="width:88px;height:88px;object-fit:cover;border-radius:10px;border:2px solid '+(i===0?'var(--pink)':'var(--line)')+';pointer-events:none">' +
       (i===0?'<div style="position:absolute;bottom:0;left:0;right:0;background:var(--pink);color:#fff;font-size:9px;font-weight:700;text-align:center;border-radius:0 0 8px 8px;padding:2px">MAIN</div>':'') +
-      (img.original?'<div style="position:absolute;top:2px;left:2px;background:var(--pink);color:#fff;font-size:8px;font-weight:700;padding:1px 5px;border-radius:4px;z-index:2">CROP</div>':'') +
+      (img.crop||img.original?'<div style="position:absolute;top:2px;left:2px;background:var(--pink);color:#fff;font-size:8px;font-weight:700;padding:1px 5px;border-radius:4px;z-index:2">CROP</div>':'') +
       '<button data-action="remove" data-i="'+i+'" data-remove-fn="'+removeFn+'" style="position:absolute;top:-4px;right:-4px;width:22px;height:22px;background:#333;color:#fff;border-radius:50%;font-size:12px;display:flex;align-items:center;justify-content:center;border:none;cursor:pointer;z-index:2" title="삭제"><span class="material-icons-round notranslate" translate="no" style="font-size:14px">close</span></button>' +
       '<div style="position:absolute;bottom:'+(i===0?'20px':'2px')+';right:2px;display:flex;gap:3px;z-index:2">' +
-        (img.original?'<button data-action="restore" data-i="'+i+'" data-list="'+listName+'" data-wrap="'+wrapId+'" data-counter="'+counterId+'" style="width:26px;height:26px;background:rgba(0,0,0,.7);color:#fff;border-radius:6px;display:flex;align-items:center;justify-content:center;border:none;cursor:pointer" title="원본 복원"><span class="material-icons-round" style="font-size:16px">undo</span></button>':'') +
+        (img.crop||img.original?'<button data-action="restore" data-i="'+i+'" data-list="'+listName+'" data-wrap="'+wrapId+'" data-counter="'+counterId+'" style="width:26px;height:26px;background:rgba(0,0,0,.7);color:#fff;border-radius:6px;display:flex;align-items:center;justify-content:center;border:none;cursor:pointer" title="크롭 취소"><span class="material-icons-round" style="font-size:16px">undo</span></button>':'') +
         '<button data-action="crop" data-i="'+i+'" data-list="'+listName+'" data-wrap="'+wrapId+'" data-counter="'+counterId+'" style="width:26px;height:26px;background:rgba(0,0,0,.7);color:#fff;border-radius:6px;display:flex;align-items:center;justify-content:center;border:none;cursor:pointer" title="1:1 크롭"><span class="material-icons-round" style="font-size:16px">crop</span></button>' +
         '<button data-action="download" data-i="'+i+'" data-list="'+listName+'" style="width:26px;height:26px;background:rgba(0,0,0,.7);color:#fff;border-radius:6px;display:flex;align-items:center;justify-content:center;border:none;cursor:pointer" title="다운로드"><span class="material-icons-round" style="font-size:16px">download</span></button>' +
       '</div>' +
@@ -3705,11 +3723,16 @@ function downloadImg(idx, listName) {
 // 원본 복원
 function restoreOriginal(idx, listName, wrapId, counterId) {
   var list = getImgList(listName);
-  if (!list || !list[idx] || !list[idx].original) return;
-  list[idx].data = list[idx].original;
-  delete list[idx].original;
+  if (!list || !list[idx]) return;
+  // 비파괴 크롭 좌표 제거
+  if (list[idx].crop) delete list[idx].crop;
+  // 레거시 파괴적 크롭(original 백업) 복원
+  if (list[idx].original) {
+    list[idx].data = list[idx].original;
+    delete list[idx].original;
+  }
   renderImgPreview(list, wrapId, counterId, listName);
-  toast('원본으로 복원됨','success');
+  toast('크롭 영역 해제','success');
 }
 
 // 1:1 크롭 모달
@@ -3775,18 +3798,25 @@ function closeCropModal() {
 
 function applyCrop() {
   if (!_cropperInstance || !_cropTarget) return;
-  var canvas = _cropperInstance.getCroppedCanvas({width:1080, height:1080, imageSmoothingQuality:'high'});
-  var croppedData = canvas.toDataURL('image/jpeg', 0.92);
+  // 비파괴 크롭: 좌표만 0~1로 정규화해서 저장 (원본 이미지 유지)
+  var cropData = _cropperInstance.getData(true);  // {x,y,width,height,rotate,scaleX,scaleY}
+  var imgData = _cropperInstance.getImageData();  // {naturalWidth,naturalHeight,...}
+  var natW = imgData.naturalWidth;
+  var natH = imgData.naturalHeight;
+  var rect = natW && natH ? {
+    x: Math.max(0, cropData.x / natW),
+    y: Math.max(0, cropData.y / natH),
+    w: Math.min(1, cropData.width / natW),
+    h: Math.min(1, cropData.height / natH)
+  } : null;
   var list = getImgList(_cropTarget.listName);
-  if (list) {
+  if (list && rect) {
     var item = list[_cropTarget.idx];
-    // 원본 보존 — 처음 크롭할 때만 원본 저장
-    if (!item.original) item.original = item.data;
-    item.data = croppedData;
+    item.crop = rect;  // 좌표만 저장, item.data는 그대로
     renderImgPreview(list, _cropTarget.wrapId, _cropTarget.counterId, _cropTarget.listName);
   }
   closeCropModal();
-  toast('크롭 완료 (원본 유지됨)','success');
+  toast('크롭 영역 저장 (원본 유지)','success');
 }
 
 // ── 로그인 안내 팝업 ──
@@ -4335,14 +4365,26 @@ async function openCampaign(id) {
   const isFull = camp.recruit_type === 'monitor' && (camp.applied_count||0) >= camp.slots;
   _slideIdx = 0;
 
-  // 슬라이드 이미지
-  const slideImgs = [camp.img1,camp.img2,camp.img3,camp.img4,camp.img5,camp.img6,camp.img7,camp.img8,camp.image_url]
-    .filter(Boolean).filter((v,i,a)=>a.indexOf(v)===i);
+  // 슬라이드 이미지 + 크롭 정보 매핑
+  const crops = camp.image_crops || {};
+  const rawSlides = [
+    {url: camp.img1, key: 'img1'}, {url: camp.img2, key: 'img2'},
+    {url: camp.img3, key: 'img3'}, {url: camp.img4, key: 'img4'},
+    {url: camp.img5, key: 'img5'}, {url: camp.img6, key: 'img6'},
+    {url: camp.img7, key: 'img7'}, {url: camp.img8, key: 'img8'},
+    {url: camp.image_url, key: null}
+  ].filter(s => s.url);
+  const seen = new Set();
+  const slideData = rawSlides.filter(s => seen.has(s.url) ? false : (seen.add(s.url), true));
+  const slideImgs = slideData.map(s => s.url);
 
   const slideHtml = slideImgs.length > 0 ? `
     <div id="campSlider" style="position:relative;overflow:hidden;border-radius:16px;margin-bottom:0;background:${getCampGrad(camp.category)};aspect-ratio:1/1;height:auto">
       <div id="campSlides" style="display:flex;height:100%;transition:transform .32s cubic-bezier(.4,0,.2,1)">
-        ${slideImgs.map((url,idx)=>`<div style="flex:0 0 100%;width:100%;height:100%;background:${getCampGrad(camp.category)}"><img src="${imgThumb(url,960,80)}" data-orig="${url}" ${idx===0?'':'loading="lazy"'} decoding="async" style="width:100%;height:100%;object-fit:cover;display:block" onerror="if(this.src!==this.dataset.orig){this.src=this.dataset.orig}else{this.parentElement.style.background='${getCampGrad(camp.category)}'}"></div>`).join('')}
+        ${slideData.map((s,idx)=>{
+          const crop = s.key ? crops[s.key] : null;
+          return `<div style="flex:0 0 100%;width:100%;height:100%;position:relative;overflow:hidden;background:${getCampGrad(camp.category)}">${renderCroppedImg(s.url, crop, {thumb:960, quality:80, lazy: idx>0})}</div>`;
+        }).join('')}
       </div>
       ${slideImgs.length>1?`
         <button onclick="slideMove(-1)" style="position:absolute;left:10px;top:50%;transform:translateY(-50%);width:30px;height:30px;background:rgba(255,255,255,.88);border:none;border-radius:50%;cursor:pointer;display:flex;align-items:center;justify-content:center;z-index:5;box-shadow:0 2px 6px rgba(0,0,0,.15)"><span class="material-icons-round" style="font-size:20px;color:#333">chevron_left</span></button>

--- a/index.html
+++ b/index.html
@@ -3445,7 +3445,7 @@ function previewSlideImgs() {
   if (!preview) return;
   preview.innerHTML = campImgData.map((img,i)=>`
     <div style="position:relative;width:68px;height:68px;border-radius:8px;overflow:hidden;border:2px solid ${i===0?'var(--pink)':'var(--line)'}">
-      <img src="${img.data}" style="width:100%;height:100%;object-fit:cover">
+      <img src="${img.data}" style="width:100%;height:100%;object-fit:contain;background:#f5f5f5">
       ${i===0?'<div style="position:absolute;bottom:0;left:0;right:0;background:var(--pink);color:#fff;font-size:9px;font-weight:700;text-align:center;padding:1px">MAIN</div>':''}
     </div>`).join('');
 }

--- a/index.html
+++ b/index.html
@@ -1140,14 +1140,17 @@ textarea.form-input{resize:vertical;min-height:80px}
     </div>
     <div class="container mypage-wrap" style="padding-left:0;padding-right:0">
       <div id="myApplyTabs" class="apply-tabs" style="padding:0 16px"></div>
-      <div style="display:flex;gap:8px;padding:8px 16px;align-items:center">
-        <select id="myApplyCampStatus" class="form-input" style="padding:6px 32px 6px 10px;font-size:12px;border-radius:8px;width:auto;flex:1" onchange="renderMyApplyList()">
+      <div style="display:flex;gap:8px;padding:8px 16px;align-items:center;flex-wrap:wrap">
+        <select id="myApplyCampStatus" class="form-input" style="padding:6px 32px 6px 10px;font-size:12px;border-radius:8px;width:auto;flex:1;min-width:110px" onchange="renderMyApplyList()">
           <option value="" data-i18n="appHistory.campStatus">キャンペーン状態</option>
           <option value="active" data-i18n="status.campaign.active">募集中</option>
           <option value="scheduled" data-i18n="status.campaign.scheduled">近日公開</option>
           <option value="closed" data-i18n="status.campaign.closed">締切</option>
         </select>
-        <select id="myApplySort" class="form-input" style="padding:6px 32px 6px 10px;font-size:12px;border-radius:8px;width:auto;flex:1" onchange="renderMyApplyList()">
+        <select id="myApplyChannel" class="form-input" style="padding:6px 32px 6px 10px;font-size:12px;border-radius:8px;width:auto;flex:1;min-width:100px" onchange="renderMyApplyList()">
+          <option value="" data-i18n="appHistory.allChannels">全チャンネル</option>
+        </select>
+        <select id="myApplySort" class="form-input" style="padding:6px 32px 6px 10px;font-size:12px;border-radius:8px;width:auto;flex:1;min-width:100px" onchange="renderMyApplyList()">
           <option value="newest" data-i18n="appHistory.sortNewest">新しい順</option>
           <option value="oldest" data-i18n="appHistory.sortOldest">古い順</option>
         </select>
@@ -1694,6 +1697,7 @@ window.I18N_JA = {
     emptySub: '今すぐKブランド体験団に応募してみましょう！',
     emptyBtn: 'キャンペーンを見る',
     applyDate: '応募日',
+    allChannels: '全チャンネル',
   },
 
   // 햄버거 메뉴
@@ -2094,6 +2098,7 @@ window.I18N_KO = {
     emptySub: '지금 바로 K브랜드 체험단에 응모해보세요!',
     emptyBtn: '캠페인 보기',
     applyDate: '응모일',
+    allChannels: '전체 채널',
   },
 
   menu: {
@@ -5389,6 +5394,17 @@ async function renderMyApplyList() {
     });
   }
 
+  // 채널 필터 (공용 populateMyApplyChannelOptions에서 드롭다운 채움)
+  populateMyApplyChannelOptions();
+  const channelFilter = $('myApplyChannel')?.value || '';
+  if (channelFilter) {
+    filtered = filtered.filter(a => {
+      const camp = allCampaigns.find(c=>c.id===a.campaign_id);
+      if (!camp?.channel) return false;
+      return camp.channel.split(',').map(s=>s.trim()).includes(channelFilter);
+    });
+  }
+
   // 정렬
   const sortVal = $('myApplySort')?.value || 'newest';
   filtered.sort((a,b) => sortVal === 'oldest'
@@ -5528,6 +5544,24 @@ function handleWithdraw() {
 document.addEventListener('DOMContentLoaded', updateLangToggleUI);
 window.addEventListener('langchange', updateLangToggleUI);
 
+// 응모이력: 내가 응모한 캠페인에 등장한 모든 채널을 드롭다운에 채움
+function populateMyApplyChannelOptions() {
+  const sel = $('myApplyChannel');
+  if (!sel) return;
+  const prev = sel.value;
+  // 내 응모 캠페인의 채널 집합
+  const chSet = new Set();
+  _myApps.forEach(a => {
+    const camp = allCampaigns.find(c=>c.id===a.campaign_id);
+    if (!camp?.channel) return;
+    camp.channel.split(',').map(s=>s.trim()).filter(Boolean).forEach(c => chSet.add(c));
+  });
+  const channels = Array.from(chSet).sort();
+  const head = `<option value="" data-i18n="appHistory.allChannels">${t('appHistory.allChannels')}</option>`;
+  const options = channels.map(c => `<option value="${esc(c)}">${esc(getChannelLabel(c))}</option>`).join('');
+  sel.innerHTML = head + options;
+  if (prev && channels.includes(prev)) sel.value = prev;
+}
 // Stage 6 알림 로직은 dev/js/notifications.js (햄버거 메뉴 모달)로 이전됨
 // ══════════════════════════════════════
 // NAVIGATION + INIT

--- a/index.html
+++ b/index.html
@@ -5091,6 +5091,26 @@ function navItemHtml(it) {
   </button>`;
 }
 
+// ── 배지 자동 갱신 (30초 폴링 + 탭 포커스) ──
+let _notifPollTimer = null;
+function startNotifPolling() {
+  if (_notifPollTimer) return;
+  _notifPollTimer = setInterval(() => {
+    if (currentUser && !document.hidden) refreshNotifBadge();
+  }, 30000);
+  document.addEventListener('visibilitychange', () => {
+    if (!document.hidden && currentUser) refreshNotifBadge();
+  });
+}
+// 앱 초기화 시 시작
+if (typeof window !== 'undefined') {
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', startNotifPolling);
+  } else {
+    startNotifPolling();
+  }
+}
+
 // ── 미읽음 배지 갱신 ──
 async function refreshNotifBadge() {
   const gnbBadge = $('gnbNotifBadge');

--- a/index.html
+++ b/index.html
@@ -3329,22 +3329,24 @@ function imgThumb(url, width, quality) {
   return url.replace('/storage/v1/object/public/', '/storage/v1/render/image/public/') + `?width=${w}&quality=${q}&resize=cover`;
 }
 
-// 비파괴 크롭 렌더 — 원본 이미지에서 특정 영역만 노출 (aspect 컨테이너 안)
-// crop = {x,y,w,h} 0~1 정규화. 없으면 단순 object-fit:cover
+// 비파괴 크롭 렌더 — background-image 방식 (퍼센트 해석 이슈 회피)
+// crop = {x,y,w,h} 0~1 정규화. opts: {thumb, quality, lazy, class, style}
+// **중요**: 반환 HTML은 단독 div (부모에 aspect-ratio 지정은 호출부 책임)
 function renderCroppedImg(url, crop, opts) {
   opts = opts || {};
-  const alt = opts.alt || '';
   const thumb = opts.thumb ? imgThumb(url, opts.thumb, opts.quality||80) : url;
-  const imgAttrs = `src="${esc(thumb)}" data-orig="${esc(url)}" alt="${esc(alt)}" onerror="if(this.src!==this.dataset.orig){this.src=this.dataset.orig}"`;
-  const lazy = opts.lazy ? 'loading="lazy" decoding="async"' : '';
   if (!crop || typeof crop.w !== 'number' || crop.w <= 0) {
-    return `<img ${imgAttrs} ${lazy} style="width:100%;height:100%;object-fit:cover;display:block">`;
+    // 크롭 정보 없음 — 기존 방식: img + object-fit:cover (fallback)
+    const lazy = opts.lazy ? 'loading="lazy" decoding="async"' : '';
+    return `<img src="${esc(thumb)}" data-orig="${esc(url)}" ${lazy} style="width:100%;height:100%;object-fit:cover;display:block" onerror="if(this.src!==this.dataset.orig){this.src=this.dataset.orig}">`;
   }
-  const scaleW = 100 / crop.w;
-  const scaleH = 100 / crop.h;
-  const offsetX = -crop.x * scaleW;
-  const offsetY = -crop.y * scaleH;
-  return `<img ${imgAttrs} ${lazy} style="position:absolute;left:${offsetX}%;top:${offsetY}%;width:${scaleW}%;height:${scaleH}%;max-width:none;display:block">`;
+  // 크롭 있음 — background-image로 렌더
+  const bgSizeW = (100 / crop.w).toFixed(4);
+  const bgSizeH = (100 / crop.h).toFixed(4);
+  const bgPosX = crop.w >= 1 ? 0 : (crop.x / (1 - crop.w) * 100).toFixed(4);
+  const bgPosY = crop.h >= 1 ? 0 : (crop.y / (1 - crop.h) * 100).toFixed(4);
+  const extra = opts.style || '';
+  return `<div style="width:100%;height:100%;background-image:url('${esc(thumb)}');background-size:${bgSizeW}% ${bgSizeH}%;background-position:${bgPosX}% ${bgPosY}%;background-repeat:no-repeat;${extra}"></div>`;
 }
 
 // lookup_values 캐시에서 라벨 우선 조회, 없으면 하드코딩 폴백
@@ -4025,7 +4027,7 @@ function buildCampCards(camps) {
     const dimImage = isFull || isScheduled || isClosed;
     return `<div class="camp-card" onclick="${isClickable?'openCampaign(\''+c.id+'\')':''}" style="${!isClickable?'opacity:.85;cursor:default':''}">
       <div class="camp-img" style="background:${c.image_url?'#f0f0f0':bgGrad};position:relative">
-        ${c.image_url?`<img src="${imgThumb(c.image_url,480)}" data-orig="${c.image_url}" loading="lazy" decoding="async" style="width:100%;height:100%;object-fit:cover;position:absolute;inset:0;${dimImage?'filter:brightness(.5)':''}" onerror="if(this.src!==this.dataset.orig){this.src=this.dataset.orig}else{this.style.display='none'}">`:''}
+        ${c.image_url?`<div style="position:absolute;inset:0;${dimImage?'filter:brightness(.5)':''}">${renderCroppedImg(c.image_url, (c.image_crops||{}).img1, {thumb:480, lazy:true})}</div>`:''}
         <div class="camp-img-overlay"></div>
         ${isScheduled?`<div style="position:absolute;inset:0;display:flex;align-items:center;justify-content:center;z-index:4"><span style="background:rgba(200,120,163,.9);color:#fff;font-size:12px;font-weight:700;padding:7px 18px;border-radius:20px;letter-spacing:.04em">${t('detail.scheduledOverlay')}</span></div>`:''}
         ${isClosed?`<div style="position:absolute;inset:0;display:flex;align-items:center;justify-content:center;z-index:4"><span style="background:rgba(0,0,0,.7);color:#fff;font-size:12px;font-weight:700;padding:7px 18px;border-radius:20px;letter-spacing:.04em">${t('detail.closedOverlay')}</span></div>`:''}

--- a/supabase/migrations/041_add_image_crops.sql
+++ b/supabase/migrations/041_add_image_crops.sql
@@ -1,0 +1,15 @@
+-- ============================================================
+-- migration: 041_add_image_crops
+-- purpose  : 캠페인 이미지 크롭 정보를 좌표만 저장 (비파괴)
+--            원본 이미지는 그대로 Supabase Storage에 유지
+--            image_crops = {img1: {x,y,w,h}, img2: {x,y,w,h}, ...}
+--            x/y/w/h 는 원본 대비 0~1 정규화 값
+--
+-- rollback:
+--   ALTER TABLE campaigns DROP COLUMN image_crops;
+-- ============================================================
+
+ALTER TABLE campaigns ADD COLUMN IF NOT EXISTS image_crops jsonb NOT NULL DEFAULT '{}'::jsonb;
+
+COMMENT ON COLUMN campaigns.image_crops IS
+  '이미지별 크롭 영역(0~1 정규화). 예: {"img1": {"x":0.1,"y":0,"w":0.8,"h":1}}. 비파괴 — 원본 이미지는 유지.';


### PR DESCRIPTION
## Summary
- 이미지 크롭 기능 제거 → object-fit:contain 일관 적용 (모든 렌더: 캠페인 카드/상세/썸네일/미리보기/관리자 폼)
- imgThumb: resize=cover → resize=contain (원본 비율 깨짐 수정)
- 드래그앤드롭 업로드 시 editCampImgChanged 플래그 세팅 (저장 누락 수정)
- 이미지 순서 변경 시 editCampImgChanged 플래그 세팅 (저장 누락 수정)
- 캠페인 상세 참여방법 locale 대응
- 응모이력 채널 필터 추가
- 응모이력 상태 배지 i18n
- 마이페이지 서브제목 i18n
- 햄버거 메뉴: 언어 토글 헤더 이전, 마이페이지 서브메뉴 항상 노출, 관리자 버튼 패널 헤더로, 구분선
- 비로그인 하단 CTA
- 결과물 알림 30초 폴링 + 탭 포커스 갱신

## ⚠️ Production DB
migration 041 (image_crops) 적용 필요 (아직이라면):
```sql
ALTER TABLE campaigns ADD COLUMN IF NOT EXISTS image_crops jsonb NOT NULL DEFAULT '{}'::jsonb;
```
(컬럼 존재해도 현재 코드는 읽지 않음 — 롤백 안전성 목적)

## Test plan
- [ ] 운영 DB에 041 적용
- [ ] 캠페인 이미지 드래그앤드롭 업로드 → 저장 → 재조회 시 반영
- [ ] 이미지 순서 변경 → 저장 → 반영
- [ ] 정사각형/풍경 이미지 모두 비율 유지 렌더

🤖 Generated with [Claude Code](https://claude.com/claude-code)