### PR TITLE
fix(admin): auto-update campaigns.updated_at on admin edits

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -2523,8 +2523,11 @@ async function insertCampaign(camp) {
 
 async function updateCampaign(campId, updates) {
   if (!db) return;
+  // 관리자 편집 경로 전용 — 호출 시점에 수정일 자동 갱신
+  // (조회수/자동 종료 등 시스템 UPDATE는 이 함수를 거치지 않아 수정일 오염 없음)
+  const payload = { ...updates, updated_at: new Date().toISOString() };
   await retryWithRefresh(async () => {
-    const {error} = await db.from('campaigns').update(updates).eq('id', campId);
+    const {error} = await db.from('campaigns').update(payload).eq('id', campId);
     if (error) throw error;
   });
 }

--- a/dev/lib/storage.js
+++ b/dev/lib/storage.js
@@ -79,8 +79,11 @@ async function insertCampaign(camp) {
 
 async function updateCampaign(campId, updates) {
   if (!db) return;
+  // 관리자 편집 경로 전용 — 호출 시점에 수정일 자동 갱신
+  // (조회수/자동 종료 등 시스템 UPDATE는 이 함수를 거치지 않아 수정일 오염 없음)
+  const payload = { ...updates, updated_at: new Date().toISOString() };
   await retryWithRefresh(async () => {
-    const {error} = await db.from('campaigns').update(updates).eq('id', campId);
+    const {error} = await db.from('campaigns').update(payload).eq('id', campId);
     if (error) throw error;
   });
 }

--- a/index.html
+++ b/index.html
@@ -2593,8 +2593,11 @@ async function insertCampaign(camp) {
 
 async function updateCampaign(campId, updates) {
   if (!db) return;
+  // 관리자 편집 경로 전용 — 호출 시점에 수정일 자동 갱신
+  // (조회수/자동 종료 등 시스템 UPDATE는 이 함수를 거치지 않아 수정일 오염 없음)
+  const payload = { ...updates, updated_at: new Date().toISOString() };
   await retryWithRefresh(async () => {
-    const {error} = await db.from('campaigns').update(updates).eq('id', campId);
+    const {error} = await db.from('campaigns').update(payload).eq('id', campId);
     if (error) throw error;
   });
 }


### PR DESCRIPTION
## Summary
캠페인 관리의 **수정일 컬럼/정렬이 실제로는 작동하지 않던 문제** 수정.

원인: campaigns.updated_at 자동 갱신 트리거 없고, 애플리케이션에서도 set 안 함.

해결: updateCampaign 헬퍼에 updated_at 자동 주입.

## 영향 범위
- ✅ 관리자 폼 저장, 상태 드롭다운 변경, 순서 변경 → 수정일 갱신
- ❌ 조회수 증가, 자동 종료 → 수정일 건드리지 않음 (updateCampaign 경유 안 함)

## DB migration
없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)