### PR TITLE
feat(brand-survey): expand status pipeline to 8 stages

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -1456,7 +1456,7 @@ textarea.form-input{resize:vertical;min-height:80px}
           <div class="kpi-row" style="margin-top:12px">
             <div class="kpi-card kpi-o"><div class="kpi-val" id="brandKpiPending">—</div><div class="kpi-lbl">검수 대기 (new+reviewing)</div></div>
             <div class="kpi-card kpi-b"><div class="kpi-val" id="brandKpiQuoted">—</div><div class="kpi-lbl">견적 전달 (quoted)</div></div>
-            <div class="kpi-card kpi-g"><div class="kpi-val" id="brandKpiDone">—</div><div class="kpi-lbl">성약 완료 (done)</div></div>
+            <div class="kpi-card kpi-g"><div class="kpi-val" id="brandKpiDone">—</div><div class="kpi-lbl">최종완료 (done)</div></div>
             <div class="kpi-card kpi-r"><div class="kpi-val" id="brandKpiLeadTime">—</div><div class="kpi-lbl">평균 처리일 (new→done)</div></div>
           </div>
 
@@ -1477,7 +1477,7 @@ textarea.form-input{resize:vertical;min-height:80px}
           <!-- 전환 깔때기 -->
           <div class="admin-card" style="margin-top:16px;padding:18px">
             <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:12px">
-              <div style="font-size:13px;font-weight:700;color:var(--ink)">전환 깔때기 (접수 → 완료)</div>
+              <div style="font-size:13px;font-weight:700;color:var(--ink)">전환 깔때기 (접수 → 최종완료)</div>
               <div style="font-size:10px;color:var(--muted)">각 단계는 "해당 단계 이상 도달한 건수" 기준</div>
             </div>
             <div id="brandFunnel" style="display:flex;flex-direction:column;gap:8px">
@@ -4564,7 +4564,7 @@ function initMultiFilters() {
     {value:'reviewer',label:'Qoo10 리뷰어'},{value:'seeding',label:'나노 시딩'}
   ], () => renderBrandApplicationsList());
   createMultiFilter('brandAppStatusMulti', '전체 상태', [
-    {value:'new',label:'신규'},{value:'reviewing',label:'검토중'},{value:'quoted',label:'견적전달'},{value:'paid',label:'입금완료'},{value:'done',label:'완료'},{value:'rejected',label:'반려'}
+    {value:'new',label:'신규'},{value:'reviewing',label:'검토중'},{value:'schedule_sent',label:'일정전달'},{value:'quoted',label:'견적전달'},{value:'campaign_registered',label:'캠페인등록'},{value:'paid',label:'입금완료'},{value:'done',label:'최종완료'},{value:'rejected',label:'반려'}
   ], () => renderBrandApplicationsList());
 }
 
