### PR TITLE
feat(admin): admin notices + influencer flags evidence uploads

### DIFF
--- a/.claude/commands/공지초안-관리자.md
+++ b/.claude/commands/공지초안-관리자.md
@@ -1,0 +1,88 @@
+---
+description: 최근 main 머지 / 개발 배포 / 명시 이슈 기반으로 관리자 공지사항 초안을 **마크다운 형식**으로 생성합니다.
+---
+
+# 공지초안-관리자
+
+REVERB JP 관리자 페이지의 `/admin/#admin-notices` 에 등록할 공지 초안을 **마크다운 포맷**으로 자동 작성합니다. 메인 Claude 는 이 스킬을 호출받으면 아래 절차로 진행합니다.
+
+> 📌 **이전 HTML(Quill) 버전**(`/공지초안`)은 2026-04-22 이후 `/공지초안-관리자` 로 교체됐습니다. 관리자 페이지 Quill 에디터가 Markdown 붙여넣기를 자동 변환하므로 MD 포맷이 더 편합니다.
+
+## 입력 해석
+
+사용자 인자(`$ARGUMENTS`) 패턴:
+
+1. **인자 없음** → 최근 `main` 머지 커밋을 자동 탐지
+   - `git log origin/main --merges --oneline -1` 로 마지막 merge 커밋 해시 추출
+   - `git log <merge>^..<merge>` 로 포함된 feature 커밋들의 메시지 수집
+2. **`PR <번호>`** → `gh pr view <번호> --json title,body,commits` 로 PR 정보 수집
+3. **`warning <짧은 설명>`** → 긴급 경고 템플릿으로 바로 작성
+4. **`system_update|release|warning|general <자유 설명>`** → 해당 카테고리로 작성
+
+## 카테고리 자동 분류 휴리스틱
+
+커밋 메시지/파일 경로를 보고 제안:
+
+- `system_update` — `supabase/migrations/`, `dev/js/admin.js`, `dev/admin/`, `retryWithRefresh`, RLS/RPC 키워드, 관리자 내부 도구 개선
+- `release` — `dev/index.html`, `dev/js/campaign.js`, `dev/lib/i18n/`, 인플루언서 UI/일본어 변경, 광고주 신청 폼 변경
+- `warning` — `chore: trigger redeploy`, `hotfix`, `revert`, `Brevo`, `rate limit`, 장애 키워드
+- `general` — 위에 해당 없는 경우
+
+복수 성격이면 가장 큰 카테고리 1개 선택하고 본문에 보조 변경사항 기재.
+
+## 출력 형식 (항상 이 구조로 메시지에 표시 + 파일 저장)
+
+````
+## 📣 공지 초안
+
+**카테고리**: system_update (시스템 업데이트)
+**제목**: 인플루언서 상세 모달 통합 개편
+**상단 고정**: ☐
+
+### 본문 (Markdown — Quill 에디터에 붙여넣으면 자동 변환)
+
+인플루언서 관리자 상세 화면이 모달 기반으로 재구성됐습니다.
+
+- 이름 옆 **인증/위반/블랙리스트 배지** 전역 노출
+- **상태 관리 + 관리자 이력** 한 카드로 통합
+- 위반 기록에 **증빙 파일 첨부** + 라이트박스 확대
+- 목록 필터·검색 상단 일관화
+
+**영향 범위**: 관리자 페이지 한정. 인플루언서 앱에는 영향 없음.
+
+### 근거 (생성 시 참고한 커밋)
+- 3a1655b feat(admin): influencer verify · violation · blacklist management
+- 88d6d3e feat(admin): violation evidence uploads + ESC close
+````
+
+동시에 아래 파일로도 저장:
+- `docs/admin-notices/{YYYY-MM-DD}-{category}-{slug}.md` — 위와 동일 Markdown 포맷
+
+`docs/admin-notices/` 폴더가 없으면 생성. slug 는 제목을 소문자·하이픈 변환.
+
+## 작성 원칙
+
+- **title**: 1줄, 35자 이내, 한국어. "무엇이 바뀌었나" 요약
+- **본문 Markdown 제한**: 관리자 페이지 Quill 에디터 paste 변환이 지원하는 요소만 사용
+  - 허용: 단락, 순서/비순서 목록(`-`, `1.`), **굵게**, *기울임*, `[링크](url)`, `> 인용`, 간단한 테이블, 인라인 `코드`
+  - 금지: 이미지 태그, 멀티라인 코드블록(```), `<script>`·`<iframe>`·`<style>` 같은 raw HTML, 복잡한 중첩 테이블
+- **영향 범위 명시**: "관리자 페이지 한정" / "인플루언서 앱만" / "운영서버만 배포됨" 등
+- **기술 용어 그대로** 쓰되, 관리자 실무진이 이해할 수 있게 한국어 설명 병기
+- **변경 이유** 가 명확하면 1문장 추가 (예: "2026-04-22 Brevo 한도 초과 재발 방지")
+- **긴급 경고**(`warning`)는 상단 고정 `☑` 로 표시 권장
+
+## 제한·안내
+
+- 이 커맨드는 **초안만 생성**. 실제 DB INSERT 는 사용자가 관리자 페이지에서 수동으로 수행
+- 직접 SQL 로 INSERT 하고 싶으면 사용자가 요청 시 `supabase/patches/YYYY-MM-DD_admin_notice.sql` 파일 추가 생성
+- 확인 없이 자동 등록 금지 — 운영 DB 에 영향
+- **Quill 붙여넣기 검증**: MD를 Quill에 붙여넣었을 때 깨지면 본문을 HTML `<p>/<ul>/<li>/<strong>/<em>/<a>/<br>` 로 재변환 필요 (관리자 페이지 Quill 설정에 따라 동작 차이 가능)
+
+## 작업 흐름
+
+1. 인자 해석 → 커밋/PR/키워드 수집
+2. 카테고리 자동 분류
+3. 제목·본문 Markdown 작성 (위 원칙 준수)
+4. `docs/admin-notices/` 폴더 없으면 `mkdir -p` 로 생성
+5. 파일 저장 + 메시지에 전체 표시
+6. 마지막에 "📋 관리자 페이지에 등록하려면: /admin/#admin-notices → 새 공지 작성 → 위 제목·본문(Markdown) 복사·붙여넣기. 변환이 깨지면 Quill 에서 `Cmd+Shift+V`(서식 없이 붙여넣기) 또는 HTML 버전 요청" 안내

--- a/.claude/commands/공지초안.md
+++ b/.claude/commands/공지초안.md
@@ -1,0 +1,85 @@
+---
+description: [Deprecated — /공지초안-관리자 사용] 최근 main 머지 / 개발 배포 / 명시 이슈 기반으로 관리자 공지사항 초안을 HTML(Quill) 포맷으로 생성합니다.
+---
+
+# 공지초안 (Deprecated — 2026-04-22)
+
+> 🚨 **2026-04-22부터 `/공지초안-관리자` 로 이관**. 기본 출력 포맷이 Quill HTML → Markdown 으로 바뀌었습니다.
+> 이 파일은 **HTML 포맷 백업용**으로만 유지합니다. Markdown 붙여넣기가 깨지거나 Quill HTML 이 직접 필요한 경우에만 이 커맨드를 호출하세요.
+
+REVERB JP 관리자 페이지의 `/admin/#admin-notices` 에 등록할 공지 초안을 자동 작성합니다. 메인 Claude 는 이 스킬을 호출받으면 아래 절차로 진행합니다.
+
+## 입력 해석
+
+사용자 인자(`$ARGUMENTS`) 패턴:
+
+1. **인자 없음** → 최근 `main` 머지 커밋을 자동 탐지
+   - `git log origin/main --merges --oneline -1` 로 마지막 merge 커밋 해시 추출
+   - `git log <merge>^..<merge>` 로 포함된 feature 커밋들의 메시지 수집
+2. **`PR <번호>`** → `gh pr view <번호> --json title,body,commits` 로 PR 정보 수집
+3. **`warning <짧은 설명>`** → 긴급 경고 템플릿으로 바로 작성
+4. **`system_update|release|warning|general <자유 설명>`** → 해당 카테고리로 작성
+
+## 카테고리 자동 분류 휴리스틱
+
+커밋 메시지/파일 경로를 보고 제안:
+
+- `system_update` — `supabase/migrations/`, `dev/js/admin.js`, `dev/admin/`, `retryWithRefresh`, RLS/RPC 키워드, 관리자 내부 도구 개선
+- `release` — `dev/index.html`, `dev/js/campaign.js`, `dev/lib/i18n/`, 인플루언서 UI/일본어 변경, 광고주 신청 폼 변경
+- `warning` — `chore: trigger redeploy`, `hotfix`, `revert`, `Brevo`, `rate limit`, 장애 키워드
+- `general` — 위에 해당 없는 경우
+
+복수 성격이면 가장 큰 카테고리 1개 선택하고 본문에 보조 변경사항 기재.
+
+## 출력 형식 (항상 이 구조로 메시지에 표시 + 파일 저장)
+
+```
+## 📣 공지 초안
+
+**카테고리**: system_update (시스템 업데이트)
+**제목**: 인플루언서 상세 모달 통합 개편
+**상단 고정**: ☐
+
+### 본문 HTML (Quill 에디터에 붙여넣기)
+<p>인플루언서 관리자 상세 화면이 모달 기반으로 재구성됐습니다.</p>
+<ul>
+  <li>이름 옆 인증/위반/블랙리스트 배지 전역 노출</li>
+  <li>상태 관리 + 관리자 이력 한 카드로 통합</li>
+  <li>위반 기록에 증빙 파일 첨부 + 라이트박스 확대</li>
+  <li>목록 필터·검색 상단 일관화</li>
+</ul>
+<p>영향 범위: 관리자 페이지 한정. 인플루언서 앱에는 영향 없음.</p>
+
+### 근거 (생성 시 참고한 커밋)
+- 3a1655b feat(admin): influencer verify · violation · blacklist management
+- 88d6d3e feat(admin): violation evidence uploads + ESC close
+```
+
+동시에 아래 파일로도 저장:
+- `docs/admin-notices/{YYYY-MM-DD}-{category}-{slug}.md` — Markdown 포맷 (제목/본문 HTML 포함)
+
+`docs/admin-notices/` 폴더가 없으면 생성. slug 는 제목을 소문자·하이픈 변환.
+
+## 작성 원칙
+
+- **title**: 1줄, 35자 이내, 한국어. "무엇이 바뀌었나" 요약
+- **body_html**: Quill 호환 HTML. `<p>`, `<ul>/<li>`, `<strong>`, `<em>`, `<a>`, `<br>` 만 사용. `<script>`, `<iframe>`, `<style>` 금지
+- **영향 범위 명시**: "관리자 페이지 한정" / "인플루언서 앱만" / "운영서버만 배포됨" 등
+- **기술 용어 그대로** 쓰되, 관리자 실무진이 이해할 수 있게 한국어 설명 병기
+- **변경 이유** 가 명확하면 1문장 추가 (예: "2026-04-22 Brevo 한도 초과 재발 방지")
+- **긴급 경고**(`warning`)는 상단 고정 `☑` 로 표시 권장
+
+## 제한·안내
+
+- 이 커맨드는 **초안만 생성**. 실제 DB INSERT 는 사용자가 관리자 페이지에서 수동으로 수행
+- 직접 SQL 로 INSERT 하고 싶으면 사용자가 요청 시 `supabase/patches/YYYY-MM-DD_admin_notice.sql` 파일 추가 생성
+- 확인 없이 자동 등록 금지 — 운영 DB 에 영향
+
+## 작업 흐름
+
+1. 인자 해석 → 커밋/PR/키워드 수집
+2. 카테고리 자동 분류
+3. 제목·본문 HTML 작성 (위 원칙 준수)
+4. `docs/admin-notices/` 폴더 없으면 `mkdir -p` 로 생성
+5. 파일 저장 + 메시지에 전체 표시
+6. 마지막에 "📋 관리자 페이지에 등록하려면: /admin/#admin-notices → 새 공지 작성 → 위 제목·본문 복사·붙여넣기" 안내

--- a/admin/index.html
+++ b/admin/index.html
@@ -574,6 +574,8 @@ textarea.form-input{resize:vertical;min-height:80px}
           <span id="stagingBadgeSide" style="display:none;background:#f59e0b;color:#fff;font-size:9px;font-weight:700;padding:2px 6px;border-radius:3px">STAGING</span>
         </span>
       </div>
+      <div class="admin-si-lbl">공지</div>
+      <div class="admin-si" data-pane="admin-notices" id="adminNoticesSi" onclick="switchAdminPane('admin-notices',this)"><span class="si-icon material-icons-round">campaign</span><span class="si-text">공지사항</span><span id="adminNoticesBadge" class="admin-si-badge" style="display:none">0</span></div>
       <div class="admin-si-lbl">대시보드</div>
       <div class="admin-si" data-pane="dashboard" onclick="switchAdminPane('dashboard',this)"><span class="si-icon material-icons-round">dashboard</span><span class="si-text">전체 현황</span></div>
       <div class="admin-si-lbl">캠페인</div>
@@ -611,6 +613,14 @@ textarea.form-input{resize:vertical;min-height:80px}
 
         <!-- DASHBOARD PANE -->
         <div id="adminPane-dashboard" class="admin-pane">
+          <!-- 최근 공지 3건 -->
+          <div class="admin-card" id="dashboardNoticesCard" style="margin-bottom:16px;display:none">
+            <div class="admin-card-header">
+              <div style="display:flex;align-items:center;gap:6px"><span class="material-icons-round notranslate" translate="no" style="font-size:16px;color:var(--pink)">campaign</span><span class="admin-card-title">최근 공지</span></div>
+              <a href="#admin-notices" onclick="switchAdminPane('admin-notices',null)" style="font-size:11px;color:var(--pink);text-decoration:none">전체 보기 ▸</a>
+            </div>
+            <div style="padding:0" id="dashboardNoticesBody"></div>
+          </div>
           <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:16px">
             <div style="font-size:16px;font-weight:700;color:var(--ink)">전체 현황</div>
             <button class="btn btn-ghost btn-sm" onclick="loadAdminData()">새로고침</button>
@@ -1659,6 +1669,46 @@ textarea.form-input{resize:vertical;min-height:80px}
           </div>
         </div>
 
+        <!-- ADMIN NOTICES PANE -->
+        <div id="adminPane-admin-notices" class="admin-pane admin-pane-list">
+          <div class="admin-sticky-header">
+            <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:12px">
+              <div style="font-size:16px;font-weight:700;color:var(--ink)">공지사항 <span style="font-size:11px;font-weight:400;color:var(--muted)">(관리자 전용)</span></div>
+              <button class="btn btn-primary btn-xs" id="btnNewAdminNotice" onclick="openAdminNoticeEdit(null)"><span class="material-icons-round notranslate" translate="no" style="font-size:14px;vertical-align:-2px">add</span> 새 공지 작성</button>
+            </div>
+            <div style="display:flex;align-items:flex-end;gap:12px;flex-wrap:wrap">
+              <div class="admin-filter-group">
+                <label>카테고리</label>
+                <select id="adminNoticeCatFilter" class="admin-filter" onchange="renderAdminNotices()">
+                  <option value="all">전체</option>
+                  <option value="system_update">시스템 업데이트</option>
+                  <option value="release">릴리스</option>
+                  <option value="warning">경고</option>
+                  <option value="general">일반</option>
+                </select>
+              </div>
+              <div class="admin-filter-group" style="flex:1;min-width:200px;margin-left:auto">
+                <label>검색</label>
+                <div style="position:relative">
+                  <span class="material-icons-round" style="position:absolute;left:8px;top:50%;transform:translateY(-50%);font-size:16px;color:var(--muted)">search</span>
+                  <input type="text" id="adminNoticeSearch" class="admin-filter-search" placeholder="제목 검색" oninput="renderAdminNotices()">
+                </div>
+              </div>
+            </div>
+          </div>
+          <div class="admin-card">
+            <div class="admin-card-header">
+              <div style="display:flex;align-items:center;gap:8px"><span class="admin-card-title">공지 목록</span><span id="adminNoticeTotal" style="font-size:12px;color:var(--muted)"></span></div>
+            </div>
+            <div class="admin-table-wrap">
+              <table class="data-table" id="adminNoticeTable">
+                <thead><tr><th style="width:70px">상태</th><th style="width:130px">카테고리</th><th>제목</th><th style="width:120px">작성자</th><th style="width:140px">작성일</th><th style="width:140px">수정</th></tr></thead>
+                <tbody id="adminNoticeBody"><tr><td colspan="6" style="text-align:center;color:var(--muted);padding:24px">로드 중...</td></tr></tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+
         <!-- ADMIN ACCOUNTS PANE -->
         <div id="adminPane-admin-accounts" class="admin-pane admin-pane-list">
           <div class="admin-sticky-header">
@@ -1920,6 +1970,65 @@ textarea.form-input{resize:vertical;min-height:80px}
     </div>
     <div class="modal-body" style="padding:20px;overflow-y:auto;flex:1;min-height:0">
       <div id="flagEditBody"></div>
+    </div>
+  </div>
+</div>
+
+<!-- 공지 작성/편집 모달 -->
+<div class="modal-overlay" id="adminNoticeEditModal" style="z-index:550">
+  <div class="modal" style="max-width:720px;border-radius:16px;margin:auto;max-height:90vh;overflow:hidden;display:flex;flex-direction:column">
+    <div class="modal-header">
+      <div class="modal-title" id="adminNoticeEditTitle">공지 작성</div>
+      <div class="modal-close" onclick="closeModal('adminNoticeEditModal')"><span class="material-icons-round notranslate" translate="no" style="font-size:18px">close</span></div>
+    </div>
+    <div class="modal-body" style="padding:20px;overflow-y:auto;flex:1;min-height:0">
+      <div style="display:grid;grid-template-columns:1fr 140px;gap:10px;margin-bottom:12px">
+        <input type="text" id="anEditTitle" class="form-input" placeholder="제목" style="font-size:13px;padding:8px 10px">
+        <select id="anEditCategory" class="form-input" style="font-size:12px;padding:8px 10px">
+          <option value="system_update">시스템 업데이트</option>
+          <option value="release">릴리스</option>
+          <option value="warning">경고</option>
+          <option value="general">일반</option>
+        </select>
+      </div>
+      <div style="display:flex;gap:12px;align-items:center;margin-bottom:8px;flex-wrap:wrap">
+        <label style="display:inline-flex;align-items:center;gap:4px;font-size:12px;color:var(--muted);cursor:pointer"><input type="checkbox" id="anEditPinned"> 상단 고정</label>
+        <label style="display:inline-flex;align-items:center;gap:4px;font-size:12px;color:var(--muted);cursor:pointer"><input type="checkbox" id="anEditHtmlMode" onchange="toggleNoticeHtmlMode()"> HTML 소스로 입력/편집</label>
+      </div>
+      <div id="anEditBodyQuill" style="min-height:220px;background:#fff"></div>
+      <textarea id="anEditBodyRaw" style="display:none;width:100%;min-height:220px;font-family:ui-monospace,Menlo,monospace;font-size:12px;padding:10px;border:1px solid var(--line);border-radius:6px;resize:vertical" placeholder="HTML 코드를 직접 입력하세요. 예) <p>안녕하세요</p><ul><li>항목</li></ul>"></textarea>
+      <div style="display:flex;gap:8px;margin-top:14px;justify-content:flex-end">
+        <button class="btn btn-ghost btn-xs" id="btnDeleteAdminNotice" onclick="onDeleteAdminNotice()" style="color:#C62828;display:none">삭제</button>
+        <button class="btn btn-ghost btn-xs" onclick="closeModal('adminNoticeEditModal')">취소</button>
+        <button class="btn btn-primary btn-xs" onclick="onSaveAdminNotice()">저장</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- 공지 상세 보기 모달 -->
+<div class="modal-overlay" id="adminNoticeViewModal" style="z-index:550">
+  <div class="modal" style="max-width:720px;border-radius:16px;margin:auto;max-height:90vh;overflow:hidden;display:flex;flex-direction:column">
+    <div class="modal-header">
+      <div class="modal-title" id="adminNoticeViewTitle">공지</div>
+      <div class="modal-close" onclick="closeModal('adminNoticeViewModal')"><span class="material-icons-round notranslate" translate="no" style="font-size:18px">close</span></div>
+    </div>
+    <div class="modal-body" style="padding:20px;overflow-y:auto;flex:1;min-height:0">
+      <div id="adminNoticeViewMeta" style="font-size:12px;color:var(--muted);margin-bottom:12px;display:flex;gap:10px;flex-wrap:wrap;align-items:center"></div>
+      <div id="adminNoticeViewBody" class="rich-content" style="font-size:13px;line-height:1.7;color:var(--ink)"></div>
+    </div>
+  </div>
+</div>
+
+<!-- 로그인 직후 미읽음 공지 팝업 -->
+<div class="modal-overlay" id="adminNoticeUnreadModal" style="z-index:560">
+  <div class="modal" style="max-width:640px;border-radius:16px;margin:auto;max-height:88vh;overflow:hidden;display:flex;flex-direction:column">
+    <div class="modal-header">
+      <div class="modal-title">새 공지사항 <span id="adminNoticeUnreadCount" style="font-size:12px;color:var(--muted);font-weight:400"></span></div>
+      <div class="modal-close" onclick="closeModal('adminNoticeUnreadModal')"><span class="material-icons-round notranslate" translate="no" style="font-size:18px">close</span></div>
+    </div>
+    <div class="modal-body" style="padding:20px;overflow-y:auto;flex:1;min-height:0">
+      <div id="adminNoticeUnreadBody"></div>
     </div>
   </div>
 </div>
@@ -3243,6 +3352,84 @@ async function swapParticipationSetOrder(idA, idB) {
 }
 
 // ══════════════════════════════════════
+// ADMIN NOTICES (관리자 전용 공지 — migration 063)
+// ══════════════════════════════════════
+
+// 공지 목록 + 본인 읽음 여부
+async function fetchAdminNotices(filters) {
+  if (!db) return [];
+  try {
+    const uid = (await db.auth.getUser()).data?.user?.id;
+    let q = db.from('admin_notices').select('*, admin_notice_reads!left(read_at,auth_id)');
+    if (filters?.category && filters.category !== 'all') q = q.eq('category', filters.category);
+    q = q.order('is_pinned', {ascending: false})
+         .order('pinned_at', {ascending: false, nullsFirst: false})
+         .order('created_at', {ascending: false});
+    const {data, error} = await q;
+    if (error) throw error;
+    return (data || []).map(n => {
+      const mine = (n.admin_notice_reads || []).find(r => r.auth_id === uid);
+      return {...n, is_read: !!mine, read_at: mine?.read_at || null, admin_notice_reads: undefined};
+    });
+  } catch(e) { console.error('[fetchAdminNotices]', e); return []; }
+}
+
+async function fetchUnreadAdminNotices() {
+  const all = await fetchAdminNotices();
+  return all.filter(n => !n.is_read);
+}
+
+async function insertAdminNotice(data) {
+  if (!db) throw new Error('DB 미연결');
+  const uid = (await db.auth.getUser()).data?.user?.id;
+  const payload = {
+    title: data.title,
+    body_html: data.body_html,
+    category: data.category,
+    is_pinned: !!data.is_pinned,
+    pinned_at: data.is_pinned ? new Date().toISOString() : null,
+    created_by: uid || null,
+    created_by_name: data.created_by_name || null,
+    updated_by: uid || null,
+    updated_by_name: data.created_by_name || null,
+  };
+  await retryWithRefresh(async () => {
+    const {error} = await db.from('admin_notices').insert(payload);
+    if (error) throw error;
+  });
+}
+
+async function updateAdminNotice(id, patch) {
+  if (!db) throw new Error('DB 미연결');
+  const uid = (await db.auth.getUser()).data?.user?.id;
+  const p = {...patch, updated_by: uid || null};
+  // is_pinned 변경 시 pinned_at 동기화
+  if (Object.prototype.hasOwnProperty.call(patch, 'is_pinned')) {
+    p.pinned_at = patch.is_pinned ? new Date().toISOString() : null;
+  }
+  await retryWithRefresh(async () => {
+    const {error} = await db.from('admin_notices').update(p).eq('id', id);
+    if (error) throw error;
+  });
+}
+
+async function deleteAdminNotice(id) {
+  if (!db) throw new Error('DB 미연결');
+  await retryWithRefresh(async () => {
+    const {error} = await db.from('admin_notices').delete().eq('id', id);
+    if (error) throw error;
+  });
+}
+
+async function markAdminNoticeRead(noticeId) {
+  if (!db || !noticeId) return;
+  await retryWithRefresh(async () => {
+    const {error} = await db.rpc('upsert_admin_notice_read', {p_notice_id: noticeId});
+    if (error) throw error;
+  });
+}
+
+// ══════════════════════════════════════
 // BRAND APPLICATIONS (광고주 신청 폼 — 052)
 // ══════════════════════════════════════
 
@@ -4264,7 +4451,8 @@ function switchAdminPane(pane, el, pushHistory) {
     'lookups': loadLookupsPane,
     'deliverables': loadDeliverables,
     'brand-applications': loadBrandApplications,
-    'brand-dashboard': loadBrandDashboard
+    'brand-dashboard': loadBrandDashboard,
+    'admin-notices': loadAdminNotices
   };
   // 브라우저 히스토리 기록 (뒤로가기 지원)
   if (pushHistory !== false) {
@@ -4372,6 +4560,16 @@ async function loadAdminData(preloaded) {
   allCampaigns = camps.slice();
   // 관리자 초기 진입 시 위반 카운트도 미리 로드 — 배지 전역 노출용
   fetchViolationCountsByInfluencer().then(vc => { _infViolationCounts = vc; }).catch(()=>{});
+  // 관리자 공지 — 사이드바 배지·대시보드 최근·로그인 팝업
+  fetchAdminNotices().then(list => {
+    _adminNoticesCache = list;
+    refreshAdminNoticeBadge();
+    renderDashboardNotices();
+    if (!window._adminNoticeUnreadShown) {
+      window._adminNoticeUnreadShown = true;
+      showAdminUnreadNoticesIfAny();
+    }
+  }).catch(()=>{});
   const approved = apps.filter(a=>a.status==='approved');
   const pending = apps.filter(a=>a.status==='pending');
 
@@ -9409,6 +9607,238 @@ async function revertBrandApp() {
   toast('되돌렸습니다.');
   closeBrandAppDetail();
   await loadBrandApplications();
+}
+
+// ══════════════════════════════════════
+// ADMIN NOTICES (관리자 전용 공지 — migration 063)
+// ══════════════════════════════════════
+
+var _adminNoticesCache = [];
+var _adminNoticeCurrent = null;
+var _adminNoticeQuill = null;
+
+const ADMIN_NOTICE_CAT_LABEL = {
+  system_update: '시스템 업데이트',
+  release: '릴리스',
+  warning: '경고',
+  general: '일반',
+};
+const ADMIN_NOTICE_CAT_STYLE = {
+  system_update: 'background:#E3F2FD;color:#1565C0',
+  release: 'background:#E8F5E9;color:#2E7D32',
+  warning: 'background:#FFEBEE;color:#C62828',
+  general: 'background:#F5F5F5;color:#616161',
+};
+
+function adminNoticeCatPill(cat) {
+  const style = ADMIN_NOTICE_CAT_STYLE[cat] || ADMIN_NOTICE_CAT_STYLE.general;
+  return `<span style="display:inline-block;font-size:10px;font-weight:700;padding:2px 8px;border-radius:3px;${style}">${esc(ADMIN_NOTICE_CAT_LABEL[cat]||cat)}</span>`;
+}
+
+async function loadAdminNotices() {
+  _adminNoticesCache = await fetchAdminNotices();
+  renderAdminNotices();
+  refreshAdminNoticeBadge();
+}
+
+function refreshAdminNoticeBadge() {
+  const badge = $('adminNoticesBadge');
+  if (!badge) return;
+  const unread = (_adminNoticesCache || []).filter(n => !n.is_read).length;
+  if (unread > 0) { badge.textContent = unread > 9 ? '9+' : unread; badge.style.display = ''; }
+  else badge.style.display = 'none';
+}
+
+function renderAdminNotices() {
+  const body = $('adminNoticeBody');
+  if (!body) return;
+  const cat = $('adminNoticeCatFilter')?.value || 'all';
+  const q = ($('adminNoticeSearch')?.value || '').trim().toLowerCase();
+  let list = (_adminNoticesCache || []).slice();
+  if (cat !== 'all') list = list.filter(n => n.category === cat);
+  if (q) list = list.filter(n => (n.title || '').toLowerCase().includes(q));
+  const total = $('adminNoticeTotal');
+  if (total) total.textContent = `${list.length}건`;
+  const isSuper = currentAdminInfo?.role === 'super_admin';
+  const canEdit = (n) => isSuper || n.created_by === currentUser?.id;
+  body.innerHTML = list.length ? list.map(n => {
+    const unreadDot = !n.is_read ? `<span style="display:inline-block;width:6px;height:6px;border-radius:50%;background:#C62828;margin-right:4px;vertical-align:middle"></span>` : '';
+    const pinIcon = n.is_pinned ? `<span class="material-icons-round notranslate" translate="no" style="font-size:14px;color:var(--pink);vertical-align:-2px" title="상단 고정">push_pin</span> ` : '';
+    return `<tr data-id="${esc(n.id)}" style="cursor:pointer;${n.is_read?'':'background:#FFFBEF'}" onclick="openAdminNoticeView(this.dataset.id)">
+      <td>${unreadDot}${n.is_read?'<span style="font-size:11px;color:var(--muted)">읽음</span>':'<span style="font-size:11px;color:#C62828;font-weight:700">미읽음</span>'}</td>
+      <td>${adminNoticeCatPill(n.category)}</td>
+      <td style="font-weight:600;color:var(--ink)">${pinIcon}${esc(n.title)}</td>
+      <td style="font-size:12px;color:var(--muted)">${esc(n.created_by_name || '—')}</td>
+      <td style="font-size:11px;color:var(--muted);white-space:nowrap">${n.created_at?formatDateTime(n.created_at):''}</td>
+      <td>${canEdit(n) ? `<button class="btn btn-ghost btn-xs" onclick="event.stopPropagation();openAdminNoticeEdit(this.closest('tr').dataset.id)"><span class="material-icons-round notranslate" translate="no" style="font-size:13px;vertical-align:-2px">edit</span> 수정</button>` : ''}</td>
+    </tr>`;
+  }).join('') : '<tr><td colspan="6" style="text-align:center;color:var(--muted);padding:24px">공지 없음</td></tr>';
+}
+
+async function openAdminNoticeView(id) {
+  const n = (_adminNoticesCache || []).find(x => x.id === id);
+  if (!n) return;
+  $('adminNoticeViewTitle').innerHTML = esc(n.title);
+  $('adminNoticeViewMeta').innerHTML = `${adminNoticeCatPill(n.category)}<span>${esc(n.created_by_name || '—')}</span><span>${n.created_at?formatDateTime(n.created_at):''}</span>${n.is_pinned?'<span style="color:var(--pink);font-weight:700;display:inline-flex;align-items:center;gap:4px"><span class="material-icons-round notranslate" translate="no" style="font-size:14px">push_pin</span>상단 고정</span>':''}`;
+  const bodyEl = $('adminNoticeViewBody');
+  if (typeof renderRich === 'function') renderRich(bodyEl, n.body_html || '');
+  else if (typeof sanitizeRich === 'function') bodyEl.innerHTML = sanitizeRich(n.body_html || '');
+  else bodyEl.innerHTML = n.body_html || '';
+  openModal('adminNoticeViewModal');
+  if (!n.is_read) {
+    try { await markAdminNoticeRead(id); n.is_read = true; refreshAdminNoticeBadge(); renderAdminNotices(); } catch(e) {}
+  }
+}
+
+function openAdminNoticeEdit(id) {
+  const n = id ? (_adminNoticesCache || []).find(x => x.id === id) : null;
+  _adminNoticeCurrent = n;
+  $('adminNoticeEditTitle').textContent = n ? '공지 수정' : '공지 작성';
+  $('anEditTitle').value = n?.title || '';
+  $('anEditCategory').value = n?.category || 'system_update';
+  $('anEditPinned').checked = !!(n?.is_pinned);
+  const delBtn = $('btnDeleteAdminNotice');
+  if (delBtn) delBtn.style.display = n ? '' : 'none';
+  // HTML 모드 기본 off. 기존 공지 중 '<p>&lt;' 같이 태그가 텍스트로 저장된 케이스 감지 시 자동 HTML 모드
+  const rawHtml = n?.body_html || '';
+  const tagAsText = /&lt;\w+/.test(rawHtml);
+  $('anEditHtmlMode').checked = tagAsText;
+  $('anEditBodyRaw').value = rawHtml;
+  openModal('adminNoticeEditModal');
+  setTimeout(() => {
+    if (!_adminNoticeQuill && typeof Quill !== 'undefined') {
+      _adminNoticeQuill = new Quill('#anEditBodyQuill', {
+        theme: 'snow',
+        modules: { toolbar: [[{header:[2,3,4,false]}],['bold','italic','underline','strike'],[{list:'ordered'},{list:'bullet'}],['link','blockquote'],['clean']], clipboard:{matchVisual:false} },
+        formats: ['header','bold','italic','underline','strike','list','link','blockquote']
+      });
+    }
+    if (_adminNoticeQuill) {
+      const initHtml = (typeof sanitizeRich === 'function') ? sanitizeRich(rawHtml) : rawHtml;
+      _adminNoticeQuill.clipboard.dangerouslyPasteHTML(initHtml, 'silent');
+    }
+    toggleNoticeHtmlMode();
+  }, 0);
+}
+
+function toggleNoticeHtmlMode() {
+  const isHtml = !!$('anEditHtmlMode')?.checked;
+  const quillHost = $('anEditBodyQuill');
+  const raw = $('anEditBodyRaw');
+  const toolbar = document.querySelector('#adminNoticeEditModal .ql-toolbar');
+  if (isHtml) {
+    if (_adminNoticeQuill && raw.value === '') raw.value = _adminNoticeQuill.root.innerHTML;
+    if (quillHost) quillHost.style.display = 'none';
+    if (toolbar) toolbar.style.display = 'none';
+    if (raw) raw.style.display = '';
+  } else {
+    if (_adminNoticeQuill && raw.value) {
+      const initHtml = (typeof sanitizeRich === 'function') ? sanitizeRich(raw.value) : raw.value;
+      _adminNoticeQuill.clipboard.dangerouslyPasteHTML(initHtml, 'silent');
+    }
+    if (raw) raw.style.display = 'none';
+    if (quillHost) quillHost.style.display = '';
+    if (toolbar) toolbar.style.display = '';
+  }
+}
+
+async function onSaveAdminNotice() {
+  const title = ($('anEditTitle')?.value || '').trim();
+  const category = $('anEditCategory')?.value || 'general';
+  const is_pinned = !!$('anEditPinned')?.checked;
+  if (!title) { toast('제목을 입력해주세요', 'error'); return; }
+  let body_html = '';
+  const isHtmlMode = !!$('anEditHtmlMode')?.checked;
+  if (isHtmlMode) {
+    const raw = $('anEditBodyRaw')?.value || '';
+    body_html = (typeof sanitizeRich === 'function') ? sanitizeRich(raw) : raw;
+  } else if (_adminNoticeQuill) {
+    const raw = _adminNoticeQuill.root.innerHTML;
+    body_html = (typeof sanitizeRich === 'function') ? sanitizeRich(raw) : raw;
+  }
+  const name = currentAdminInfo?.name || currentUserProfile?.name || '관리자';
+  try {
+    if (_adminNoticeCurrent) {
+      await updateAdminNotice(_adminNoticeCurrent.id, {title, body_html, category, is_pinned, updated_by_name: name});
+      toast('공지가 수정되었습니다', 'success');
+    } else {
+      await insertAdminNotice({title, body_html, category, is_pinned, created_by_name: name});
+      toast('공지가 등록되었습니다', 'success');
+    }
+    closeModal('adminNoticeEditModal');
+    await loadAdminNotices();
+  } catch(e) { toast('저장 오류: ' + (e.message || e), 'error'); }
+}
+
+async function onDeleteAdminNotice() {
+  if (!_adminNoticeCurrent) return;
+  if (!confirm('공지를 삭제할까요? 모든 관리자의 읽음 이력도 함께 삭제됩니다.')) return;
+  try {
+    await deleteAdminNotice(_adminNoticeCurrent.id);
+    toast('삭제되었습니다');
+    closeModal('adminNoticeEditModal');
+    await loadAdminNotices();
+  } catch(e) { toast('삭제 오류: ' + (e.message || e), 'error'); }
+}
+
+// 대시보드 최근 공지 3건 렌더
+function renderDashboardNotices() {
+  const card = $('dashboardNoticesCard');
+  const body = $('dashboardNoticesBody');
+  if (!card || !body) return;
+  const list = (_adminNoticesCache || []).slice(0, 3);
+  if (!list.length) { card.style.display = 'none'; return; }
+  card.style.display = '';
+  body.innerHTML = list.map(n => `
+    <div style="padding:12px 16px;border-bottom:1px solid var(--line);display:flex;align-items:center;gap:10px;cursor:pointer" onclick="openAdminNoticeView('${esc(n.id)}')">
+      ${!n.is_read ? '<span style="display:inline-block;width:6px;height:6px;border-radius:50%;background:#C62828;flex-shrink:0"></span>' : '<span style="display:inline-block;width:6px;height:6px;flex-shrink:0"></span>'}
+      ${adminNoticeCatPill(n.category)}
+      <div style="flex:1;font-size:13px;color:var(--ink);font-weight:${n.is_read?'400':'600'};overflow:hidden;text-overflow:ellipsis;white-space:nowrap">${n.is_pinned?'<span class="material-icons-round notranslate" translate="no" style="font-size:13px;color:var(--pink);vertical-align:-2px">push_pin</span> ':''}${esc(n.title)}</div>
+      <div style="font-size:11px;color:var(--muted);flex-shrink:0">${n.created_at?formatDate(n.created_at):''}</div>
+    </div>
+  `).join('');
+}
+
+// 로그인 직후 미읽음 공지 팝업
+async function showAdminUnreadNoticesIfAny() {
+  if (!Array.isArray(_adminNoticesCache) || _adminNoticesCache.length === 0) return;
+  const unread = _adminNoticesCache.filter(n => !n.is_read);
+  if (unread.length === 0) return;
+  const countEl = $('adminNoticeUnreadCount');
+  if (countEl) countEl.textContent = `${unread.length}건`;
+  const body = $('adminNoticeUnreadBody');
+  if (body) {
+    body.innerHTML = unread.slice(0, 5).map(n => `
+      <div style="padding:14px;border:1px solid var(--line);border-radius:8px;margin-bottom:10px">
+        <div style="display:flex;align-items:center;gap:8px;margin-bottom:6px">${adminNoticeCatPill(n.category)}<div style="font-weight:700;font-size:14px;color:var(--ink)">${n.is_pinned?'<span class="material-icons-round notranslate" translate="no" style="font-size:14px;color:var(--pink);vertical-align:-2px">push_pin</span> ':''}${esc(n.title)}</div></div>
+        <div style="font-size:11px;color:var(--muted);margin-bottom:8px">${esc(n.created_by_name||'—')} · ${n.created_at?formatDateTime(n.created_at):''}</div>
+        <div class="rich-content" data-notice-body="${esc(n.id)}" style="font-size:12px;line-height:1.6;color:var(--ink);max-height:140px;overflow:hidden"></div>
+        <div style="text-align:right;margin-top:8px"><button class="btn btn-primary btn-xs" onclick="onMarkUnreadFromPopup('${esc(n.id)}')">확인</button></div>
+      </div>
+    `).join('');
+    // 본문 부분만 renderRich(el, raw) 시그니처로 주입
+    unread.slice(0, 5).forEach(n => {
+      const el = document.querySelector(`[data-notice-body="${n.id}"]`);
+      if (!el) return;
+      if (typeof renderRich === 'function') renderRich(el, n.body_html || '');
+      else if (typeof sanitizeRich === 'function') el.innerHTML = sanitizeRich(n.body_html || '');
+      else el.innerHTML = n.body_html || '';
+    });
+  }
+  openModal('adminNoticeUnreadModal');
+}
+
+async function onMarkUnreadFromPopup(id) {
+  try {
+    await markAdminNoticeRead(id);
+    const n = (_adminNoticesCache || []).find(x => x.id === id);
+    if (n) n.is_read = true;
+    refreshAdminNoticeBadge();
+    renderDashboardNotices();
+    const stillUnread = (_adminNoticesCache || []).some(x => !x.is_read);
+    if (!stillUnread) closeModal('adminNoticeUnreadModal');
+    else showAdminUnreadNoticesIfAny();
+  } catch(e) { toast('오류: ' + (e.message || e), 'error'); }
 }
 // ══════════════════════════════════════
 // ADMIN APP — 관리자 페이지 초기화

--- a/dev/admin/index.html
+++ b/dev/admin/index.html
@@ -69,6 +69,8 @@
           <span id="stagingBadgeSide" style="display:none;background:#f59e0b;color:#fff;font-size:9px;font-weight:700;padding:2px 6px;border-radius:3px">STAGING</span>
         </span>
       </div>
+      <div class="admin-si-lbl">공지</div>
+      <div class="admin-si" data-pane="admin-notices" id="adminNoticesSi" onclick="switchAdminPane('admin-notices',this)"><span class="si-icon material-icons-round">campaign</span><span class="si-text">공지사항</span><span id="adminNoticesBadge" class="admin-si-badge" style="display:none">0</span></div>
       <div class="admin-si-lbl">대시보드</div>
       <div class="admin-si" data-pane="dashboard" onclick="switchAdminPane('dashboard',this)"><span class="si-icon material-icons-round">dashboard</span><span class="si-text">전체 현황</span></div>
       <div class="admin-si-lbl">캠페인</div>
@@ -106,6 +108,14 @@
 
         <!-- DASHBOARD PANE -->
         <div id="adminPane-dashboard" class="admin-pane">
+          <!-- 최근 공지 3건 -->
+          <div class="admin-card" id="dashboardNoticesCard" style="margin-bottom:16px;display:none">
+            <div class="admin-card-header">
+              <div style="display:flex;align-items:center;gap:6px"><span class="material-icons-round notranslate" translate="no" style="font-size:16px;color:var(--pink)">campaign</span><span class="admin-card-title">최근 공지</span></div>
+              <a href="#admin-notices" onclick="switchAdminPane('admin-notices',null)" style="font-size:11px;color:var(--pink);text-decoration:none">전체 보기 ▸</a>
+            </div>
+            <div style="padding:0" id="dashboardNoticesBody"></div>
+          </div>
           <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:16px">
             <div style="font-size:16px;font-weight:700;color:var(--ink)">전체 현황</div>
             <button class="btn btn-ghost btn-sm" onclick="loadAdminData()">새로고침</button>
@@ -1154,6 +1164,46 @@
           </div>
         </div>
 
+        <!-- ADMIN NOTICES PANE -->
+        <div id="adminPane-admin-notices" class="admin-pane admin-pane-list">
+          <div class="admin-sticky-header">
+            <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:12px">
+              <div style="font-size:16px;font-weight:700;color:var(--ink)">공지사항 <span style="font-size:11px;font-weight:400;color:var(--muted)">(관리자 전용)</span></div>
+              <button class="btn btn-primary btn-xs" id="btnNewAdminNotice" onclick="openAdminNoticeEdit(null)"><span class="material-icons-round notranslate" translate="no" style="font-size:14px;vertical-align:-2px">add</span> 새 공지 작성</button>
+            </div>
+            <div style="display:flex;align-items:flex-end;gap:12px;flex-wrap:wrap">
+              <div class="admin-filter-group">
+                <label>카테고리</label>
+                <select id="adminNoticeCatFilter" class="admin-filter" onchange="renderAdminNotices()">
+                  <option value="all">전체</option>
+                  <option value="system_update">시스템 업데이트</option>
+                  <option value="release">릴리스</option>
+                  <option value="warning">경고</option>
+                  <option value="general">일반</option>
+                </select>
+              </div>
+              <div class="admin-filter-group" style="flex:1;min-width:200px;margin-left:auto">
+                <label>검색</label>
+                <div style="position:relative">
+                  <span class="material-icons-round" style="position:absolute;left:8px;top:50%;transform:translateY(-50%);font-size:16px;color:var(--muted)">search</span>
+                  <input type="text" id="adminNoticeSearch" class="admin-filter-search" placeholder="제목 검색" oninput="renderAdminNotices()">
+                </div>
+              </div>
+            </div>
+          </div>
+          <div class="admin-card">
+            <div class="admin-card-header">
+              <div style="display:flex;align-items:center;gap:8px"><span class="admin-card-title">공지 목록</span><span id="adminNoticeTotal" style="font-size:12px;color:var(--muted)"></span></div>
+            </div>
+            <div class="admin-table-wrap">
+              <table class="data-table" id="adminNoticeTable">
+                <thead><tr><th style="width:70px">상태</th><th style="width:130px">카테고리</th><th>제목</th><th style="width:120px">작성자</th><th style="width:140px">작성일</th><th style="width:140px">수정</th></tr></thead>
+                <tbody id="adminNoticeBody"><tr><td colspan="6" style="text-align:center;color:var(--muted);padding:24px">로드 중...</td></tr></tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+
         <!-- ADMIN ACCOUNTS PANE -->
         <div id="adminPane-admin-accounts" class="admin-pane admin-pane-list">
           <div class="admin-sticky-header">
@@ -1417,6 +1467,65 @@
     </div>
     <div class="modal-body" style="padding:20px;overflow-y:auto;flex:1;min-height:0">
       <div id="flagEditBody"></div>
+    </div>
+  </div>
+</div>
+
+<!-- 공지 작성/편집 모달 -->
+<div class="modal-overlay" id="adminNoticeEditModal" style="z-index:550">
+  <div class="modal" style="max-width:720px;border-radius:16px;margin:auto;max-height:90vh;overflow:hidden;display:flex;flex-direction:column">
+    <div class="modal-header">
+      <div class="modal-title" id="adminNoticeEditTitle">공지 작성</div>
+      <div class="modal-close" onclick="closeModal('adminNoticeEditModal')"><span class="material-icons-round notranslate" translate="no" style="font-size:18px">close</span></div>
+    </div>
+    <div class="modal-body" style="padding:20px;overflow-y:auto;flex:1;min-height:0">
+      <div style="display:grid;grid-template-columns:1fr 140px;gap:10px;margin-bottom:12px">
+        <input type="text" id="anEditTitle" class="form-input" placeholder="제목" style="font-size:13px;padding:8px 10px">
+        <select id="anEditCategory" class="form-input" style="font-size:12px;padding:8px 10px">
+          <option value="system_update">시스템 업데이트</option>
+          <option value="release">릴리스</option>
+          <option value="warning">경고</option>
+          <option value="general">일반</option>
+        </select>
+      </div>
+      <div style="display:flex;gap:12px;align-items:center;margin-bottom:8px;flex-wrap:wrap">
+        <label style="display:inline-flex;align-items:center;gap:4px;font-size:12px;color:var(--muted);cursor:pointer"><input type="checkbox" id="anEditPinned"> 상단 고정</label>
+        <label style="display:inline-flex;align-items:center;gap:4px;font-size:12px;color:var(--muted);cursor:pointer"><input type="checkbox" id="anEditHtmlMode" onchange="toggleNoticeHtmlMode()"> HTML 소스로 입력/편집</label>
+      </div>
+      <div id="anEditBodyQuill" style="min-height:220px;background:#fff"></div>
+      <textarea id="anEditBodyRaw" style="display:none;width:100%;min-height:220px;font-family:ui-monospace,Menlo,monospace;font-size:12px;padding:10px;border:1px solid var(--line);border-radius:6px;resize:vertical" placeholder="HTML 코드를 직접 입력하세요. 예) <p>안녕하세요</p><ul><li>항목</li></ul>"></textarea>
+      <div style="display:flex;gap:8px;margin-top:14px;justify-content:flex-end">
+        <button class="btn btn-ghost btn-xs" id="btnDeleteAdminNotice" onclick="onDeleteAdminNotice()" style="color:#C62828;display:none">삭제</button>
+        <button class="btn btn-ghost btn-xs" onclick="closeModal('adminNoticeEditModal')">취소</button>
+        <button class="btn btn-primary btn-xs" onclick="onSaveAdminNotice()">저장</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- 공지 상세 보기 모달 -->
+<div class="modal-overlay" id="adminNoticeViewModal" style="z-index:550">
+  <div class="modal" style="max-width:720px;border-radius:16px;margin:auto;max-height:90vh;overflow:hidden;display:flex;flex-direction:column">
+    <div class="modal-header">
+      <div class="modal-title" id="adminNoticeViewTitle">공지</div>
+      <div class="modal-close" onclick="closeModal('adminNoticeViewModal')"><span class="material-icons-round notranslate" translate="no" style="font-size:18px">close</span></div>
+    </div>
+    <div class="modal-body" style="padding:20px;overflow-y:auto;flex:1;min-height:0">
+      <div id="adminNoticeViewMeta" style="font-size:12px;color:var(--muted);margin-bottom:12px;display:flex;gap:10px;flex-wrap:wrap;align-items:center"></div>
+      <div id="adminNoticeViewBody" class="rich-content" style="font-size:13px;line-height:1.7;color:var(--ink)"></div>
+    </div>
+  </div>
+</div>
+
+<!-- 로그인 직후 미읽음 공지 팝업 -->
+<div class="modal-overlay" id="adminNoticeUnreadModal" style="z-index:560">
+  <div class="modal" style="max-width:640px;border-radius:16px;margin:auto;max-height:88vh;overflow:hidden;display:flex;flex-direction:column">
+    <div class="modal-header">
+      <div class="modal-title">새 공지사항 <span id="adminNoticeUnreadCount" style="font-size:12px;color:var(--muted);font-weight:400"></span></div>
+      <div class="modal-close" onclick="closeModal('adminNoticeUnreadModal')"><span class="material-icons-round notranslate" translate="no" style="font-size:18px">close</span></div>
+    </div>
+    <div class="modal-body" style="padding:20px;overflow-y:auto;flex:1;min-height:0">
+      <div id="adminNoticeUnreadBody"></div>
     </div>
   </div>
 </div>

--- a/dev/js/admin.js
+++ b/dev/js/admin.js
@@ -114,7 +114,8 @@ function switchAdminPane(pane, el, pushHistory) {
     'lookups': loadLookupsPane,
     'deliverables': loadDeliverables,
     'brand-applications': loadBrandApplications,
-    'brand-dashboard': loadBrandDashboard
+    'brand-dashboard': loadBrandDashboard,
+    'admin-notices': loadAdminNotices
   };
   // 브라우저 히스토리 기록 (뒤로가기 지원)
   if (pushHistory !== false) {
@@ -222,6 +223,16 @@ async function loadAdminData(preloaded) {
   allCampaigns = camps.slice();
   // 관리자 초기 진입 시 위반 카운트도 미리 로드 — 배지 전역 노출용
   fetchViolationCountsByInfluencer().then(vc => { _infViolationCounts = vc; }).catch(()=>{});
+  // 관리자 공지 — 사이드바 배지·대시보드 최근·로그인 팝업
+  fetchAdminNotices().then(list => {
+    _adminNoticesCache = list;
+    refreshAdminNoticeBadge();
+    renderDashboardNotices();
+    if (!window._adminNoticeUnreadShown) {
+      window._adminNoticeUnreadShown = true;
+      showAdminUnreadNoticesIfAny();
+    }
+  }).catch(()=>{});
   const approved = apps.filter(a=>a.status==='approved');
   const pending = apps.filter(a=>a.status==='pending');
 
@@ -5259,4 +5270,236 @@ async function revertBrandApp() {
   toast('되돌렸습니다.');
   closeBrandAppDetail();
   await loadBrandApplications();
+}
+
+// ══════════════════════════════════════
+// ADMIN NOTICES (관리자 전용 공지 — migration 063)
+// ══════════════════════════════════════
+
+var _adminNoticesCache = [];
+var _adminNoticeCurrent = null;
+var _adminNoticeQuill = null;
+
+const ADMIN_NOTICE_CAT_LABEL = {
+  system_update: '시스템 업데이트',
+  release: '릴리스',
+  warning: '경고',
+  general: '일반',
+};
+const ADMIN_NOTICE_CAT_STYLE = {
+  system_update: 'background:#E3F2FD;color:#1565C0',
+  release: 'background:#E8F5E9;color:#2E7D32',
+  warning: 'background:#FFEBEE;color:#C62828',
+  general: 'background:#F5F5F5;color:#616161',
+};
+
+function adminNoticeCatPill(cat) {
+  const style = ADMIN_NOTICE_CAT_STYLE[cat] || ADMIN_NOTICE_CAT_STYLE.general;
+  return `<span style="display:inline-block;font-size:10px;font-weight:700;padding:2px 8px;border-radius:3px;${style}">${esc(ADMIN_NOTICE_CAT_LABEL[cat]||cat)}</span>`;
+}
+
+async function loadAdminNotices() {
+  _adminNoticesCache = await fetchAdminNotices();
+  renderAdminNotices();
+  refreshAdminNoticeBadge();
+}
+
+function refreshAdminNoticeBadge() {
+  const badge = $('adminNoticesBadge');
+  if (!badge) return;
+  const unread = (_adminNoticesCache || []).filter(n => !n.is_read).length;
+  if (unread > 0) { badge.textContent = unread > 9 ? '9+' : unread; badge.style.display = ''; }
+  else badge.style.display = 'none';
+}
+
+function renderAdminNotices() {
+  const body = $('adminNoticeBody');
+  if (!body) return;
+  const cat = $('adminNoticeCatFilter')?.value || 'all';
+  const q = ($('adminNoticeSearch')?.value || '').trim().toLowerCase();
+  let list = (_adminNoticesCache || []).slice();
+  if (cat !== 'all') list = list.filter(n => n.category === cat);
+  if (q) list = list.filter(n => (n.title || '').toLowerCase().includes(q));
+  const total = $('adminNoticeTotal');
+  if (total) total.textContent = `${list.length}건`;
+  const isSuper = currentAdminInfo?.role === 'super_admin';
+  const canEdit = (n) => isSuper || n.created_by === currentUser?.id;
+  body.innerHTML = list.length ? list.map(n => {
+    const unreadDot = !n.is_read ? `<span style="display:inline-block;width:6px;height:6px;border-radius:50%;background:#C62828;margin-right:4px;vertical-align:middle"></span>` : '';
+    const pinIcon = n.is_pinned ? `<span class="material-icons-round notranslate" translate="no" style="font-size:14px;color:var(--pink);vertical-align:-2px" title="상단 고정">push_pin</span> ` : '';
+    return `<tr data-id="${esc(n.id)}" style="cursor:pointer;${n.is_read?'':'background:#FFFBEF'}" onclick="openAdminNoticeView(this.dataset.id)">
+      <td>${unreadDot}${n.is_read?'<span style="font-size:11px;color:var(--muted)">읽음</span>':'<span style="font-size:11px;color:#C62828;font-weight:700">미읽음</span>'}</td>
+      <td>${adminNoticeCatPill(n.category)}</td>
+      <td style="font-weight:600;color:var(--ink)">${pinIcon}${esc(n.title)}</td>
+      <td style="font-size:12px;color:var(--muted)">${esc(n.created_by_name || '—')}</td>
+      <td style="font-size:11px;color:var(--muted);white-space:nowrap">${n.created_at?formatDateTime(n.created_at):''}</td>
+      <td>${canEdit(n) ? `<button class="btn btn-ghost btn-xs" onclick="event.stopPropagation();openAdminNoticeEdit(this.closest('tr').dataset.id)"><span class="material-icons-round notranslate" translate="no" style="font-size:13px;vertical-align:-2px">edit</span> 수정</button>` : ''}</td>
+    </tr>`;
+  }).join('') : '<tr><td colspan="6" style="text-align:center;color:var(--muted);padding:24px">공지 없음</td></tr>';
+}
+
+async function openAdminNoticeView(id) {
+  const n = (_adminNoticesCache || []).find(x => x.id === id);
+  if (!n) return;
+  $('adminNoticeViewTitle').innerHTML = esc(n.title);
+  $('adminNoticeViewMeta').innerHTML = `${adminNoticeCatPill(n.category)}<span>${esc(n.created_by_name || '—')}</span><span>${n.created_at?formatDateTime(n.created_at):''}</span>${n.is_pinned?'<span style="color:var(--pink);font-weight:700;display:inline-flex;align-items:center;gap:4px"><span class="material-icons-round notranslate" translate="no" style="font-size:14px">push_pin</span>상단 고정</span>':''}`;
+  const bodyEl = $('adminNoticeViewBody');
+  if (typeof renderRich === 'function') renderRich(bodyEl, n.body_html || '');
+  else if (typeof sanitizeRich === 'function') bodyEl.innerHTML = sanitizeRich(n.body_html || '');
+  else bodyEl.innerHTML = n.body_html || '';
+  openModal('adminNoticeViewModal');
+  if (!n.is_read) {
+    try { await markAdminNoticeRead(id); n.is_read = true; refreshAdminNoticeBadge(); renderAdminNotices(); } catch(e) {}
+  }
+}
+
+function openAdminNoticeEdit(id) {
+  const n = id ? (_adminNoticesCache || []).find(x => x.id === id) : null;
+  _adminNoticeCurrent = n;
+  $('adminNoticeEditTitle').textContent = n ? '공지 수정' : '공지 작성';
+  $('anEditTitle').value = n?.title || '';
+  $('anEditCategory').value = n?.category || 'system_update';
+  $('anEditPinned').checked = !!(n?.is_pinned);
+  const delBtn = $('btnDeleteAdminNotice');
+  if (delBtn) delBtn.style.display = n ? '' : 'none';
+  // HTML 모드 기본 off. 기존 공지 중 '<p>&lt;' 같이 태그가 텍스트로 저장된 케이스 감지 시 자동 HTML 모드
+  const rawHtml = n?.body_html || '';
+  const tagAsText = /&lt;\w+/.test(rawHtml);
+  $('anEditHtmlMode').checked = tagAsText;
+  $('anEditBodyRaw').value = rawHtml;
+  openModal('adminNoticeEditModal');
+  setTimeout(() => {
+    if (!_adminNoticeQuill && typeof Quill !== 'undefined') {
+      _adminNoticeQuill = new Quill('#anEditBodyQuill', {
+        theme: 'snow',
+        modules: { toolbar: [[{header:[2,3,4,false]}],['bold','italic','underline','strike'],[{list:'ordered'},{list:'bullet'}],['link','blockquote'],['clean']], clipboard:{matchVisual:false} },
+        formats: ['header','bold','italic','underline','strike','list','link','blockquote']
+      });
+    }
+    if (_adminNoticeQuill) {
+      const initHtml = (typeof sanitizeRich === 'function') ? sanitizeRich(rawHtml) : rawHtml;
+      _adminNoticeQuill.clipboard.dangerouslyPasteHTML(initHtml, 'silent');
+    }
+    toggleNoticeHtmlMode();
+  }, 0);
+}
+
+function toggleNoticeHtmlMode() {
+  const isHtml = !!$('anEditHtmlMode')?.checked;
+  const quillHost = $('anEditBodyQuill');
+  const raw = $('anEditBodyRaw');
+  const toolbar = document.querySelector('#adminNoticeEditModal .ql-toolbar');
+  if (isHtml) {
+    if (_adminNoticeQuill && raw.value === '') raw.value = _adminNoticeQuill.root.innerHTML;
+    if (quillHost) quillHost.style.display = 'none';
+    if (toolbar) toolbar.style.display = 'none';
+    if (raw) raw.style.display = '';
+  } else {
+    if (_adminNoticeQuill && raw.value) {
+      const initHtml = (typeof sanitizeRich === 'function') ? sanitizeRich(raw.value) : raw.value;
+      _adminNoticeQuill.clipboard.dangerouslyPasteHTML(initHtml, 'silent');
+    }
+    if (raw) raw.style.display = 'none';
+    if (quillHost) quillHost.style.display = '';
+    if (toolbar) toolbar.style.display = '';
+  }
+}
+
+async function onSaveAdminNotice() {
+  const title = ($('anEditTitle')?.value || '').trim();
+  const category = $('anEditCategory')?.value || 'general';
+  const is_pinned = !!$('anEditPinned')?.checked;
+  if (!title) { toast('제목을 입력해주세요', 'error'); return; }
+  let body_html = '';
+  const isHtmlMode = !!$('anEditHtmlMode')?.checked;
+  if (isHtmlMode) {
+    const raw = $('anEditBodyRaw')?.value || '';
+    body_html = (typeof sanitizeRich === 'function') ? sanitizeRich(raw) : raw;
+  } else if (_adminNoticeQuill) {
+    const raw = _adminNoticeQuill.root.innerHTML;
+    body_html = (typeof sanitizeRich === 'function') ? sanitizeRich(raw) : raw;
+  }
+  const name = currentAdminInfo?.name || currentUserProfile?.name || '관리자';
+  try {
+    if (_adminNoticeCurrent) {
+      await updateAdminNotice(_adminNoticeCurrent.id, {title, body_html, category, is_pinned, updated_by_name: name});
+      toast('공지가 수정되었습니다', 'success');
+    } else {
+      await insertAdminNotice({title, body_html, category, is_pinned, created_by_name: name});
+      toast('공지가 등록되었습니다', 'success');
+    }
+    closeModal('adminNoticeEditModal');
+    await loadAdminNotices();
+  } catch(e) { toast('저장 오류: ' + (e.message || e), 'error'); }
+}
+
+async function onDeleteAdminNotice() {
+  if (!_adminNoticeCurrent) return;
+  if (!confirm('공지를 삭제할까요? 모든 관리자의 읽음 이력도 함께 삭제됩니다.')) return;
+  try {
+    await deleteAdminNotice(_adminNoticeCurrent.id);
+    toast('삭제되었습니다');
+    closeModal('adminNoticeEditModal');
+    await loadAdminNotices();
+  } catch(e) { toast('삭제 오류: ' + (e.message || e), 'error'); }
+}
+
+// 대시보드 최근 공지 3건 렌더
+function renderDashboardNotices() {
+  const card = $('dashboardNoticesCard');
+  const body = $('dashboardNoticesBody');
+  if (!card || !body) return;
+  const list = (_adminNoticesCache || []).slice(0, 3);
+  if (!list.length) { card.style.display = 'none'; return; }
+  card.style.display = '';
+  body.innerHTML = list.map(n => `
+    <div style="padding:12px 16px;border-bottom:1px solid var(--line);display:flex;align-items:center;gap:10px;cursor:pointer" onclick="openAdminNoticeView('${esc(n.id)}')">
+      ${!n.is_read ? '<span style="display:inline-block;width:6px;height:6px;border-radius:50%;background:#C62828;flex-shrink:0"></span>' : '<span style="display:inline-block;width:6px;height:6px;flex-shrink:0"></span>'}
+      ${adminNoticeCatPill(n.category)}
+      <div style="flex:1;font-size:13px;color:var(--ink);font-weight:${n.is_read?'400':'600'};overflow:hidden;text-overflow:ellipsis;white-space:nowrap">${n.is_pinned?'<span class="material-icons-round notranslate" translate="no" style="font-size:13px;color:var(--pink);vertical-align:-2px">push_pin</span> ':''}${esc(n.title)}</div>
+      <div style="font-size:11px;color:var(--muted);flex-shrink:0">${n.created_at?formatDate(n.created_at):''}</div>
+    </div>
+  `).join('');
+}
+
+// 로그인 직후 미읽음 공지 팝업
+async function showAdminUnreadNoticesIfAny() {
+  if (!Array.isArray(_adminNoticesCache) || _adminNoticesCache.length === 0) return;
+  const unread = _adminNoticesCache.filter(n => !n.is_read);
+  if (unread.length === 0) return;
+  const countEl = $('adminNoticeUnreadCount');
+  if (countEl) countEl.textContent = `${unread.length}건`;
+  const body = $('adminNoticeUnreadBody');
+  if (body) {
+    body.innerHTML = unread.slice(0, 5).map(n => `
+      <div style="padding:14px;border:1px solid var(--line);border-radius:8px;margin-bottom:10px">
+        <div style="display:flex;align-items:center;gap:8px;margin-bottom:6px">${adminNoticeCatPill(n.category)}<div style="font-weight:700;font-size:14px;color:var(--ink)">${n.is_pinned?'<span class="material-icons-round notranslate" translate="no" style="font-size:14px;color:var(--pink);vertical-align:-2px">push_pin</span> ':''}${esc(n.title)}</div></div>
+        <div style="font-size:11px;color:var(--muted);margin-bottom:8px">${esc(n.created_by_name||'—')} · ${n.created_at?formatDateTime(n.created_at):''}</div>
+        <div class="rich-content" data-notice-body="${esc(n.id)}" style="font-size:12px;line-height:1.6;color:var(--ink);max-height:140px;overflow:hidden"></div>
+        <div style="text-align:right;margin-top:8px"><button class="btn btn-primary btn-xs" onclick="onMarkUnreadFromPopup('${esc(n.id)}')">확인</button></div>
+      </div>
+    `).join('');
+    // 본문 부분만 renderRich(el, raw) 시그니처로 주입
+    unread.slice(0, 5).forEach(n => {
+      const el = document.querySelector(`[data-notice-body="${n.id}"]`);
+      if (!el) return;
+      if (typeof renderRich === 'function') renderRich(el, n.body_html || '');
+      else if (typeof sanitizeRich === 'function') el.innerHTML = sanitizeRich(n.body_html || '');
+      else el.innerHTML = n.body_html || '';
+    });
+  }
+  openModal('adminNoticeUnreadModal');
+}
+
+async function onMarkUnreadFromPopup(id) {
+  try {
+    await markAdminNoticeRead(id);
+    const n = (_adminNoticesCache || []).find(x => x.id === id);
+    if (n) n.is_read = true;
+    refreshAdminNoticeBadge();
+    renderDashboardNotices();
+    const stillUnread = (_adminNoticesCache || []).some(x => !x.is_read);
+    if (!stillUnread) closeModal('adminNoticeUnreadModal');
+    else showAdminUnreadNoticesIfAny();
+  } catch(e) { toast('오류: ' + (e.message || e), 'error'); }
 }

--- a/dev/lib/storage.js
+++ b/dev/lib/storage.js
@@ -912,6 +912,84 @@ async function swapParticipationSetOrder(idA, idB) {
 }
 
 // ══════════════════════════════════════
+// ADMIN NOTICES (관리자 전용 공지 — migration 063)
+// ══════════════════════════════════════
+
+// 공지 목록 + 본인 읽음 여부
+async function fetchAdminNotices(filters) {
+  if (!db) return [];
+  try {
+    const uid = (await db.auth.getUser()).data?.user?.id;
+    let q = db.from('admin_notices').select('*, admin_notice_reads!left(read_at,auth_id)');
+    if (filters?.category && filters.category !== 'all') q = q.eq('category', filters.category);
+    q = q.order('is_pinned', {ascending: false})
+         .order('pinned_at', {ascending: false, nullsFirst: false})
+         .order('created_at', {ascending: false});
+    const {data, error} = await q;
+    if (error) throw error;
+    return (data || []).map(n => {
+      const mine = (n.admin_notice_reads || []).find(r => r.auth_id === uid);
+      return {...n, is_read: !!mine, read_at: mine?.read_at || null, admin_notice_reads: undefined};
+    });
+  } catch(e) { console.error('[fetchAdminNotices]', e); return []; }
+}
+
+async function fetchUnreadAdminNotices() {
+  const all = await fetchAdminNotices();
+  return all.filter(n => !n.is_read);
+}
+
+async function insertAdminNotice(data) {
+  if (!db) throw new Error('DB 미연결');
+  const uid = (await db.auth.getUser()).data?.user?.id;
+  const payload = {
+    title: data.title,
+    body_html: data.body_html,
+    category: data.category,
+    is_pinned: !!data.is_pinned,
+    pinned_at: data.is_pinned ? new Date().toISOString() : null,
+    created_by: uid || null,
+    created_by_name: data.created_by_name || null,
+    updated_by: uid || null,
+    updated_by_name: data.created_by_name || null,
+  };
+  await retryWithRefresh(async () => {
+    const {error} = await db.from('admin_notices').insert(payload);
+    if (error) throw error;
+  });
+}
+
+async function updateAdminNotice(id, patch) {
+  if (!db) throw new Error('DB 미연결');
+  const uid = (await db.auth.getUser()).data?.user?.id;
+  const p = {...patch, updated_by: uid || null};
+  // is_pinned 변경 시 pinned_at 동기화
+  if (Object.prototype.hasOwnProperty.call(patch, 'is_pinned')) {
+    p.pinned_at = patch.is_pinned ? new Date().toISOString() : null;
+  }
+  await retryWithRefresh(async () => {
+    const {error} = await db.from('admin_notices').update(p).eq('id', id);
+    if (error) throw error;
+  });
+}
+
+async function deleteAdminNotice(id) {
+  if (!db) throw new Error('DB 미연결');
+  await retryWithRefresh(async () => {
+    const {error} = await db.from('admin_notices').delete().eq('id', id);
+    if (error) throw error;
+  });
+}
+
+async function markAdminNoticeRead(noticeId) {
+  if (!db || !noticeId) return;
+  await retryWithRefresh(async () => {
+    const {error} = await db.rpc('upsert_admin_notice_read', {p_notice_id: noticeId});
+    if (error) throw error;
+  });
+}
+
+// ══════════════════════════════════════
 // BRAND APPLICATIONS (광고주 신청 폼 — 052)
 // ══════════════════════════════════════
 

--- a/docs/admin-notices/2026-04-22-system_update-influencer-flags.md
+++ b/docs/admin-notices/2026-04-22-system_update-influencer-flags.md
@@ -1,0 +1,35 @@
+---
+category: system_update
+title: 인플루언서 인증·위반·블랙 관리 기능 추가
+is_pinned: false
+generated_at: 2026-04-22
+source_pr: 109
+---
+
+# 인플루언서 인증·위반·블랙 관리 기능 추가
+
+## 본문 HTML (Quill 붙여넣기용)
+
+```html
+<p>관리자 페이지에 인플루언서 상태를 직접 관리할 수 있는 기능이 추가되었습니다. DB 마이그레이션 059~062 가 개발·운영 서버 모두 적용 완료된 상태입니다.</p>
+<p><strong>주요 변경</strong></p>
+<ul>
+  <li>인플루언서 이름 옆에 <strong>인증 / 위반 카운트 / 블랙리스트</strong> 상태 배지가 전역 노출 (목록·신청 관리·캠페인 신청자·결과물 관리·상세 모달)</li>
+  <li>인플루언서 이름을 클릭하면 어디서든 동일한 풀 상세 모달이 열리도록 통합 (기존 간이 모달 삭제)</li>
+  <li>상세 모달 안에서 <strong>인증 토글 · 위반 등록 · 블랙리스트 등록/해제</strong>를 한 화면에서 처리. 관리자 이력은 같은 카드 하단에 누적 pill + 타임라인 + 편집 아이콘으로 정리</li>
+  <li>위반 기록에 <strong>증빙 이미지/PDF 복수 첨부</strong> 가능. 썸네일 클릭 시 라이트박스 확대. 파일은 비공개 버킷 <code>influencer-flag-evidence</code> 에 저장</li>
+  <li>인플루언서 목록 필터를 상단으로 이관: 채널·인증·위반 상태 드롭다운 + 이름·이메일·SNS 핸들 검색 추가</li>
+  <li>캠페인 · 신청자 목록에도 동일 스펙 검색창 추가</li>
+  <li>모든 모달은 ESC 키로 닫기 가능</li>
+</ul>
+<p><strong>영향 범위</strong>: 관리자 페이지 한정. 인플루언서 앱·광고주 페이지에는 영향 없음.</p>
+<p><strong>권한</strong>: 배지 조회는 모든 관리자. 인증/위반/블랙 조작은 <code>campaign_admin</code> 이상.</p>
+```
+
+## 등록 안내
+관리자 페이지 → `공지사항` 메뉴 → `새 공지 작성` → 카테고리 `시스템 업데이트` 선택 → 제목·본문 복사 붙여넣기.
+
+## 근거 커밋
+- `3a1655b` feat(admin): influencer verify · violation · blacklist management
+- `88d6d3e` feat(admin): violation evidence uploads + ESC close + status UI cleanup
+- PR #109: feat(admin): influencer verify · violation · blacklist + evidence uploads

--- a/index.html
+++ b/index.html
@@ -3426,6 +3426,84 @@ async function swapParticipationSetOrder(idA, idB) {
 }
 
 // ══════════════════════════════════════
+// ADMIN NOTICES (관리자 전용 공지 — migration 063)
+// ══════════════════════════════════════
+
+// 공지 목록 + 본인 읽음 여부
+async function fetchAdminNotices(filters) {
+  if (!db) return [];
+  try {
+    const uid = (await db.auth.getUser()).data?.user?.id;
+    let q = db.from('admin_notices').select('*, admin_notice_reads!left(read_at,auth_id)');
+    if (filters?.category && filters.category !== 'all') q = q.eq('category', filters.category);
+    q = q.order('is_pinned', {ascending: false})
+         .order('pinned_at', {ascending: false, nullsFirst: false})
+         .order('created_at', {ascending: false});
+    const {data, error} = await q;
+    if (error) throw error;
+    return (data || []).map(n => {
+      const mine = (n.admin_notice_reads || []).find(r => r.auth_id === uid);
+      return {...n, is_read: !!mine, read_at: mine?.read_at || null, admin_notice_reads: undefined};
+    });
+  } catch(e) { console.error('[fetchAdminNotices]', e); return []; }
+}
+
+async function fetchUnreadAdminNotices() {
+  const all = await fetchAdminNotices();
+  return all.filter(n => !n.is_read);
+}
+
+async function insertAdminNotice(data) {
+  if (!db) throw new Error('DB 미연결');
+  const uid = (await db.auth.getUser()).data?.user?.id;
+  const payload = {
+    title: data.title,
+    body_html: data.body_html,
+    category: data.category,
+    is_pinned: !!data.is_pinned,
+    pinned_at: data.is_pinned ? new Date().toISOString() : null,
+    created_by: uid || null,
+    created_by_name: data.created_by_name || null,
+    updated_by: uid || null,
+    updated_by_name: data.created_by_name || null,
+  };
+  await retryWithRefresh(async () => {
+    const {error} = await db.from('admin_notices').insert(payload);
+    if (error) throw error;
+  });
+}
+
+async function updateAdminNotice(id, patch) {
+  if (!db) throw new Error('DB 미연결');
+  const uid = (await db.auth.getUser()).data?.user?.id;
+  const p = {...patch, updated_by: uid || null};
+  // is_pinned 변경 시 pinned_at 동기화
+  if (Object.prototype.hasOwnProperty.call(patch, 'is_pinned')) {
+    p.pinned_at = patch.is_pinned ? new Date().toISOString() : null;
+  }
+  await retryWithRefresh(async () => {
+    const {error} = await db.from('admin_notices').update(p).eq('id', id);
+    if (error) throw error;
+  });
+}
+
+async function deleteAdminNotice(id) {
+  if (!db) throw new Error('DB 미연결');
+  await retryWithRefresh(async () => {
+    const {error} = await db.from('admin_notices').delete().eq('id', id);
+    if (error) throw error;
+  });
+}
+
+async function markAdminNoticeRead(noticeId) {
+  if (!db || !noticeId) return;
+  await retryWithRefresh(async () => {
+    const {error} = await db.rpc('upsert_admin_notice_read', {p_notice_id: noticeId});
+    if (error) throw error;
+  });
+}
+
+// ══════════════════════════════════════
 // BRAND APPLICATIONS (광고주 신청 폼 — 052)
 // ══════════════════════════════════════
 

--- a/supabase/migrations/063_admin_notices.sql
+++ b/supabase/migrations/063_admin_notices.sql
@@ -1,0 +1,229 @@
+-- ============================================================
+-- 063_admin_notices.sql
+-- 관리자 공지사항 + 읽음 이력
+--
+-- 테이블:
+--   admin_notices       — 공지 본문 (리치 텍스트, 카테고리, 고정)
+--   admin_notice_reads  — 읽음 이력 (관리자별)
+--
+-- RPC:
+--   upsert_admin_notice_read(p_notice_id uuid) — 읽음 처리 (SECURITY DEFINER)
+--
+-- ROLLBACK 방법:
+--   DROP FUNCTION IF EXISTS public.upsert_admin_notice_read(uuid);
+--   DROP TABLE IF EXISTS public.admin_notice_reads;
+--   DROP TABLE IF EXISTS public.admin_notices;
+-- ============================================================
+
+-- ============================================================
+-- Step 1: admin_notices 테이블
+-- ============================================================
+CREATE TABLE IF NOT EXISTS public.admin_notices (
+  id               uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  title            text        NOT NULL,
+  body_html        text        NOT NULL,                   -- DOMPurify sanitize 된 Quill HTML
+  category         text        NOT NULL
+                               CHECK (category IN ('system_update','general','warning','release')),
+  is_pinned        boolean     NOT NULL DEFAULT false,
+  pinned_at        timestamptz,                            -- 고정 시점 (정렬 기준)
+  created_by       uuid,                                   -- admins.auth_id soft ref
+  created_by_name  text,                                   -- 작성자 이름 스냅샷 (삭제 후 표시용)
+  created_at       timestamptz NOT NULL DEFAULT now(),
+  updated_at       timestamptz NOT NULL DEFAULT now(),
+  updated_by       uuid,                                   -- admins.auth_id soft ref
+  updated_by_name  text                                    -- 최종 수정자 이름 스냅샷
+);
+
+-- 목록 정렬용 인덱스: 고정 공지 최상단 → 고정 시점 역순 → 작성일 역순
+CREATE INDEX IF NOT EXISTS idx_admin_notices_list
+  ON public.admin_notices (is_pinned DESC, pinned_at DESC NULLS LAST, created_at DESC);
+
+-- updated_at 자동 갱신 트리거
+CREATE OR REPLACE FUNCTION public.touch_admin_notices_updated_at()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_admin_notices_updated_at ON public.admin_notices;
+CREATE TRIGGER trg_admin_notices_updated_at
+  BEFORE UPDATE ON public.admin_notices
+  FOR EACH ROW EXECUTE FUNCTION public.touch_admin_notices_updated_at();
+
+-- ============================================================
+-- Step 2: admin_notice_reads 테이블
+-- ============================================================
+CREATE TABLE IF NOT EXISTS public.admin_notice_reads (
+  notice_id  uuid        NOT NULL REFERENCES public.admin_notices(id) ON DELETE CASCADE,
+  auth_id    uuid        NOT NULL,
+  read_at    timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (notice_id, auth_id)
+);
+
+-- auth_id 단독 인덱스: "내가 읽지 않은 공지 수" 쿼리용
+CREATE INDEX IF NOT EXISTS idx_admin_notice_reads_auth
+  ON public.admin_notice_reads (auth_id);
+
+-- ============================================================
+-- Step 3: RLS — admin_notices
+-- ============================================================
+ALTER TABLE public.admin_notices ENABLE ROW LEVEL SECURITY;
+
+-- SELECT: 모든 관리자
+CREATE POLICY "admin_notices_select"
+  ON public.admin_notices FOR SELECT
+  TO authenticated
+  USING (public.is_admin());
+
+-- INSERT: campaign_admin 이상 (super_admin 포함)
+CREATE POLICY "admin_notices_insert"
+  ON public.admin_notices FOR INSERT
+  TO authenticated
+  WITH CHECK (public.is_campaign_admin());
+
+-- UPDATE: super_admin은 전체, 일반 관리자는 본인 작성 공지만
+CREATE POLICY "admin_notices_update"
+  ON public.admin_notices FOR UPDATE
+  TO authenticated
+  USING (
+    public.is_campaign_admin()
+    AND (public.is_super_admin() OR created_by = auth.uid())
+  )
+  WITH CHECK (
+    public.is_campaign_admin()
+    AND (public.is_super_admin() OR created_by = auth.uid())
+  );
+
+-- DELETE: UPDATE 와 동일 규칙
+CREATE POLICY "admin_notices_delete"
+  ON public.admin_notices FOR DELETE
+  TO authenticated
+  USING (
+    public.is_campaign_admin()
+    AND (public.is_super_admin() OR created_by = auth.uid())
+  );
+
+-- ============================================================
+-- Step 4: RLS — admin_notice_reads
+-- ============================================================
+ALTER TABLE public.admin_notice_reads ENABLE ROW LEVEL SECURITY;
+
+-- SELECT:
+--   (a) 본인 읽음 이력 조회 (마이 읽음 상태 확인)
+--   (b) is_admin() 전체 허용 — 공지 목록과 LEFT JOIN 할 때 본인 행만 필터링은
+--       클라이언트 또는 RPC 레벨에서 처리. 정책은 관리자면 전체 허용.
+CREATE POLICY "admin_notice_reads_select"
+  ON public.admin_notice_reads FOR SELECT
+  TO authenticated
+  USING (public.is_admin());
+
+-- INSERT: 본인 행만, 관리자여야 함
+CREATE POLICY "admin_notice_reads_insert"
+  ON public.admin_notice_reads FOR INSERT
+  TO authenticated
+  WITH CHECK (auth_id = auth.uid() AND public.is_admin());
+
+-- UPDATE/DELETE 정책 없음 — upsert_admin_notice_read RPC 전용 (직접 조작 차단)
+
+-- ============================================================
+-- Step 5: RPC — upsert_admin_notice_read
+--   현재 로그인한 관리자의 읽음을 upsert.
+--   SECURITY DEFINER이므로 RLS bypass — INSERT 권한 문제 없이 동작.
+--   search_path = '' 로 schema 탈취 방어.
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.upsert_admin_notice_read(p_notice_id uuid)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_uid uuid := auth.uid();
+BEGIN
+  -- 비관리자 호출 차단
+  IF NOT public.is_admin() THEN
+    RAISE EXCEPTION 'permission denied: admin only';
+  END IF;
+
+  -- 공지가 존재하는지 확인 (없으면 FK 위반으로 바로 에러)
+  INSERT INTO public.admin_notice_reads (notice_id, auth_id, read_at)
+  VALUES (p_notice_id, v_uid, now())
+  ON CONFLICT (notice_id, auth_id) DO UPDATE
+    SET read_at = now();         -- 재방문 시 read_at 갱신
+END;
+$$;
+
+-- anon 호출 차단 (authenticated 만 exec 허용)
+REVOKE EXECUTE ON FUNCTION public.upsert_admin_notice_read(uuid) FROM anon;
+GRANT  EXECUTE ON FUNCTION public.upsert_admin_notice_read(uuid) TO authenticated;
+
+-- ============================================================
+-- 검증 쿼리 (수동 실행)
+-- ============================================================
+
+-- [1] 테이블 존재 확인
+-- SELECT table_name
+-- FROM information_schema.tables
+-- WHERE table_schema = 'public'
+--   AND table_name IN ('admin_notices','admin_notice_reads')
+-- ORDER BY table_name;
+-- 기대: 2개 행
+
+-- [2] RLS 정책 목록
+-- SELECT tablename, policyname, cmd, qual
+-- FROM pg_policies
+-- WHERE tablename IN ('admin_notices','admin_notice_reads')
+-- ORDER BY tablename, policyname;
+-- 기대: admin_notices 4건 (select/insert/update/delete)
+--       admin_notice_reads 2건 (select/insert)
+
+-- [3] RPC prosecdef 확인
+-- SELECT proname, prosecdef, proconfig
+-- FROM pg_proc
+-- WHERE proname = 'upsert_admin_notice_read';
+-- 기대: prosecdef = true, proconfig 에 'search_path=' 포함
+
+-- [4] 샘플 INSERT + RPC 테스트 (관리자 세션에서 실행)
+-- INSERT INTO public.admin_notices
+--   (title, body_html, category, is_pinned, pinned_at, created_by, created_by_name)
+-- VALUES
+--   ('시스템 점검 안내',
+--    '<p>2026-04-25 02:00 ~ 04:00 시스템 점검 예정입니다.</p>',
+--    'system_update', true, now(),
+--    auth.uid(), '테스트관리자')
+-- RETURNING id, created_at;
+--
+-- SELECT public.upsert_admin_notice_read('<위에서 나온 id>');
+--
+-- SELECT * FROM public.admin_notice_reads
+-- WHERE notice_id = '<위에서 나온 id>';
+-- 기대: read_at 기록된 1행
+
+-- [5] 미읽음 공지 수 확인 쿼리 (fetchUnreadAdminNotices 내부 동일 로직)
+-- SELECT COUNT(*)
+-- FROM public.admin_notices n
+-- WHERE NOT EXISTS (
+--   SELECT 1 FROM public.admin_notice_reads r
+--   WHERE r.notice_id = n.id
+--     AND r.auth_id = auth.uid()
+-- );
+-- 기대: upsert 전 공지 총 수, upsert 후 1 감소
+
+-- ============================================================
+-- 실행 체크리스트
+-- ============================================================
+-- 개발서버(qysmxtipobomefudyixw):
+--   [ ] Supabase SQL Editor에서 이 파일 전체 실행
+--   [ ] 검증 쿼리 [1]~[5] 순서대로 확인
+--   [ ] fetchAdminNotices / markAdminNoticeRead 클라이언트 함수 동작 확인
+--   [ ] 개발서버 화면에서 공지 등록 → 목록 노출 → 읽음 처리 확인
+--
+-- 운영서버(twofagomeizrtkwlhsuv):
+--   [ ] 개발서버 검증 완료 후 동일 SQL 실행
+--   [ ] 검증 쿼리 [1]~[3] 재확인 (데이터 INSERT는 선택)

--- a/supabase/patches/2026-04-22_delete_brand_application_test_data_prod.sql
+++ b/supabase/patches/2026-04-22_delete_brand_application_test_data_prod.sql
@@ -1,0 +1,74 @@
+-- ============================================================
+-- patch   : 2026-04-22_delete_brand_application_test_data_prod
+-- purpose : 운영 DB의 테스트 광고주 신청 2건 삭제
+-- env     : 운영서버 ONLY (twofagomeizrtkwlhsuv.supabase.co, Sydney ap-southeast-2)
+--           ※ 개발서버(qysmxtipobomefudyixw)에는 실행 금지
+-- targets :
+--   - wnsgud1124@daum.net
+--   - semia670@gamil.com  (오타 포함 원본 이메일 그대로)
+-- author  : jfun@jfun.co.kr
+-- date    : 2026-04-22
+--
+-- 주의:
+--   Migration 057 적용으로 brand_applications.business_license_path 컬럼 및
+--   brand-docs Storage 버킷이 제거됨. 따라서 Storage 고아 파일 정리 불필요.
+--
+-- FK 관계 확인:
+--   - brand_applications.reviewed_by → auth.users(id) ON DELETE SET NULL
+--     (역방향 FK 없음 — 다른 테이블이 brand_applications를 참조하지 않음)
+--   - brand_app_daily_counter 는 독립 채번 카운터, FK 관계 없음
+--   → CASCADE 삭제 대상 없음. brand_applications 단독 DELETE 가능.
+-- ============================================================
+
+
+-- ============================================================
+-- STEP 1 — 삭제 대상 사전 확인
+--
+-- 실행 후 결과를 육안으로 확인:
+--   - 삭제할 이메일 2건만 조회되는지 확인
+-- ============================================================
+SELECT
+  id,
+  application_no,
+  form_type,
+  brand_name,
+  contact_name,
+  email,
+  status,
+  created_at
+FROM public.brand_applications
+WHERE email IN (
+  'wnsgud1124@daum.net',
+  'semia670@gamil.com'
+)
+ORDER BY created_at;
+
+
+-- ============================================================
+-- STEP 2 — DB 행 삭제 (STEP 1 육안 확인 완료 후 실행)
+-- ============================================================
+BEGIN;
+
+-- 삭제 실행
+DELETE FROM public.brand_applications
+WHERE email IN (
+  'wnsgud1124@daum.net',
+  'semia670@gamil.com'
+);
+
+-- 삭제 후 검증: 0이어야 정상
+SELECT count(*) AS remaining_rows
+FROM public.brand_applications
+WHERE email IN (
+  'wnsgud1124@daum.net',
+  'semia670@gamil.com'
+);
+-- 기대값: remaining_rows = 0
+
+COMMIT;
+
+-- ============================================================
+-- ROLLBACK (실수로 잘못 삭제한 경우)
+-- SQL Editor는 자동 커밋이므로 COMMIT 이후에는 되돌릴 수 없음.
+-- 필요 시 Supabase Dashboard → Database → Backups 에서 Point-in-Time Recovery 사용.
+-- ============================================================


### PR DESCRIPTION
## Summary
- 관리자 공지사항 기능 (시스템 업데이트 + 일반 공지) — 카테고리 4종, 상단 고정, Quill 리치 텍스트, per-admin 읽음 추적
- 인플루언서 위반 증빙 파일 업로드 (비공개 버킷, 썸네일 + 라이트박스)
- 모든 모달 ESC 키 닫기
- \`/공지초안\` 슬래시 커맨드 (최근 PR/머지 커밋 기반 공지 초안 자동 작성)

## Database migration
- \`063_admin_notices.sql\` — 운영 DB에 이미 적용 완료 (사용자 확인)

## Test plan
- [x] 개발서버 검증 완료
- [x] reverb-reviewer GO (이모지 3곳 Material Icon 교체 후)
- [ ] 운영 배포 후 /admin/#admin-notices 접근 확인
- [ ] 공지 등록 → 다른 관리자 로그인 시 팝업 노출 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)