### PR TITLE
feat(admin): multi-select campaign filter + UX polish

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -1276,16 +1276,16 @@ textarea.form-input{resize:vertical;min-height:80px}
             </div>
             <div style="display:flex;align-items:flex-end;gap:12px;flex-wrap:wrap">
               <div class="admin-filter-group">
+                <label>캠페인</label>
+                <div id="appCampMulti" class="mf-wrap" style="max-width:260px"><button type="button" class="mf-btn" style="max-width:260px;overflow:hidden;text-overflow:ellipsis">전체 캠페인</button><div class="mf-drop" style="min-width:320px;max-width:420px"></div></div>
+              </div>
+              <div class="admin-filter-group">
                 <label>캠페인 타입</label>
                 <div id="appTypeMulti" class="mf-wrap"><button type="button" class="mf-btn">전체 타입</button><div class="mf-drop"></div></div>
               </div>
               <div class="admin-filter-group">
                 <label>신청 상태</label>
                 <div id="appStatusMulti" class="mf-wrap"><button type="button" class="mf-btn">전체 상태</button><div class="mf-drop"></div></div>
-              </div>
-              <div class="admin-filter-group">
-                <label>캠페인</label>
-                <div id="appCampMulti" class="mf-wrap" style="max-width:260px"><button type="button" class="mf-btn" style="max-width:260px;overflow:hidden;text-overflow:ellipsis">전체 캠페인</button><div class="mf-drop" style="min-width:320px;max-width:420px"></div></div>
               </div>
               <div class="admin-filter-group" style="justify-content:flex-end">
                 <label>&nbsp;</label>
@@ -1325,18 +1325,18 @@ textarea.form-input{resize:vertical;min-height:80px}
             </div>
             <div style="display:flex;align-items:flex-end;gap:12px;flex-wrap:wrap">
               <div class="admin-filter-group">
+                <label>캠페인</label>
+                <select id="delivCampFilter" class="admin-filter" onchange="highlightFilter(this);renderDeliverablesList()" style="max-width:240px">
+                  <option value="all">전체 캠페인</option>
+                </select>
+              </div>
+              <div class="admin-filter-group">
                 <label>결과물 타입</label>
                 <div id="delivKindMulti" class="mf-wrap"><button type="button" class="mf-btn">전체 타입</button><div class="mf-drop"></div></div>
               </div>
               <div class="admin-filter-group">
                 <label>검수 상태</label>
                 <div id="delivStatusMulti" class="mf-wrap"><button type="button" class="mf-btn">전체 상태</button><div class="mf-drop"></div></div>
-              </div>
-              <div class="admin-filter-group">
-                <label>캠페인</label>
-                <select id="delivCampFilter" class="admin-filter" onchange="highlightFilter(this);renderDeliverablesList()" style="max-width:240px">
-                  <option value="all">전체 캠페인</option>
-                </select>
               </div>
               <div class="admin-filter-group" style="justify-content:flex-end">
                 <label>&nbsp;</label>

--- a/admin/index.html
+++ b/admin/index.html
@@ -1285,9 +1285,7 @@ textarea.form-input{resize:vertical;min-height:80px}
               </div>
               <div class="admin-filter-group">
                 <label>캠페인</label>
-                <select id="appCampFilter" class="admin-filter" onchange="highlightFilter(this);renderAppCampList()" style="max-width:240px">
-                  <option value="all">전체 캠페인</option>
-                </select>
+                <div id="appCampMulti" class="mf-wrap" style="max-width:260px"><button type="button" class="mf-btn" style="max-width:260px;overflow:hidden;text-overflow:ellipsis">전체 캠페인</button><div class="mf-drop" style="min-width:320px;max-width:420px"></div></div>
               </div>
               <div class="admin-filter-group" style="justify-content:flex-end">
                 <label>&nbsp;</label>