@@ -8604,12 +8604,14 @@ var _brandAppCurrentId = null; // 상세 모달 열린 신청 ID
 
 // 상태 라벨·컬러
 var BRAND_APP_STATUS = {
-  'new':       {label:'신규',     color:'#C33',   bg:'#FEE'},
-  'reviewing': {label:'검토중',   color:'#B88',   bg:'#FFE'},
-  'quoted':    {label:'견적전달', color:'#08A',   bg:'#DEF'},
-  'paid':      {label:'입금완료', color:'#6A2',   bg:'#EFE'},
-  'done':      {label:'완료',     color:'#555',   bg:'#EEE'},
-  'rejected':  {label:'반려',     color:'#999',   bg:'#F5F5F5'}
+  'new':                 {label:'신규',       color:'#C33',   bg:'#FEE'},
+  'reviewing':           {label:'검토중',     color:'#B88',   bg:'#FFE'},
+  'schedule_sent':       {label:'일정전달',   color:'#A36',   bg:'#FDEEF4'},
+  'quoted':              {label:'견적전달',   color:'#08A',   bg:'#DEF'},
+  'campaign_registered': {label:'캠페인등록', color:'#274',   bg:'#E6F3E8'},
+  'paid':                {label:'입금완료',   color:'#6A2',   bg:'#EFE'},
+  'done':                {label:'최종완료',   color:'#555',   bg:'#EEE'},
+  'rejected':            {label:'반려',       color:'#999',   bg:'#F5F5F5'}
 };
 
 function brandAppStatusBadge(status) {
@@ -9179,26 +9181,30 @@ var _brandStatusDonut = null;
 var _brandTrendDays = 7;
 
 var BRAND_STATUS_LABEL_KO = {
-  new: '신규', reviewing: '검토중', quoted: '견적전달',
-  paid: '입금완료', done: '완료', rejected: '반려'
+  new: '신규', reviewing: '검토중', schedule_sent: '일정전달', quoted: '견적전달',
+  campaign_registered: '캠페인등록', paid: '입금완료', done: '최종완료', rejected: '반려'
 };
 var BRAND_STATUS_COLOR = {
-  new:      '#C878A3',   // 핑크 (대기)
-  reviewing:'#E8A355',   // 오렌지
-  quoted:   '#5B8FD6',   // 블루
-  paid:     '#6BB38E',   // 그린 (입금)
-  done:     '#1F9D55',   // 짙은 그린 (완료)
-  rejected: '#B0B0B8'    // 회색 (종료)
+  new:                 '#C878A3',   // 핑크 (대기)
+  reviewing:           '#E8A355',   // 오렌지
+  schedule_sent:       '#D97AA6',   // 진한 핑크
+  quoted:              '#5B8FD6',   // 블루
+  campaign_registered: '#4CA070',   // 연한 그린
+  paid:                '#6BB38E',   // 그린 (입금)
+  done:                '#1F9D55',   // 짙은 그린 (최종완료)
+  rejected:            '#B0B0B8'    // 회색 (종료)
 };
 var BRAND_FUNNEL_STAGES = [
-  {key:'new',       label:'접수 (new)'},
-  {key:'reviewing', label:'검토 (reviewing)'},
-  {key:'quoted',    label:'견적 전달 (quoted)'},
-  {key:'paid',      label:'입금 완료 (paid)'},
-  {key:'done',      label:'성약 (done)'}
+  {key:'new',                 label:'접수 (new)'},
+  {key:'reviewing',           label:'검토 (reviewing)'},
+  {key:'schedule_sent',       label:'일정 전달 (schedule_sent)'},
+  {key:'quoted',              label:'견적 전달 (quoted)'},
+  {key:'campaign_registered', label:'캠페인 등록 (campaign_registered)'},
+  {key:'paid',                label:'입금 완료 (paid)'},
+  {key:'done',                label:'최종 완료 (done)'}
 ];
 // 전환 깔때기용: status가 이 단계 이상이면 도달한 것으로 간주 (rejected 제외)
-var BRAND_STATUS_ORDER_FOR_FUNNEL = {new:0, reviewing:1, quoted:2, paid:3, done:4, rejected:-1};
+var BRAND_STATUS_ORDER_FOR_FUNNEL = {new:0, reviewing:1, schedule_sent:2, quoted:3, campaign_registered:4, paid:5, done:6, rejected:-1};
 
 async function loadBrandDashboard() {
   // 로딩 표시
@@ -9259,7 +9265,7 @@ function renderBrandKPIs(apps) {
   // 견적 합계
   var estimated = apps.reduce(function(s,a){ return s + (Number(a.estimated_krw) || 0); }, 0);
   var finalSum = apps
-    .filter(function(a){ return ['quoted','paid','done'].indexOf(a.status) !== -1; })
+    .filter(function(a){ return ['quoted','campaign_registered','paid','done'].indexOf(a.status) !== -1; })
     .reduce(function(s,a){ return s + (Number(a.final_quote_krw) || Number(a.estimated_krw) || 0); }, 0);
 
   var fmtKRW = function(n) { return '₩ ' + Math.round(n).toLocaleString('ko-KR'); };
@@ -9364,7 +9370,7 @@ function renderBrandStatusDonut(apps) {
   if (!canvas) return;
   if (_brandStatusDonut) { _brandStatusDonut.destroy(); _brandStatusDonut = null; }
 
-  var keys = ['new','reviewing','quoted','paid','done','rejected'];
+  var keys = ['new','reviewing','schedule_sent','quoted','campaign_registered','paid','done','rejected'];
   var counts = keys.map(function(k){ return apps.filter(function(a){ return a.status === k; }).length; });
   var total = counts.reduce(function(s,n){ return s+n; }, 0);
   if (totalLabel) totalLabel.textContent = total ? ('전체 ' + total + '건') : '';
@@ -9551,7 +9557,7 @@ function getFilteredBrandApps() {
     if (_brandAppSort.field === 'estimated') {
       av = Number(a.estimated_krw || 0); bv = Number(b.estimated_krw || 0);
     } else if (_brandAppSort.field === 'status') {
-      var BRAND_APP_STATUS_ORDER = {new:0, reviewing:1, quoted:2, paid:3, done:4, rejected:5};
+      var BRAND_APP_STATUS_ORDER = {new:0, reviewing:1, schedule_sent:2, quoted:3, campaign_registered:4, paid:5, done:6, rejected:7};
       av = BRAND_APP_STATUS_ORDER[a.status] ?? 99;
       bv = BRAND_APP_STATUS_ORDER[b.status] ?? 99;
     } else {

--- a/dev/admin/index.html
+++ b/dev/admin/index.html
@@ -951,7 +951,7 @@
           <div class="kpi-row" style="margin-top:12px">
             <div class="kpi-card kpi-o"><div class="kpi-val" id="brandKpiPending">—</div><div class="kpi-lbl">검수 대기 (new+reviewing)</div></div>
             <div class="kpi-card kpi-b"><div class="kpi-val" id="brandKpiQuoted">—</div><div class="kpi-lbl">견적 전달 (quoted)</div></div>
-            <div class="kpi-card kpi-g"><div class="kpi-val" id="brandKpiDone">—</div><div class="kpi-lbl">성약 완료 (done)</div></div>
+            <div class="kpi-card kpi-g"><div class="kpi-val" id="brandKpiDone">—</div><div class="kpi-lbl">최종완료 (done)</div></div>
             <div class="kpi-card kpi-r"><div class="kpi-val" id="brandKpiLeadTime">—</div><div class="kpi-lbl">평균 처리일 (new→done)</div></div>
           </div>
 
@@ -972,7 +972,7 @@
           <!-- 전환 깔때기 -->
           <div class="admin-card" style="margin-top:16px;padding:18px">
             <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:12px">
-              <div style="font-size:13px;font-weight:700;color:var(--ink)">전환 깔때기 (접수 → 완료)</div>
+              <div style="font-size:13px;font-weight:700;color:var(--ink)">전환 깔때기 (접수 → 최종완료)</div>
               <div style="font-size:10px;color:var(--muted)">각 단계는 "해당 단계 이상 도달한 건수" 기준</div>
             </div>
             <div id="brandFunnel" style="display:flex;flex-direction:column;gap:8px">

--- a/dev/js/admin.js
+++ b/dev/js/admin.js
@@ -204,7 +204,7 @@ function initMultiFilters() {
     {value:'reviewer',label:'Qoo10 리뷰어'},{value:'seeding',label:'나노 시딩'}
   ], () => renderBrandApplicationsList());
   createMultiFilter('brandAppStatusMulti', '전체 상태', [
-    {value:'new',label:'신규'},{value:'reviewing',label:'검토중'},{value:'quoted',label:'견적전달'},{value:'paid',label:'입금완료'},{value:'done',label:'완료'},{value:'rejected',label:'반려'}
+    {value:'new',label:'신규'},{value:'reviewing',label:'검토중'},{value:'schedule_sent',label:'일정전달'},{value:'quoted',label:'견적전달'},{value:'campaign_registered',label:'캠페인등록'},{value:'paid',label:'입금완료'},{value:'done',label:'최종완료'},{value:'rejected',label:'반려'}
   ], () => renderBrandApplicationsList());
 }
 
@@ -4244,12 +4244,14 @@ var _brandAppCurrentId = null; // 상세 모달 열린 신청 ID
 
 // 상태 라벨·컬러
 var BRAND_APP_STATUS = {
-  'new':       {label:'신규',     color:'#C33',   bg:'#FEE'},
-  'reviewing': {label:'검토중',   color:'#B88',   bg:'#FFE'},
-  'quoted':    {label:'견적전달', color:'#08A',   bg:'#DEF'},
-  'paid':      {label:'입금완료', color:'#6A2',   bg:'#EFE'},
-  'done':      {label:'완료',     color:'#555',   bg:'#EEE'},
-  'rejected':  {label:'반려',     color:'#999',   bg:'#F5F5F5'}
+  'new':                 {label:'신규',       color:'#C33',   bg:'#FEE'},
+  'reviewing':           {label:'검토중',     color:'#B88',   bg:'#FFE'},
+  'schedule_sent':       {label:'일정전달',   color:'#A36',   bg:'#FDEEF4'},
+  'quoted':              {label:'견적전달',   color:'#08A',   bg:'#DEF'},
+  'campaign_registered': {label:'캠페인등록', color:'#274',   bg:'#E6F3E8'},
+  'paid':                {label:'입금완료',   color:'#6A2',   bg:'#EFE'},
+  'done':                {label:'최종완료',   color:'#555',   bg:'#EEE'},
+  'rejected':            {label:'반려',       color:'#999',   bg:'#F5F5F5'}
 };
 
 function brandAppStatusBadge(status) {
@@ -4819,26 +4821,30 @@ var _brandStatusDonut = null;
 var _brandTrendDays = 7;
 
 var BRAND_STATUS_LABEL_KO = {
-  new: '신규', reviewing: '검토중', quoted: '견적전달',
-  paid: '입금완료', done: '완료', rejected: '반려'
+  new: '신규', reviewing: '검토중', schedule_sent: '일정전달', quoted: '견적전달',
+  campaign_registered: '캠페인등록', paid: '입금완료', done: '최종완료', rejected: '반려'
 };
 var BRAND_STATUS_COLOR = {
-  new:      '#C878A3',   // 핑크 (대기)
-  reviewing:'#E8A355',   // 오렌지
-  quoted:   '#5B8FD6',   // 블루
-  paid:     '#6BB38E',   // 그린 (입금)
-  done:     '#1F9D55',   // 짙은 그린 (완료)
-  rejected: '#B0B0B8'    // 회색 (종료)
+  new:                 '#C878A3',   // 핑크 (대기)
+  reviewing:           '#E8A355',   // 오렌지
+  schedule_sent:       '#D97AA6',   // 진한 핑크
+  quoted:              '#5B8FD6',   // 블루
+  campaign_registered: '#4CA070',   // 연한 그린
+  paid:                '#6BB38E',   // 그린 (입금)
+  done:                '#1F9D55',   // 짙은 그린 (최종완료)
+  rejected:            '#B0B0B8'    // 회색 (종료)
 };
 var BRAND_FUNNEL_STAGES = [
-  {key:'new',       label:'접수 (new)'},
-  {key:'reviewing', label:'검토 (reviewing)'},
-  {key:'quoted',    label:'견적 전달 (quoted)'},
-  {key:'paid',      label:'입금 완료 (paid)'},
-  {key:'done',      label:'성약 (done)'}
+  {key:'new',                 label:'접수 (new)'},
+  {key:'reviewing',           label:'검토 (reviewing)'},
+  {key:'schedule_sent',       label:'일정 전달 (schedule_sent)'},
+  {key:'quoted',              label:'견적 전달 (quoted)'},
+  {key:'campaign_registered', label:'캠페인 등록 (campaign_registered)'},
+  {key:'paid',                label:'입금 완료 (paid)'},
+  {key:'done',                label:'최종 완료 (done)'}
 ];
 // 전환 깔때기용: status가 이 단계 이상이면 도달한 것으로 간주 (rejected 제외)
-var BRAND_STATUS_ORDER_FOR_FUNNEL = {new:0, reviewing:1, quoted:2, paid:3, done:4, rejected:-1};
+var BRAND_STATUS_ORDER_FOR_FUNNEL = {new:0, reviewing:1, schedule_sent:2, quoted:3, campaign_registered:4, paid:5, done:6, rejected:-1};
 
 async function loadBrandDashboard() {
   // 로딩 표시
@@ -4899,7 +4905,7 @@ function renderBrandKPIs(apps) {
   // 견적 합계
   var estimated = apps.reduce(function(s,a){ return s + (Number(a.estimated_krw) || 0); }, 0);
   var finalSum = apps
-    .filter(function(a){ return ['quoted','paid','done'].indexOf(a.status) !== -1; })
+    .filter(function(a){ return ['quoted','campaign_registered','paid','done'].indexOf(a.status) !== -1; })
     .reduce(function(s,a){ return s + (Number(a.final_quote_krw) || Number(a.estimated_krw) || 0); }, 0);
 
   var fmtKRW = function(n) { return '₩ ' + Math.round(n).toLocaleString('ko-KR'); };
@@ -5004,7 +5010,7 @@ function renderBrandStatusDonut(apps) {
   if (!canvas) return;
   if (_brandStatusDonut) { _brandStatusDonut.destroy(); _brandStatusDonut = null; }
 
-  var keys = ['new','reviewing','quoted','paid','done','rejected'];
+  var keys = ['new','reviewing','schedule_sent','quoted','campaign_registered','paid','done','rejected'];
   var counts = keys.map(function(k){ return apps.filter(function(a){ return a.status === k; }).length; });
   var total = counts.reduce(function(s,n){ return s+n; }, 0);
   if (totalLabel) totalLabel.textContent = total ? ('전체 ' + total + '건') : '';
@@ -5191,7 +5197,7 @@ function getFilteredBrandApps() {
     if (_brandAppSort.field === 'estimated') {
       av = Number(a.estimated_krw || 0); bv = Number(b.estimated_krw || 0);
     } else if (_brandAppSort.field === 'status') {
-      var BRAND_APP_STATUS_ORDER = {new:0, reviewing:1, quoted:2, paid:3, done:4, rejected:5};
+      var BRAND_APP_STATUS_ORDER = {new:0, reviewing:1, schedule_sent:2, quoted:3, campaign_registered:4, paid:5, done:6, rejected:7};
       av = BRAND_APP_STATUS_ORDER[a.status] ?? 99;
       bv = BRAND_APP_STATUS_ORDER[b.status] ?? 99;
     } else {

--- a/supabase/migrations/064_brand_app_expand_statuses.sql
+++ b/supabase/migrations/064_brand_app_expand_statuses.sql
@@ -1,0 +1,24 @@
+-- 064_brand_app_expand_statuses.sql
+-- 브랜드 서베이 상태값 확장: 일정전달(schedule_sent), 캠페인등록(campaign_registered) 2단계 추가
+-- 기존 상태값(new, reviewing, quoted, paid, done, rejected)은 유지 — 기존 데이터 마이그레이션 불필요
+-- 전이 순서: new → reviewing → schedule_sent → quoted → campaign_registered → paid → done / rejected
+
+BEGIN;
+
+ALTER TABLE brand_applications
+  DROP CONSTRAINT IF EXISTS brand_applications_status_check;
+
+ALTER TABLE brand_applications
+  ADD CONSTRAINT brand_applications_status_check
+  CHECK (status IN (
+    'new',
+    'reviewing',
+    'schedule_sent',
+    'quoted',
+    'campaign_registered',
+    'paid',
+    'done',
+    'rejected'
+  ));
+
+COMMIT;


### PR DESCRIPTION
## Summary
브랜드서베이 상태 파이프라인을 6→8 단계로 확장.

신규 → 검토중 → **일정전달** → 견적전달 → **캠페인등록** → 입금완료 → 최종완료 / 반려

## DB migration
- `064_brand_app_expand_statuses.sql` — 개발·운영 DB 적용 완료 (check_clause 확인됨)
- 기존 6개 상태값 그대로 보존 (backward compatible)

## 클라이언트 동기 변경
- BRAND_APP_STATUS 맵, 정렬 순서, 멀티필터, 도넛 차트 keys, 퍼널 단계
- done 라벨: 완료 → 최종완료
- KPI finalSum 합계에 campaign_registered 포함
- 대시보드 라벨: '성약 완료 (done)' → '최종완료 (done)', 퍼널 헤더 '접수 → 최종완료'

## Test plan
- [x] supabase-expert migration 안정성 검증 OK
- [x] reverb-reviewer GO
- [x] 개발·운영 DB 적용 완료
- [ ] 운영 배포 후 상태 드롭다운 8개 노출 확인
- [ ] 신규/검토중 건을 일정전달로 전이해보기

🤖 Generated with [Claude Code](https://claude.com/claude-code)