### PR TITLE
feat(brand-survey): add orient_sheet_sent status (9 stages)

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -4564,7 +4564,7 @@ function initMultiFilters() {
     {value:'reviewer',label:'Qoo10 리뷰어'},{value:'seeding',label:'나노 시딩'}
   ], () => renderBrandApplicationsList());
   createMultiFilter('brandAppStatusMulti', '전체 상태', [
-    {value:'new',label:'신규'},{value:'reviewing',label:'검토중'},{value:'schedule_sent',label:'일정전달'},{value:'quoted',label:'견적전달'},{value:'campaign_registered',label:'캠페인등록'},{value:'paid',label:'입금완료'},{value:'done',label:'최종완료'},{value:'rejected',label:'반려'}
+    {value:'new',label:'신규'},{value:'reviewing',label:'검토중'},{value:'schedule_sent',label:'일정전달'},{value:'quoted',label:'견적전달'},{value:'orient_sheet_sent',label:'오리엔시트 전달'},{value:'campaign_registered',label:'캠페인등록'},{value:'paid',label:'입금완료'},{value:'done',label:'최종완료'},{value:'rejected',label:'반려'}
   ], () => renderBrandApplicationsList());
 }
 
@@ -8604,14 +8604,15 @@ var _brandAppCurrentId = null; // 상세 모달 열린 신청 ID
 
 // 상태 라벨·컬러
 var BRAND_APP_STATUS = {
-  'new':                 {label:'신규',       color:'#C33',   bg:'#FEE'},
-  'reviewing':           {label:'검토중',     color:'#B88',   bg:'#FFE'},
-  'schedule_sent':       {label:'일정전달',   color:'#A36',   bg:'#FDEEF4'},
-  'quoted':              {label:'견적전달',   color:'#08A',   bg:'#DEF'},
-  'campaign_registered': {label:'캠페인등록', color:'#274',   bg:'#E6F3E8'},
-  'paid':                {label:'입금완료',   color:'#6A2',   bg:'#EFE'},
-  'done':                {label:'최종완료',   color:'#555',   bg:'#EEE'},
-  'rejected':            {label:'반려',       color:'#999',   bg:'#F5F5F5'}
+  'new':                 {label:'신규',           color:'#C33',   bg:'#FEE'},
+  'reviewing':           {label:'검토중',         color:'#B88',   bg:'#FFE'},
+  'schedule_sent':       {label:'일정전달',       color:'#A36',   bg:'#FDEEF4'},
+  'quoted':              {label:'견적전달',       color:'#08A',   bg:'#DEF'},
+  'orient_sheet_sent':   {label:'오리엔시트 전달', color:'#735',   bg:'#F2E6F0'},
+  'campaign_registered': {label:'캠페인등록',     color:'#274',   bg:'#E6F3E8'},
+  'paid':                {label:'입금완료',       color:'#6A2',   bg:'#EFE'},
+  'done':                {label:'최종완료',       color:'#555',   bg:'#EEE'},
+  'rejected':            {label:'반려',           color:'#999',   bg:'#F5F5F5'}
 };
 
 function brandAppStatusBadge(status) {
@@ -9182,13 +9183,15 @@ var _brandTrendDays = 7;
 
 var BRAND_STATUS_LABEL_KO = {
   new: '신규', reviewing: '검토중', schedule_sent: '일정전달', quoted: '견적전달',
-  campaign_registered: '캠페인등록', paid: '입금완료', done: '최종완료', rejected: '반려'
+  orient_sheet_sent: '오리엔시트 전달', campaign_registered: '캠페인등록',
+  paid: '입금완료', done: '최종완료', rejected: '반려'
 };
 var BRAND_STATUS_COLOR = {
   new:                 '#C878A3',   // 핑크 (대기)
   reviewing:           '#E8A355',   // 오렌지
   schedule_sent:       '#D97AA6',   // 진한 핑크
   quoted:              '#5B8FD6',   // 블루
+  orient_sheet_sent:   '#8C6BC0',   // 퍼플 (오리엔시트)
   campaign_registered: '#4CA070',   // 연한 그린
   paid:                '#6BB38E',   // 그린 (입금)
   done:                '#1F9D55',   // 짙은 그린 (최종완료)
@@ -9199,12 +9202,13 @@ var BRAND_FUNNEL_STAGES = [
   {key:'reviewing',           label:'검토 (reviewing)'},
   {key:'schedule_sent',       label:'일정 전달 (schedule_sent)'},
   {key:'quoted',              label:'견적 전달 (quoted)'},
+  {key:'orient_sheet_sent',   label:'오리엔시트 전달 (orient_sheet_sent)'},
   {key:'campaign_registered', label:'캠페인 등록 (campaign_registered)'},
   {key:'paid',                label:'입금 완료 (paid)'},
   {key:'done',                label:'최종 완료 (done)'}
 ];
 // 전환 깔때기용: status가 이 단계 이상이면 도달한 것으로 간주 (rejected 제외)
-var BRAND_STATUS_ORDER_FOR_FUNNEL = {new:0, reviewing:1, schedule_sent:2, quoted:3, campaign_registered:4, paid:5, done:6, rejected:-1};
+var BRAND_STATUS_ORDER_FOR_FUNNEL = {new:0, reviewing:1, schedule_sent:2, quoted:3, orient_sheet_sent:4, campaign_registered:5, paid:6, done:7, rejected:-1};
 
 async function loadBrandDashboard() {
   // 로딩 표시
@@ -9265,7 +9269,7 @@ function renderBrandKPIs(apps) {
   // 견적 합계
   var estimated = apps.reduce(function(s,a){ return s + (Number(a.estimated_krw) || 0); }, 0);
   var finalSum = apps
-    .filter(function(a){ return ['quoted','campaign_registered','paid','done'].indexOf(a.status) !== -1; })
+    .filter(function(a){ return ['quoted','orient_sheet_sent','campaign_registered','paid','done'].indexOf(a.status) !== -1; })
     .reduce(function(s,a){ return s + (Number(a.final_quote_krw) || Number(a.estimated_krw) || 0); }, 0);
 
   var fmtKRW = function(n) { return '₩ ' + Math.round(n).toLocaleString('ko-KR'); };
@@ -9370,7 +9374,7 @@ function renderBrandStatusDonut(apps) {
   if (!canvas) return;
   if (_brandStatusDonut) { _brandStatusDonut.destroy(); _brandStatusDonut = null; }
 
-  var keys = ['new','reviewing','schedule_sent','quoted','campaign_registered','paid','done','rejected'];
+  var keys = ['new','reviewing','schedule_sent','quoted','orient_sheet_sent','campaign_registered','paid','done','rejected'];
   var counts = keys.map(function(k){ return apps.filter(function(a){ return a.status === k; }).length; });
   var total = counts.reduce(function(s,n){ return s+n; }, 0);
   if (totalLabel) totalLabel.textContent = total ? ('전체 ' + total + '건') : '';
@@ -9557,7 +9561,7 @@ function getFilteredBrandApps() {
     if (_brandAppSort.field === 'estimated') {
       av = Number(a.estimated_krw || 0); bv = Number(b.estimated_krw || 0);
     } else if (_brandAppSort.field === 'status') {
-      var BRAND_APP_STATUS_ORDER = {new:0, reviewing:1, schedule_sent:2, quoted:3, campaign_registered:4, paid:5, done:6, rejected:7};
+      var BRAND_APP_STATUS_ORDER = {new:0, reviewing:1, schedule_sent:2, quoted:3, orient_sheet_sent:4, campaign_registered:5, paid:6, done:7, rejected:8};
       av = BRAND_APP_STATUS_ORDER[a.status] ?? 99;
       bv = BRAND_APP_STATUS_ORDER[b.status] ?? 99;
     } else {

--- a/dev/js/admin.js
+++ b/dev/js/admin.js
@@ -204,7 +204,7 @@ function initMultiFilters() {
     {value:'reviewer',label:'Qoo10 리뷰어'},{value:'seeding',label:'나노 시딩'}
   ], () => renderBrandApplicationsList());
   createMultiFilter('brandAppStatusMulti', '전체 상태', [
-    {value:'new',label:'신규'},{value:'reviewing',label:'검토중'},{value:'schedule_sent',label:'일정전달'},{value:'quoted',label:'견적전달'},{value:'campaign_registered',label:'캠페인등록'},{value:'paid',label:'입금완료'},{value:'done',label:'최종완료'},{value:'rejected',label:'반려'}
+    {value:'new',label:'신규'},{value:'reviewing',label:'검토중'},{value:'schedule_sent',label:'일정전달'},{value:'quoted',label:'견적전달'},{value:'orient_sheet_sent',label:'오리엔시트 전달'},{value:'campaign_registered',label:'캠페인등록'},{value:'paid',label:'입금완료'},{value:'done',label:'최종완료'},{value:'rejected',label:'반려'}
   ], () => renderBrandApplicationsList());
 }
 
@@ -4244,14 +4244,15 @@ var _brandAppCurrentId = null; // 상세 모달 열린 신청 ID
 
 // 상태 라벨·컬러
 var BRAND_APP_STATUS = {
-  'new':                 {label:'신규',       color:'#C33',   bg:'#FEE'},
-  'reviewing':           {label:'검토중',     color:'#B88',   bg:'#FFE'},
-  'schedule_sent':       {label:'일정전달',   color:'#A36',   bg:'#FDEEF4'},
-  'quoted':              {label:'견적전달',   color:'#08A',   bg:'#DEF'},
-  'campaign_registered': {label:'캠페인등록', color:'#274',   bg:'#E6F3E8'},
-  'paid':                {label:'입금완료',   color:'#6A2',   bg:'#EFE'},
-  'done':                {label:'최종완료',   color:'#555',   bg:'#EEE'},
-  'rejected':            {label:'반려',       color:'#999',   bg:'#F5F5F5'}
+  'new':                 {label:'신규',           color:'#C33',   bg:'#FEE'},
+  'reviewing':           {label:'검토중',         color:'#B88',   bg:'#FFE'},
+  'schedule_sent':       {label:'일정전달',       color:'#A36',   bg:'#FDEEF4'},
+  'quoted':              {label:'견적전달',       color:'#08A',   bg:'#DEF'},
+  'orient_sheet_sent':   {label:'오리엔시트 전달', color:'#735',   bg:'#F2E6F0'},
+  'campaign_registered': {label:'캠페인등록',     color:'#274',   bg:'#E6F3E8'},
+  'paid':                {label:'입금완료',       color:'#6A2',   bg:'#EFE'},
+  'done':                {label:'최종완료',       color:'#555',   bg:'#EEE'},
+  'rejected':            {label:'반려',           color:'#999',   bg:'#F5F5F5'}
 };
 
 function brandAppStatusBadge(status) {
@@ -4822,13 +4823,15 @@ var _brandTrendDays = 7;
 
 var BRAND_STATUS_LABEL_KO = {
   new: '신규', reviewing: '검토중', schedule_sent: '일정전달', quoted: '견적전달',
-  campaign_registered: '캠페인등록', paid: '입금완료', done: '최종완료', rejected: '반려'
+  orient_sheet_sent: '오리엔시트 전달', campaign_registered: '캠페인등록',
+  paid: '입금완료', done: '최종완료', rejected: '반려'
 };
 var BRAND_STATUS_COLOR = {
   new:                 '#C878A3',   // 핑크 (대기)
   reviewing:           '#E8A355',   // 오렌지
   schedule_sent:       '#D97AA6',   // 진한 핑크
   quoted:              '#5B8FD6',   // 블루
+  orient_sheet_sent:   '#8C6BC0',   // 퍼플 (오리엔시트)
   campaign_registered: '#4CA070',   // 연한 그린
   paid:                '#6BB38E',   // 그린 (입금)
   done:                '#1F9D55',   // 짙은 그린 (최종완료)
@@ -4839,12 +4842,13 @@ var BRAND_FUNNEL_STAGES = [
   {key:'reviewing',           label:'검토 (reviewing)'},
   {key:'schedule_sent',       label:'일정 전달 (schedule_sent)'},
   {key:'quoted',              label:'견적 전달 (quoted)'},
+  {key:'orient_sheet_sent',   label:'오리엔시트 전달 (orient_sheet_sent)'},
   {key:'campaign_registered', label:'캠페인 등록 (campaign_registered)'},
   {key:'paid',                label:'입금 완료 (paid)'},
   {key:'done',                label:'최종 완료 (done)'}
 ];
 // 전환 깔때기용: status가 이 단계 이상이면 도달한 것으로 간주 (rejected 제외)
-var BRAND_STATUS_ORDER_FOR_FUNNEL = {new:0, reviewing:1, schedule_sent:2, quoted:3, campaign_registered:4, paid:5, done:6, rejected:-1};
+var BRAND_STATUS_ORDER_FOR_FUNNEL = {new:0, reviewing:1, schedule_sent:2, quoted:3, orient_sheet_sent:4, campaign_registered:5, paid:6, done:7, rejected:-1};
 
 async function loadBrandDashboard() {
   // 로딩 표시
@@ -4905,7 +4909,7 @@ function renderBrandKPIs(apps) {
   // 견적 합계
   var estimated = apps.reduce(function(s,a){ return s + (Number(a.estimated_krw) || 0); }, 0);
   var finalSum = apps
-    .filter(function(a){ return ['quoted','campaign_registered','paid','done'].indexOf(a.status) !== -1; })
+    .filter(function(a){ return ['quoted','orient_sheet_sent','campaign_registered','paid','done'].indexOf(a.status) !== -1; })
     .reduce(function(s,a){ return s + (Number(a.final_quote_krw) || Number(a.estimated_krw) || 0); }, 0);
 
   var fmtKRW = function(n) { return '₩ ' + Math.round(n).toLocaleString('ko-KR'); };
@@ -5010,7 +5014,7 @@ function renderBrandStatusDonut(apps) {
   if (!canvas) return;
   if (_brandStatusDonut) { _brandStatusDonut.destroy(); _brandStatusDonut = null; }
 
-  var keys = ['new','reviewing','schedule_sent','quoted','campaign_registered','paid','done','rejected'];
+  var keys = ['new','reviewing','schedule_sent','quoted','orient_sheet_sent','campaign_registered','paid','done','rejected'];
   var counts = keys.map(function(k){ return apps.filter(function(a){ return a.status === k; }).length; });
   var total = counts.reduce(function(s,n){ return s+n; }, 0);
   if (totalLabel) totalLabel.textContent = total ? ('전체 ' + total + '건') : '';
@@ -5197,7 +5201,7 @@ function getFilteredBrandApps() {
     if (_brandAppSort.field === 'estimated') {
       av = Number(a.estimated_krw || 0); bv = Number(b.estimated_krw || 0);
     } else if (_brandAppSort.field === 'status') {
-      var BRAND_APP_STATUS_ORDER = {new:0, reviewing:1, schedule_sent:2, quoted:3, campaign_registered:4, paid:5, done:6, rejected:7};
+      var BRAND_APP_STATUS_ORDER = {new:0, reviewing:1, schedule_sent:2, quoted:3, orient_sheet_sent:4, campaign_registered:5, paid:6, done:7, rejected:8};
       av = BRAND_APP_STATUS_ORDER[a.status] ?? 99;
       bv = BRAND_APP_STATUS_ORDER[b.status] ?? 99;
     } else {

--- a/supabase/migrations/065_brand_app_add_orient_sheet_sent.sql
+++ b/supabase/migrations/065_brand_app_add_orient_sheet_sent.sql
@@ -1,0 +1,26 @@
+-- 065_brand_app_add_orient_sheet_sent.sql
+-- 브랜드 서베이 상태에 'orient_sheet_sent' (오리엔시트 전달) 추가
+-- 파이프라인 순서: new → reviewing → schedule_sent → quoted → orient_sheet_sent
+--                 → campaign_registered → paid → done / rejected
+-- 기존 상태값은 그대로 유지 — 기존 데이터 마이그레이션 불필요
+
+BEGIN;
+
+ALTER TABLE brand_applications
+  DROP CONSTRAINT IF EXISTS brand_applications_status_check;
+
+ALTER TABLE brand_applications
+  ADD CONSTRAINT brand_applications_status_check
+  CHECK (status IN (
+    'new',
+    'reviewing',
+    'schedule_sent',
+    'quoted',
+    'orient_sheet_sent',
+    'campaign_registered',
+    'paid',
+    'done',
+    'rejected'
+  ));
+
+COMMIT;


### PR DESCRIPTION
## Summary
견적전달 다음 단계로 '오리엔시트 전달' 상태 추가 (9단계).

신규 → 검토중 → 일정전달 → 견적전달 → **오리엔시트 전달** → 캠페인등록 → 입금완료 → 최종완료 / 반려

## DB migration
- `065_brand_app_add_orient_sheet_sent.sql` — 개발·운영 DB 적용 완료 확인
- 기존 8개 상태값 보존 (backward compatible)

## Test plan
- [x] reverb-reviewer GO
- [x] 개발·운영 DB 적용 완료
- [ ] 운영 배포 후 상태 드롭다운 9개 노출 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)