### PR TITLE
fix(sales-reviewer): use real IBK account on submission success page

### DIFF
--- a/dev/sales/reviewer.html
+++ b/dev/sales/reviewer.html
@@ -1349,21 +1349,15 @@ body {
       <div class="bank-info">
         <div class="bank-info-row">
           <span class="k"><span class="ko-only">은행</span><span class="ja-only">銀行</span></span>
-          <span class="v">
-            <span class="ko-only">우리은행</span>
-            <span class="ja-only">Woori Bank</span>
-          </span>
+          <span class="v">기업은행</span>
         </div>
         <div class="bank-info-row">
           <span class="k"><span class="ko-only">계좌번호</span><span class="ja-only">口座番号</span></span>
-          <span class="v">1005-XXX-XXXXXX</span>
+          <span class="v">077-156976-01-055</span>
         </div>
         <div class="bank-info-row">
           <span class="k"><span class="ko-only">예금주</span><span class="ja-only">口座名義</span></span>
-          <span class="v">
-            <span class="ko-only">(주)제이펀</span>
-            <span class="ja-only">株式会社ジェイファン</span>
-          </span>
+          <span class="v">(주)제이펀</span>
         </div>
       </div>
       <div class="bank-amount">

--- a/sales/reviewer.html
+++ b/sales/reviewer.html
@@ -1349,21 +1349,15 @@ body {
       <div class="bank-info">
         <div class="bank-info-row">
           <span class="k"><span class="ko-only">은행</span><span class="ja-only">銀行</span></span>
-          <span class="v">
-            <span class="ko-only">우리은행</span>
-            <span class="ja-only">Woori Bank</span>
-          </span>
+          <span class="v">기업은행</span>
         </div>
         <div class="bank-info-row">
           <span class="k"><span class="ko-only">계좌번호</span><span class="ja-only">口座番号</span></span>
-          <span class="v">1005-XXX-XXXXXX</span>
+          <span class="v">077-156976-01-055</span>
         </div>
         <div class="bank-info-row">
           <span class="k"><span class="ko-only">예금주</span><span class="ja-only">口座名義</span></span>
-          <span class="v">
-            <span class="ko-only">(주)제이펀</span>
-            <span class="ja-only">株式会社ジェイファン</span>
-          </span>
+          <span class="v">(주)제이펀</span>
         </div>
       </div>
       <div class="bank-amount">


### PR DESCRIPTION
## Summary

리뷰어 신청 폼 제출 완료 페이지의 입금 안내 박스에서 placeholder(우리은행 1005-XXX-XXXXXX) → **실 운영 계좌(기업은행 077-156976-01-055, (주)제이펀)** 로 교체.

### 변경
- 은행: 우리은행 → **기업은행**
- 계좌번호: 1005-XXX-XXXXXX → **077-156976-01-055**
- 예금주: (주)제이펀 (변경 없음)
- 값 셀은 한글만 (이전 ko-only/ja-only 분기 제거). 라벨(은행/銀行 등)은 양언어 유지.

### 영향
- `dev/sales/reviewer.html` + 빌드 산출물 `sales/reviewer.html` 동기화 (md5 일치 확인)
- seeding.html / index.html 영향 없음 (해당 박스 없음 — seeding은 매칭 후 정산 플로우)

[via reverb-reviewer] PASS — stale 우리은행 0건, admin/메일 템플릿/마이그레이션에 잔존 계좌 없음.

## Test plan

- [x] dev에서 sales-dev.globalreverb.com/reviewer 폼 제출 → 새 계좌 정보 노출 확인
- [ ] 운영 sales.globalreverb.com/reviewer 폼 제출 → 새 계좌 정보 노출 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)