### PR TITLE
fix(sales): auto-prepend https:// on product URL input

### DIFF
--- a/sales/reviewer.html
+++ b/sales/reviewer.html
@@ -1217,7 +1217,7 @@ body {
         </div>
         <div class="field">
           <label><span class="ko-only">Qoo10 상품 URL</span><span class="ja-only">Qoo10商品URL</span><span class="req">*</span></label>
-          <input type="url" class="p-url" placeholder="https://www.qoo10.jp/g/..." required>
+          <input type="url" class="p-url" placeholder="www.qoo10.jp/g/..." required>
         </div>
         <div class="field">
           <label><span class="ko-only">엔화 가격</span><span class="ja-only">JPY価格</span><span class="req">*</span></label>
@@ -1740,7 +1740,7 @@ function addProduct() {
       </div>
       <div class="field">
         <label><span class="ko-only">Qoo10 상품 URL</span><span class="ja-only">Qoo10商品URL</span><span class="req">*</span></label>
-        <input type="url" class="p-url" placeholder="https://www.qoo10.jp/g/..." required>
+        <input type="url" class="p-url" placeholder="www.qoo10.jp/g/..." required>
       </div>
       <div class="field">
         <label><span class="ko-only">엔화 가격</span><span class="ja-only">JPY価格</span><span class="req">*</span></label>
@@ -1830,6 +1830,16 @@ document.addEventListener('wheel', function() {
   const el = document.activeElement;
   if (el && el.tagName === 'INPUT' && el.type === 'number') el.blur();
 }, { passive: true });
+
+// .p-url 입력에 스킴이 없으면 포커스 아웃 시 https:// 자동 보정 (동적 추가 필드까지 커버)
+document.addEventListener('focusout', function(e) {
+  const el = e.target;
+  if (!el || !el.classList || !el.classList.contains('p-url')) return;
+  const v = (el.value || '').trim();
+  if (v && !/^https?:\/\//i.test(v)) {
+    el.value = 'https://' + v;
+  }
+});
 </script>
 
 </body>

--- a/sales/seeding.html
+++ b/sales/seeding.html
@@ -1074,7 +1074,7 @@ body {
         </div>
         <div class="field">
           <label><span class="ko-only">상품 URL</span><span class="ja-only">商品URL</span><span class="req">*</span></label>
-          <input type="url" class="p-url" placeholder="https://..." required>
+          <input type="url" class="p-url" placeholder="www.brand.com/product/..." required>
         </div>
         <div class="field">
           <label><span class="ko-only">엔화 가격 (참고용)</span><span class="ja-only">JPY価格 (参考)</span><span class="req">*</span></label>
@@ -1520,7 +1520,7 @@ function addProduct() {
       </div>
       <div class="field">
         <label><span class="ko-only">상품 URL</span><span class="ja-only">商品URL</span><span class="req">*</span></label>
-        <input type="url" class="p-url" placeholder="https://..." required>
+        <input type="url" class="p-url" placeholder="www.brand.com/product/..." required>
       </div>
       <div class="field">
         <label><span class="ko-only">엔화 가격 (참고용)</span><span class="ja-only">JPY価格 (参考)</span><span class="req">*</span></label>
@@ -1587,6 +1587,16 @@ document.addEventListener('wheel', function() {
   const el = document.activeElement;
   if (el && el.tagName === 'INPUT' && el.type === 'number') el.blur();
 }, { passive: true });
+
+// .p-url 입력에 스킴이 없으면 포커스 아웃 시 https:// 자동 보정 (동적 추가 필드까지 커버)
+document.addEventListener('focusout', function(e) {
+  const el = e.target;
+  if (!el || !el.classList || !el.classList.contains('p-url')) return;
+  const v = (el.value || '').trim();
+  if (v && !/^https?:\/\//i.test(v)) {
+    el.value = 'https://' + v;
+  }
+});
 </script>
 
 </body>


### PR DESCRIPTION
## Summary
- `.p-url` 입력 필드에 blur(focusout) 시 스킴이 없으면 `https://` 자동 prepend
- placeholder를 `https://` 없는 형태로 변경 (`www.qoo10.jp/g/...`, `www.brand.com/product/...`)
- reviewer/seeding 양쪽 폼, 정적/동적 카드 모두 커버

## Why
사용자가 직접 타이핑할 때 `https://` 를 빼먹는 경우가 많아 `<input type="url">` 기본 검증에 걸려 다음 단계로 진행 불가. UX 개선으로 해결.

## Test plan
- [x] 개발(Vercel preview)에서 `www.qoo10.jp/g/abc` 입력 → Tab → 자동으로 `https://` prepend 확인
- [x] 이미 `https://` 로 시작하는 값은 중복 prepend 없음
- [x] 빈 값일 때 `https://` 단독 prepend 없음
- [x] 제품 추가 버튼으로 동적 생성된 카드도 동일 동작
- [x] reverb-reviewer GO

🤖 Generated with [Claude Code](https://claude.com/claude-code)