@@ -4326,10 +4324,44 @@ function resetCampFilters() {
 function resetAppFilters() {
   resetMultiFilter('appTypeMulti', '전체 타입');
   resetMultiFilter('appStatusMulti', '전체 상태');
-  const cf = $('appCampFilter');
-  if (cf) { cf.value = 'all'; if (typeof highlightFilter === 'function') highlightFilter(cf); }
+  resetMultiFilter('appCampMulti', '전체 캠페인');
   const s = $('appSearch'); if (s) s.value = '';
   renderAppCampList();
+}
+
+// 캠페인 다중 선택 드롭다운 — 캠페인 목록 변화 시에만 재생성, 선택 상태 보존
+function syncAppCampMulti(sortedCamps) {
+  const wrap = $('appCampMulti');
+  if (!wrap) return;
+  const drop = wrap.querySelector('.mf-drop');
+  if (!drop) return;
+  const newKey = sortedCamps.map(c => c.id).join('|');
+  if (wrap.dataset.optKey === newKey && drop.children.length > 0) return;
+  const prev = getMultiFilterValues('appCampMulti');
+  const options = sortedCamps.map(c => ({
+    value: c.id,
+    label: (c.campaign_no ? `[${c.campaign_no}] ` : '') + (c.title || '(제목 없음)')
+  }));
+  createMultiFilter('appCampMulti', '전체 캠페인', options, () => renderAppCampList());
+  wrap.dataset.optKey = newKey;
+  if (prev.length > 0) {
+    const allCb = drop.querySelector('input[value="all"]');
+    let restored = 0;
+    prev.forEach(v => {
+      const cb = drop.querySelector(`input[value="${CSS && CSS.escape ? CSS.escape(v) : v.replace(/"/g,'\\"')}"]`);
+      if (cb) { cb.checked = true; restored++; }
+    });
+    if (restored > 0 && allCb) {
+      allCb.checked = false;
+      const btn = wrap.querySelector('.mf-btn');
+      const itemCbs = [...drop.querySelectorAll('input:not([value="all"])')];
+      const selected = itemCbs.filter(c => c.checked);
+      if (btn) {
+        btn.textContent = selected.map(c => c.parentElement.textContent.trim()).join(', ');
+        btn.classList.add('has-selection');
+      }
+    }
+  }
 }
 
 // ── 다중 선택 드롭다운 필터 ──
@@ -5881,19 +5913,9 @@ async function renderAppCampList() {
   let apps = allAppsRaw.slice();
   const users = _appListCache.users;
 
-  // 캠페인 드롭다운 옵션 동기화 (최근 생성순)
-  const campFilterEl = $('appCampFilter');
-  if (campFilterEl) {
-    const prev = campFilterEl.value || 'all';
-    const sorted = camps.slice().sort((a,b) => new Date(b.created_at) - new Date(a.created_at));
-    const hasPrev = prev === 'all' || sorted.some(c => c.id === prev);
-    campFilterEl.innerHTML = '<option value="all">전체 캠페인</option>' + sorted.map(c => {
-      const label = (c.campaign_no ? `[${c.campaign_no}] ` : '') + (c.title || '(제목 없음)');
-      return `<option value="${esc(c.id)}">${esc(label)}</option>`;
-    }).join('');
-    campFilterEl.value = hasPrev ? prev : 'all';
-    if (typeof highlightFilter === 'function') highlightFilter(campFilterEl);
-  }
+  // 캠페인 다중 선택 드롭다운 동기화 (최근 생성순)
+  const sortedCampsForFilter = camps.slice().sort((a,b) => new Date(b.created_at) - new Date(a.created_at));
+  syncAppCampMulti(sortedCampsForFilter);
 
   // 타입 필터 (다중 선택)
   const appTypeVals = getMultiFilterValues('appTypeMulti');
@@ -5906,9 +5928,9 @@ async function renderAppCampList() {
   const appStatusVals = getMultiFilterValues('appStatusMulti');
   if (appStatusVals.length) apps = apps.filter(a => appStatusVals.includes(a.status));
 
-  // 캠페인 단일 선택 필터
-  const campFilterVal = campFilterEl?.value || 'all';
-  if (campFilterVal && campFilterVal !== 'all') apps = apps.filter(a => a.campaign_id === campFilterVal);
+  // 캠페인 다중 선택 필터
+  const campFilterVals = getMultiFilterValues('appCampMulti');
+  if (campFilterVals.length) apps = apps.filter(a => campFilterVals.includes(a.campaign_id));
 
   // 검색 필터
   const searchVal = ($('appSearch')?.value || '').trim().toLowerCase();
@@ -5923,10 +5945,7 @@ async function renderAppCampList() {
     });
   }
 
-  updateFilterResetBtn('btnAppFilterReset', ['appTypeMulti','appStatusMulti'], 'appSearch');
-  // 캠페인 단일 선택 필터도 활성 조건에 포함
-  const resetBtn = $('btnAppFilterReset');
-  if (resetBtn && campFilterVal && campFilterVal !== 'all') resetBtn.style.display = '';
+  updateFilterResetBtn('btnAppFilterReset', ['appTypeMulti','appStatusMulti','appCampMulti'], 'appSearch');
 
   const appDir = appSortDir === 'asc' ? 1 : -1;
   if (appSortKey === 'status') {

--- a/admin/index.html
+++ b/admin/index.html
@@ -1326,9 +1326,7 @@ textarea.form-input{resize:vertical;min-height:80px}
             <div style="display:flex;align-items:flex-end;gap:12px;flex-wrap:wrap">
               <div class="admin-filter-group">
                 <label>캠페인</label>
-                <select id="delivCampFilter" class="admin-filter" onchange="highlightFilter(this);renderDeliverablesList()" style="max-width:240px">
-                  <option value="all">전체 캠페인</option>
-                </select>
+                <div id="delivCampMulti" class="mf-wrap" style="max-width:260px"><button type="button" class="mf-btn" style="max-width:260px;overflow:hidden;text-overflow:ellipsis">전체 캠페인</button><div class="mf-drop" style="min-width:320px;max-width:420px"></div></div>
               </div>
               <div class="admin-filter-group">
                 <label>결과물 타입</label>
@@ -4329,20 +4327,20 @@ function resetAppFilters() {
   renderAppCampList();
 }
 
-// 캠페인 다중 선택 드롭다운 — 캠페인 목록 변화 시에만 재생성, 선택 상태 보존
-function syncAppCampMulti(sortedCamps) {
-  const wrap = $('appCampMulti');
+// 캠페인 다중 선택 드롭다운 공통 헬퍼 — 옵션 리스트 변화 시에만 재생성, 이전 선택 상태 보존
+function syncCampMultiFilter(containerId, sortedCamps, onChange) {
+  const wrap = $(containerId);
   if (!wrap) return;
   const drop = wrap.querySelector('.mf-drop');
   if (!drop) return;
   const newKey = sortedCamps.map(c => c.id).join('|');
   if (wrap.dataset.optKey === newKey && drop.children.length > 0) return;
-  const prev = getMultiFilterValues('appCampMulti');
+  const prev = getMultiFilterValues(containerId);
   const options = sortedCamps.map(c => ({
     value: c.id,
     label: (c.campaign_no ? `[${c.campaign_no}] ` : '') + (c.title || '(제목 없음)')
   }));
-  createMultiFilter('appCampMulti', '전체 캠페인', options, () => renderAppCampList());
+  createMultiFilter(containerId, '전체 캠페인', options, onChange);
   wrap.dataset.optKey = newKey;
   if (prev.length > 0) {
     const allCb = drop.querySelector('input[value="all"]');
@@ -5915,7 +5913,7 @@ async function renderAppCampList() {
 
   // 캠페인 다중 선택 드롭다운 동기화 (최근 생성순)
   const sortedCampsForFilter = camps.slice().sort((a,b) => new Date(b.created_at) - new Date(a.created_at));
-  syncAppCampMulti(sortedCampsForFilter);
+  syncCampMultiFilter('appCampMulti', sortedCampsForFilter, () => renderAppCampList());
 
   // 타입 필터 (다중 선택)
   const appTypeVals = getMultiFilterValues('appTypeMulti');
@@ -7319,7 +7317,7 @@ function toggleDelivSort(col) {
 function resetDelivFiltersAndSort() {
   resetMultiFilter('delivKindMulti', '전체 타입');
   resetMultiFilter('delivStatusMulti', '전체 상태');
-  const c = $('delivCampFilter'); if (c) { c.value = 'all'; highlightFilter(c); }
+  resetMultiFilter('delivCampMulti', '전체 캠페인');
   const q = $('delivSearch'); if (q) q.value = '';
   _delivSort = {col: null, dir: null};
   renderDeliverablesList();
@@ -7339,17 +7337,6 @@ function applyDelivSortIndicators() {
 }
 
 async function loadDeliverables() {
-  // 캠페인 드롭다운 채우기 (첫 로드만)
-  const sel = $('delivCampFilter');
-  if (sel && sel.options.length <= 1) {
-    const camps = await fetchCampaigns().catch(() => []);
-    camps.forEach(c => {
-      const opt = document.createElement('option');
-      opt.value = c.id;
-      opt.textContent = c.title;
-      sel.appendChild(opt);
-    });
-  }
   await renderDeliverablesList();
 }
 
@@ -7360,11 +7347,16 @@ async function renderDeliverablesList() {
   const tbody = $('delivTableBody');
   if (!tbody) return;
   tbody.innerHTML = '<tr><td colspan="7" style="text-align:center;color:var(--muted);padding:24px"><span class="spinner" style="width:20px;height:20px;border-width:2px;border-color:rgba(200,120,163,.2);border-top-color:var(--pink)"></span></td></tr>';
+  // 캠페인 드롭다운 옵션 동기화 (최근 생성순)
+  const campsForFilter = await fetchCampaigns().catch(() => []);
+  const sortedCampsForFilter = campsForFilter.slice().sort((a,b) => new Date(b.created_at) - new Date(a.created_at));
+  syncCampMultiFilter('delivCampMulti', sortedCampsForFilter, () => renderDeliverablesList());
   const delivStatusVals = getMultiFilterValues('delivStatusMulti');
   const delivKindVals = getMultiFilterValues('delivKindMulti');
+  const delivCampVals = getMultiFilterValues('delivCampMulti');
   const status = delivStatusVals.length === 1 ? delivStatusVals[0] : 'all';
   const kind = delivKindVals.length === 1 ? delivKindVals[0] : 'all';
-  const campId = $('delivCampFilter')?.value || 'all';
+  const campId = delivCampVals.length === 1 ? delivCampVals[0] : 'all';
   const search = ($('delivSearch')?.value || '').trim().toLowerCase();
   const rows = await fetchDeliverables({status, kind, campaign_id: campId});
   _delivCache = rows;
@@ -7372,6 +7364,7 @@ async function renderDeliverablesList() {
   let filtered = rows.slice();
   if (delivStatusVals.length > 1) filtered = filtered.filter(r => delivStatusVals.includes(r.status));
   if (delivKindVals.length > 1) filtered = filtered.filter(r => delivKindVals.includes(r.kind));
+  if (delivCampVals.length > 1) filtered = filtered.filter(r => delivCampVals.includes(r.campaign_id));
   if (search) filtered = filtered.filter(r => {
     const n = (r.influencers?.name || '') + ' ' + (r.influencers?.name_kana || '') + ' ' + (r.influencers?.email || '');
     const camp = r.campaigns || {};
@@ -7380,7 +7373,7 @@ async function renderDeliverablesList() {
       || (camp.brand || '').toLowerCase().includes(search)
       || (camp.campaign_no || '').toLowerCase().includes(search);
   });
-  updateFilterResetBtn('btnDelivFilterReset', ['delivKindMulti','delivStatusMulti'], 'delivSearch');
+  updateFilterResetBtn('btnDelivFilterReset', ['delivKindMulti','delivStatusMulti','delivCampMulti'], 'delivSearch');
   // 수동 정렬 적용 (설정돼 있으면 fetchDeliverables의 order()를 덮어씀)
   if (_delivSort.col) {
     const dir = _delivSort.dir === 'desc' ? -1 : 1;

--- a/admin/index.html
+++ b/admin/index.html
@@ -4588,7 +4588,7 @@ async function loadAdminCampaigns(useCache) {
               ${c.campaign_no ? `<span style="font-family:monospace;font-size:10px;font-weight:600;color:var(--muted);letter-spacing:0.02em">${esc(c.campaign_no)}</span>` : ''}
             </div>
             <strong style="cursor:pointer;color:var(--ink)" onclick="openCampPreviewModal('${c.id}')">${esc(c.title)}</strong>
-            <div style="font-size:11px;color:var(--muted);margin-top:2px">${esc(c.brand)}${c.campaign_no ? ` · <span style="font-family:monospace;font-size:10px;letter-spacing:0.02em">${esc(c.campaign_no)}</span>` : ''}</div>
+            <div style="font-size:11px;color:var(--muted);margin-top:2px">${esc(c.brand)}</div>
             ${c.post_deadline ? `<div style="font-size:10px;color:var(--muted);margin-top:1px">게시: ~${formatDate(c.post_deadline)} ${dDayLabel(c.post_deadline)}</div>` : ''}
           </div>
         </div>

--- a/dev/admin/index.html
+++ b/dev/admin/index.html
@@ -821,9 +821,7 @@
             <div style="display:flex;align-items:flex-end;gap:12px;flex-wrap:wrap">
               <div class="admin-filter-group">
                 <label>캠페인</label>
-                <select id="delivCampFilter" class="admin-filter" onchange="highlightFilter(this);renderDeliverablesList()" style="max-width:240px">
-                  <option value="all">전체 캠페인</option>
-                </select>
+                <div id="delivCampMulti" class="mf-wrap" style="max-width:260px"><button type="button" class="mf-btn" style="max-width:260px;overflow:hidden;text-overflow:ellipsis">전체 캠페인</button><div class="mf-drop" style="min-width:320px;max-width:420px"></div></div>
               </div>
               <div class="admin-filter-group">
                 <label>결과물 타입</label>

--- a/dev/admin/index.html
+++ b/dev/admin/index.html
@@ -780,9 +780,7 @@
               </div>
               <div class="admin-filter-group">
                 <label>캠페인</label>
-                <select id="appCampFilter" class="admin-filter" onchange="highlightFilter(this);renderAppCampList()" style="max-width:240px">
-                  <option value="all">전체 캠페인</option>
-                </select>
+                <div id="appCampMulti" class="mf-wrap" style="max-width:260px"><button type="button" class="mf-btn" style="max-width:260px;overflow:hidden;text-overflow:ellipsis">전체 캠페인</button><div class="mf-drop" style="min-width:320px;max-width:420px"></div></div>
               </div>
               <div class="admin-filter-group" style="justify-content:flex-end">
                 <label>&nbsp;</label>

--- a/dev/admin/index.html
+++ b/dev/admin/index.html
@@ -771,16 +771,16 @@
             </div>
             <div style="display:flex;align-items:flex-end;gap:12px;flex-wrap:wrap">
               <div class="admin-filter-group">
+                <label>캠페인</label>
+                <div id="appCampMulti" class="mf-wrap" style="max-width:260px"><button type="button" class="mf-btn" style="max-width:260px;overflow:hidden;text-overflow:ellipsis">전체 캠페인</button><div class="mf-drop" style="min-width:320px;max-width:420px"></div></div>
+              </div>
+              <div class="admin-filter-group">
                 <label>캠페인 타입</label>
                 <div id="appTypeMulti" class="mf-wrap"><button type="button" class="mf-btn">전체 타입</button><div class="mf-drop"></div></div>
               </div>
               <div class="admin-filter-group">
                 <label>신청 상태</label>
                 <div id="appStatusMulti" class="mf-wrap"><button type="button" class="mf-btn">전체 상태</button><div class="mf-drop"></div></div>
-              </div>
-              <div class="admin-filter-group">
-                <label>캠페인</label>
-                <div id="appCampMulti" class="mf-wrap" style="max-width:260px"><button type="button" class="mf-btn" style="max-width:260px;overflow:hidden;text-overflow:ellipsis">전체 캠페인</button><div class="mf-drop" style="min-width:320px;max-width:420px"></div></div>
               </div>
               <div class="admin-filter-group" style="justify-content:flex-end">
                 <label>&nbsp;</label>
@@ -820,18 +820,18 @@
             </div>
             <div style="display:flex;align-items:flex-end;gap:12px;flex-wrap:wrap">
               <div class="admin-filter-group">
+                <label>캠페인</label>
+                <select id="delivCampFilter" class="admin-filter" onchange="highlightFilter(this);renderDeliverablesList()" style="max-width:240px">
+                  <option value="all">전체 캠페인</option>
+                </select>
+              </div>
+              <div class="admin-filter-group">
                 <label>결과물 타입</label>
                 <div id="delivKindMulti" class="mf-wrap"><button type="button" class="mf-btn">전체 타입</button><div class="mf-drop"></div></div>
               </div>
               <div class="admin-filter-group">
                 <label>검수 상태</label>
                 <div id="delivStatusMulti" class="mf-wrap"><button type="button" class="mf-btn">전체 상태</button><div class="mf-drop"></div></div>
-              </div>
-              <div class="admin-filter-group">
-                <label>캠페인</label>
-                <select id="delivCampFilter" class="admin-filter" onchange="highlightFilter(this);renderDeliverablesList()" style="max-width:240px">
-                  <option value="all">전체 캠페인</option>
-                </select>
               </div>
               <div class="admin-filter-group" style="justify-content:flex-end">
                 <label>&nbsp;</label>

--- a/dev/js/admin.js
+++ b/dev/js/admin.js
@@ -401,20 +401,20 @@ function resetAppFilters() {
   renderAppCampList();
 }
 
-// 캠페인 다중 선택 드롭다운 — 캠페인 목록 변화 시에만 재생성, 선택 상태 보존
-function syncAppCampMulti(sortedCamps) {
-  const wrap = $('appCampMulti');
+// 캠페인 다중 선택 드롭다운 공통 헬퍼 — 옵션 리스트 변화 시에만 재생성, 이전 선택 상태 보존
+function syncCampMultiFilter(containerId, sortedCamps, onChange) {
+  const wrap = $(containerId);
   if (!wrap) return;
   const drop = wrap.querySelector('.mf-drop');
   if (!drop) return;
   const newKey = sortedCamps.map(c => c.id).join('|');
   if (wrap.dataset.optKey === newKey && drop.children.length > 0) return;
-  const prev = getMultiFilterValues('appCampMulti');
+  const prev = getMultiFilterValues(containerId);
   const options = sortedCamps.map(c => ({
     value: c.id,
     label: (c.campaign_no ? `[${c.campaign_no}] ` : '') + (c.title || '(제목 없음)')
   }));
-  createMultiFilter('appCampMulti', '전체 캠페인', options, () => renderAppCampList());
+  createMultiFilter(containerId, '전체 캠페인', options, onChange);
   wrap.dataset.optKey = newKey;
   if (prev.length > 0) {
     const allCb = drop.querySelector('input[value="all"]');
@@ -1987,7 +1987,7 @@ async function renderAppCampList() {
 
   // 캠페인 다중 선택 드롭다운 동기화 (최근 생성순)
   const sortedCampsForFilter = camps.slice().sort((a,b) => new Date(b.created_at) - new Date(a.created_at));
-  syncAppCampMulti(sortedCampsForFilter);
+  syncCampMultiFilter('appCampMulti', sortedCampsForFilter, () => renderAppCampList());
 
   // 타입 필터 (다중 선택)
   const appTypeVals = getMultiFilterValues('appTypeMulti');
@@ -3391,7 +3391,7 @@ function toggleDelivSort(col) {
 function resetDelivFiltersAndSort() {
   resetMultiFilter('delivKindMulti', '전체 타입');
   resetMultiFilter('delivStatusMulti', '전체 상태');
-  const c = $('delivCampFilter'); if (c) { c.value = 'all'; highlightFilter(c); }
+  resetMultiFilter('delivCampMulti', '전체 캠페인');
   const q = $('delivSearch'); if (q) q.value = '';
   _delivSort = {col: null, dir: null};
   renderDeliverablesList();
@@ -3411,17 +3411,6 @@ function applyDelivSortIndicators() {
 }
 
 async function loadDeliverables() {
-  // 캠페인 드롭다운 채우기 (첫 로드만)
-  const sel = $('delivCampFilter');
-  if (sel && sel.options.length <= 1) {
-    const camps = await fetchCampaigns().catch(() => []);
-    camps.forEach(c => {
-      const opt = document.createElement('option');
-      opt.value = c.id;
-      opt.textContent = c.title;
-      sel.appendChild(opt);
-    });
-  }
   await renderDeliverablesList();
 }
 
@@ -3432,11 +3421,16 @@ async function renderDeliverablesList() {
   const tbody = $('delivTableBody');
   if (!tbody) return;
   tbody.innerHTML = '<tr><td colspan="7" style="text-align:center;color:var(--muted);padding:24px"><span class="spinner" style="width:20px;height:20px;border-width:2px;border-color:rgba(200,120,163,.2);border-top-color:var(--pink)"></span></td></tr>';
+  // 캠페인 드롭다운 옵션 동기화 (최근 생성순)
+  const campsForFilter = await fetchCampaigns().catch(() => []);
+  const sortedCampsForFilter = campsForFilter.slice().sort((a,b) => new Date(b.created_at) - new Date(a.created_at));
+  syncCampMultiFilter('delivCampMulti', sortedCampsForFilter, () => renderDeliverablesList());
   const delivStatusVals = getMultiFilterValues('delivStatusMulti');
   const delivKindVals = getMultiFilterValues('delivKindMulti');
+  const delivCampVals = getMultiFilterValues('delivCampMulti');
   const status = delivStatusVals.length === 1 ? delivStatusVals[0] : 'all';
   const kind = delivKindVals.length === 1 ? delivKindVals[0] : 'all';
-  const campId = $('delivCampFilter')?.value || 'all';
+  const campId = delivCampVals.length === 1 ? delivCampVals[0] : 'all';
   const search = ($('delivSearch')?.value || '').trim().toLowerCase();
   const rows = await fetchDeliverables({status, kind, campaign_id: campId});
   _delivCache = rows;
@@ -3444,6 +3438,7 @@ async function renderDeliverablesList() {
   let filtered = rows.slice();
   if (delivStatusVals.length > 1) filtered = filtered.filter(r => delivStatusVals.includes(r.status));
   if (delivKindVals.length > 1) filtered = filtered.filter(r => delivKindVals.includes(r.kind));
+  if (delivCampVals.length > 1) filtered = filtered.filter(r => delivCampVals.includes(r.campaign_id));
   if (search) filtered = filtered.filter(r => {
     const n = (r.influencers?.name || '') + ' ' + (r.influencers?.name_kana || '') + ' ' + (r.influencers?.email || '');
     const camp = r.campaigns || {};
@@ -3452,7 +3447,7 @@ async function renderDeliverablesList() {
       || (camp.brand || '').toLowerCase().includes(search)
       || (camp.campaign_no || '').toLowerCase().includes(search);
   });
-  updateFilterResetBtn('btnDelivFilterReset', ['delivKindMulti','delivStatusMulti'], 'delivSearch');
+  updateFilterResetBtn('btnDelivFilterReset', ['delivKindMulti','delivStatusMulti','delivCampMulti'], 'delivSearch');
   // 수동 정렬 적용 (설정돼 있으면 fetchDeliverables의 order()를 덮어씀)
   if (_delivSort.col) {
     const dir = _delivSort.dir === 'desc' ? -1 : 1;

--- a/dev/js/admin.js
+++ b/dev/js/admin.js
@@ -396,10 +396,44 @@ function resetCampFilters() {
 function resetAppFilters() {
   resetMultiFilter('appTypeMulti', '전체 타입');
   resetMultiFilter('appStatusMulti', '전체 상태');
-  const cf = $('appCampFilter');
-  if (cf) { cf.value = 'all'; if (typeof highlightFilter === 'function') highlightFilter(cf); }
+  resetMultiFilter('appCampMulti', '전체 캠페인');
   const s = $('appSearch'); if (s) s.value = '';
   renderAppCampList();
+}
+
+// 캠페인 다중 선택 드롭다운 — 캠페인 목록 변화 시에만 재생성, 선택 상태 보존
+function syncAppCampMulti(sortedCamps) {
+  const wrap = $('appCampMulti');
+  if (!wrap) return;
+  const drop = wrap.querySelector('.mf-drop');
+  if (!drop) return;
+  const newKey = sortedCamps.map(c => c.id).join('|');
+  if (wrap.dataset.optKey === newKey && drop.children.length > 0) return;
+  const prev = getMultiFilterValues('appCampMulti');
+  const options = sortedCamps.map(c => ({
+    value: c.id,
+    label: (c.campaign_no ? `[${c.campaign_no}] ` : '') + (c.title || '(제목 없음)')
+  }));
+  createMultiFilter('appCampMulti', '전체 캠페인', options, () => renderAppCampList());
+  wrap.dataset.optKey = newKey;
+  if (prev.length > 0) {
+    const allCb = drop.querySelector('input[value="all"]');
+    let restored = 0;
+    prev.forEach(v => {
+      const cb = drop.querySelector(`input[value="${CSS && CSS.escape ? CSS.escape(v) : v.replace(/"/g,'\\"')}"]`);
+      if (cb) { cb.checked = true; restored++; }
+    });
+    if (restored > 0 && allCb) {
+      allCb.checked = false;
+      const btn = wrap.querySelector('.mf-btn');
+      const itemCbs = [...drop.querySelectorAll('input:not([value="all"])')];
+      const selected = itemCbs.filter(c => c.checked);
+      if (btn) {
+        btn.textContent = selected.map(c => c.parentElement.textContent.trim()).join(', ');
+        btn.classList.add('has-selection');
+      }
+    }
+  }
 }
 
 // ── 다중 선택 드롭다운 필터 ──
@@ -1951,19 +1985,9 @@ async function renderAppCampList() {
   let apps = allAppsRaw.slice();
   const users = _appListCache.users;
 
-  // 캠페인 드롭다운 옵션 동기화 (최근 생성순)
-  const campFilterEl = $('appCampFilter');
-  if (campFilterEl) {
-    const prev = campFilterEl.value || 'all';
-    const sorted = camps.slice().sort((a,b) => new Date(b.created_at) - new Date(a.created_at));
-    const hasPrev = prev === 'all' || sorted.some(c => c.id === prev);
-    campFilterEl.innerHTML = '<option value="all">전체 캠페인</option>' + sorted.map(c => {
-      const label = (c.campaign_no ? `[${c.campaign_no}] ` : '') + (c.title || '(제목 없음)');
-      return `<option value="${esc(c.id)}">${esc(label)}</option>`;
-    }).join('');
-    campFilterEl.value = hasPrev ? prev : 'all';
-    if (typeof highlightFilter === 'function') highlightFilter(campFilterEl);
-  }
+  // 캠페인 다중 선택 드롭다운 동기화 (최근 생성순)
+  const sortedCampsForFilter = camps.slice().sort((a,b) => new Date(b.created_at) - new Date(a.created_at));
+  syncAppCampMulti(sortedCampsForFilter);
 
   // 타입 필터 (다중 선택)
   const appTypeVals = getMultiFilterValues('appTypeMulti');
@@ -1976,9 +2000,9 @@ async function renderAppCampList() {
   const appStatusVals = getMultiFilterValues('appStatusMulti');
   if (appStatusVals.length) apps = apps.filter(a => appStatusVals.includes(a.status));
 
-  // 캠페인 단일 선택 필터
-  const campFilterVal = campFilterEl?.value || 'all';
-  if (campFilterVal && campFilterVal !== 'all') apps = apps.filter(a => a.campaign_id === campFilterVal);
+  // 캠페인 다중 선택 필터
+  const campFilterVals = getMultiFilterValues('appCampMulti');
+  if (campFilterVals.length) apps = apps.filter(a => campFilterVals.includes(a.campaign_id));
 
   // 검색 필터
   const searchVal = ($('appSearch')?.value || '').trim().toLowerCase();
@@ -1993,10 +2017,7 @@ async function renderAppCampList() {
     });
   }
 
-  updateFilterResetBtn('btnAppFilterReset', ['appTypeMulti','appStatusMulti'], 'appSearch');
-  // 캠페인 단일 선택 필터도 활성 조건에 포함
-  const resetBtn = $('btnAppFilterReset');
-  if (resetBtn && campFilterVal && campFilterVal !== 'all') resetBtn.style.display = '';
+  updateFilterResetBtn('btnAppFilterReset', ['appTypeMulti','appStatusMulti','appCampMulti'], 'appSearch');
 
   const appDir = appSortDir === 'asc' ? 1 : -1;
   if (appSortKey === 'status') {

--- a/dev/js/admin.js
+++ b/dev/js/admin.js
@@ -662,7 +662,7 @@ async function loadAdminCampaigns(useCache) {
               ${c.campaign_no ? `<span style="font-family:monospace;font-size:10px;font-weight:600;color:var(--muted);letter-spacing:0.02em">${esc(c.campaign_no)}</span>` : ''}
             </div>
             <strong style="cursor:pointer;color:var(--ink)" onclick="openCampPreviewModal('${c.id}')">${esc(c.title)}</strong>
-            <div style="font-size:11px;color:var(--muted);margin-top:2px">${esc(c.brand)}${c.campaign_no ? ` · <span style="font-family:monospace;font-size:10px;letter-spacing:0.02em">${esc(c.campaign_no)}</span>` : ''}</div>
+            <div style="font-size:11px;color:var(--muted);margin-top:2px">${esc(c.brand)}</div>
             ${c.post_deadline ? `<div style="font-size:10px;color:var(--muted);margin-top:1px">게시: ~${formatDate(c.post_deadline)} ${dDayLabel(c.post_deadline)}</div>` : ''}
           </div>
         </div>


### PR DESCRIPTION
## Summary
관리자 목록 페인 필터 UX 정리 번들.

## Changes
- **신청관리**: 캠페인 필터 신규 추가 → 다중 선택 mf-wrap으로 전환
- **결과물관리**: 캠페인 단일 select → 다중 선택 mf-wrap으로 통일
- **필터 순서**: 캠페인 드롭다운을 맨 왼쪽으로 일관 배치 (신청/결과물)
- **캠페인 관리 리스트**: 브랜드명 옆 중복 CAMP-XXX 제거 (상단 라인에서 이미 표시)
- 공통 헬퍼 `syncCampMultiFilter(containerId, sortedCamps, onChange)` 추출

## Test plan
- [x] 신청관리 / 결과물관리 필터 다중 선택 동작 확인
- [x] 필터 초기화 버튼 캠페인 필터만 활성 상태에서도 노출
- [x] 캠페인 관리 목록 셀 중복 ID 사라짐
- [x] reverb-reviewer GO × 각 커밋

🤖 Generated with [Claude Code](https://claude.com/claude-code)