### PR TITLE
release: campaign form — recruit period range pickers + tightened date bounds + UX polish

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -1070,7 +1070,7 @@ textarea.form-input{resize:vertical;min-height:80px}
 
             <div class="form-row" style="grid-template-columns:1fr 1fr">
               <div class="form-group"><label class="form-label">모집 마감일 <span style="background:var(--pink);color:#fff;font-size:9px;font-weight:700;padding:1px 5px;border-radius:3px;margin-left:4px">필수</span></label><input type="date" id="editCampDeadline" class="form-input" onchange="suggestPostDeadline('editCampDeadline','editCampPostDeadline');validateDeadlines('editCampDeadline','editCampPostDeadline','editPostDeadlineWarn');syncCampDateMinMax('editCamp');validateCampDateRangesInline('editCamp')"></div>
-              <div class="form-group"><label class="form-label">노출 마감일</label><input type="date" id="editCampPostDeadline" class="form-input" onchange="validateDeadlines('editCampDeadline','editCampPostDeadline','editPostDeadlineWarn');syncCampDateMinMax('editCamp');validateCampDateRangesInline('editCamp')"><div id="editPostDeadlineWarn" class="form-error" style="display:none;margin-top:4px"></div><div class="form-hint">이 날짜 이후 캠페인이 인플루언서 사이트에서 숨겨집니다</div></div>
+              <div class="form-group"><label class="form-label">결과물 제출 마감일</label><input type="date" id="editCampSubmissionEnd" class="form-input" onchange="validateCampDateRangesInline('editCamp')"><div class="form-hint">이 날짜 이후 결과물 제출 불가. 비우면 노출 마감일로 폴백</div></div>
             </div>
             <div class="form-row" id="editCampPurchaseRow" style="grid-template-columns:1fr 1fr;display:none">
               <div class="form-group"><label class="form-label">구매 시작일</label><input type="date" id="editCampPurchaseStart" class="form-input" onchange="validateCampDateRangesInline('editCamp')"><div class="form-hint">리뷰어용</div></div>
@@ -1081,7 +1081,7 @@ textarea.form-input{resize:vertical;min-height:80px}
               <div class="form-group"><label class="form-label">방문 마감일</label><input type="date" id="editCampVisitEnd" class="form-input" onchange="validateCampDateRangesInline('editCamp')"></div>
             </div>
             <div class="form-row" style="grid-template-columns:1fr 1fr">
-              <div class="form-group"><label class="form-label">결과물 제출 마감일</label><input type="date" id="editCampSubmissionEnd" class="form-input" onchange="validateCampDateRangesInline('editCamp')"><div class="form-hint">이 날짜 이후 결과물 제출 불가. 비우면 노출 마감일로 폴백</div></div>
+              <div class="form-group"><label class="form-label">노출 마감일 <span style="background:var(--pink);color:#fff;font-size:9px;font-weight:700;padding:1px 5px;border-radius:3px;margin-left:4px">필수</span></label><input type="date" id="editCampPostDeadline" class="form-input" onchange="validateDeadlines('editCampDeadline','editCampPostDeadline','editPostDeadlineWarn');syncCampDateMinMax('editCamp');validateCampDateRangesInline('editCamp')"><div id="editPostDeadlineWarn" class="form-error" style="display:none;margin-top:4px"></div><div class="form-hint">이 날짜 이후 캠페인이 인플루언서 사이트에서 숨겨집니다</div></div>
             </div>
             <div id="editCampDateRangesWarn" class="form-error" style="display:none;margin-top:6px"></div>
             <div class="form-group"><label class="form-label">당선 발표 안내</label><input type="text" id="editCampWinnerAnnounce" class="form-input" placeholder="選考後、LINEにてご連絡"><div class="form-hint">인플루언서 캠페인 상세에 표시되는 문구. 비우면 기본값</div></div>
@@ -1282,17 +1282,16 @@ textarea.form-input{resize:vertical;min-height:80px}
               </div>
             </div>
 
-            <!-- 모집 마감일 / 투고 마감일 -->
+            <!-- 모집 마감일 / 결과물 제출 마감일 -->
             <div class="form-row" style="grid-template-columns:1fr 1fr">
               <div class="form-group">
                 <label class="form-label">모집 마감일 <span style="background:var(--pink);color:#fff;font-size:9px;font-weight:700;padding:1px 5px;border-radius:3px;margin-left:4px">필수</span></label>
                 <input type="date" id="newCampDeadline" class="form-input" onchange="suggestPostDeadline('newCampDeadline','newCampPostDeadline');validateDeadlines('newCampDeadline','newCampPostDeadline','newPostDeadlineWarn');syncCampDateMinMax('newCamp');validateCampDateRangesInline('newCamp')">
               </div>
               <div class="form-group">
-                <label class="form-label">노출 마감일 <span style="background:var(--pink);color:#fff;font-size:9px;font-weight:700;padding:1px 5px;border-radius:3px;margin-left:4px">필수</span></label>
-                <input type="date" id="newCampPostDeadline" class="form-input" onchange="validateDeadlines('newCampDeadline','newCampPostDeadline','newPostDeadlineWarn');syncCampDateMinMax('newCamp');validateCampDateRangesInline('newCamp')">
-                <div id="newPostDeadlineWarn" class="form-error" style="display:none;margin-top:4px"></div>
-                <div class="form-hint">이 날짜 이후 캠페인이 인플루언서 사이트에서 숨겨집니다</div>
+                <label class="form-label">결과물 제출 마감일</label>
+                <input type="date" id="newCampSubmissionEnd" class="form-input" onchange="validateCampDateRangesInline('newCamp')">
+                <div class="form-hint">이 날짜 이후 결과물(영수증·게시물 URL) 제출 불가. 비우면 노출 마감일로 폴백</div>
               </div>
             </div>
 
@@ -1321,9 +1320,10 @@ textarea.form-input{resize:vertical;min-height:80px}
             </div>
             <div class="form-row" style="grid-template-columns:1fr 1fr">
               <div class="form-group">
-                <label class="form-label">결과물 제출 마감일</label>
-                <input type="date" id="newCampSubmissionEnd" class="form-input" onchange="validateCampDateRangesInline('newCamp')">
-                <div class="form-hint">이 날짜 이후 결과물(영수증·게시물 URL) 제출 불가. 비우면 노출 마감일로 폴백</div>
+                <label class="form-label">노출 마감일 <span style="background:var(--pink);color:#fff;font-size:9px;font-weight:700;padding:1px 5px;border-radius:3px;margin-left:4px">필수</span></label>
+                <input type="date" id="newCampPostDeadline" class="form-input" onchange="validateDeadlines('newCampDeadline','newCampPostDeadline','newPostDeadlineWarn');syncCampDateMinMax('newCamp');validateCampDateRangesInline('newCamp')">
+                <div id="newPostDeadlineWarn" class="form-error" style="display:none;margin-top:4px"></div>
+                <div class="form-hint">이 날짜 이후 캠페인이 인플루언서 사이트에서 숨겨집니다</div>
               </div>
             </div>
             <div id="newCampDateRangesWarn" class="form-error" style="display:none;margin-top:6px"></div>

--- a/admin/index.html
+++ b/admin/index.html
@@ -981,6 +981,9 @@ textarea.form-input{resize:vertical;min-height:80px}
               </div>
             </div>
             <div class="form-row" style="grid-template-columns:1fr 1fr">
+              <div class="form-group"><label class="form-label">카테고리</label>
+                <select id="editCampCategory" class="form-input"></select>
+              </div>
               <div class="form-group"><label class="form-label">상태</label>
                 <select id="editCampStatus" class="form-input">
                   <option value="draft">준비</option><option value="scheduled">모집예정</option><option value="active">모집중</option><option value="paused">일시정지</option><option value="closed">종료</option>
@@ -1061,10 +1064,6 @@ textarea.form-input{resize:vertical;min-height:80px}
               </div>
             </div>
             <div class="form-row" style="grid-template-columns:1fr 1fr">
-              <div class="form-group">
-                <label class="form-label">카테고리</label>
-                <select id="editCampCategory" class="form-input"></select>
-              </div>
               <div class="form-group">
                 <label class="form-label">콘텐츠 종류 <span style="font-size:11px;font-weight:400;color:var(--muted)">(복수 선택 가능)</span></label>
                 <div style="display:flex;gap:8px;flex-wrap:wrap;margin-top:6px" id="editCampContentTypeWrap"></div>
@@ -1227,6 +1226,12 @@ textarea.form-input{resize:vertical;min-height:80px}
                 </div>
               </div>
             </div>
+            <div class="form-row" style="grid-template-columns:1fr 1fr">
+              <div class="form-group">
+                <label class="form-label">카테고리</label>
+                <select id="newCampCategory" class="form-input"></select>
+              </div>
+            </div>
 
             <div style="font-size:14px;font-weight:700;color:var(--ink);padding-bottom:8px;margin:20px 0 12px;border-bottom:2px solid var(--pink)">제품 정보</div>
             <div style="display:grid;grid-template-columns:1fr 1fr;gap:40px">
@@ -1303,10 +1308,6 @@ textarea.form-input{resize:vertical;min-height:80px}
               </div>
             </div>
             <div class="form-row" style="grid-template-columns:1fr 1fr">
-              <div class="form-group">
-                <label class="form-label">카테고리</label>
-                <select id="newCampCategory" class="form-input"></select>
-              </div>
               <div class="form-group">
                 <label class="form-label">콘텐츠 종류 <span style="background:var(--pink);color:#fff;font-size:9px;font-weight:700;padding:1px 5px;border-radius:3px;margin-left:4px">필수</span> <span style="font-size:11px;font-weight:400;color:var(--muted)">(복수 선택 가능)</span></label>
                 <div style="display:flex;gap:8px;flex-wrap:wrap;margin-top:6px" id="newCampContentTypeWrap"></div>
@@ -5027,7 +5028,7 @@ function switchAdminPane(pane, el, pushHistory) {
     if (defaultRt) { defaultRt.checked = true; toggleRT(defaultRt); }
     // lookup_values 동적 렌더
     renderChannelCheckboxes('new', 'monitor', []);
-    renderContentTypeCheckboxes('new', []);
+    renderContentTypeCheckboxes('new', [], 'monitor');
     renderCategorySelect('new', '');
     applyMinFollowersVisibility('new', 'monitor');
     applyDeadlineFieldsVisibility('new', 'monitor');
@@ -5837,7 +5838,7 @@ async function openEditCampaign(campId) {
   const selectedContent = (camp.content_types||'').split(',').map(t=>t.trim()).filter(Boolean);
   await Promise.all([
     renderChannelCheckboxes('edit', rtVal, selectedChannels),
-    renderContentTypeCheckboxes('edit', selectedContent),
+    renderContentTypeCheckboxes('edit', selectedContent, rtVal),
     renderCategorySelect('edit', camp.category||'')
   ]);
   // 기준 채널 선택값 복원 (없으면 첫 번째 채널)
@@ -5957,12 +5958,34 @@ function syncCampDateMinMax(prefix) {
     if (seLower) seEl.min = seLower; else seEl.removeAttribute('min');
     if (pdl) seEl.max = pdl; else seEl.removeAttribute('max');
   }
-  // 캠페인 노출 마감일: 모집 종료일 이후
+  // 캠페인 노출 마감일: 결과물 제출 마감일(우선) 또는 모집 종료일 이후
   const postEl = $(prefix+'PostDeadline');
   if (postEl) {
-    if (dl) postEl.min = dl; else postEl.removeAttribute('min');
+    const postLower = se || dl || '';
+    if (postLower) postEl.min = postLower; else postEl.removeAttribute('min');
     postEl.removeAttribute('max');
   }
+  // flatpickr range picker (구매·방문) 도 같은 경계로 비활성 날짜 처리
+  if (typeof syncCampRangePickerBounds === 'function') syncCampRangePickerBounds(prefix);
+}
+
+// flatpickr range picker 의 minDate/maxDate 를 hidden input 값에 맞춰 동적 갱신
+//   구매·방문: [recruit_start || deadline] ~ [submission_end || post_deadline]
+//   모집: 제한 없음 (관리자가 자유 입력)
+function syncCampRangePickerBounds(prefix) {
+  if (!_campRangePickers) return;
+  const rs = $(prefix+'RecruitStart')?.value || '';
+  const dl = $(prefix+'Deadline')?.value || '';
+  const pdl = $(prefix+'PostDeadline')?.value || '';
+  const se = $(prefix+'SubmissionEnd')?.value || '';
+  const lower = rs || dl || '';
+  const upperPV = se || pdl || '';
+  ['Purchase', 'Visit'].forEach(kind => {
+    const fp = _campRangePickers[prefix + kind + 'Range'];
+    if (!fp) return;
+    fp.set('minDate', lower || null);
+    fp.set('maxDate', upperPV || null);
+  });
 }
 
 // 입력값 검증 (저장 시 + onchange 인라인 경고). 위반 메시지 배열 반환.
@@ -5995,6 +6018,7 @@ function validateCampDateRanges(prefix) {
   const upperPVLabel = se ? '결과물 제출 마감일' : '캠페인 노출 마감일';
   if (rs && dl && new Date(dl) < new Date(rs)) errs.push({kind:'recruit', msg:'모집 종료일은 모집 시작일 이후여야 합니다'});
   if (dl && pdl && new Date(pdl) < new Date(dl)) errs.push({kind:'post', msg:'캠페인 노출 마감일은 모집 종료일 이후여야 합니다'});
+  if (se && pdl && new Date(pdl) < new Date(se)) errs.push({kind:'post', msg:'캠페인 노출 마감일은 결과물 제출 마감일 이후여야 합니다'});
   if (!inPVRange(ps)) errs.push({kind:'purchase', msg:`구매 시작일은 모집 시작일~${upperPVLabel} 사이여야 합니다`});
   if (!inPVRange(pe)) errs.push({kind:'purchase', msg:`구매 마감일은 모집 시작일~${upperPVLabel} 사이여야 합니다`});
   if (ps && pe && new Date(pe) < new Date(ps)) errs.push({kind:'purchase', msg:'구매 마감일은 구매 시작일 이후여야 합니다'});
@@ -7902,7 +7926,7 @@ async function addCampaign() {
   // 동적 영역 재렌더 (체크 해제 + 전체 채널 다시 표시)
   await Promise.all([
     renderChannelCheckboxes('new', null, []),
-    renderContentTypeCheckboxes('new', []),
+    renderContentTypeCheckboxes('new', [], null),
     renderCategorySelect('new', '')
   ]);
   // 주의사항 번들 초기화 (신규 캠페인은 빈 상태로 시작 — 관리자가 번들 선택)
@@ -8180,11 +8204,18 @@ function applyChannelMatchVisibility(formMode) {
   group.style.display = count >= 2 ? 'flex' : 'none';
 }
 
-async function renderContentTypeCheckboxes(formMode, preSelectedLabels) {
+async function renderContentTypeCheckboxes(formMode, preSelectedLabels, recruitType) {
   const cfg = _formCfg[formMode]; if (!cfg) return;
   const wrap = $(cfg.ctWrap); if (!wrap) return;
   let items = [];
   try { items = await fetchLookups('content_type'); } catch(e) { return; }
+  // 리뷰어(monitor) 캠페인은 Qoo10 리뷰 형식상 콘텐츠가 동영상·이미지 위주이므로 옵션 제한.
+  // 기존에 다른 코드(피드/릴스 등)가 저장되어 있다면 옵션 미노출이라 저장 시 자동 폐기됨 (운영 의도).
+  if (recruitType === 'monitor') {
+    const dropped = (preSelectedLabels || []).filter(lbl => !items.some(c => (c.code === 'video' || c.code === 'image') && c.name_ja === lbl));
+    if (dropped.length) console.warn('[renderContentTypeCheckboxes] monitor 캠페인이라 다음 콘텐츠 코드는 폼에서 폐기됨:', dropped);
+    items = items.filter(c => c.code === 'video' || c.code === 'image');
+  }
   const checked = new Set(preSelectedLabels || []);
   wrap.innerHTML = items.map(c =>
     `<label style="display:flex;align-items:center;gap:5px;padding:6px 13px;border:1.5px solid var(--line);border-radius:20px;cursor:pointer;font-size:13px;font-weight:500;transition:.15s" id="${esc(cfg.ctPrefix+c.code)}"><input type="checkbox" name="${esc(cfg.ctName)}" value="${esc(c.name_ja)}" onchange="toggleCT(this)" style="display:none">${esc(c.name_ko)}</label>`
@@ -8213,6 +8244,9 @@ async function filterChannelsByRecruitType(formMode, recruitType) {
   // 현재 체크된 코드 보존
   const checked = Array.from(document.querySelectorAll(`input[name="${cfg.chName}"]:checked`)).map(c => c.value);
   await renderChannelCheckboxes(formMode, recruitType, checked);
+  // 콘텐츠 종류도 모집 타입에 맞춰 재렌더 (monitor=동영상·이미지만, gifting/visit=전체)
+  const checkedCT = Array.from(document.querySelectorAll(`input[name="${cfg.ctName}"]:checked`)).map(c => c.value);
+  await renderContentTypeCheckboxes(formMode, checkedCT, recruitType);
   // 참여방법 번들 드롭다운도 모집 타입에 맞춰 갱신 (선택값은 유지 시도)
   const psetSel = $(formMode === 'edit' ? 'editCampPsetSelect' : 'newCampPsetSelect');
   await populateCampPsetDropdown(formMode, recruitType, psetSel?.value || null);

--- a/admin/index.html
+++ b/admin/index.html
@@ -5989,11 +5989,23 @@ function validateCampDateRanges(prefix) {
 //   - 모집 종료일 변경 시 결과물 제출 마감일 자동 제안 + min/max 갱신 + 인라인 검증
 // ─────────────────────────────────────────────────────────────────
 const _campRangePickers = Object.create(null);
+const _pastRecruitStartWarned = Object.create(null); // prefix별 마지막으로 알린 과거 시작일 (중복 방지)
 const RANGE_KIND_HIDDEN_IDS = {
   recruit:  ['RecruitStart', 'Deadline'],
   purchase: ['PurchaseStart', 'PurchaseEnd'],
   visit:    ['VisitStart', 'VisitEnd'],
 };
+
+// 모집 시작일이 오늘 이전이면 의도 확인 알럿 1회 (차단 없음, 같은 값 재호출 안 함)
+async function maybeWarnPastRecruitStart(prefix, startStr) {
+  if (!startStr) return;
+  const today = new Date(); today.setHours(0, 0, 0, 0);
+  const start = new Date(startStr); start.setHours(0, 0, 0, 0);
+  if (start >= today) { _pastRecruitStartWarned[prefix] = null; return; }
+  if (_pastRecruitStartWarned[prefix] === startStr) return;
+  _pastRecruitStartWarned[prefix] = startStr;
+  await showConfirm(`모집 시작일(${startStr})이 오늘보다 이전입니다.\n과거 날짜로 등록하는 것이 맞나요?`);
+}
 function _fpFormatYmd(d) {
   if (!d) return '';
   const yyyy = d.getFullYear();
@@ -6023,9 +6035,11 @@ function setupCampRangePickers() {
         const endEl   = $(prefix + endSuffix);
         if (startEl) startEl.value = _fpFormatYmd(start);
         if (endEl)   endEl.value   = _fpFormatYmd(end);
-        // 모집 기간 종료일이 새로 잡힌 경우 결과물 제출 마감일 자동 제안
-        if (kind === 'recruit' && end) {
-          suggestSubmissionEnd(prefix);
+        if (kind === 'recruit') {
+          // 시작일이 오늘 이전이면 의도 확인 (차단 없음, 같은 값 재호출 안 함)
+          if (start) maybeWarnPastRecruitStart(prefix, _fpFormatYmd(start));
+          // 종료일까지 잡혔으면 결과물 제출 마감일 자동 제안
+          if (end) suggestSubmissionEnd(prefix);
         }
         syncCampDateMinMax(prefix);
         validateCampDateRangesInline(prefix);

--- a/admin/index.html
+++ b/admin/index.html
@@ -1061,20 +1061,21 @@ textarea.form-input{resize:vertical;min-height:80px}
             </div>
 
             <div class="form-row" style="grid-template-columns:1fr 1fr">
-              <div class="form-group"><label class="form-label">모집 마감일 <span style="background:var(--pink);color:#fff;font-size:9px;font-weight:700;padding:1px 5px;border-radius:3px;margin-left:4px">필수</span></label><input type="date" id="editCampDeadline" class="form-input" onchange="suggestPostDeadline('editCampDeadline','editCampPostDeadline');validateDeadlines('editCampDeadline','editCampPostDeadline','editPostDeadlineWarn')"></div>
-              <div class="form-group"><label class="form-label">게시 마감일</label><input type="date" id="editCampPostDeadline" class="form-input" onchange="validateDeadlines('editCampDeadline','editCampPostDeadline','editPostDeadlineWarn')"><div id="editPostDeadlineWarn" class="form-error" style="display:none;margin-top:4px"></div></div>
+              <div class="form-group"><label class="form-label">모집 마감일 <span style="background:var(--pink);color:#fff;font-size:9px;font-weight:700;padding:1px 5px;border-radius:3px;margin-left:4px">필수</span></label><input type="date" id="editCampDeadline" class="form-input" onchange="suggestPostDeadline('editCampDeadline','editCampPostDeadline');validateDeadlines('editCampDeadline','editCampPostDeadline','editPostDeadlineWarn');syncCampDateMinMax('editCamp');validateCampDateRangesInline('editCamp')"></div>
+              <div class="form-group"><label class="form-label">노출 마감일</label><input type="date" id="editCampPostDeadline" class="form-input" onchange="validateDeadlines('editCampDeadline','editCampPostDeadline','editPostDeadlineWarn');syncCampDateMinMax('editCamp');validateCampDateRangesInline('editCamp')"><div id="editPostDeadlineWarn" class="form-error" style="display:none;margin-top:4px"></div><div class="form-hint">이 날짜 이후 캠페인이 인플루언서 사이트에서 숨겨집니다</div></div>
             </div>
             <div class="form-row" id="editCampPurchaseRow" style="grid-template-columns:1fr 1fr;display:none">
-              <div class="form-group"><label class="form-label">구매 시작일</label><input type="date" id="editCampPurchaseStart" class="form-input"><div class="form-hint">리뷰어용</div></div>
-              <div class="form-group"><label class="form-label">구매 마감일</label><input type="date" id="editCampPurchaseEnd" class="form-input"></div>
+              <div class="form-group"><label class="form-label">구매 시작일</label><input type="date" id="editCampPurchaseStart" class="form-input" onchange="validateCampDateRangesInline('editCamp')"><div class="form-hint">리뷰어용</div></div>
+              <div class="form-group"><label class="form-label">구매 마감일</label><input type="date" id="editCampPurchaseEnd" class="form-input" onchange="validateCampDateRangesInline('editCamp')"></div>
             </div>
             <div class="form-row" id="editCampVisitRow" style="grid-template-columns:1fr 1fr;display:none">
-              <div class="form-group"><label class="form-label">방문 시작일</label><input type="date" id="editCampVisitStart" class="form-input"><div class="form-hint">방문형용</div></div>
-              <div class="form-group"><label class="form-label">방문 마감일</label><input type="date" id="editCampVisitEnd" class="form-input"></div>
+              <div class="form-group"><label class="form-label">방문 시작일</label><input type="date" id="editCampVisitStart" class="form-input" onchange="validateCampDateRangesInline('editCamp')"><div class="form-hint">방문형용</div></div>
+              <div class="form-group"><label class="form-label">방문 마감일</label><input type="date" id="editCampVisitEnd" class="form-input" onchange="validateCampDateRangesInline('editCamp')"></div>
             </div>
             <div class="form-row" style="grid-template-columns:1fr 1fr">
-              <div class="form-group"><label class="form-label">결과물 제출 마감일</label><input type="date" id="editCampSubmissionEnd" class="form-input"><div class="form-hint">이 날짜 이후 결과물 제출 불가. 비우면 게시 마감일로 폴백</div></div>
+              <div class="form-group"><label class="form-label">결과물 제출 마감일</label><input type="date" id="editCampSubmissionEnd" class="form-input" onchange="validateCampDateRangesInline('editCamp')"><div class="form-hint">이 날짜 이후 결과물 제출 불가. 비우면 노출 마감일로 폴백</div></div>
             </div>
+            <div id="editCampDateRangesWarn" class="form-error" style="display:none;margin-top:6px"></div>
             <div class="form-group"><label class="form-label">당선 발표 안내</label><input type="text" id="editCampWinnerAnnounce" class="form-input" placeholder="選考後、LINEにてご連絡"><div class="form-hint">인플루언서 캠페인 상세에 표시되는 문구. 비우면 기본값</div></div>
             <div style="font-size:14px;font-weight:700;color:var(--ink);padding-bottom:8px;margin:20px 0 12px;border-bottom:2px solid var(--pink)">콘텐츠 가이드</div>
             <div class="form-group"><label class="form-label">캠페인 설명</label><div class="quill-host" id="editCampDesc"></div></div>
@@ -1269,46 +1270,47 @@ textarea.form-input{resize:vertical;min-height:80px}
             <div class="form-row" style="grid-template-columns:1fr 1fr">
               <div class="form-group">
                 <label class="form-label">모집 마감일 <span style="background:var(--pink);color:#fff;font-size:9px;font-weight:700;padding:1px 5px;border-radius:3px;margin-left:4px">필수</span></label>
-                <input type="date" id="newCampDeadline" class="form-input" onchange="suggestPostDeadline('newCampDeadline','newCampPostDeadline');validateDeadlines('newCampDeadline','newCampPostDeadline','newPostDeadlineWarn')">
+                <input type="date" id="newCampDeadline" class="form-input" onchange="suggestPostDeadline('newCampDeadline','newCampPostDeadline');validateDeadlines('newCampDeadline','newCampPostDeadline','newPostDeadlineWarn');syncCampDateMinMax('newCamp');validateCampDateRangesInline('newCamp')">
               </div>
               <div class="form-group">
-                <label class="form-label">게시 마감일 <span style="background:var(--pink);color:#fff;font-size:9px;font-weight:700;padding:1px 5px;border-radius:3px;margin-left:4px">필수</span></label>
-                <input type="date" id="newCampPostDeadline" class="form-input" onchange="validateDeadlines('newCampDeadline','newCampPostDeadline','newPostDeadlineWarn')">
+                <label class="form-label">노출 마감일 <span style="background:var(--pink);color:#fff;font-size:9px;font-weight:700;padding:1px 5px;border-radius:3px;margin-left:4px">필수</span></label>
+                <input type="date" id="newCampPostDeadline" class="form-input" onchange="validateDeadlines('newCampDeadline','newCampPostDeadline','newPostDeadlineWarn');syncCampDateMinMax('newCamp');validateCampDateRangesInline('newCamp')">
                 <div id="newPostDeadlineWarn" class="form-error" style="display:none;margin-top:4px"></div>
-                <div class="form-hint">제품 수령 후 이 날짜까지 게시해주세요</div>
+                <div class="form-hint">이 날짜 이후 캠페인이 인플루언서 사이트에서 숨겨집니다</div>
               </div>
             </div>
 
-            <!-- 타입별 기한 (Stage 1) -->
+            <!-- 타입별 기한 (Stage 1) — 모든 일자는 모집~노출 마감 사이로 강제 -->
             <div class="form-row" id="newCampPurchaseRow" style="grid-template-columns:1fr 1fr;display:none">
               <div class="form-group">
                 <label class="form-label">구매 시작일</label>
-                <input type="date" id="newCampPurchaseStart" class="form-input">
+                <input type="date" id="newCampPurchaseStart" class="form-input" onchange="validateCampDateRangesInline('newCamp')">
                 <div class="form-hint">리뷰어용. 이 기간 내 구매한 영수증만 인정</div>
               </div>
               <div class="form-group">
                 <label class="form-label">구매 마감일</label>
-                <input type="date" id="newCampPurchaseEnd" class="form-input">
+                <input type="date" id="newCampPurchaseEnd" class="form-input" onchange="validateCampDateRangesInline('newCamp')">
               </div>
             </div>
             <div class="form-row" id="newCampVisitRow" style="grid-template-columns:1fr 1fr;display:none">
               <div class="form-group">
                 <label class="form-label">방문 시작일</label>
-                <input type="date" id="newCampVisitStart" class="form-input">
+                <input type="date" id="newCampVisitStart" class="form-input" onchange="validateCampDateRangesInline('newCamp')">
                 <div class="form-hint">방문형용. 이 기간 내 매장 방문 가능</div>
               </div>
               <div class="form-group">
                 <label class="form-label">방문 마감일</label>
-                <input type="date" id="newCampVisitEnd" class="form-input">
+                <input type="date" id="newCampVisitEnd" class="form-input" onchange="validateCampDateRangesInline('newCamp')">
               </div>
             </div>
             <div class="form-row" style="grid-template-columns:1fr 1fr">
               <div class="form-group">
                 <label class="form-label">결과물 제출 마감일</label>
-                <input type="date" id="newCampSubmissionEnd" class="form-input">
-                <div class="form-hint">이 날짜 이후 결과물(영수증·게시물 URL) 제출 불가. 비우면 게시 마감일로 폴백</div>
+                <input type="date" id="newCampSubmissionEnd" class="form-input" onchange="validateCampDateRangesInline('newCamp')">
+                <div class="form-hint">이 날짜 이후 결과물(영수증·게시물 URL) 제출 불가. 비우면 노출 마감일로 폴백</div>
               </div>
             </div>
+            <div id="newCampDateRangesWarn" class="form-error" style="display:none;margin-top:6px"></div>
             <div class="form-group">
               <label class="form-label">당선 발표 안내</label>
               <input type="text" id="newCampWinnerAnnounce" class="form-input" value="選考後、LINEにてご連絡" placeholder="選考後、LINEにてご連絡">
@@ -2463,7 +2465,7 @@ textarea.form-input{resize:vertical;min-height:80px}
   </div>
 </div>
 
-<!-- 게시 마감일 자동 제안 confirm 모달 -->
+<!-- 노출 마감일 자동 제안 confirm 모달 -->
 <div class="modal-overlay" id="confirmModal" style="z-index:610">
   <div class="modal" style="max-width:420px;border-radius:24px;margin:auto;text-align:center">
     <div class="modal-body" style="padding:28px 24px 22px">
@@ -5562,7 +5564,7 @@ async function loadAdminCampaigns(useCache) {
             </div>
             <strong style="cursor:pointer;color:var(--ink)" onclick="openCampPreviewModal('${c.id}')">${esc(c.title)}</strong>
             <div style="font-size:11px;color:var(--muted);margin-top:2px">${esc(c.brand)}</div>
-            ${c.post_deadline ? `<div style="font-size:10px;color:var(--muted);margin-top:1px">게시: ~${formatDate(c.post_deadline)} ${dDayLabel(c.post_deadline)}</div>` : ''}
+            ${c.post_deadline ? `<div style="font-size:10px;color:var(--muted);margin-top:1px">노출: ~${formatDate(c.post_deadline)} ${dDayLabel(c.post_deadline)}</div>` : ''}
           </div>
         </div>
       </td>
@@ -5723,6 +5725,9 @@ async function openEditCampaign(campId) {
   sv('editCampVisitStart', camp.visit_start||'');
   sv('editCampVisitEnd', camp.visit_end||'');
   sv('editCampSubmissionEnd', camp.submission_end||'');
+  // 일자 입력 min/max 동기화 + 인라인 경고 초기 평가
+  syncCampDateMinMax('editCamp');
+  validateCampDateRangesInline('editCamp');
   sv('editCampWinnerAnnounce', camp.winner_announce || '選考後、LINEにてご連絡');
   sv('editCampDesc', camp.description||'');
   sv('editCampHashtags', camp.hashtags||'');
@@ -5822,7 +5827,7 @@ function resolveConfirmModal(ok) {
   if (_confirmResolver) { _confirmResolver(!!ok); _confirmResolver = null; }
 }
 
-// 모집 마감일 입력 시 게시 마감일을 +14일로 자동 채우기 (확인 모달)
+// 모집 마감일 입력 시 노출 마감일을 +14일로 자동 채우기 (확인 모달)
 async function suggestPostDeadline(deadlineId, postDeadlineId) {
   const dl = $(deadlineId)?.value;
   if (!dl) return;
@@ -5836,7 +5841,7 @@ async function suggestPostDeadline(deadlineId, postDeadlineId) {
   if (!postEl) return;
   // 이미 입력된 값이 같으면 무시
   if (postEl.value === suggested) return;
-  const ok = await showConfirm(`게시 마감일을 ${yyyy}년 ${mm}월 ${dd}일로 입력하시겠습니까?\n(모집 마감일 + 2주)`);
+  const ok = await showConfirm(`노출 마감일을 ${yyyy}년 ${mm}월 ${dd}일로 입력하시겠습니까?\n(모집 마감일 + 2주)`);
   if (ok) postEl.value = suggested;
 }
 
@@ -5846,10 +5851,65 @@ function validateDeadlines(deadlineId, postDeadlineId, warnId) {
   const warn = $(warnId);
   if (!warn) return;
   if (dl && pdl && new Date(pdl) < new Date(dl)) {
-    warn.textContent = '게시 마감일은 모집 마감일 이후여야 합니다';
+    warn.textContent = '노출 마감일은 모집 마감일 이후여야 합니다';
     warn.style.display = 'block';
   } else {
     warn.style.display = 'none';
+  }
+}
+
+// 모집~노출 마감 사이로 구매·방문·결과물제출 일자 강제. prefix = 'newCamp' | 'editCamp'
+const CAMP_DATE_FIELDS = ['PurchaseStart','PurchaseEnd','VisitStart','VisitEnd','SubmissionEnd'];
+
+// HTML5 input min/max 속성을 deadline ~ post_deadline 으로 동기화 (브라우저 단 차단)
+function syncCampDateMinMax(prefix) {
+  const dl = $(prefix+'Deadline')?.value || '';
+  const pdl = $(prefix+'PostDeadline')?.value || '';
+  CAMP_DATE_FIELDS.forEach(suffix => {
+    const el = $(prefix+suffix);
+    if (!el) return;
+    if (dl) el.min = dl; else el.removeAttribute('min');
+    if (pdl) el.max = pdl; else el.removeAttribute('max');
+  });
+}
+
+// 입력값 검증 (저장 시 + onchange 인라인 경고). 위반 메시지 배열 반환.
+function validateCampDateRanges(prefix) {
+  const dl = $(prefix+'Deadline')?.value || '';
+  const pdl = $(prefix+'PostDeadline')?.value || '';
+  const ps = $(prefix+'PurchaseStart')?.value || '';
+  const pe = $(prefix+'PurchaseEnd')?.value || '';
+  const vs = $(prefix+'VisitStart')?.value || '';
+  const ve = $(prefix+'VisitEnd')?.value || '';
+  const se = $(prefix+'SubmissionEnd')?.value || '';
+  const errs = [];
+  const between = (val) => {
+    if (!val) return true;
+    if (dl && new Date(val) < new Date(dl)) return false;
+    if (pdl && new Date(val) > new Date(pdl)) return false;
+    return true;
+  };
+  if (!between(ps)) errs.push('구매 시작일은 모집 마감일~노출 마감일 사이여야 합니다');
+  if (!between(pe)) errs.push('구매 마감일은 모집 마감일~노출 마감일 사이여야 합니다');
+  if (ps && pe && new Date(pe) < new Date(ps)) errs.push('구매 마감일은 구매 시작일 이후여야 합니다');
+  if (!between(vs)) errs.push('방문 시작일은 모집 마감일~노출 마감일 사이여야 합니다');
+  if (!between(ve)) errs.push('방문 마감일은 모집 마감일~노출 마감일 사이여야 합니다');
+  if (vs && ve && new Date(ve) < new Date(vs)) errs.push('방문 마감일은 방문 시작일 이후여야 합니다');
+  if (!between(se)) errs.push('결과물 제출 마감일은 모집 마감일~노출 마감일 사이여야 합니다');
+  return errs;
+}
+
+// onchange 인라인 경고 (저장 차단은 별도 체크)
+function validateCampDateRangesInline(prefix) {
+  const errs = validateCampDateRanges(prefix);
+  const warn = $(prefix+'DateRangesWarn');
+  if (!warn) return;
+  if (errs.length === 0) {
+    warn.style.display = 'none';
+    warn.textContent = '';
+  } else {
+    warn.innerHTML = errs.map(e => `· ${e}`).join('<br>');
+    warn.style.display = 'block';
   }
 }
 
@@ -5868,9 +5928,11 @@ async function saveCampaignEdit() {
     const editDeadline = gv('editCampDeadline');
     const editPostDeadline = gv('editCampPostDeadline');
     if (editPostDeadline && editDeadline && new Date(editPostDeadline) < new Date(editDeadline)) {
-      toast('게시 마감일은 모집 마감일 이후여야 합니다','error');
+      toast('노출 마감일은 모집 마감일 이후여야 합니다','error');
       return;
     }
+    const editDateErrs = validateCampDateRanges('editCamp');
+    if (editDateErrs.length) { toast(editDateErrs[0], 'error'); return; }
     const editStatus = gv('editCampStatus');
     if (editDeadline && (editStatus === 'active' || editStatus === 'scheduled')) {
       const dl = new Date(editDeadline); dl.setHours(23,59,59,999);
@@ -6174,7 +6236,7 @@ function renderCampPreview(mode) {
           ${camp.slots?`<div class="cp-info-row"><div class="cp-info-key">募集人数</div><div class="cp-info-val">${camp.slots}名</div></div>`:''}
           ${camp.min_followers?`<div class="cp-info-row"><div class="cp-info-key">最小フォロワー</div><div class="cp-info-val">${camp.min_followers.toLocaleString()}</div></div>`:''}
           <div class="cp-info-row"><div class="cp-info-key">当選発表</div><div class="cp-info-val">${esc(camp.winner_announce||'選考後、LINEにてご連絡')}</div></div>
-          <div class="cp-info-row"><div class="cp-info-key">投稿締切</div><div class="cp-info-val" style="font-weight:600">${camp.post_deadline?fmt(camp.post_deadline):'—'}</div></div>
+          <div class="cp-info-row"><div class="cp-info-key">掲載期限</div><div class="cp-info-val" style="font-weight:600">${camp.post_deadline?fmt(camp.post_deadline):'—'}</div></div>
           ${(camp.recruit_type==='monitor'&&(camp.purchase_start||camp.purchase_end))?`<div class="cp-info-row"><div class="cp-info-key">購入期間</div><div class="cp-info-val">${fmt(camp.purchase_start)} 〜 ${fmt(camp.purchase_end)}</div></div>`:''}
           ${(camp.recruit_type==='visit'&&(camp.visit_start||camp.visit_end))?`<div class="cp-info-row"><div class="cp-info-key">訪問期間</div><div class="cp-info-val">${fmt(camp.visit_start)} 〜 ${fmt(camp.visit_end)}</div></div>`:''}
           ${camp.submission_end?`<div class="cp-info-row"><div class="cp-info-key">提出締切</div><div class="cp-info-val" style="font-weight:600">${fmt(camp.submission_end)}</div></div>`:''}
@@ -7536,9 +7598,11 @@ async function addCampaign() {
   }
   const postDeadline = $('newCampPostDeadline')?.value;
   if (postDeadline && deadline && new Date(postDeadline) < new Date(deadline)) {
-    toast('게시 마감일은 모집 마감일 이후여야 합니다','error');
+    toast('노출 마감일은 모집 마감일 이후여야 합니다','error');
     return;
   }
+  const newDateErrs = validateCampDateRanges('newCamp');
+  if (newDateErrs.length) { toast(newDateErrs[0], 'error'); return; }
   const catEmojiMap = {beauty:'💄',food:'🍜',fashion:'👗',health:'💪',other:'📦'};
   const cat = $('newCampCategory').value;
   const ch = Array.from(document.querySelectorAll('input[name="newChannel"]:checked')).map(c=>c.value).join(',');

--- a/admin/index.html
+++ b/admin/index.html
@@ -5989,22 +5989,36 @@ function validateCampDateRanges(prefix) {
 //   - 모집 종료일 변경 시 결과물 제출 마감일 자동 제안 + min/max 갱신 + 인라인 검증
 // ─────────────────────────────────────────────────────────────────
 const _campRangePickers = Object.create(null);
-const _pastRecruitStartWarned = Object.create(null); // prefix별 마지막으로 알린 과거 시작일 (중복 방지)
 const RANGE_KIND_HIDDEN_IDS = {
   recruit:  ['RecruitStart', 'Deadline'],
   purchase: ['PurchaseStart', 'PurchaseEnd'],
   visit:    ['VisitStart', 'VisitEnd'],
 };
 
-// 모집 시작일이 오늘 이전이면 의도 확인 알럿 1회 (차단 없음, 같은 값 재호출 안 함)
-async function maybeWarnPastRecruitStart(prefix, startStr) {
-  if (!startStr) return;
+// flatpickr 캘린더 popup 하단에 추가하는 인라인 경고 div를 1회만 생성·재사용
+function _ensureFpWarnNode(fp) {
+  if (fp && fp._reverbWarnNode) return fp._reverbWarnNode;
+  if (!fp || !fp.calendarContainer) return null;
+  const node = document.createElement('div');
+  node.className = 'fp-past-warn';
+  node.style.cssText = 'display:none;padding:8px 12px;font-size:11px;font-weight:600;color:#C62828;background:#FFEBEE;border-top:1px solid #FFCDD2;text-align:center;line-height:1.5';
+  fp.calendarContainer.appendChild(node);
+  fp._reverbWarnNode = node;
+  return node;
+}
+// 모집 시작일이 오늘 이전이면 캘린더 popup 하단에 빨간 글씨 표시 (차단·모달 닫힘 없음)
+function updateRecruitPastWarn(fp, startDate) {
+  const node = _ensureFpWarnNode(fp);
+  if (!node) return;
+  if (!startDate) { node.style.display = 'none'; return; }
   const today = new Date(); today.setHours(0, 0, 0, 0);
-  const start = new Date(startStr); start.setHours(0, 0, 0, 0);
-  if (start >= today) { _pastRecruitStartWarned[prefix] = null; return; }
-  if (_pastRecruitStartWarned[prefix] === startStr) return;
-  _pastRecruitStartWarned[prefix] = startStr;
-  await showConfirm(`모집 시작일(${startStr})이 오늘보다 이전입니다.\n과거 날짜로 등록하는 것이 맞나요?`);
+  const start = new Date(startDate); start.setHours(0, 0, 0, 0);
+  if (start < today) {
+    node.textContent = '모집 시작일이 오늘보다 이전입니다. 과거 날짜로 등록하는 것이 맞는지 확인해주세요.';
+    node.style.display = 'block';
+  } else {
+    node.style.display = 'none';
+  }
 }
 function _fpFormatYmd(d) {
   if (!d) return '';
@@ -6028,7 +6042,13 @@ function setupCampRangePickers() {
       dateFormat: 'Y-m-d',
       altInput: false,
       locale: (typeof flatpickr !== 'undefined' && flatpickr.l10ns && flatpickr.l10ns.ko) ? 'ko' : 'default',
-      onChange: (selectedDates) => {
+      onOpen: (selectedDates, _str, fpInst) => {
+        if (kind !== 'recruit') return;
+        // 캘린더 열릴 때마다 현재 hidden input의 시작일을 기준으로 경고 평가
+        const cur = $(prefix + startSuffix)?.value || '';
+        updateRecruitPastWarn(fpInst, cur ? new Date(cur) : null);
+      },
+      onChange: (selectedDates, _str, fpInst) => {
         const start = selectedDates[0] || null;
         const end   = selectedDates[1] || null;
         const startEl = $(prefix + startSuffix);
@@ -6036,8 +6056,8 @@ function setupCampRangePickers() {
         if (startEl) startEl.value = _fpFormatYmd(start);
         if (endEl)   endEl.value   = _fpFormatYmd(end);
         if (kind === 'recruit') {
-          // 시작일이 오늘 이전이면 의도 확인 (차단 없음, 같은 값 재호출 안 함)
-          if (start) maybeWarnPastRecruitStart(prefix, _fpFormatYmd(start));
+          // 캘린더 popup 하단 인라인 경고 갱신 (과거 시작일이면 빨간 글씨 표시, 그 외 숨김)
+          updateRecruitPastWarn(fpInst, start);
           // 종료일까지 잡혔으면 결과물 제출 마감일 자동 제안
           if (end) suggestSubmissionEnd(prefix);
         }

--- a/admin/index.html
+++ b/admin/index.html
@@ -1082,8 +1082,8 @@ textarea.form-input{resize:vertical;min-height:80px}
               </div>
               <div class="form-group">
                 <label class="form-label">결과물 제출 마감일</label>
-                <input type="date" id="editCampSubmissionEnd" class="form-input" onchange="validateCampDateRangesInline('editCamp')">
-                <div class="form-hint">이 날짜 이후 결과물 제출 불가. 비우면 노출 마감일로 폴백</div>
+                <input type="date" id="editCampSubmissionEnd" class="form-input" onchange="syncCampDateMinMax('editCamp');validateCampDateRangesInline('editCamp')">
+                <div class="form-hint">이 날짜 이후 결과물 제출 불가. 비우면 캠페인 노출 마감일로 폴백</div>
                 <div id="editCampSubmissionWarn" class="form-error" style="display:none;margin-top:4px"></div>
               </div>
             </div>
@@ -1109,7 +1109,7 @@ textarea.form-input{resize:vertical;min-height:80px}
             </div>
             <div class="form-row" style="grid-template-columns:1fr 1fr">
               <div class="form-group">
-                <label class="form-label">노출 마감일 <span style="background:var(--pink);color:#fff;font-size:9px;font-weight:700;padding:1px 5px;border-radius:3px;margin-left:4px">필수</span></label>
+                <label class="form-label">캠페인 노출 마감일 <span style="background:var(--pink);color:#fff;font-size:9px;font-weight:700;padding:1px 5px;border-radius:3px;margin-left:4px">필수</span></label>
                 <input type="date" id="editCampPostDeadline" class="form-input" onchange="syncCampDateMinMax('editCamp');validateCampDateRangesInline('editCamp')">
                 <div class="form-hint">이 날짜 이후 캠페인이 인플루언서 사이트에서 숨겨집니다</div>
                 <div id="editCampPostDeadlineWarn" class="form-error" style="display:none;margin-top:4px"></div>
@@ -1325,8 +1325,8 @@ textarea.form-input{resize:vertical;min-height:80px}
               </div>
               <div class="form-group">
                 <label class="form-label">결과물 제출 마감일</label>
-                <input type="date" id="newCampSubmissionEnd" class="form-input" onchange="validateCampDateRangesInline('newCamp')">
-                <div class="form-hint">이 날짜 이후 결과물(영수증·게시물 URL) 제출 불가. 비우면 노출 마감일로 폴백</div>
+                <input type="date" id="newCampSubmissionEnd" class="form-input" onchange="syncCampDateMinMax('newCamp');validateCampDateRangesInline('newCamp')">
+                <div class="form-hint">이 날짜 이후 결과물(영수증·게시물 URL) 제출 불가. 비우면 캠페인 노출 마감일로 폴백</div>
                 <div id="newCampSubmissionWarn" class="form-error" style="display:none;margin-top:4px"></div>
               </div>
             </div>
@@ -1354,7 +1354,7 @@ textarea.form-input{resize:vertical;min-height:80px}
             </div>
             <div class="form-row" style="grid-template-columns:1fr 1fr">
               <div class="form-group">
-                <label class="form-label">노출 마감일 <span style="background:var(--pink);color:#fff;font-size:9px;font-weight:700;padding:1px 5px;border-radius:3px;margin-left:4px">필수</span></label>
+                <label class="form-label">캠페인 노출 마감일 <span style="background:var(--pink);color:#fff;font-size:9px;font-weight:700;padding:1px 5px;border-radius:3px;margin-left:4px">필수</span></label>
                 <input type="date" id="newCampPostDeadline" class="form-input" onchange="syncCampDateMinMax('newCamp');validateCampDateRangesInline('newCamp')">
                 <div class="form-hint">이 날짜 이후 캠페인이 인플루언서 사이트에서 숨겨집니다</div>
                 <div id="newCampPostDeadlineWarn" class="form-error" style="display:none;margin-top:4px"></div>
@@ -2514,7 +2514,7 @@ textarea.form-input{resize:vertical;min-height:80px}
   </div>
 </div>
 
-<!-- 노출 마감일 자동 제안 confirm 모달 -->
+<!-- 캠페인 노출 마감일 자동 제안 confirm 모달 -->
 <div class="modal-overlay" id="confirmModal" style="z-index:610">
   <div class="modal" style="max-width:420px;border-radius:24px;margin:auto;text-align:center">
     <div class="modal-body" style="padding:28px 24px 22px">
@@ -5645,7 +5645,7 @@ async function loadAdminCampaigns(useCache) {
             </div>
             <strong style="cursor:pointer;color:var(--ink)" onclick="openCampPreviewModal('${c.id}')">${esc(c.title)}</strong>
             <div style="font-size:11px;color:var(--muted);margin-top:2px">${esc(c.brand)}</div>
-            ${c.post_deadline ? `<div style="font-size:10px;color:var(--muted);margin-top:1px">노출: ~${formatDate(c.post_deadline)} ${dDayLabel(c.post_deadline)}</div>` : ''}
+            ${c.post_deadline ? `<div style="font-size:10px;color:var(--muted);margin-top:1px">캠페인 노출: ~${formatDate(c.post_deadline)} ${dDayLabel(c.post_deadline)}</div>` : ''}
           </div>
         </div>
       </td>
@@ -5930,22 +5930,34 @@ async function suggestSubmissionEnd(prefix) {
   }
 }
 
-// 일자 자식 input들의 min/max를 [recruit_start || deadline] ~ post_deadline 으로 동기화 (브라우저 단 차단)
-const CAMP_DATE_FIELDS = ['PurchaseStart','PurchaseEnd','VisitStart','VisitEnd','SubmissionEnd','PostDeadline'];
+// 일자 자식 input들의 min/max 를 운영 흐름에 맞춰 동기화 (브라우저 단 차단)
+//   구매·방문: [recruit_start||deadline] ~ [submission_end || post_deadline]
+//   결과물 제출 마감일: max(recruit_start||deadline, purchase_end, visit_end) ~ post_deadline
+//   캠페인 노출 마감일: deadline ~ (없음)
 function syncCampDateMinMax(prefix) {
   const rs = $(prefix+'RecruitStart')?.value || '';
   const dl = $(prefix+'Deadline')?.value || '';
   const pdl = $(prefix+'PostDeadline')?.value || '';
-  // 자식 일자들은 모집 시작일(없으면 모집 종료일) 이후로만 입력 가능
+  const pe = $(prefix+'PurchaseEnd')?.value || '';
+  const ve = $(prefix+'VisitEnd')?.value || '';
+  const se = $(prefix+'SubmissionEnd')?.value || '';
   const lower = rs || dl || '';
-  CAMP_DATE_FIELDS.forEach(suffix => {
-    if (suffix === 'PostDeadline') return; // post_deadline 은 자식이 아니라 자체 입력
+  const upperPV = se || pdl || '';
+  // 구매·방문: lower ~ upperPV
+  ['PurchaseStart','PurchaseEnd','VisitStart','VisitEnd'].forEach(suffix => {
     const el = $(prefix+suffix);
     if (!el) return;
     if (lower) el.min = lower; else el.removeAttribute('min');
-    if (pdl) el.max = pdl; else el.removeAttribute('max');
+    if (upperPV) el.max = upperPV; else el.removeAttribute('max');
   });
-  // 노출 마감일은 모집 종료일 이후만 (range picker 가 보장하지만 native input 도 강제)
+  // 결과물 제출 마감일: 구매·방문 종료일 이후 (없으면 lower) ~ 캠페인 노출 마감일
+  const seEl = $(prefix+'SubmissionEnd');
+  if (seEl) {
+    const seLower = [lower, pe, ve].filter(Boolean).sort().pop() || '';
+    if (seLower) seEl.min = seLower; else seEl.removeAttribute('min');
+    if (pdl) seEl.max = pdl; else seEl.removeAttribute('max');
+  }
+  // 캠페인 노출 마감일: 모집 종료일 이후
   const postEl = $(prefix+'PostDeadline');
   if (postEl) {
     if (dl) postEl.min = dl; else postEl.removeAttribute('min');
@@ -5954,7 +5966,7 @@ function syncCampDateMinMax(prefix) {
 }
 
 // 입력값 검증 (저장 시 + onchange 인라인 경고). 위반 메시지 배열 반환.
-//   경계: 모집 시작일 ~ 노출 마감일 사이
+//   경계: 모집 시작일 ~ 캠페인 노출 마감일 사이
 function validateCampDateRanges(prefix) {
   const rs = $(prefix+'RecruitStart')?.value || '';
   const dl = $(prefix+'Deadline')?.value || '';
@@ -5972,15 +5984,28 @@ function validateCampDateRanges(prefix) {
     if (pdl && new Date(val) > new Date(pdl)) return false;
     return true;
   };
+  // 구매·방문 일자의 상한은 결과물 제출 마감일(우선) 또는 캠페인 노출 마감일(폴백)
+  const upperPV = se || pdl || '';
+  const inPVRange = (val) => {
+    if (!val) return true;
+    if (lower && new Date(val) < new Date(lower)) return false;
+    if (upperPV && new Date(val) > new Date(upperPV)) return false;
+    return true;
+  };
+  const upperPVLabel = se ? '결과물 제출 마감일' : '캠페인 노출 마감일';
   if (rs && dl && new Date(dl) < new Date(rs)) errs.push({kind:'recruit', msg:'모집 종료일은 모집 시작일 이후여야 합니다'});
-  if (dl && pdl && new Date(pdl) < new Date(dl)) errs.push({kind:'post', msg:'노출 마감일은 모집 종료일 이후여야 합니다'});
-  if (!between(ps)) errs.push({kind:'purchase', msg:'구매 시작일은 모집 시작일~노출 마감일 사이여야 합니다'});
-  if (!between(pe)) errs.push({kind:'purchase', msg:'구매 마감일은 모집 시작일~노출 마감일 사이여야 합니다'});
+  if (dl && pdl && new Date(pdl) < new Date(dl)) errs.push({kind:'post', msg:'캠페인 노출 마감일은 모집 종료일 이후여야 합니다'});
+  if (!inPVRange(ps)) errs.push({kind:'purchase', msg:`구매 시작일은 모집 시작일~${upperPVLabel} 사이여야 합니다`});
+  if (!inPVRange(pe)) errs.push({kind:'purchase', msg:`구매 마감일은 모집 시작일~${upperPVLabel} 사이여야 합니다`});
   if (ps && pe && new Date(pe) < new Date(ps)) errs.push({kind:'purchase', msg:'구매 마감일은 구매 시작일 이후여야 합니다'});
-  if (!between(vs)) errs.push({kind:'visit', msg:'방문 시작일은 모집 시작일~노출 마감일 사이여야 합니다'});
-  if (!between(ve)) errs.push({kind:'visit', msg:'방문 마감일은 모집 시작일~노출 마감일 사이여야 합니다'});
+  if (!inPVRange(vs)) errs.push({kind:'visit', msg:`방문 시작일은 모집 시작일~${upperPVLabel} 사이여야 합니다`});
+  if (!inPVRange(ve)) errs.push({kind:'visit', msg:`방문 마감일은 모집 시작일~${upperPVLabel} 사이여야 합니다`});
   if (vs && ve && new Date(ve) < new Date(vs)) errs.push({kind:'visit', msg:'방문 마감일은 방문 시작일 이후여야 합니다'});
-  if (!between(se)) errs.push({kind:'submission', msg:'결과물 제출 마감일은 모집 시작일~노출 마감일 사이여야 합니다'});
+  // 결과물 제출 마감일: 모집 시작 ~ 캠페인 노출 마감 사이 + 구매·방문 종료일 이후
+  if (se && lower && new Date(se) < new Date(lower)) errs.push({kind:'submission', msg:'결과물 제출 마감일은 모집 시작일 이후여야 합니다'});
+  if (se && pdl && new Date(se) > new Date(pdl)) errs.push({kind:'submission', msg:'결과물 제출 마감일은 캠페인 노출 마감일 이전이어야 합니다'});
+  if (se && pe && new Date(se) < new Date(pe)) errs.push({kind:'submission', msg:'결과물 제출 마감일은 구매 종료일 이후여야 합니다'});
+  if (se && ve && new Date(se) < new Date(ve)) errs.push({kind:'submission', msg:'결과물 제출 마감일은 방문 종료일 이후여야 합니다'});
   return errs;
 }
 
@@ -6134,7 +6159,7 @@ async function saveCampaignEdit() {
     const editDeadline = gv('editCampDeadline');
     const editPostDeadline = gv('editCampPostDeadline');
     if (editPostDeadline && editDeadline && new Date(editPostDeadline) < new Date(editDeadline)) {
-      toast('노출 마감일은 모집 마감일 이후여야 합니다','error');
+      toast('캠페인 노출 마감일은 모집 종료일 이후여야 합니다','error');
       return;
     }
     const editDateErrs = validateCampDateRanges('editCamp');
@@ -7805,7 +7830,7 @@ async function addCampaign() {
   }
   const postDeadline = $('newCampPostDeadline')?.value;
   if (postDeadline && deadline && new Date(postDeadline) < new Date(deadline)) {
-    toast('노출 마감일은 모집 종료일 이후여야 합니다','error');
+    toast('캠페인 노출 마감일은 모집 종료일 이후여야 합니다','error');
     return;
   }
   const newDateErrs = validateCampDateRanges('newCamp');

--- a/admin/index.html
+++ b/admin/index.html
@@ -1077,9 +1077,15 @@ textarea.form-input{resize:vertical;min-height:80px}
                 <input type="text" id="editCampRecruitRange" class="form-input fp-range" placeholder="시작일 ~ 종료일 선택" data-range-prefix="editCamp" data-range-kind="recruit" readonly>
                 <input type="hidden" id="editCampRecruitStart">
                 <input type="hidden" id="editCampDeadline">
-                <div id="editPostDeadlineWarn" class="form-error" style="display:none;margin-top:4px"></div>
+                <div class="form-hint">인플루언서를 모집하는 기간을 설정하세요</div>
+                <div id="editCampRecruitWarn" class="form-error" style="display:none;margin-top:4px"></div>
               </div>
-              <div class="form-group"><label class="form-label">결과물 제출 마감일</label><input type="date" id="editCampSubmissionEnd" class="form-input" onchange="validateCampDateRangesInline('editCamp')"><div class="form-hint">이 날짜 이후 결과물 제출 불가. 비우면 노출 마감일로 폴백</div></div>
+              <div class="form-group">
+                <label class="form-label">결과물 제출 마감일</label>
+                <input type="date" id="editCampSubmissionEnd" class="form-input" onchange="validateCampDateRangesInline('editCamp')">
+                <div class="form-hint">이 날짜 이후 결과물 제출 불가. 비우면 노출 마감일로 폴백</div>
+                <div id="editCampSubmissionWarn" class="form-error" style="display:none;margin-top:4px"></div>
+              </div>
             </div>
             <div class="form-row" id="editCampPurchaseRow" style="grid-template-columns:1fr 1fr;display:none">
               <div class="form-group">
@@ -1088,6 +1094,7 @@ textarea.form-input{resize:vertical;min-height:80px}
                 <input type="hidden" id="editCampPurchaseStart">
                 <input type="hidden" id="editCampPurchaseEnd">
                 <div class="form-hint">리뷰어용. 이 기간 내 구매한 영수증만 인정</div>
+                <div id="editCampPurchaseWarn" class="form-error" style="display:none;margin-top:4px"></div>
               </div>
             </div>
             <div class="form-row" id="editCampVisitRow" style="grid-template-columns:1fr 1fr;display:none">
@@ -1097,12 +1104,17 @@ textarea.form-input{resize:vertical;min-height:80px}
                 <input type="hidden" id="editCampVisitStart">
                 <input type="hidden" id="editCampVisitEnd">
                 <div class="form-hint">방문형용. 이 기간 내 매장 방문 가능</div>
+                <div id="editCampVisitWarn" class="form-error" style="display:none;margin-top:4px"></div>
               </div>
             </div>
             <div class="form-row" style="grid-template-columns:1fr 1fr">
-              <div class="form-group"><label class="form-label">노출 마감일 <span style="background:var(--pink);color:#fff;font-size:9px;font-weight:700;padding:1px 5px;border-radius:3px;margin-left:4px">필수</span></label><input type="date" id="editCampPostDeadline" class="form-input" onchange="syncCampDateMinMax('editCamp');validateCampDateRangesInline('editCamp')"><div class="form-hint">이 날짜 이후 캠페인이 인플루언서 사이트에서 숨겨집니다</div></div>
+              <div class="form-group">
+                <label class="form-label">노출 마감일 <span style="background:var(--pink);color:#fff;font-size:9px;font-weight:700;padding:1px 5px;border-radius:3px;margin-left:4px">필수</span></label>
+                <input type="date" id="editCampPostDeadline" class="form-input" onchange="syncCampDateMinMax('editCamp');validateCampDateRangesInline('editCamp')">
+                <div class="form-hint">이 날짜 이후 캠페인이 인플루언서 사이트에서 숨겨집니다</div>
+                <div id="editCampPostDeadlineWarn" class="form-error" style="display:none;margin-top:4px"></div>
+              </div>
             </div>
-            <div id="editCampDateRangesWarn" class="form-error" style="display:none;margin-top:6px"></div>
             <div class="form-group"><label class="form-label">당선 발표 안내</label><input type="text" id="editCampWinnerAnnounce" class="form-input" placeholder="選考後、LINEにてご連絡"><div class="form-hint">인플루언서 캠페인 상세에 표시되는 문구. 비우면 기본값</div></div>
             <div style="font-size:14px;font-weight:700;color:var(--ink);padding-bottom:8px;margin:20px 0 12px;border-bottom:2px solid var(--pink)">콘텐츠 가이드</div>
             <div class="form-group"><label class="form-label">캠페인 설명</label><div class="quill-host" id="editCampDesc"></div></div>
@@ -1308,12 +1320,14 @@ textarea.form-input{resize:vertical;min-height:80px}
                 <input type="text" id="newCampRecruitRange" class="form-input fp-range" placeholder="시작일 ~ 종료일 선택" data-range-prefix="newCamp" data-range-kind="recruit" readonly>
                 <input type="hidden" id="newCampRecruitStart">
                 <input type="hidden" id="newCampDeadline">
-                <div id="newPostDeadlineWarn" class="form-error" style="display:none;margin-top:4px"></div>
+                <div class="form-hint">인플루언서를 모집하는 기간을 설정하세요</div>
+                <div id="newCampRecruitWarn" class="form-error" style="display:none;margin-top:4px"></div>
               </div>
               <div class="form-group">
                 <label class="form-label">결과물 제출 마감일</label>
                 <input type="date" id="newCampSubmissionEnd" class="form-input" onchange="validateCampDateRangesInline('newCamp')">
                 <div class="form-hint">이 날짜 이후 결과물(영수증·게시물 URL) 제출 불가. 비우면 노출 마감일로 폴백</div>
+                <div id="newCampSubmissionWarn" class="form-error" style="display:none;margin-top:4px"></div>
               </div>
             </div>
 
@@ -1325,6 +1339,7 @@ textarea.form-input{resize:vertical;min-height:80px}
                 <input type="hidden" id="newCampPurchaseStart">
                 <input type="hidden" id="newCampPurchaseEnd">
                 <div class="form-hint">리뷰어용. 이 기간 내 구매한 영수증만 인정</div>
+                <div id="newCampPurchaseWarn" class="form-error" style="display:none;margin-top:4px"></div>
               </div>
             </div>
             <div class="form-row" id="newCampVisitRow" style="grid-template-columns:1fr 1fr;display:none">
@@ -1334,6 +1349,7 @@ textarea.form-input{resize:vertical;min-height:80px}
                 <input type="hidden" id="newCampVisitStart">
                 <input type="hidden" id="newCampVisitEnd">
                 <div class="form-hint">방문형용. 이 기간 내 매장 방문 가능</div>
+                <div id="newCampVisitWarn" class="form-error" style="display:none;margin-top:4px"></div>
               </div>
             </div>
             <div class="form-row" style="grid-template-columns:1fr 1fr">
@@ -1341,9 +1357,9 @@ textarea.form-input{resize:vertical;min-height:80px}
                 <label class="form-label">노출 마감일 <span style="background:var(--pink);color:#fff;font-size:9px;font-weight:700;padding:1px 5px;border-radius:3px;margin-left:4px">필수</span></label>
                 <input type="date" id="newCampPostDeadline" class="form-input" onchange="syncCampDateMinMax('newCamp');validateCampDateRangesInline('newCamp')">
                 <div class="form-hint">이 날짜 이후 캠페인이 인플루언서 사이트에서 숨겨집니다</div>
+                <div id="newCampPostDeadlineWarn" class="form-error" style="display:none;margin-top:4px"></div>
               </div>
             </div>
-            <div id="newCampDateRangesWarn" class="form-error" style="display:none;margin-top:6px"></div>
             <div class="form-group">
               <label class="form-label">당선 발표 안내</label>
               <input type="text" id="newCampWinnerAnnounce" class="form-input" value="選考後、LINEにてご連絡" placeholder="選考後、LINEにてご連絡">
@@ -5914,20 +5930,6 @@ async function suggestSubmissionEnd(prefix) {
   }
 }
 
-// (legacy) 모집 종료일 < 노출 마감일 인라인 경고 — flatpickr range picker 도입 후엔 사실상 미사용. 호출처 호환용 stub.
-function validateDeadlines(deadlineId, postDeadlineId, warnId) {
-  const dl = $(deadlineId)?.value;
-  const pdl = $(postDeadlineId)?.value;
-  const warn = $(warnId);
-  if (!warn) return;
-  if (dl && pdl && new Date(pdl) < new Date(dl)) {
-    warn.textContent = '노출 마감일은 모집 종료일 이후여야 합니다';
-    warn.style.display = 'block';
-  } else {
-    warn.style.display = 'none';
-  }
-}
-
 // 일자 자식 input들의 min/max를 [recruit_start || deadline] ~ post_deadline 으로 동기화 (브라우저 단 차단)
 const CAMP_DATE_FIELDS = ['PurchaseStart','PurchaseEnd','VisitStart','VisitEnd','SubmissionEnd','PostDeadline'];
 function syncCampDateMinMax(prefix) {
@@ -5970,17 +5972,26 @@ function validateCampDateRanges(prefix) {
     if (pdl && new Date(val) > new Date(pdl)) return false;
     return true;
   };
-  if (rs && dl && new Date(dl) < new Date(rs)) errs.push('모집 종료일은 모집 시작일 이후여야 합니다');
-  if (dl && pdl && new Date(pdl) < new Date(dl)) errs.push('노출 마감일은 모집 종료일 이후여야 합니다');
-  if (!between(ps)) errs.push('구매 시작일은 모집 시작일~노출 마감일 사이여야 합니다');
-  if (!between(pe)) errs.push('구매 마감일은 모집 시작일~노출 마감일 사이여야 합니다');
-  if (ps && pe && new Date(pe) < new Date(ps)) errs.push('구매 마감일은 구매 시작일 이후여야 합니다');
-  if (!between(vs)) errs.push('방문 시작일은 모집 시작일~노출 마감일 사이여야 합니다');
-  if (!between(ve)) errs.push('방문 마감일은 모집 시작일~노출 마감일 사이여야 합니다');
-  if (vs && ve && new Date(ve) < new Date(vs)) errs.push('방문 마감일은 방문 시작일 이후여야 합니다');
-  if (!between(se)) errs.push('결과물 제출 마감일은 모집 시작일~노출 마감일 사이여야 합니다');
+  if (rs && dl && new Date(dl) < new Date(rs)) errs.push({kind:'recruit', msg:'모집 종료일은 모집 시작일 이후여야 합니다'});
+  if (dl && pdl && new Date(pdl) < new Date(dl)) errs.push({kind:'post', msg:'노출 마감일은 모집 종료일 이후여야 합니다'});
+  if (!between(ps)) errs.push({kind:'purchase', msg:'구매 시작일은 모집 시작일~노출 마감일 사이여야 합니다'});
+  if (!between(pe)) errs.push({kind:'purchase', msg:'구매 마감일은 모집 시작일~노출 마감일 사이여야 합니다'});
+  if (ps && pe && new Date(pe) < new Date(ps)) errs.push({kind:'purchase', msg:'구매 마감일은 구매 시작일 이후여야 합니다'});
+  if (!between(vs)) errs.push({kind:'visit', msg:'방문 시작일은 모집 시작일~노출 마감일 사이여야 합니다'});
+  if (!between(ve)) errs.push({kind:'visit', msg:'방문 마감일은 모집 시작일~노출 마감일 사이여야 합니다'});
+  if (vs && ve && new Date(ve) < new Date(vs)) errs.push({kind:'visit', msg:'방문 마감일은 방문 시작일 이후여야 합니다'});
+  if (!between(se)) errs.push({kind:'submission', msg:'결과물 제출 마감일은 모집 시작일~노출 마감일 사이여야 합니다'});
   return errs;
 }
+
+// 종류별 row 아래 div 매핑 — 한 row에 여러 위반이 있으면 같은 div에 누적 표시
+const CAMP_DATE_WARN_TARGETS = {
+  recruit:    'RecruitWarn',
+  post:       'PostDeadlineWarn',
+  purchase:   'PurchaseWarn',
+  visit:      'VisitWarn',
+  submission: 'SubmissionWarn',
+};
 
 // ─────────────────────────────────────────────────────────────────
 // flatpickr range picker 통합 (모집·구매·방문 3개 영역)
@@ -6042,6 +6053,8 @@ function setupCampRangePickers() {
       dateFormat: 'Y-m-d',
       altInput: false,
       locale: (typeof flatpickr !== 'undefined' && flatpickr.l10ns && flatpickr.l10ns.ko) ? 'ko' : 'default',
+      static: true,            // 캘린더 popup을 input의 부모(form-group)에 붙여 스크롤 시 따라다님
+      position: 'below',       // 항상 input 아래로 표시 (자동 위/아래 결정 비활성)
       onOpen: (selectedDates, _str, fpInst) => {
         if (kind !== 'recruit') return;
         // 캘린더 열릴 때마다 현재 hidden input의 시작일을 기준으로 경고 평가
@@ -6086,18 +6099,24 @@ function applyCampRangeValues(prefix, values) {
   });
 }
 
-// onchange 인라인 경고 (저장 차단은 별도 체크)
+// onchange 인라인 경고 — 종류별로 분산해서 해당 row 바로 아래 div 에 출력 (저장 차단은 별도 체크)
 function validateCampDateRangesInline(prefix) {
   const errs = validateCampDateRanges(prefix);
-  const warn = $(prefix+'DateRangesWarn');
-  if (!warn) return;
-  if (errs.length === 0) {
-    warn.style.display = 'none';
-    warn.textContent = '';
-  } else {
-    warn.innerHTML = errs.map(e => `· ${e}`).join('<br>');
-    warn.style.display = 'block';
-  }
+  const groups = Object.create(null);
+  Object.keys(CAMP_DATE_WARN_TARGETS).forEach(k => { groups[k] = []; });
+  errs.forEach(e => { if (groups[e.kind]) groups[e.kind].push(e.msg); });
+  Object.keys(CAMP_DATE_WARN_TARGETS).forEach(k => {
+    const div = $(prefix + CAMP_DATE_WARN_TARGETS[k]);
+    if (!div) return;
+    const list = groups[k];
+    if (!list || list.length === 0) {
+      div.style.display = 'none';
+      div.textContent = '';
+    } else {
+      div.innerHTML = list.map(m => `· ${esc(m)}`).join('<br>');
+      div.style.display = 'block';
+    }
+  });
 }
 
 async function saveCampaignEdit() {
@@ -6119,7 +6138,7 @@ async function saveCampaignEdit() {
       return;
     }
     const editDateErrs = validateCampDateRanges('editCamp');
-    if (editDateErrs.length) { toast(editDateErrs[0], 'error'); return; }
+    if (editDateErrs.length) { toast(editDateErrs[0].msg, 'error'); validateCampDateRangesInline('editCamp'); return; }
     const editStatus = gv('editCampStatus');
     if (editDeadline && (editStatus === 'active' || editStatus === 'scheduled')) {
       const dl = new Date(editDeadline); dl.setHours(23,59,59,999);
@@ -7790,7 +7809,7 @@ async function addCampaign() {
     return;
   }
   const newDateErrs = validateCampDateRanges('newCamp');
-  if (newDateErrs.length) { toast(newDateErrs[0], 'error'); return; }
+  if (newDateErrs.length) { toast(newDateErrs[0].msg, 'error'); validateCampDateRangesInline('newCamp'); return; }
   const catEmojiMap = {beauty:'💄',food:'🍜',fashion:'👗',health:'💪',other:'📦'};
   const cat = $('newCampCategory').value;
   const ch = Array.from(document.querySelectorAll('input[name="newChannel"]:checked')).map(c=>c.value).join(',');

--- a/admin/index.html
+++ b/admin/index.html
@@ -29,6 +29,9 @@
 <link href="https://cdnjs.cloudflare.com/ajax/libs/cropperjs/1.6.2/cropper.min.css" rel="stylesheet">
 <script src="https://cdnjs.cloudflare.com/ajax/libs/cropperjs/1.6.2/cropper.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/chart.js@4/dist/chart.umd.min.js"></script>
+<link href="https://cdn.jsdelivr.net/npm/flatpickr@4.6.13/dist/flatpickr.min.css" rel="stylesheet">
+<script src="https://cdn.jsdelivr.net/npm/flatpickr@4.6.13/dist/flatpickr.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/flatpickr@4.6.13/dist/l10n/ko.js"></script>
 <style id="admin-cloak">body{visibility:hidden!important}</style>
 <style>
 /* ══════════════════════════════════
@@ -1069,19 +1072,35 @@ textarea.form-input{resize:vertical;min-height:80px}
             </div>
 
             <div class="form-row" style="grid-template-columns:1fr 1fr">
-              <div class="form-group"><label class="form-label">모집 마감일 <span style="background:var(--pink);color:#fff;font-size:9px;font-weight:700;padding:1px 5px;border-radius:3px;margin-left:4px">필수</span></label><input type="date" id="editCampDeadline" class="form-input" onchange="suggestPostDeadline('editCampDeadline','editCampPostDeadline');validateDeadlines('editCampDeadline','editCampPostDeadline','editPostDeadlineWarn');syncCampDateMinMax('editCamp');validateCampDateRangesInline('editCamp')"></div>
+              <div class="form-group">
+                <label class="form-label">모집 기간 <span style="background:var(--pink);color:#fff;font-size:9px;font-weight:700;padding:1px 5px;border-radius:3px;margin-left:4px">필수</span></label>
+                <input type="text" id="editCampRecruitRange" class="form-input fp-range" placeholder="시작일 ~ 종료일 선택" data-range-prefix="editCamp" data-range-kind="recruit" readonly>
+                <input type="hidden" id="editCampRecruitStart">
+                <input type="hidden" id="editCampDeadline">
+                <div id="editPostDeadlineWarn" class="form-error" style="display:none;margin-top:4px"></div>
+              </div>
               <div class="form-group"><label class="form-label">결과물 제출 마감일</label><input type="date" id="editCampSubmissionEnd" class="form-input" onchange="validateCampDateRangesInline('editCamp')"><div class="form-hint">이 날짜 이후 결과물 제출 불가. 비우면 노출 마감일로 폴백</div></div>
             </div>
             <div class="form-row" id="editCampPurchaseRow" style="grid-template-columns:1fr 1fr;display:none">
-              <div class="form-group"><label class="form-label">구매 시작일</label><input type="date" id="editCampPurchaseStart" class="form-input" onchange="validateCampDateRangesInline('editCamp')"><div class="form-hint">리뷰어용</div></div>
-              <div class="form-group"><label class="form-label">구매 마감일</label><input type="date" id="editCampPurchaseEnd" class="form-input" onchange="validateCampDateRangesInline('editCamp')"></div>
+              <div class="form-group">
+                <label class="form-label">구매 기간</label>
+                <input type="text" id="editCampPurchaseRange" class="form-input fp-range" placeholder="시작일 ~ 종료일 선택" data-range-prefix="editCamp" data-range-kind="purchase" readonly>
+                <input type="hidden" id="editCampPurchaseStart">
+                <input type="hidden" id="editCampPurchaseEnd">
+                <div class="form-hint">리뷰어용. 이 기간 내 구매한 영수증만 인정</div>
+              </div>
             </div>
             <div class="form-row" id="editCampVisitRow" style="grid-template-columns:1fr 1fr;display:none">
-              <div class="form-group"><label class="form-label">방문 시작일</label><input type="date" id="editCampVisitStart" class="form-input" onchange="validateCampDateRangesInline('editCamp')"><div class="form-hint">방문형용</div></div>
-              <div class="form-group"><label class="form-label">방문 마감일</label><input type="date" id="editCampVisitEnd" class="form-input" onchange="validateCampDateRangesInline('editCamp')"></div>
+              <div class="form-group">
+                <label class="form-label">방문 기간</label>
+                <input type="text" id="editCampVisitRange" class="form-input fp-range" placeholder="시작일 ~ 종료일 선택" data-range-prefix="editCamp" data-range-kind="visit" readonly>
+                <input type="hidden" id="editCampVisitStart">
+                <input type="hidden" id="editCampVisitEnd">
+                <div class="form-hint">방문형용. 이 기간 내 매장 방문 가능</div>
+              </div>
             </div>
             <div class="form-row" style="grid-template-columns:1fr 1fr">
-              <div class="form-group"><label class="form-label">노출 마감일 <span style="background:var(--pink);color:#fff;font-size:9px;font-weight:700;padding:1px 5px;border-radius:3px;margin-left:4px">필수</span></label><input type="date" id="editCampPostDeadline" class="form-input" onchange="validateDeadlines('editCampDeadline','editCampPostDeadline','editPostDeadlineWarn');syncCampDateMinMax('editCamp');validateCampDateRangesInline('editCamp')"><div id="editPostDeadlineWarn" class="form-error" style="display:none;margin-top:4px"></div><div class="form-hint">이 날짜 이후 캠페인이 인플루언서 사이트에서 숨겨집니다</div></div>
+              <div class="form-group"><label class="form-label">노출 마감일 <span style="background:var(--pink);color:#fff;font-size:9px;font-weight:700;padding:1px 5px;border-radius:3px;margin-left:4px">필수</span></label><input type="date" id="editCampPostDeadline" class="form-input" onchange="syncCampDateMinMax('editCamp');validateCampDateRangesInline('editCamp')"><div class="form-hint">이 날짜 이후 캠페인이 인플루언서 사이트에서 숨겨집니다</div></div>
             </div>
             <div id="editCampDateRangesWarn" class="form-error" style="display:none;margin-top:6px"></div>
             <div class="form-group"><label class="form-label">당선 발표 안내</label><input type="text" id="editCampWinnerAnnounce" class="form-input" placeholder="選考後、LINEにてご連絡"><div class="form-hint">인플루언서 캠페인 상세에 표시되는 문구. 비우면 기본값</div></div>
@@ -1282,11 +1301,14 @@ textarea.form-input{resize:vertical;min-height:80px}
               </div>
             </div>
 
-            <!-- 모집 마감일 / 결과물 제출 마감일 -->
+            <!-- 모집 기간 / 결과물 제출 마감일 -->
             <div class="form-row" style="grid-template-columns:1fr 1fr">
               <div class="form-group">
-                <label class="form-label">모집 마감일 <span style="background:var(--pink);color:#fff;font-size:9px;font-weight:700;padding:1px 5px;border-radius:3px;margin-left:4px">필수</span></label>
-                <input type="date" id="newCampDeadline" class="form-input" onchange="suggestPostDeadline('newCampDeadline','newCampPostDeadline');validateDeadlines('newCampDeadline','newCampPostDeadline','newPostDeadlineWarn');syncCampDateMinMax('newCamp');validateCampDateRangesInline('newCamp')">
+                <label class="form-label">모집 기간 <span style="background:var(--pink);color:#fff;font-size:9px;font-weight:700;padding:1px 5px;border-radius:3px;margin-left:4px">필수</span></label>
+                <input type="text" id="newCampRecruitRange" class="form-input fp-range" placeholder="시작일 ~ 종료일 선택" data-range-prefix="newCamp" data-range-kind="recruit" readonly>
+                <input type="hidden" id="newCampRecruitStart">
+                <input type="hidden" id="newCampDeadline">
+                <div id="newPostDeadlineWarn" class="form-error" style="display:none;margin-top:4px"></div>
               </div>
               <div class="form-group">
                 <label class="form-label">결과물 제출 마감일</label>
@@ -1295,34 +1317,29 @@ textarea.form-input{resize:vertical;min-height:80px}
               </div>
             </div>
 
-            <!-- 타입별 기한 (Stage 1) — 모든 일자는 모집~노출 마감 사이로 강제 -->
+            <!-- 타입별 기한 — 모든 일자는 모집 시작 ~ 노출 마감 사이로 강제 -->
             <div class="form-row" id="newCampPurchaseRow" style="grid-template-columns:1fr 1fr;display:none">
               <div class="form-group">
-                <label class="form-label">구매 시작일</label>
-                <input type="date" id="newCampPurchaseStart" class="form-input" onchange="validateCampDateRangesInline('newCamp')">
+                <label class="form-label">구매 기간</label>
+                <input type="text" id="newCampPurchaseRange" class="form-input fp-range" placeholder="시작일 ~ 종료일 선택" data-range-prefix="newCamp" data-range-kind="purchase" readonly>
+                <input type="hidden" id="newCampPurchaseStart">
+                <input type="hidden" id="newCampPurchaseEnd">
                 <div class="form-hint">리뷰어용. 이 기간 내 구매한 영수증만 인정</div>
-              </div>
-              <div class="form-group">
-                <label class="form-label">구매 마감일</label>
-                <input type="date" id="newCampPurchaseEnd" class="form-input" onchange="validateCampDateRangesInline('newCamp')">
               </div>
             </div>
             <div class="form-row" id="newCampVisitRow" style="grid-template-columns:1fr 1fr;display:none">
               <div class="form-group">
-                <label class="form-label">방문 시작일</label>
-                <input type="date" id="newCampVisitStart" class="form-input" onchange="validateCampDateRangesInline('newCamp')">
+                <label class="form-label">방문 기간</label>
+                <input type="text" id="newCampVisitRange" class="form-input fp-range" placeholder="시작일 ~ 종료일 선택" data-range-prefix="newCamp" data-range-kind="visit" readonly>
+                <input type="hidden" id="newCampVisitStart">
+                <input type="hidden" id="newCampVisitEnd">
                 <div class="form-hint">방문형용. 이 기간 내 매장 방문 가능</div>
-              </div>
-              <div class="form-group">
-                <label class="form-label">방문 마감일</label>
-                <input type="date" id="newCampVisitEnd" class="form-input" onchange="validateCampDateRangesInline('newCamp')">
               </div>
             </div>
             <div class="form-row" style="grid-template-columns:1fr 1fr">
               <div class="form-group">
                 <label class="form-label">노출 마감일 <span style="background:var(--pink);color:#fff;font-size:9px;font-weight:700;padding:1px 5px;border-radius:3px;margin-left:4px">필수</span></label>
-                <input type="date" id="newCampPostDeadline" class="form-input" onchange="validateDeadlines('newCampDeadline','newCampPostDeadline','newPostDeadlineWarn');syncCampDateMinMax('newCamp');validateCampDateRangesInline('newCamp')">
-                <div id="newPostDeadlineWarn" class="form-error" style="display:none;margin-top:4px"></div>
+                <input type="date" id="newCampPostDeadline" class="form-input" onchange="syncCampDateMinMax('newCamp');validateCampDateRangesInline('newCamp')">
                 <div class="form-hint">이 날짜 이후 캠페인이 인플루언서 사이트에서 숨겨집니다</div>
               </div>
             </div>
@@ -2820,11 +2837,39 @@ async function fetchCampaigns() {
     const data = await fetchAllPaged(() =>
       db.from('campaigns').select('*').order('order_index', {ascending: true, nullsFirst: false})
     );
-    if (data.length > 0) { await autoCloseCampaigns(data); return data; }
+    if (data.length > 0) {
+      await autoOpenCampaigns(data);   // scheduled → active (recruit_start 도래)
+      await autoCloseCampaigns(data);  // active → closed (deadline 경과)
+      return data;
+    }
     return DEMO_CAMPAIGNS.slice();
   } catch(e) {
     return DEMO_CAMPAIGNS.slice();
   }
+}
+
+// 모집 시작일 도래 캠페인 자동 활성화 (scheduled → active)
+//   recruit_start 가 오늘(JST 자정 기준) 이하이고 status='scheduled' 면 active 로 전환.
+//   deadline 이 이미 경과한 경우는 autoCloseCampaigns 가 이어서 닫음.
+async function autoOpenCampaigns(camps) {
+  if (!db) return camps;
+  const now = new Date();
+  now.setHours(0, 0, 0, 0);
+  const toOpen = camps.filter(c => {
+    if (c.status !== 'scheduled' || !c.recruit_start) return false;
+    const rs = new Date(c.recruit_start);
+    rs.setHours(0, 0, 0, 0);
+    return now >= rs;
+  });
+  if (!toOpen.length) return camps;
+  const results = await Promise.allSettled(toOpen.map(c => {
+    c.status = 'active';
+    return db.from('campaigns').update({ status: 'active' }).eq('id', c.id);
+  }));
+  results.forEach((r, i) => {
+    if (r.status === 'rejected') console.warn('autoOpenCampaigns 실패:', toOpen[i]?.id, r.reason);
+  });
+  return camps;
 }
 
 // 마감일 경과 캠페인 자동 상태 변경 (병렬 UPDATE)
@@ -4928,6 +4973,10 @@ function switchAdminPane(pane, el, pushHistory) {
   document.querySelectorAll('.admin-si').forEach(s=>s.classList.remove('on'));
   const paneEl = $('adminPane-'+pane);
   if (paneEl) paneEl.classList.add('on');
+  // 캠페인 등록·편집 진입 시 flatpickr range picker mount (idempotent)
+  if (pane === 'add-campaign' || pane === 'edit-campaign') {
+    if (typeof setupCampRangePickers === 'function') setupCampRangePickers();
+  }
   // 사이드바 활성 상태를 data-pane 속성으로 검색
   if (!el) {
     const sidePane = {'add-campaign':'campaigns','edit-campaign':'campaigns',
@@ -5734,13 +5783,15 @@ async function openEditCampaign(campId) {
   sv('editCampProductPrice', camp.product_price||0);
   sv('editCampReward', camp.reward||0);
   sv('editCampRewardNote', camp.reward_note||'');
-  sv('editCampDeadline', camp.deadline||'');
   sv('editCampPostDeadline', camp.post_deadline||'');
-  sv('editCampPurchaseStart', camp.purchase_start||'');
-  sv('editCampPurchaseEnd', camp.purchase_end||'');
-  sv('editCampVisitStart', camp.visit_start||'');
-  sv('editCampVisitEnd', camp.visit_end||'');
   sv('editCampSubmissionEnd', camp.submission_end||'');
+  // flatpickr range picker mount + 값 주입 (모집·구매·방문 3개)
+  setupCampRangePickers();
+  applyCampRangeValues('editCamp', {
+    recruit:  [camp.recruit_start || '', camp.deadline || ''],
+    purchase: [camp.purchase_start || '', camp.purchase_end || ''],
+    visit:    [camp.visit_start || '', camp.visit_end || ''],
+  });
   // 일자 입력 min/max 동기화 + 인라인 경고 초기 평가
   syncCampDateMinMax('editCamp');
   validateCampDateRangesInline('editCamp');
@@ -5843,54 +5894,67 @@ function resolveConfirmModal(ok) {
   if (_confirmResolver) { _confirmResolver(!!ok); _confirmResolver = null; }
 }
 
-// 모집 마감일 입력 시 노출 마감일을 +14일로 자동 채우기 (확인 모달)
-async function suggestPostDeadline(deadlineId, postDeadlineId) {
-  const dl = $(deadlineId)?.value;
+// 모집 종료일 입력 시 결과물 제출 마감일을 +14일로 자동 제안 (확인 모달)
+async function suggestSubmissionEnd(prefix) {
+  const dl = $(prefix+'Deadline')?.value;
   if (!dl) return;
-  const post = new Date(dl);
-  post.setDate(post.getDate() + 14);
-  const yyyy = post.getFullYear();
-  const mm = String(post.getMonth() + 1).padStart(2, '0');
-  const dd = String(post.getDate()).padStart(2, '0');
+  const target = new Date(dl);
+  target.setDate(target.getDate() + 14);
+  const yyyy = target.getFullYear();
+  const mm = String(target.getMonth() + 1).padStart(2, '0');
+  const dd = String(target.getDate()).padStart(2, '0');
   const suggested = `${yyyy}-${mm}-${dd}`;
-  const postEl = $(postDeadlineId);
-  if (!postEl) return;
-  // 이미 입력된 값이 같으면 무시
-  if (postEl.value === suggested) return;
-  const ok = await showConfirm(`노출 마감일을 ${yyyy}년 ${mm}월 ${dd}일로 입력하시겠습니까?\n(모집 마감일 + 2주)`);
-  if (ok) postEl.value = suggested;
+  const seEl = $(prefix+'SubmissionEnd');
+  if (!seEl || seEl.value === suggested) return;
+  const ok = await showConfirm(`결과물 제출 마감일을 ${yyyy}년 ${mm}월 ${dd}일로 입력하시겠습니까?\n(모집 종료일 + 2주)`);
+  if (ok) {
+    seEl.value = suggested;
+    syncCampDateMinMax(prefix);
+    validateCampDateRangesInline(prefix);
+  }
 }
 
+// (legacy) 모집 종료일 < 노출 마감일 인라인 경고 — flatpickr range picker 도입 후엔 사실상 미사용. 호출처 호환용 stub.
 function validateDeadlines(deadlineId, postDeadlineId, warnId) {
   const dl = $(deadlineId)?.value;
   const pdl = $(postDeadlineId)?.value;
   const warn = $(warnId);
   if (!warn) return;
   if (dl && pdl && new Date(pdl) < new Date(dl)) {
-    warn.textContent = '노출 마감일은 모집 마감일 이후여야 합니다';
+    warn.textContent = '노출 마감일은 모집 종료일 이후여야 합니다';
     warn.style.display = 'block';
   } else {
     warn.style.display = 'none';
   }
 }
 
-// 모집~노출 마감 사이로 구매·방문·결과물제출 일자 강제. prefix = 'newCamp' | 'editCamp'
-const CAMP_DATE_FIELDS = ['PurchaseStart','PurchaseEnd','VisitStart','VisitEnd','SubmissionEnd'];
-
-// HTML5 input min/max 속성을 deadline ~ post_deadline 으로 동기화 (브라우저 단 차단)
+// 일자 자식 input들의 min/max를 [recruit_start || deadline] ~ post_deadline 으로 동기화 (브라우저 단 차단)
+const CAMP_DATE_FIELDS = ['PurchaseStart','PurchaseEnd','VisitStart','VisitEnd','SubmissionEnd','PostDeadline'];
 function syncCampDateMinMax(prefix) {
+  const rs = $(prefix+'RecruitStart')?.value || '';
   const dl = $(prefix+'Deadline')?.value || '';
   const pdl = $(prefix+'PostDeadline')?.value || '';
+  // 자식 일자들은 모집 시작일(없으면 모집 종료일) 이후로만 입력 가능
+  const lower = rs || dl || '';
   CAMP_DATE_FIELDS.forEach(suffix => {
+    if (suffix === 'PostDeadline') return; // post_deadline 은 자식이 아니라 자체 입력
     const el = $(prefix+suffix);
     if (!el) return;
-    if (dl) el.min = dl; else el.removeAttribute('min');
+    if (lower) el.min = lower; else el.removeAttribute('min');
     if (pdl) el.max = pdl; else el.removeAttribute('max');
   });
+  // 노출 마감일은 모집 종료일 이후만 (range picker 가 보장하지만 native input 도 강제)
+  const postEl = $(prefix+'PostDeadline');
+  if (postEl) {
+    if (dl) postEl.min = dl; else postEl.removeAttribute('min');
+    postEl.removeAttribute('max');
+  }
 }
 
 // 입력값 검증 (저장 시 + onchange 인라인 경고). 위반 메시지 배열 반환.
+//   경계: 모집 시작일 ~ 노출 마감일 사이
 function validateCampDateRanges(prefix) {
+  const rs = $(prefix+'RecruitStart')?.value || '';
   const dl = $(prefix+'Deadline')?.value || '';
   const pdl = $(prefix+'PostDeadline')?.value || '';
   const ps = $(prefix+'PurchaseStart')?.value || '';
@@ -5899,20 +5963,93 @@ function validateCampDateRanges(prefix) {
   const ve = $(prefix+'VisitEnd')?.value || '';
   const se = $(prefix+'SubmissionEnd')?.value || '';
   const errs = [];
+  const lower = rs || dl || '';
   const between = (val) => {
     if (!val) return true;
-    if (dl && new Date(val) < new Date(dl)) return false;
+    if (lower && new Date(val) < new Date(lower)) return false;
     if (pdl && new Date(val) > new Date(pdl)) return false;
     return true;
   };
-  if (!between(ps)) errs.push('구매 시작일은 모집 마감일~노출 마감일 사이여야 합니다');
-  if (!between(pe)) errs.push('구매 마감일은 모집 마감일~노출 마감일 사이여야 합니다');
+  if (rs && dl && new Date(dl) < new Date(rs)) errs.push('모집 종료일은 모집 시작일 이후여야 합니다');
+  if (dl && pdl && new Date(pdl) < new Date(dl)) errs.push('노출 마감일은 모집 종료일 이후여야 합니다');
+  if (!between(ps)) errs.push('구매 시작일은 모집 시작일~노출 마감일 사이여야 합니다');
+  if (!between(pe)) errs.push('구매 마감일은 모집 시작일~노출 마감일 사이여야 합니다');
   if (ps && pe && new Date(pe) < new Date(ps)) errs.push('구매 마감일은 구매 시작일 이후여야 합니다');
-  if (!between(vs)) errs.push('방문 시작일은 모집 마감일~노출 마감일 사이여야 합니다');
-  if (!between(ve)) errs.push('방문 마감일은 모집 마감일~노출 마감일 사이여야 합니다');
+  if (!between(vs)) errs.push('방문 시작일은 모집 시작일~노출 마감일 사이여야 합니다');
+  if (!between(ve)) errs.push('방문 마감일은 모집 시작일~노출 마감일 사이여야 합니다');
   if (vs && ve && new Date(ve) < new Date(vs)) errs.push('방문 마감일은 방문 시작일 이후여야 합니다');
-  if (!between(se)) errs.push('결과물 제출 마감일은 모집 마감일~노출 마감일 사이여야 합니다');
+  if (!between(se)) errs.push('결과물 제출 마감일은 모집 시작일~노출 마감일 사이여야 합니다');
   return errs;
+}
+
+// ─────────────────────────────────────────────────────────────────
+// flatpickr range picker 통합 (모집·구매·방문 3개 영역)
+//   - input[data-range-prefix][data-range-kind] 마크업을 mount 대상으로 사용
+//   - hidden start/end input 두 개에 값을 동기화 (저장 로직은 hidden ID 그대로)
+//   - 모집 종료일 변경 시 결과물 제출 마감일 자동 제안 + min/max 갱신 + 인라인 검증
+// ─────────────────────────────────────────────────────────────────
+const _campRangePickers = Object.create(null);
+const RANGE_KIND_HIDDEN_IDS = {
+  recruit:  ['RecruitStart', 'Deadline'],
+  purchase: ['PurchaseStart', 'PurchaseEnd'],
+  visit:    ['VisitStart', 'VisitEnd'],
+};
+function _fpFormatYmd(d) {
+  if (!d) return '';
+  const yyyy = d.getFullYear();
+  const mm = String(d.getMonth() + 1).padStart(2, '0');
+  const dd = String(d.getDate()).padStart(2, '0');
+  return `${yyyy}-${mm}-${dd}`;
+}
+function setupCampRangePickers() {
+  if (typeof flatpickr === 'undefined') return; // CDN 로드 실패 fallback (text input 그대로)
+  const els = document.querySelectorAll('input.fp-range[data-range-prefix]');
+  els.forEach(el => {
+    const id = el.id;
+    if (_campRangePickers[id]) return; // 이미 mount
+    const prefix = el.dataset.rangePrefix;
+    const kind   = el.dataset.rangeKind;
+    const [startSuffix, endSuffix] = RANGE_KIND_HIDDEN_IDS[kind] || [];
+    if (!startSuffix || !endSuffix) return;
+    _campRangePickers[id] = flatpickr(el, {
+      mode: 'range',
+      dateFormat: 'Y-m-d',
+      altInput: false,
+      locale: (typeof flatpickr !== 'undefined' && flatpickr.l10ns && flatpickr.l10ns.ko) ? 'ko' : 'default',
+      onChange: (selectedDates) => {
+        const start = selectedDates[0] || null;
+        const end   = selectedDates[1] || null;
+        const startEl = $(prefix + startSuffix);
+        const endEl   = $(prefix + endSuffix);
+        if (startEl) startEl.value = _fpFormatYmd(start);
+        if (endEl)   endEl.value   = _fpFormatYmd(end);
+        // 모집 기간 종료일이 새로 잡힌 경우 결과물 제출 마감일 자동 제안
+        if (kind === 'recruit' && end) {
+          suggestSubmissionEnd(prefix);
+        }
+        syncCampDateMinMax(prefix);
+        validateCampDateRangesInline(prefix);
+      },
+    });
+  });
+}
+// 편집 모달 열림·신규 폼 진입 시 외부에서 setDate 로 값 주입 (또는 클리어)
+function applyCampRangeValues(prefix, values) {
+  // values = { recruit:[start,end], purchase:[start,end], visit:[start,end] }
+  Object.keys(RANGE_KIND_HIDDEN_IDS).forEach(kind => {
+    const id = prefix + (kind === 'recruit' ? 'RecruitRange' : kind === 'purchase' ? 'PurchaseRange' : 'VisitRange');
+    const fp = _campRangePickers[id];
+    const pair = (values && values[kind]) || [null, null];
+    const [s, e] = pair;
+    const [startSuffix, endSuffix] = RANGE_KIND_HIDDEN_IDS[kind];
+    if ($(prefix + startSuffix)) $(prefix + startSuffix).value = s || '';
+    if ($(prefix + endSuffix))   $(prefix + endSuffix).value   = e || '';
+    if (fp) {
+      if (s && e) fp.setDate([s, e], false);
+      else if (s) fp.setDate([s], false);
+      else fp.clear(false);
+    }
+  });
 }
 
 // onchange 인라인 경고 (저장 차단은 별도 체크)
@@ -5977,6 +6114,7 @@ async function saveCampaignEdit() {
       product_price: parseInt(gv('editCampProductPrice'))||0,
       reward: parseInt(gv('editCampReward'))||0,
       reward_note: gv('editCampRewardNote') || null,
+      recruit_start: gv('editCampRecruitStart')||null,
       deadline: gv('editCampDeadline')||null,
       post_deadline: gv('editCampPostDeadline')||null,
       purchase_start: gv('editCampPurchaseStart')||null,
@@ -6037,7 +6175,7 @@ async function duplicateCampaign(campId) {
       caution_items: Array.isArray(src.caution_items) ? JSON.parse(JSON.stringify(src.caution_items)) : [],
       product_price: src.product_price, reward: src.reward, reward_note: src.reward_note,
       slots: src.slots, applied_count: 0,
-      deadline: src.deadline, post_deadline: src.post_deadline, post_days: src.post_days,
+      recruit_start: src.recruit_start, deadline: src.deadline, post_deadline: src.post_deadline, post_days: src.post_days,
       purchase_start: src.purchase_start, purchase_end: src.purchase_end,
       visit_start: src.visit_start, visit_end: src.visit_end,
       submission_end: src.submission_end,
@@ -6154,6 +6292,7 @@ function buildPreviewCamp(mode) {
     slots: parseInt(val(g+'Slots'))||10,
     min_followers: parseInt(val(g+'MinFollowers'))||0,
     primary_channel: val(g+'PrimaryChannel')||null,
+    recruit_start: val(g+'RecruitStart')||null,
     deadline: val(g+'Deadline')||null,
     post_deadline: val(g+'PostDeadline')||null,
     purchase_start: val(g+'PurchaseStart')||null,
@@ -6248,7 +6387,7 @@ function renderCampPreview(mode) {
           <div class="cp-info-row"><div class="cp-info-key">募集タイプ</div><div class="cp-info-val">${rtBadge?`<span class="cp-rt-badge" style="background:${rtBadge.bg};color:${rtBadge.color}">${rtBadge.label}</span>`:'—'}</div></div>
           ${channelNames.length?`<div class="cp-info-row"><div class="cp-info-key">チャンネル</div><div class="cp-info-val"><div class="cp-chips">${channelNames.map((n,i)=>(i>0?`<span class="cp-chip-sep">${chSep}</span>`:'')+`<span class="cp-chip">${esc(n)}</span>`).join('')}</div></div></div>`:''}
           ${contentTypeNames.length?`<div class="cp-info-row"><div class="cp-info-key">コンテンツ種類</div><div class="cp-info-val"><div class="cp-chips">${contentTypeNames.map(n=>`<span class="cp-chip cp-chip-sm">${esc(n)}</span>`).join('')}</div></div></div>`:''}
-          <div class="cp-info-row"><div class="cp-info-key">募集期間</div><div class="cp-info-val">${fmt(new Date())} 〜 ${fmt(camp.deadline)}</div></div>
+          <div class="cp-info-row"><div class="cp-info-key">募集期間</div><div class="cp-info-val">${fmt(camp.recruit_start || new Date())} 〜 ${fmt(camp.deadline)}</div></div>
           ${camp.slots?`<div class="cp-info-row"><div class="cp-info-key">募集人数</div><div class="cp-info-val">${camp.slots}名</div></div>`:''}
           ${camp.min_followers?`<div class="cp-info-row"><div class="cp-info-key">最小フォロワー</div><div class="cp-info-val">${camp.min_followers.toLocaleString()}</div></div>`:''}
           <div class="cp-info-row"><div class="cp-info-key">当選発表</div><div class="cp-info-val">${esc(camp.winner_announce||'選考後、LINEにてご連絡')}</div></div>
@@ -7613,7 +7752,7 @@ async function addCampaign() {
   }
   const postDeadline = $('newCampPostDeadline')?.value;
   if (postDeadline && deadline && new Date(postDeadline) < new Date(deadline)) {
-    toast('노출 마감일은 모집 마감일 이후여야 합니다','error');
+    toast('노출 마감일은 모집 종료일 이후여야 합니다','error');
     return;
   }
   const newDateErrs = validateCampDateRanges('newCamp');
@@ -7645,6 +7784,7 @@ async function addCampaign() {
     reward: parseInt($('newCampReward').value)||0,
     reward_note: ($('newCampRewardNote')?.value || '').trim() || null,
     slots, applied_count:0,
+    recruit_start: $('newCampRecruitStart')?.value||null,
     deadline: deadline||null,
     post_deadline: $('newCampPostDeadline')?.value||null,
     post_days: $('newCampPostDeadline')?.value
@@ -7671,9 +7811,12 @@ async function addCampaign() {
   renderImgPreview(campImgData, 'campImgPreviewWrap', 'campImgCounter', 'campImgData');
 
   ['newCampTitle','newCampBrand','newCampProduct','newCampProductUrl',
-   'newCampSlots','newCampDeadline','newCampPostDeadline',
-   'newCampHashtags','newCampMentions',
+   'newCampSlots','newCampRecruitStart','newCampDeadline','newCampPostDeadline',
+   'newCampPurchaseStart','newCampPurchaseEnd','newCampVisitStart','newCampVisitEnd',
+   'newCampSubmissionEnd','newCampHashtags','newCampMentions',
    'newCampProductPrice','newCampReward','newCampRewardNote'].forEach(id => { const el=$(id); if(el) el.value=''; });
+  // flatpickr range picker 클리어
+  applyCampRangeValues('newCamp', { recruit:[null,null], purchase:[null,null], visit:[null,null] });
   // 리치 에디터 초기화
   ['newCampDesc','newCampAppeal','newCampGuide','newCampNg'].forEach(id => setRichValue(id, ''));
   document.querySelectorAll('input[name="recruitType"]').forEach(r=>r.checked=false);

--- a/admin/index.html
+++ b/admin/index.html
@@ -6236,7 +6236,6 @@ function renderCampPreview(mode) {
           ${camp.slots?`<div class="cp-info-row"><div class="cp-info-key">募集人数</div><div class="cp-info-val">${camp.slots}名</div></div>`:''}
           ${camp.min_followers?`<div class="cp-info-row"><div class="cp-info-key">最小フォロワー</div><div class="cp-info-val">${camp.min_followers.toLocaleString()}</div></div>`:''}
           <div class="cp-info-row"><div class="cp-info-key">当選発表</div><div class="cp-info-val">${esc(camp.winner_announce||'選考後、LINEにてご連絡')}</div></div>
-          <div class="cp-info-row"><div class="cp-info-key">掲載期限</div><div class="cp-info-val" style="font-weight:600">${camp.post_deadline?fmt(camp.post_deadline):'—'}</div></div>
           ${(camp.recruit_type==='monitor'&&(camp.purchase_start||camp.purchase_end))?`<div class="cp-info-row"><div class="cp-info-key">購入期間</div><div class="cp-info-val">${fmt(camp.purchase_start)} 〜 ${fmt(camp.purchase_end)}</div></div>`:''}
           ${(camp.recruit_type==='visit'&&(camp.visit_start||camp.visit_end))?`<div class="cp-info-row"><div class="cp-info-key">訪問期間</div><div class="cp-info-val">${fmt(camp.visit_start)} 〜 ${fmt(camp.visit_end)}</div></div>`:''}
           ${camp.submission_end?`<div class="cp-info-row"><div class="cp-info-key">提出締切</div><div class="cp-info-val" style="font-weight:600">${fmt(camp.submission_end)}</div></div>`:''}

--- a/admin/index.html
+++ b/admin/index.html
@@ -961,6 +961,23 @@ textarea.form-input{resize:vertical;min-height:80px}
               <div class="form-group"><label class="form-label">브랜드명 <span style="background:var(--pink);color:#fff;font-size:9px;font-weight:700;padding:1px 5px;border-radius:3px;margin-left:4px">필수</span></label><input type="text" id="editCampBrand" class="form-input"></div>
             </div>
             <div class="form-row" style="grid-template-columns:1fr 1fr">
+              <div class="form-group">
+                <label class="form-label">모집 타입 <span style="background:var(--pink);color:#fff;font-size:9px;font-weight:700;padding:1px 5px;border-radius:3px;margin-left:4px">필수</span></label>
+                <div style="display:flex;gap:8px">
+                  <label style="display:flex;align-items:center;justify-content:center;gap:6px;padding:9px 16px;border:2px solid var(--line);border-radius:10px;cursor:pointer;font-size:13px;font-weight:600;transition:.15s;flex:1;text-align:center" id="edit-rt-monitor"><input type="radio" name="editRecruitType" value="monitor" onchange="toggleEditRT(this);filterChannelsByRecruitType('edit','monitor');applyMinFollowersVisibility('edit','monitor')" style="display:none"><span class="material-icons-round notranslate" translate="no" style="font-size:18px;color:var(--muted)">radio_button_unchecked</span> 리뷰어</label>
+                  <label style="display:flex;align-items:center;justify-content:center;gap:6px;padding:9px 16px;border:2px solid var(--line);border-radius:10px;cursor:pointer;font-size:13px;font-weight:600;transition:.15s;flex:1;text-align:center" id="edit-rt-gifting"><input type="radio" name="editRecruitType" value="gifting" onchange="toggleEditRT(this);filterChannelsByRecruitType('edit','gifting');applyMinFollowersVisibility('edit','gifting')" style="display:none"><span class="material-icons-round notranslate" translate="no" style="font-size:18px;color:var(--muted)">radio_button_unchecked</span> 기프팅</label>
+                  <label style="display:flex;align-items:center;justify-content:center;gap:6px;padding:9px 16px;border:2px solid var(--line);border-radius:10px;cursor:pointer;font-size:13px;font-weight:600;transition:.15s;flex:1;text-align:center" id="edit-rt-visit"><input type="radio" name="editRecruitType" value="visit" onchange="toggleEditRT(this);filterChannelsByRecruitType('edit','visit');applyMinFollowersVisibility('edit','visit')" style="display:none"><span class="material-icons-round notranslate" translate="no" style="font-size:18px;color:var(--muted)">radio_button_unchecked</span> 방문형</label>
+                </div>
+              </div>
+              <div class="form-group">
+                <label class="form-label">모집 인원 <span style="background:var(--pink);color:#fff;font-size:9px;font-weight:700;padding:1px 5px;border-radius:3px;margin-left:4px">필수</span></label>
+                <div style="display:flex;align-items:center;gap:6px">
+                  <input type="number" id="editCampSlots" class="form-input" placeholder="20" min="1" style="flex:1">
+                  <span style="font-size:13px;color:var(--muted);font-weight:600">명</span>
+                </div>
+              </div>
+            </div>
+            <div class="form-row" style="grid-template-columns:1fr 1fr">
               <div class="form-group"><label class="form-label">상태</label>
                 <select id="editCampStatus" class="form-input">
                   <option value="draft">준비</option><option value="scheduled">모집예정</option><option value="active">모집중</option><option value="paused">일시정지</option><option value="closed">종료</option>
@@ -1017,15 +1034,6 @@ textarea.form-input{resize:vertical;min-height:80px}
             </div>
 
             <div style="font-size:14px;font-weight:700;color:var(--ink);padding-bottom:8px;margin:20px 0 12px;border-bottom:2px solid var(--pink)">모집 조건</div>
-            <div class="form-group">
-              <label class="form-label">모집 타입/인원 <span style="background:var(--pink);color:#fff;font-size:9px;font-weight:700;padding:1px 5px;border-radius:3px;margin-left:4px">필수</span></label>
-              <div style="display:flex;gap:8px;margin-top:6px">
-                <label style="display:flex;align-items:center;justify-content:center;gap:6px;padding:9px 16px;border:2px solid var(--line);border-radius:10px;cursor:pointer;font-size:13px;font-weight:600;transition:.15s;flex:1;text-align:center" id="edit-rt-monitor"><input type="radio" name="editRecruitType" value="monitor" onchange="toggleEditRT(this);filterChannelsByRecruitType('edit','monitor');applyMinFollowersVisibility('edit','monitor')" style="display:none"><span class="material-icons-round notranslate" translate="no" style="font-size:18px;color:var(--muted)">radio_button_unchecked</span> 리뷰어</label>
-                <label style="display:flex;align-items:center;justify-content:center;gap:6px;padding:9px 16px;border:2px solid var(--line);border-radius:10px;cursor:pointer;font-size:13px;font-weight:600;transition:.15s;flex:1;text-align:center" id="edit-rt-gifting"><input type="radio" name="editRecruitType" value="gifting" onchange="toggleEditRT(this);filterChannelsByRecruitType('edit','gifting');applyMinFollowersVisibility('edit','gifting')" style="display:none"><span class="material-icons-round notranslate" translate="no" style="font-size:18px;color:var(--muted)">radio_button_unchecked</span> 기프팅</label>
-                <label style="display:flex;align-items:center;justify-content:center;gap:6px;padding:9px 16px;border:2px solid var(--line);border-radius:10px;cursor:pointer;font-size:13px;font-weight:600;transition:.15s;flex:1;text-align:center" id="edit-rt-visit"><input type="radio" name="editRecruitType" value="visit" onchange="toggleEditRT(this);filterChannelsByRecruitType('edit','visit');applyMinFollowersVisibility('edit','visit')" style="display:none"><span class="material-icons-round notranslate" translate="no" style="font-size:18px;color:var(--muted)">radio_button_unchecked</span> 방문형</label>
-                <input type="number" id="editCampSlots" class="form-input" placeholder="20" min="1" style="width:80px;flex-shrink:0">
-              </div>
-            </div>
             <div class="form-row" style="grid-template-columns:1fr 1fr">
               <div class="form-group">
                 <label class="form-label" style="margin:0 0 6px">채널 <span style="font-size:11px;font-weight:400;color:var(--muted)">(복수 선택 가능)</span></label>
@@ -1165,6 +1173,29 @@ textarea.form-input{resize:vertical;min-height:80px}
                 <input type="text" id="newCampBrand" class="form-input" placeholder="이니스프리">
               </div>
             </div>
+            <div class="form-row" style="grid-template-columns:1fr 1fr">
+              <div class="form-group">
+                <label class="form-label">모집 타입 <span style="background:var(--pink);color:#fff;font-size:9px;font-weight:700;padding:1px 5px;border-radius:3px;margin-left:4px">필수</span></label>
+                <div style="display:flex;gap:8px">
+                  <label style="display:flex;align-items:center;justify-content:center;gap:6px;padding:9px 16px;border:2px solid var(--line);border-radius:10px;cursor:pointer;font-size:13px;font-weight:600;transition:.15s;flex:1;text-align:center" id="rt-monitor">
+                    <input type="radio" name="recruitType" value="monitor" onchange="toggleRT(this);filterChannelsByRecruitType('new','monitor');applyMinFollowersVisibility('new','monitor')" style="display:none"><span class="material-icons-round notranslate" translate="no" style="font-size:18px;color:var(--muted)">radio_button_unchecked</span> 리뷰어
+                  </label>
+                  <label style="display:flex;align-items:center;justify-content:center;gap:6px;padding:9px 16px;border:2px solid var(--line);border-radius:10px;cursor:pointer;font-size:13px;font-weight:600;transition:.15s;flex:1;text-align:center" id="rt-gifting">
+                    <input type="radio" name="recruitType" value="gifting" onchange="toggleRT(this);filterChannelsByRecruitType('new','gifting');applyMinFollowersVisibility('new','gifting')" style="display:none"><span class="material-icons-round notranslate" translate="no" style="font-size:18px;color:var(--muted)">radio_button_unchecked</span> 기프팅
+                  </label>
+                  <label style="display:flex;align-items:center;justify-content:center;gap:6px;padding:9px 16px;border:2px solid var(--line);border-radius:10px;cursor:pointer;font-size:13px;font-weight:600;transition:.15s;flex:1;text-align:center" id="rt-visit">
+                    <input type="radio" name="recruitType" value="visit" onchange="toggleRT(this);filterChannelsByRecruitType('new','visit');applyMinFollowersVisibility('new','visit')" style="display:none"><span class="material-icons-round notranslate" translate="no" style="font-size:18px;color:var(--muted)">radio_button_unchecked</span> 방문형
+                  </label>
+                </div>
+              </div>
+              <div class="form-group">
+                <label class="form-label">모집 인원 <span style="background:var(--pink);color:#fff;font-size:9px;font-weight:700;padding:1px 5px;border-radius:3px;margin-left:4px">필수</span></label>
+                <div style="display:flex;align-items:center;gap:6px">
+                  <input type="number" id="newCampSlots" class="form-input" placeholder="20" min="1" value="20" style="flex:1">
+                  <span style="font-size:13px;color:var(--muted);font-weight:600">명</span>
+                </div>
+              </div>
+            </div>
 
             <div style="font-size:14px;font-weight:700;color:var(--ink);padding-bottom:8px;margin:20px 0 12px;border-bottom:2px solid var(--pink)">제품 정보</div>
             <div style="display:grid;grid-template-columns:1fr 1fr;gap:40px">
@@ -1217,21 +1248,6 @@ textarea.form-input{resize:vertical;min-height:80px}
             </div>
 
             <div style="font-size:14px;font-weight:700;color:var(--ink);padding-bottom:8px;margin:20px 0 12px;border-bottom:2px solid var(--pink)">모집 조건</div>
-            <div class="form-group">
-              <label class="form-label">모집 타입/인원 <span style="background:var(--pink);color:#fff;font-size:9px;font-weight:700;padding:1px 5px;border-radius:3px;margin-left:4px">필수</span></label>
-              <div style="display:flex;gap:8px;margin-top:6px">
-                <label style="display:flex;align-items:center;justify-content:center;gap:6px;padding:9px 16px;border:2px solid var(--line);border-radius:10px;cursor:pointer;font-size:13px;font-weight:600;transition:.15s;flex:1;text-align:center" id="rt-monitor">
-                  <input type="radio" name="recruitType" value="monitor" onchange="toggleRT(this);filterChannelsByRecruitType('new','monitor');applyMinFollowersVisibility('new','monitor')" style="display:none"><span class="material-icons-round notranslate" translate="no" style="font-size:18px;color:var(--muted)">radio_button_unchecked</span> 리뷰어
-                </label>
-                <label style="display:flex;align-items:center;justify-content:center;gap:6px;padding:9px 16px;border:2px solid var(--line);border-radius:10px;cursor:pointer;font-size:13px;font-weight:600;transition:.15s;flex:1;text-align:center" id="rt-gifting">
-                  <input type="radio" name="recruitType" value="gifting" onchange="toggleRT(this);filterChannelsByRecruitType('new','gifting');applyMinFollowersVisibility('new','gifting')" style="display:none"><span class="material-icons-round notranslate" translate="no" style="font-size:18px;color:var(--muted)">radio_button_unchecked</span> 기프팅
-                </label>
-                <label style="display:flex;align-items:center;justify-content:center;gap:6px;padding:9px 16px;border:2px solid var(--line);border-radius:10px;cursor:pointer;font-size:13px;font-weight:600;transition:.15s;flex:1;text-align:center" id="rt-visit">
-                  <input type="radio" name="recruitType" value="visit" onchange="toggleRT(this);filterChannelsByRecruitType('new','visit');applyMinFollowersVisibility('new','visit')" style="display:none"><span class="material-icons-round notranslate" translate="no" style="font-size:18px;color:var(--muted)">radio_button_unchecked</span> 방문형
-                </label>
-                <input type="number" id="newCampSlots" class="form-input" placeholder="20" min="1" value="20" style="width:80px;flex-shrink:0">
-              </div>
-            </div>
             <div class="form-row" style="grid-template-columns:1fr 1fr">
               <div class="form-group">
                 <label class="form-label" style="margin:0 0 6px">채널 <span style="font-size:11px;font-weight:400;color:var(--muted)">(복수 선택 가능)</span></label>

--- a/dev/admin/index.html
+++ b/dev/admin/index.html
@@ -371,7 +371,7 @@
 
             <div class="form-row" style="grid-template-columns:1fr 1fr">
               <div class="form-group"><label class="form-label">모집 마감일 <span style="background:var(--pink);color:#fff;font-size:9px;font-weight:700;padding:1px 5px;border-radius:3px;margin-left:4px">필수</span></label><input type="date" id="editCampDeadline" class="form-input" onchange="suggestPostDeadline('editCampDeadline','editCampPostDeadline');validateDeadlines('editCampDeadline','editCampPostDeadline','editPostDeadlineWarn');syncCampDateMinMax('editCamp');validateCampDateRangesInline('editCamp')"></div>
-              <div class="form-group"><label class="form-label">노출 마감일</label><input type="date" id="editCampPostDeadline" class="form-input" onchange="validateDeadlines('editCampDeadline','editCampPostDeadline','editPostDeadlineWarn');syncCampDateMinMax('editCamp');validateCampDateRangesInline('editCamp')"><div id="editPostDeadlineWarn" class="form-error" style="display:none;margin-top:4px"></div><div class="form-hint">이 날짜 이후 캠페인이 인플루언서 사이트에서 숨겨집니다</div></div>
+              <div class="form-group"><label class="form-label">결과물 제출 마감일</label><input type="date" id="editCampSubmissionEnd" class="form-input" onchange="validateCampDateRangesInline('editCamp')"><div class="form-hint">이 날짜 이후 결과물 제출 불가. 비우면 노출 마감일로 폴백</div></div>
             </div>
             <div class="form-row" id="editCampPurchaseRow" style="grid-template-columns:1fr 1fr;display:none">
               <div class="form-group"><label class="form-label">구매 시작일</label><input type="date" id="editCampPurchaseStart" class="form-input" onchange="validateCampDateRangesInline('editCamp')"><div class="form-hint">리뷰어용</div></div>
@@ -382,7 +382,7 @@
               <div class="form-group"><label class="form-label">방문 마감일</label><input type="date" id="editCampVisitEnd" class="form-input" onchange="validateCampDateRangesInline('editCamp')"></div>
             </div>
             <div class="form-row" style="grid-template-columns:1fr 1fr">
-              <div class="form-group"><label class="form-label">결과물 제출 마감일</label><input type="date" id="editCampSubmissionEnd" class="form-input" onchange="validateCampDateRangesInline('editCamp')"><div class="form-hint">이 날짜 이후 결과물 제출 불가. 비우면 노출 마감일로 폴백</div></div>
+              <div class="form-group"><label class="form-label">노출 마감일 <span style="background:var(--pink);color:#fff;font-size:9px;font-weight:700;padding:1px 5px;border-radius:3px;margin-left:4px">필수</span></label><input type="date" id="editCampPostDeadline" class="form-input" onchange="validateDeadlines('editCampDeadline','editCampPostDeadline','editPostDeadlineWarn');syncCampDateMinMax('editCamp');validateCampDateRangesInline('editCamp')"><div id="editPostDeadlineWarn" class="form-error" style="display:none;margin-top:4px"></div><div class="form-hint">이 날짜 이후 캠페인이 인플루언서 사이트에서 숨겨집니다</div></div>
             </div>
             <div id="editCampDateRangesWarn" class="form-error" style="display:none;margin-top:6px"></div>
             <div class="form-group"><label class="form-label">당선 발표 안내</label><input type="text" id="editCampWinnerAnnounce" class="form-input" placeholder="選考後、LINEにてご連絡"><div class="form-hint">인플루언서 캠페인 상세에 표시되는 문구. 비우면 기본값</div></div>
@@ -583,17 +583,16 @@
               </div>
             </div>
 
-            <!-- 모집 마감일 / 투고 마감일 -->
+            <!-- 모집 마감일 / 결과물 제출 마감일 -->
             <div class="form-row" style="grid-template-columns:1fr 1fr">
               <div class="form-group">
                 <label class="form-label">모집 마감일 <span style="background:var(--pink);color:#fff;font-size:9px;font-weight:700;padding:1px 5px;border-radius:3px;margin-left:4px">필수</span></label>
                 <input type="date" id="newCampDeadline" class="form-input" onchange="suggestPostDeadline('newCampDeadline','newCampPostDeadline');validateDeadlines('newCampDeadline','newCampPostDeadline','newPostDeadlineWarn');syncCampDateMinMax('newCamp');validateCampDateRangesInline('newCamp')">
               </div>
               <div class="form-group">
-                <label class="form-label">노출 마감일 <span style="background:var(--pink);color:#fff;font-size:9px;font-weight:700;padding:1px 5px;border-radius:3px;margin-left:4px">필수</span></label>
-                <input type="date" id="newCampPostDeadline" class="form-input" onchange="validateDeadlines('newCampDeadline','newCampPostDeadline','newPostDeadlineWarn');syncCampDateMinMax('newCamp');validateCampDateRangesInline('newCamp')">
-                <div id="newPostDeadlineWarn" class="form-error" style="display:none;margin-top:4px"></div>
-                <div class="form-hint">이 날짜 이후 캠페인이 인플루언서 사이트에서 숨겨집니다</div>
+                <label class="form-label">결과물 제출 마감일</label>
+                <input type="date" id="newCampSubmissionEnd" class="form-input" onchange="validateCampDateRangesInline('newCamp')">
+                <div class="form-hint">이 날짜 이후 결과물(영수증·게시물 URL) 제출 불가. 비우면 노출 마감일로 폴백</div>
               </div>
             </div>
 
@@ -622,9 +621,10 @@
             </div>
             <div class="form-row" style="grid-template-columns:1fr 1fr">
               <div class="form-group">
-                <label class="form-label">결과물 제출 마감일</label>
-                <input type="date" id="newCampSubmissionEnd" class="form-input" onchange="validateCampDateRangesInline('newCamp')">
-                <div class="form-hint">이 날짜 이후 결과물(영수증·게시물 URL) 제출 불가. 비우면 노출 마감일로 폴백</div>
+                <label class="form-label">노출 마감일 <span style="background:var(--pink);color:#fff;font-size:9px;font-weight:700;padding:1px 5px;border-radius:3px;margin-left:4px">필수</span></label>
+                <input type="date" id="newCampPostDeadline" class="form-input" onchange="validateDeadlines('newCampDeadline','newCampPostDeadline','newPostDeadlineWarn');syncCampDateMinMax('newCamp');validateCampDateRangesInline('newCamp')">
+                <div id="newPostDeadlineWarn" class="form-error" style="display:none;margin-top:4px"></div>
+                <div class="form-hint">이 날짜 이후 캠페인이 인플루언서 사이트에서 숨겨집니다</div>
               </div>
             </div>
             <div id="newCampDateRangesWarn" class="form-error" style="display:none;margin-top:6px"></div>

--- a/dev/admin/index.html
+++ b/dev/admin/index.html
@@ -362,20 +362,21 @@
             </div>
 
             <div class="form-row" style="grid-template-columns:1fr 1fr">
-              <div class="form-group"><label class="form-label">모집 마감일 <span style="background:var(--pink);color:#fff;font-size:9px;font-weight:700;padding:1px 5px;border-radius:3px;margin-left:4px">필수</span></label><input type="date" id="editCampDeadline" class="form-input" onchange="suggestPostDeadline('editCampDeadline','editCampPostDeadline');validateDeadlines('editCampDeadline','editCampPostDeadline','editPostDeadlineWarn')"></div>
-              <div class="form-group"><label class="form-label">게시 마감일</label><input type="date" id="editCampPostDeadline" class="form-input" onchange="validateDeadlines('editCampDeadline','editCampPostDeadline','editPostDeadlineWarn')"><div id="editPostDeadlineWarn" class="form-error" style="display:none;margin-top:4px"></div></div>
+              <div class="form-group"><label class="form-label">모집 마감일 <span style="background:var(--pink);color:#fff;font-size:9px;font-weight:700;padding:1px 5px;border-radius:3px;margin-left:4px">필수</span></label><input type="date" id="editCampDeadline" class="form-input" onchange="suggestPostDeadline('editCampDeadline','editCampPostDeadline');validateDeadlines('editCampDeadline','editCampPostDeadline','editPostDeadlineWarn');syncCampDateMinMax('editCamp');validateCampDateRangesInline('editCamp')"></div>
+              <div class="form-group"><label class="form-label">노출 마감일</label><input type="date" id="editCampPostDeadline" class="form-input" onchange="validateDeadlines('editCampDeadline','editCampPostDeadline','editPostDeadlineWarn');syncCampDateMinMax('editCamp');validateCampDateRangesInline('editCamp')"><div id="editPostDeadlineWarn" class="form-error" style="display:none;margin-top:4px"></div><div class="form-hint">이 날짜 이후 캠페인이 인플루언서 사이트에서 숨겨집니다</div></div>
             </div>
             <div class="form-row" id="editCampPurchaseRow" style="grid-template-columns:1fr 1fr;display:none">
-              <div class="form-group"><label class="form-label">구매 시작일</label><input type="date" id="editCampPurchaseStart" class="form-input"><div class="form-hint">리뷰어용</div></div>
-              <div class="form-group"><label class="form-label">구매 마감일</label><input type="date" id="editCampPurchaseEnd" class="form-input"></div>
+              <div class="form-group"><label class="form-label">구매 시작일</label><input type="date" id="editCampPurchaseStart" class="form-input" onchange="validateCampDateRangesInline('editCamp')"><div class="form-hint">리뷰어용</div></div>
+              <div class="form-group"><label class="form-label">구매 마감일</label><input type="date" id="editCampPurchaseEnd" class="form-input" onchange="validateCampDateRangesInline('editCamp')"></div>
             </div>
             <div class="form-row" id="editCampVisitRow" style="grid-template-columns:1fr 1fr;display:none">
-              <div class="form-group"><label class="form-label">방문 시작일</label><input type="date" id="editCampVisitStart" class="form-input"><div class="form-hint">방문형용</div></div>
-              <div class="form-group"><label class="form-label">방문 마감일</label><input type="date" id="editCampVisitEnd" class="form-input"></div>
+              <div class="form-group"><label class="form-label">방문 시작일</label><input type="date" id="editCampVisitStart" class="form-input" onchange="validateCampDateRangesInline('editCamp')"><div class="form-hint">방문형용</div></div>
+              <div class="form-group"><label class="form-label">방문 마감일</label><input type="date" id="editCampVisitEnd" class="form-input" onchange="validateCampDateRangesInline('editCamp')"></div>
             </div>
             <div class="form-row" style="grid-template-columns:1fr 1fr">
-              <div class="form-group"><label class="form-label">결과물 제출 마감일</label><input type="date" id="editCampSubmissionEnd" class="form-input"><div class="form-hint">이 날짜 이후 결과물 제출 불가. 비우면 게시 마감일로 폴백</div></div>
+              <div class="form-group"><label class="form-label">결과물 제출 마감일</label><input type="date" id="editCampSubmissionEnd" class="form-input" onchange="validateCampDateRangesInline('editCamp')"><div class="form-hint">이 날짜 이후 결과물 제출 불가. 비우면 노출 마감일로 폴백</div></div>
             </div>
+            <div id="editCampDateRangesWarn" class="form-error" style="display:none;margin-top:6px"></div>
             <div class="form-group"><label class="form-label">당선 발표 안내</label><input type="text" id="editCampWinnerAnnounce" class="form-input" placeholder="選考後、LINEにてご連絡"><div class="form-hint">인플루언서 캠페인 상세에 표시되는 문구. 비우면 기본값</div></div>
             <div style="font-size:14px;font-weight:700;color:var(--ink);padding-bottom:8px;margin:20px 0 12px;border-bottom:2px solid var(--pink)">콘텐츠 가이드</div>
             <div class="form-group"><label class="form-label">캠페인 설명</label><div class="quill-host" id="editCampDesc"></div></div>
@@ -570,46 +571,47 @@
             <div class="form-row" style="grid-template-columns:1fr 1fr">
               <div class="form-group">
                 <label class="form-label">모집 마감일 <span style="background:var(--pink);color:#fff;font-size:9px;font-weight:700;padding:1px 5px;border-radius:3px;margin-left:4px">필수</span></label>
-                <input type="date" id="newCampDeadline" class="form-input" onchange="suggestPostDeadline('newCampDeadline','newCampPostDeadline');validateDeadlines('newCampDeadline','newCampPostDeadline','newPostDeadlineWarn')">
+                <input type="date" id="newCampDeadline" class="form-input" onchange="suggestPostDeadline('newCampDeadline','newCampPostDeadline');validateDeadlines('newCampDeadline','newCampPostDeadline','newPostDeadlineWarn');syncCampDateMinMax('newCamp');validateCampDateRangesInline('newCamp')">
               </div>
               <div class="form-group">
-                <label class="form-label">게시 마감일 <span style="background:var(--pink);color:#fff;font-size:9px;font-weight:700;padding:1px 5px;border-radius:3px;margin-left:4px">필수</span></label>
-                <input type="date" id="newCampPostDeadline" class="form-input" onchange="validateDeadlines('newCampDeadline','newCampPostDeadline','newPostDeadlineWarn')">
+                <label class="form-label">노출 마감일 <span style="background:var(--pink);color:#fff;font-size:9px;font-weight:700;padding:1px 5px;border-radius:3px;margin-left:4px">필수</span></label>
+                <input type="date" id="newCampPostDeadline" class="form-input" onchange="validateDeadlines('newCampDeadline','newCampPostDeadline','newPostDeadlineWarn');syncCampDateMinMax('newCamp');validateCampDateRangesInline('newCamp')">
                 <div id="newPostDeadlineWarn" class="form-error" style="display:none;margin-top:4px"></div>
-                <div class="form-hint">제품 수령 후 이 날짜까지 게시해주세요</div>
+                <div class="form-hint">이 날짜 이후 캠페인이 인플루언서 사이트에서 숨겨집니다</div>
               </div>
             </div>
 
-            <!-- 타입별 기한 (Stage 1) -->
+            <!-- 타입별 기한 (Stage 1) — 모든 일자는 모집~노출 마감 사이로 강제 -->
             <div class="form-row" id="newCampPurchaseRow" style="grid-template-columns:1fr 1fr;display:none">
               <div class="form-group">
                 <label class="form-label">구매 시작일</label>
-                <input type="date" id="newCampPurchaseStart" class="form-input">
+                <input type="date" id="newCampPurchaseStart" class="form-input" onchange="validateCampDateRangesInline('newCamp')">
                 <div class="form-hint">리뷰어용. 이 기간 내 구매한 영수증만 인정</div>
               </div>
               <div class="form-group">
                 <label class="form-label">구매 마감일</label>
-                <input type="date" id="newCampPurchaseEnd" class="form-input">
+                <input type="date" id="newCampPurchaseEnd" class="form-input" onchange="validateCampDateRangesInline('newCamp')">
               </div>
             </div>
             <div class="form-row" id="newCampVisitRow" style="grid-template-columns:1fr 1fr;display:none">
               <div class="form-group">
                 <label class="form-label">방문 시작일</label>
-                <input type="date" id="newCampVisitStart" class="form-input">
+                <input type="date" id="newCampVisitStart" class="form-input" onchange="validateCampDateRangesInline('newCamp')">
                 <div class="form-hint">방문형용. 이 기간 내 매장 방문 가능</div>
               </div>
               <div class="form-group">
                 <label class="form-label">방문 마감일</label>
-                <input type="date" id="newCampVisitEnd" class="form-input">
+                <input type="date" id="newCampVisitEnd" class="form-input" onchange="validateCampDateRangesInline('newCamp')">
               </div>
             </div>
             <div class="form-row" style="grid-template-columns:1fr 1fr">
               <div class="form-group">
                 <label class="form-label">결과물 제출 마감일</label>
-                <input type="date" id="newCampSubmissionEnd" class="form-input">
-                <div class="form-hint">이 날짜 이후 결과물(영수증·게시물 URL) 제출 불가. 비우면 게시 마감일로 폴백</div>
+                <input type="date" id="newCampSubmissionEnd" class="form-input" onchange="validateCampDateRangesInline('newCamp')">
+                <div class="form-hint">이 날짜 이후 결과물(영수증·게시물 URL) 제출 불가. 비우면 노출 마감일로 폴백</div>
               </div>
             </div>
+            <div id="newCampDateRangesWarn" class="form-error" style="display:none;margin-top:6px"></div>
             <div class="form-group">
               <label class="form-label">당선 발표 안내</label>
               <input type="text" id="newCampWinnerAnnounce" class="form-input" value="選考後、LINEにてご連絡" placeholder="選考後、LINEにてご連絡">
@@ -1766,7 +1768,7 @@
   </div>
 </div>
 
-<!-- 게시 마감일 자동 제안 confirm 모달 -->
+<!-- 노출 마감일 자동 제안 confirm 모달 -->
 <div class="modal-overlay" id="confirmModal" style="z-index:610">
   <div class="modal" style="max-width:420px;border-radius:24px;margin:auto;text-align:center">
     <div class="modal-body" style="padding:28px 24px 22px">

--- a/dev/admin/index.html
+++ b/dev/admin/index.html
@@ -282,6 +282,9 @@
               </div>
             </div>
             <div class="form-row" style="grid-template-columns:1fr 1fr">
+              <div class="form-group"><label class="form-label">카테고리</label>
+                <select id="editCampCategory" class="form-input"></select>
+              </div>
               <div class="form-group"><label class="form-label">상태</label>
                 <select id="editCampStatus" class="form-input">
                   <option value="draft">준비</option><option value="scheduled">모집예정</option><option value="active">모집중</option><option value="paused">일시정지</option><option value="closed">종료</option>
@@ -362,10 +365,6 @@
               </div>
             </div>
             <div class="form-row" style="grid-template-columns:1fr 1fr">
-              <div class="form-group">
-                <label class="form-label">카테고리</label>
-                <select id="editCampCategory" class="form-input"></select>
-              </div>
               <div class="form-group">
                 <label class="form-label">콘텐츠 종류 <span style="font-size:11px;font-weight:400;color:var(--muted)">(복수 선택 가능)</span></label>
                 <div style="display:flex;gap:8px;flex-wrap:wrap;margin-top:6px" id="editCampContentTypeWrap"></div>
@@ -528,6 +527,12 @@
                 </div>
               </div>
             </div>
+            <div class="form-row" style="grid-template-columns:1fr 1fr">
+              <div class="form-group">
+                <label class="form-label">카테고리</label>
+                <select id="newCampCategory" class="form-input"></select>
+              </div>
+            </div>
 
             <div style="font-size:14px;font-weight:700;color:var(--ink);padding-bottom:8px;margin:20px 0 12px;border-bottom:2px solid var(--pink)">제품 정보</div>
             <div style="display:grid;grid-template-columns:1fr 1fr;gap:40px">
@@ -604,10 +609,6 @@
               </div>
             </div>
             <div class="form-row" style="grid-template-columns:1fr 1fr">
-              <div class="form-group">
-                <label class="form-label">카테고리</label>
-                <select id="newCampCategory" class="form-input"></select>
-              </div>
               <div class="form-group">
                 <label class="form-label">콘텐츠 종류 <span style="background:var(--pink);color:#fff;font-size:9px;font-weight:700;padding:1px 5px;border-radius:3px;margin-left:4px">필수</span> <span style="font-size:11px;font-weight:400;color:var(--muted)">(복수 선택 가능)</span></label>
                 <div style="display:flex;gap:8px;flex-wrap:wrap;margin-top:6px" id="newCampContentTypeWrap"></div>

--- a/dev/admin/index.html
+++ b/dev/admin/index.html
@@ -378,9 +378,15 @@
                 <input type="text" id="editCampRecruitRange" class="form-input fp-range" placeholder="시작일 ~ 종료일 선택" data-range-prefix="editCamp" data-range-kind="recruit" readonly>
                 <input type="hidden" id="editCampRecruitStart">
                 <input type="hidden" id="editCampDeadline">
-                <div id="editPostDeadlineWarn" class="form-error" style="display:none;margin-top:4px"></div>
+                <div class="form-hint">인플루언서를 모집하는 기간을 설정하세요</div>
+                <div id="editCampRecruitWarn" class="form-error" style="display:none;margin-top:4px"></div>
               </div>
-              <div class="form-group"><label class="form-label">결과물 제출 마감일</label><input type="date" id="editCampSubmissionEnd" class="form-input" onchange="validateCampDateRangesInline('editCamp')"><div class="form-hint">이 날짜 이후 결과물 제출 불가. 비우면 노출 마감일로 폴백</div></div>
+              <div class="form-group">
+                <label class="form-label">결과물 제출 마감일</label>
+                <input type="date" id="editCampSubmissionEnd" class="form-input" onchange="validateCampDateRangesInline('editCamp')">
+                <div class="form-hint">이 날짜 이후 결과물 제출 불가. 비우면 노출 마감일로 폴백</div>
+                <div id="editCampSubmissionWarn" class="form-error" style="display:none;margin-top:4px"></div>
+              </div>
             </div>
             <div class="form-row" id="editCampPurchaseRow" style="grid-template-columns:1fr 1fr;display:none">
               <div class="form-group">
@@ -389,6 +395,7 @@
                 <input type="hidden" id="editCampPurchaseStart">
                 <input type="hidden" id="editCampPurchaseEnd">
                 <div class="form-hint">리뷰어용. 이 기간 내 구매한 영수증만 인정</div>
+                <div id="editCampPurchaseWarn" class="form-error" style="display:none;margin-top:4px"></div>
               </div>
             </div>
             <div class="form-row" id="editCampVisitRow" style="grid-template-columns:1fr 1fr;display:none">
@@ -398,12 +405,17 @@
                 <input type="hidden" id="editCampVisitStart">
                 <input type="hidden" id="editCampVisitEnd">
                 <div class="form-hint">방문형용. 이 기간 내 매장 방문 가능</div>
+                <div id="editCampVisitWarn" class="form-error" style="display:none;margin-top:4px"></div>
               </div>
             </div>
             <div class="form-row" style="grid-template-columns:1fr 1fr">
-              <div class="form-group"><label class="form-label">노출 마감일 <span style="background:var(--pink);color:#fff;font-size:9px;font-weight:700;padding:1px 5px;border-radius:3px;margin-left:4px">필수</span></label><input type="date" id="editCampPostDeadline" class="form-input" onchange="syncCampDateMinMax('editCamp');validateCampDateRangesInline('editCamp')"><div class="form-hint">이 날짜 이후 캠페인이 인플루언서 사이트에서 숨겨집니다</div></div>
+              <div class="form-group">
+                <label class="form-label">노출 마감일 <span style="background:var(--pink);color:#fff;font-size:9px;font-weight:700;padding:1px 5px;border-radius:3px;margin-left:4px">필수</span></label>
+                <input type="date" id="editCampPostDeadline" class="form-input" onchange="syncCampDateMinMax('editCamp');validateCampDateRangesInline('editCamp')">
+                <div class="form-hint">이 날짜 이후 캠페인이 인플루언서 사이트에서 숨겨집니다</div>
+                <div id="editCampPostDeadlineWarn" class="form-error" style="display:none;margin-top:4px"></div>
+              </div>
             </div>
-            <div id="editCampDateRangesWarn" class="form-error" style="display:none;margin-top:6px"></div>
             <div class="form-group"><label class="form-label">당선 발표 안내</label><input type="text" id="editCampWinnerAnnounce" class="form-input" placeholder="選考後、LINEにてご連絡"><div class="form-hint">인플루언서 캠페인 상세에 표시되는 문구. 비우면 기본값</div></div>
             <div style="font-size:14px;font-weight:700;color:var(--ink);padding-bottom:8px;margin:20px 0 12px;border-bottom:2px solid var(--pink)">콘텐츠 가이드</div>
             <div class="form-group"><label class="form-label">캠페인 설명</label><div class="quill-host" id="editCampDesc"></div></div>
@@ -609,12 +621,14 @@
                 <input type="text" id="newCampRecruitRange" class="form-input fp-range" placeholder="시작일 ~ 종료일 선택" data-range-prefix="newCamp" data-range-kind="recruit" readonly>
                 <input type="hidden" id="newCampRecruitStart">
                 <input type="hidden" id="newCampDeadline">
-                <div id="newPostDeadlineWarn" class="form-error" style="display:none;margin-top:4px"></div>
+                <div class="form-hint">인플루언서를 모집하는 기간을 설정하세요</div>
+                <div id="newCampRecruitWarn" class="form-error" style="display:none;margin-top:4px"></div>
               </div>
               <div class="form-group">
                 <label class="form-label">결과물 제출 마감일</label>
                 <input type="date" id="newCampSubmissionEnd" class="form-input" onchange="validateCampDateRangesInline('newCamp')">
                 <div class="form-hint">이 날짜 이후 결과물(영수증·게시물 URL) 제출 불가. 비우면 노출 마감일로 폴백</div>
+                <div id="newCampSubmissionWarn" class="form-error" style="display:none;margin-top:4px"></div>
               </div>
             </div>
 
@@ -626,6 +640,7 @@
                 <input type="hidden" id="newCampPurchaseStart">
                 <input type="hidden" id="newCampPurchaseEnd">
                 <div class="form-hint">리뷰어용. 이 기간 내 구매한 영수증만 인정</div>
+                <div id="newCampPurchaseWarn" class="form-error" style="display:none;margin-top:4px"></div>
               </div>
             </div>
             <div class="form-row" id="newCampVisitRow" style="grid-template-columns:1fr 1fr;display:none">
@@ -635,6 +650,7 @@
                 <input type="hidden" id="newCampVisitStart">
                 <input type="hidden" id="newCampVisitEnd">
                 <div class="form-hint">방문형용. 이 기간 내 매장 방문 가능</div>
+                <div id="newCampVisitWarn" class="form-error" style="display:none;margin-top:4px"></div>
               </div>
             </div>
             <div class="form-row" style="grid-template-columns:1fr 1fr">
@@ -642,9 +658,9 @@
                 <label class="form-label">노출 마감일 <span style="background:var(--pink);color:#fff;font-size:9px;font-weight:700;padding:1px 5px;border-radius:3px;margin-left:4px">필수</span></label>
                 <input type="date" id="newCampPostDeadline" class="form-input" onchange="syncCampDateMinMax('newCamp');validateCampDateRangesInline('newCamp')">
                 <div class="form-hint">이 날짜 이후 캠페인이 인플루언서 사이트에서 숨겨집니다</div>
+                <div id="newCampPostDeadlineWarn" class="form-error" style="display:none;margin-top:4px"></div>
               </div>
             </div>
-            <div id="newCampDateRangesWarn" class="form-error" style="display:none;margin-top:6px"></div>
             <div class="form-group">
               <label class="form-label">당선 발표 안내</label>
               <input type="text" id="newCampWinnerAnnounce" class="form-input" value="選考後、LINEにてご連絡" placeholder="選考後、LINEにてご連絡">

--- a/dev/admin/index.html
+++ b/dev/admin/index.html
@@ -29,6 +29,9 @@
 <link href="https://cdnjs.cloudflare.com/ajax/libs/cropperjs/1.6.2/cropper.min.css" rel="stylesheet">
 <script src="https://cdnjs.cloudflare.com/ajax/libs/cropperjs/1.6.2/cropper.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/chart.js@4/dist/chart.umd.min.js"></script>
+<link href="https://cdn.jsdelivr.net/npm/flatpickr@4.6.13/dist/flatpickr.min.css" rel="stylesheet">
+<script src="https://cdn.jsdelivr.net/npm/flatpickr@4.6.13/dist/flatpickr.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/flatpickr@4.6.13/dist/l10n/ko.js"></script>
 <link rel="stylesheet" href="../css/base.css">
 <link rel="stylesheet" href="../css/components.css">
 <link rel="stylesheet" href="../css/admin.css">
@@ -370,19 +373,35 @@
             </div>
 
             <div class="form-row" style="grid-template-columns:1fr 1fr">
-              <div class="form-group"><label class="form-label">모집 마감일 <span style="background:var(--pink);color:#fff;font-size:9px;font-weight:700;padding:1px 5px;border-radius:3px;margin-left:4px">필수</span></label><input type="date" id="editCampDeadline" class="form-input" onchange="suggestPostDeadline('editCampDeadline','editCampPostDeadline');validateDeadlines('editCampDeadline','editCampPostDeadline','editPostDeadlineWarn');syncCampDateMinMax('editCamp');validateCampDateRangesInline('editCamp')"></div>
+              <div class="form-group">
+                <label class="form-label">모집 기간 <span style="background:var(--pink);color:#fff;font-size:9px;font-weight:700;padding:1px 5px;border-radius:3px;margin-left:4px">필수</span></label>
+                <input type="text" id="editCampRecruitRange" class="form-input fp-range" placeholder="시작일 ~ 종료일 선택" data-range-prefix="editCamp" data-range-kind="recruit" readonly>
+                <input type="hidden" id="editCampRecruitStart">
+                <input type="hidden" id="editCampDeadline">
+                <div id="editPostDeadlineWarn" class="form-error" style="display:none;margin-top:4px"></div>
+              </div>
               <div class="form-group"><label class="form-label">결과물 제출 마감일</label><input type="date" id="editCampSubmissionEnd" class="form-input" onchange="validateCampDateRangesInline('editCamp')"><div class="form-hint">이 날짜 이후 결과물 제출 불가. 비우면 노출 마감일로 폴백</div></div>
             </div>
             <div class="form-row" id="editCampPurchaseRow" style="grid-template-columns:1fr 1fr;display:none">
-              <div class="form-group"><label class="form-label">구매 시작일</label><input type="date" id="editCampPurchaseStart" class="form-input" onchange="validateCampDateRangesInline('editCamp')"><div class="form-hint">리뷰어용</div></div>
-              <div class="form-group"><label class="form-label">구매 마감일</label><input type="date" id="editCampPurchaseEnd" class="form-input" onchange="validateCampDateRangesInline('editCamp')"></div>
+              <div class="form-group">
+                <label class="form-label">구매 기간</label>
+                <input type="text" id="editCampPurchaseRange" class="form-input fp-range" placeholder="시작일 ~ 종료일 선택" data-range-prefix="editCamp" data-range-kind="purchase" readonly>
+                <input type="hidden" id="editCampPurchaseStart">
+                <input type="hidden" id="editCampPurchaseEnd">
+                <div class="form-hint">리뷰어용. 이 기간 내 구매한 영수증만 인정</div>
+              </div>
             </div>
             <div class="form-row" id="editCampVisitRow" style="grid-template-columns:1fr 1fr;display:none">
-              <div class="form-group"><label class="form-label">방문 시작일</label><input type="date" id="editCampVisitStart" class="form-input" onchange="validateCampDateRangesInline('editCamp')"><div class="form-hint">방문형용</div></div>
-              <div class="form-group"><label class="form-label">방문 마감일</label><input type="date" id="editCampVisitEnd" class="form-input" onchange="validateCampDateRangesInline('editCamp')"></div>
+              <div class="form-group">
+                <label class="form-label">방문 기간</label>
+                <input type="text" id="editCampVisitRange" class="form-input fp-range" placeholder="시작일 ~ 종료일 선택" data-range-prefix="editCamp" data-range-kind="visit" readonly>
+                <input type="hidden" id="editCampVisitStart">
+                <input type="hidden" id="editCampVisitEnd">
+                <div class="form-hint">방문형용. 이 기간 내 매장 방문 가능</div>
+              </div>
             </div>
             <div class="form-row" style="grid-template-columns:1fr 1fr">
-              <div class="form-group"><label class="form-label">노출 마감일 <span style="background:var(--pink);color:#fff;font-size:9px;font-weight:700;padding:1px 5px;border-radius:3px;margin-left:4px">필수</span></label><input type="date" id="editCampPostDeadline" class="form-input" onchange="validateDeadlines('editCampDeadline','editCampPostDeadline','editPostDeadlineWarn');syncCampDateMinMax('editCamp');validateCampDateRangesInline('editCamp')"><div id="editPostDeadlineWarn" class="form-error" style="display:none;margin-top:4px"></div><div class="form-hint">이 날짜 이후 캠페인이 인플루언서 사이트에서 숨겨집니다</div></div>
+              <div class="form-group"><label class="form-label">노출 마감일 <span style="background:var(--pink);color:#fff;font-size:9px;font-weight:700;padding:1px 5px;border-radius:3px;margin-left:4px">필수</span></label><input type="date" id="editCampPostDeadline" class="form-input" onchange="syncCampDateMinMax('editCamp');validateCampDateRangesInline('editCamp')"><div class="form-hint">이 날짜 이후 캠페인이 인플루언서 사이트에서 숨겨집니다</div></div>
             </div>
             <div id="editCampDateRangesWarn" class="form-error" style="display:none;margin-top:6px"></div>
             <div class="form-group"><label class="form-label">당선 발표 안내</label><input type="text" id="editCampWinnerAnnounce" class="form-input" placeholder="選考後、LINEにてご連絡"><div class="form-hint">인플루언서 캠페인 상세에 표시되는 문구. 비우면 기본값</div></div>
@@ -583,11 +602,14 @@
               </div>
             </div>
 
-            <!-- 모집 마감일 / 결과물 제출 마감일 -->
+            <!-- 모집 기간 / 결과물 제출 마감일 -->
             <div class="form-row" style="grid-template-columns:1fr 1fr">
               <div class="form-group">
-                <label class="form-label">모집 마감일 <span style="background:var(--pink);color:#fff;font-size:9px;font-weight:700;padding:1px 5px;border-radius:3px;margin-left:4px">필수</span></label>
-                <input type="date" id="newCampDeadline" class="form-input" onchange="suggestPostDeadline('newCampDeadline','newCampPostDeadline');validateDeadlines('newCampDeadline','newCampPostDeadline','newPostDeadlineWarn');syncCampDateMinMax('newCamp');validateCampDateRangesInline('newCamp')">
+                <label class="form-label">모집 기간 <span style="background:var(--pink);color:#fff;font-size:9px;font-weight:700;padding:1px 5px;border-radius:3px;margin-left:4px">필수</span></label>
+                <input type="text" id="newCampRecruitRange" class="form-input fp-range" placeholder="시작일 ~ 종료일 선택" data-range-prefix="newCamp" data-range-kind="recruit" readonly>
+                <input type="hidden" id="newCampRecruitStart">
+                <input type="hidden" id="newCampDeadline">
+                <div id="newPostDeadlineWarn" class="form-error" style="display:none;margin-top:4px"></div>
               </div>
               <div class="form-group">
                 <label class="form-label">결과물 제출 마감일</label>
@@ -596,34 +618,29 @@
               </div>
             </div>
 
-            <!-- 타입별 기한 (Stage 1) — 모든 일자는 모집~노출 마감 사이로 강제 -->
+            <!-- 타입별 기한 — 모든 일자는 모집 시작 ~ 노출 마감 사이로 강제 -->
             <div class="form-row" id="newCampPurchaseRow" style="grid-template-columns:1fr 1fr;display:none">
               <div class="form-group">
-                <label class="form-label">구매 시작일</label>
-                <input type="date" id="newCampPurchaseStart" class="form-input" onchange="validateCampDateRangesInline('newCamp')">
+                <label class="form-label">구매 기간</label>
+                <input type="text" id="newCampPurchaseRange" class="form-input fp-range" placeholder="시작일 ~ 종료일 선택" data-range-prefix="newCamp" data-range-kind="purchase" readonly>
+                <input type="hidden" id="newCampPurchaseStart">
+                <input type="hidden" id="newCampPurchaseEnd">
                 <div class="form-hint">리뷰어용. 이 기간 내 구매한 영수증만 인정</div>
-              </div>
-              <div class="form-group">
-                <label class="form-label">구매 마감일</label>
-                <input type="date" id="newCampPurchaseEnd" class="form-input" onchange="validateCampDateRangesInline('newCamp')">
               </div>
             </div>
             <div class="form-row" id="newCampVisitRow" style="grid-template-columns:1fr 1fr;display:none">
               <div class="form-group">
-                <label class="form-label">방문 시작일</label>
-                <input type="date" id="newCampVisitStart" class="form-input" onchange="validateCampDateRangesInline('newCamp')">
+                <label class="form-label">방문 기간</label>
+                <input type="text" id="newCampVisitRange" class="form-input fp-range" placeholder="시작일 ~ 종료일 선택" data-range-prefix="newCamp" data-range-kind="visit" readonly>
+                <input type="hidden" id="newCampVisitStart">
+                <input type="hidden" id="newCampVisitEnd">
                 <div class="form-hint">방문형용. 이 기간 내 매장 방문 가능</div>
-              </div>
-              <div class="form-group">
-                <label class="form-label">방문 마감일</label>
-                <input type="date" id="newCampVisitEnd" class="form-input" onchange="validateCampDateRangesInline('newCamp')">
               </div>
             </div>
             <div class="form-row" style="grid-template-columns:1fr 1fr">
               <div class="form-group">
                 <label class="form-label">노출 마감일 <span style="background:var(--pink);color:#fff;font-size:9px;font-weight:700;padding:1px 5px;border-radius:3px;margin-left:4px">필수</span></label>
-                <input type="date" id="newCampPostDeadline" class="form-input" onchange="validateDeadlines('newCampDeadline','newCampPostDeadline','newPostDeadlineWarn');syncCampDateMinMax('newCamp');validateCampDateRangesInline('newCamp')">
-                <div id="newPostDeadlineWarn" class="form-error" style="display:none;margin-top:4px"></div>
+                <input type="date" id="newCampPostDeadline" class="form-input" onchange="syncCampDateMinMax('newCamp');validateCampDateRangesInline('newCamp')">
                 <div class="form-hint">이 날짜 이후 캠페인이 인플루언서 사이트에서 숨겨집니다</div>
               </div>
             </div>

--- a/dev/admin/index.html
+++ b/dev/admin/index.html
@@ -262,6 +262,23 @@
               <div class="form-group"><label class="form-label">브랜드명 <span style="background:var(--pink);color:#fff;font-size:9px;font-weight:700;padding:1px 5px;border-radius:3px;margin-left:4px">필수</span></label><input type="text" id="editCampBrand" class="form-input"></div>
             </div>
             <div class="form-row" style="grid-template-columns:1fr 1fr">
+              <div class="form-group">
+                <label class="form-label">모집 타입 <span style="background:var(--pink);color:#fff;font-size:9px;font-weight:700;padding:1px 5px;border-radius:3px;margin-left:4px">필수</span></label>
+                <div style="display:flex;gap:8px">
+                  <label style="display:flex;align-items:center;justify-content:center;gap:6px;padding:9px 16px;border:2px solid var(--line);border-radius:10px;cursor:pointer;font-size:13px;font-weight:600;transition:.15s;flex:1;text-align:center" id="edit-rt-monitor"><input type="radio" name="editRecruitType" value="monitor" onchange="toggleEditRT(this);filterChannelsByRecruitType('edit','monitor');applyMinFollowersVisibility('edit','monitor')" style="display:none"><span class="material-icons-round notranslate" translate="no" style="font-size:18px;color:var(--muted)">radio_button_unchecked</span> 리뷰어</label>
+                  <label style="display:flex;align-items:center;justify-content:center;gap:6px;padding:9px 16px;border:2px solid var(--line);border-radius:10px;cursor:pointer;font-size:13px;font-weight:600;transition:.15s;flex:1;text-align:center" id="edit-rt-gifting"><input type="radio" name="editRecruitType" value="gifting" onchange="toggleEditRT(this);filterChannelsByRecruitType('edit','gifting');applyMinFollowersVisibility('edit','gifting')" style="display:none"><span class="material-icons-round notranslate" translate="no" style="font-size:18px;color:var(--muted)">radio_button_unchecked</span> 기프팅</label>
+                  <label style="display:flex;align-items:center;justify-content:center;gap:6px;padding:9px 16px;border:2px solid var(--line);border-radius:10px;cursor:pointer;font-size:13px;font-weight:600;transition:.15s;flex:1;text-align:center" id="edit-rt-visit"><input type="radio" name="editRecruitType" value="visit" onchange="toggleEditRT(this);filterChannelsByRecruitType('edit','visit');applyMinFollowersVisibility('edit','visit')" style="display:none"><span class="material-icons-round notranslate" translate="no" style="font-size:18px;color:var(--muted)">radio_button_unchecked</span> 방문형</label>
+                </div>
+              </div>
+              <div class="form-group">
+                <label class="form-label">모집 인원 <span style="background:var(--pink);color:#fff;font-size:9px;font-weight:700;padding:1px 5px;border-radius:3px;margin-left:4px">필수</span></label>
+                <div style="display:flex;align-items:center;gap:6px">
+                  <input type="number" id="editCampSlots" class="form-input" placeholder="20" min="1" style="flex:1">
+                  <span style="font-size:13px;color:var(--muted);font-weight:600">명</span>
+                </div>
+              </div>
+            </div>
+            <div class="form-row" style="grid-template-columns:1fr 1fr">
               <div class="form-group"><label class="form-label">상태</label>
                 <select id="editCampStatus" class="form-input">
                   <option value="draft">준비</option><option value="scheduled">모집예정</option><option value="active">모집중</option><option value="paused">일시정지</option><option value="closed">종료</option>
@@ -318,15 +335,6 @@
             </div>
 
             <div style="font-size:14px;font-weight:700;color:var(--ink);padding-bottom:8px;margin:20px 0 12px;border-bottom:2px solid var(--pink)">모집 조건</div>
-            <div class="form-group">
-              <label class="form-label">모집 타입/인원 <span style="background:var(--pink);color:#fff;font-size:9px;font-weight:700;padding:1px 5px;border-radius:3px;margin-left:4px">필수</span></label>
-              <div style="display:flex;gap:8px;margin-top:6px">
-                <label style="display:flex;align-items:center;justify-content:center;gap:6px;padding:9px 16px;border:2px solid var(--line);border-radius:10px;cursor:pointer;font-size:13px;font-weight:600;transition:.15s;flex:1;text-align:center" id="edit-rt-monitor"><input type="radio" name="editRecruitType" value="monitor" onchange="toggleEditRT(this);filterChannelsByRecruitType('edit','monitor');applyMinFollowersVisibility('edit','monitor')" style="display:none"><span class="material-icons-round notranslate" translate="no" style="font-size:18px;color:var(--muted)">radio_button_unchecked</span> 리뷰어</label>
-                <label style="display:flex;align-items:center;justify-content:center;gap:6px;padding:9px 16px;border:2px solid var(--line);border-radius:10px;cursor:pointer;font-size:13px;font-weight:600;transition:.15s;flex:1;text-align:center" id="edit-rt-gifting"><input type="radio" name="editRecruitType" value="gifting" onchange="toggleEditRT(this);filterChannelsByRecruitType('edit','gifting');applyMinFollowersVisibility('edit','gifting')" style="display:none"><span class="material-icons-round notranslate" translate="no" style="font-size:18px;color:var(--muted)">radio_button_unchecked</span> 기프팅</label>
-                <label style="display:flex;align-items:center;justify-content:center;gap:6px;padding:9px 16px;border:2px solid var(--line);border-radius:10px;cursor:pointer;font-size:13px;font-weight:600;transition:.15s;flex:1;text-align:center" id="edit-rt-visit"><input type="radio" name="editRecruitType" value="visit" onchange="toggleEditRT(this);filterChannelsByRecruitType('edit','visit');applyMinFollowersVisibility('edit','visit')" style="display:none"><span class="material-icons-round notranslate" translate="no" style="font-size:18px;color:var(--muted)">radio_button_unchecked</span> 방문형</label>
-                <input type="number" id="editCampSlots" class="form-input" placeholder="20" min="1" style="width:80px;flex-shrink:0">
-              </div>
-            </div>
             <div class="form-row" style="grid-template-columns:1fr 1fr">
               <div class="form-group">
                 <label class="form-label" style="margin:0 0 6px">채널 <span style="font-size:11px;font-weight:400;color:var(--muted)">(복수 선택 가능)</span></label>
@@ -466,6 +474,29 @@
                 <input type="text" id="newCampBrand" class="form-input" placeholder="이니스프리">
               </div>
             </div>
+            <div class="form-row" style="grid-template-columns:1fr 1fr">
+              <div class="form-group">
+                <label class="form-label">모집 타입 <span style="background:var(--pink);color:#fff;font-size:9px;font-weight:700;padding:1px 5px;border-radius:3px;margin-left:4px">필수</span></label>
+                <div style="display:flex;gap:8px">
+                  <label style="display:flex;align-items:center;justify-content:center;gap:6px;padding:9px 16px;border:2px solid var(--line);border-radius:10px;cursor:pointer;font-size:13px;font-weight:600;transition:.15s;flex:1;text-align:center" id="rt-monitor">
+                    <input type="radio" name="recruitType" value="monitor" onchange="toggleRT(this);filterChannelsByRecruitType('new','monitor');applyMinFollowersVisibility('new','monitor')" style="display:none"><span class="material-icons-round notranslate" translate="no" style="font-size:18px;color:var(--muted)">radio_button_unchecked</span> 리뷰어
+                  </label>
+                  <label style="display:flex;align-items:center;justify-content:center;gap:6px;padding:9px 16px;border:2px solid var(--line);border-radius:10px;cursor:pointer;font-size:13px;font-weight:600;transition:.15s;flex:1;text-align:center" id="rt-gifting">
+                    <input type="radio" name="recruitType" value="gifting" onchange="toggleRT(this);filterChannelsByRecruitType('new','gifting');applyMinFollowersVisibility('new','gifting')" style="display:none"><span class="material-icons-round notranslate" translate="no" style="font-size:18px;color:var(--muted)">radio_button_unchecked</span> 기프팅
+                  </label>
+                  <label style="display:flex;align-items:center;justify-content:center;gap:6px;padding:9px 16px;border:2px solid var(--line);border-radius:10px;cursor:pointer;font-size:13px;font-weight:600;transition:.15s;flex:1;text-align:center" id="rt-visit">
+                    <input type="radio" name="recruitType" value="visit" onchange="toggleRT(this);filterChannelsByRecruitType('new','visit');applyMinFollowersVisibility('new','visit')" style="display:none"><span class="material-icons-round notranslate" translate="no" style="font-size:18px;color:var(--muted)">radio_button_unchecked</span> 방문형
+                  </label>
+                </div>
+              </div>
+              <div class="form-group">
+                <label class="form-label">모집 인원 <span style="background:var(--pink);color:#fff;font-size:9px;font-weight:700;padding:1px 5px;border-radius:3px;margin-left:4px">필수</span></label>
+                <div style="display:flex;align-items:center;gap:6px">
+                  <input type="number" id="newCampSlots" class="form-input" placeholder="20" min="1" value="20" style="flex:1">
+                  <span style="font-size:13px;color:var(--muted);font-weight:600">명</span>
+                </div>
+              </div>
+            </div>
 
             <div style="font-size:14px;font-weight:700;color:var(--ink);padding-bottom:8px;margin:20px 0 12px;border-bottom:2px solid var(--pink)">제품 정보</div>
             <div style="display:grid;grid-template-columns:1fr 1fr;gap:40px">
@@ -518,21 +549,6 @@
             </div>
 
             <div style="font-size:14px;font-weight:700;color:var(--ink);padding-bottom:8px;margin:20px 0 12px;border-bottom:2px solid var(--pink)">모집 조건</div>
-            <div class="form-group">
-              <label class="form-label">모집 타입/인원 <span style="background:var(--pink);color:#fff;font-size:9px;font-weight:700;padding:1px 5px;border-radius:3px;margin-left:4px">필수</span></label>
-              <div style="display:flex;gap:8px;margin-top:6px">
-                <label style="display:flex;align-items:center;justify-content:center;gap:6px;padding:9px 16px;border:2px solid var(--line);border-radius:10px;cursor:pointer;font-size:13px;font-weight:600;transition:.15s;flex:1;text-align:center" id="rt-monitor">
-                  <input type="radio" name="recruitType" value="monitor" onchange="toggleRT(this);filterChannelsByRecruitType('new','monitor');applyMinFollowersVisibility('new','monitor')" style="display:none"><span class="material-icons-round notranslate" translate="no" style="font-size:18px;color:var(--muted)">radio_button_unchecked</span> 리뷰어
-                </label>
-                <label style="display:flex;align-items:center;justify-content:center;gap:6px;padding:9px 16px;border:2px solid var(--line);border-radius:10px;cursor:pointer;font-size:13px;font-weight:600;transition:.15s;flex:1;text-align:center" id="rt-gifting">
-                  <input type="radio" name="recruitType" value="gifting" onchange="toggleRT(this);filterChannelsByRecruitType('new','gifting');applyMinFollowersVisibility('new','gifting')" style="display:none"><span class="material-icons-round notranslate" translate="no" style="font-size:18px;color:var(--muted)">radio_button_unchecked</span> 기프팅
-                </label>
-                <label style="display:flex;align-items:center;justify-content:center;gap:6px;padding:9px 16px;border:2px solid var(--line);border-radius:10px;cursor:pointer;font-size:13px;font-weight:600;transition:.15s;flex:1;text-align:center" id="rt-visit">
-                  <input type="radio" name="recruitType" value="visit" onchange="toggleRT(this);filterChannelsByRecruitType('new','visit');applyMinFollowersVisibility('new','visit')" style="display:none"><span class="material-icons-round notranslate" translate="no" style="font-size:18px;color:var(--muted)">radio_button_unchecked</span> 방문형
-                </label>
-                <input type="number" id="newCampSlots" class="form-input" placeholder="20" min="1" value="20" style="width:80px;flex-shrink:0">
-              </div>
-            </div>
             <div class="form-row" style="grid-template-columns:1fr 1fr">
               <div class="form-group">
                 <label class="form-label" style="margin:0 0 6px">채널 <span style="font-size:11px;font-weight:400;color:var(--muted)">(복수 선택 가능)</span></label>

--- a/dev/admin/index.html
+++ b/dev/admin/index.html
@@ -383,8 +383,8 @@
               </div>
               <div class="form-group">
                 <label class="form-label">결과물 제출 마감일</label>
-                <input type="date" id="editCampSubmissionEnd" class="form-input" onchange="validateCampDateRangesInline('editCamp')">
-                <div class="form-hint">이 날짜 이후 결과물 제출 불가. 비우면 노출 마감일로 폴백</div>
+                <input type="date" id="editCampSubmissionEnd" class="form-input" onchange="syncCampDateMinMax('editCamp');validateCampDateRangesInline('editCamp')">
+                <div class="form-hint">이 날짜 이후 결과물 제출 불가. 비우면 캠페인 노출 마감일로 폴백</div>
                 <div id="editCampSubmissionWarn" class="form-error" style="display:none;margin-top:4px"></div>
               </div>
             </div>
@@ -410,7 +410,7 @@
             </div>
             <div class="form-row" style="grid-template-columns:1fr 1fr">
               <div class="form-group">
-                <label class="form-label">노출 마감일 <span style="background:var(--pink);color:#fff;font-size:9px;font-weight:700;padding:1px 5px;border-radius:3px;margin-left:4px">필수</span></label>
+                <label class="form-label">캠페인 노출 마감일 <span style="background:var(--pink);color:#fff;font-size:9px;font-weight:700;padding:1px 5px;border-radius:3px;margin-left:4px">필수</span></label>
                 <input type="date" id="editCampPostDeadline" class="form-input" onchange="syncCampDateMinMax('editCamp');validateCampDateRangesInline('editCamp')">
                 <div class="form-hint">이 날짜 이후 캠페인이 인플루언서 사이트에서 숨겨집니다</div>
                 <div id="editCampPostDeadlineWarn" class="form-error" style="display:none;margin-top:4px"></div>
@@ -626,8 +626,8 @@
               </div>
               <div class="form-group">
                 <label class="form-label">결과물 제출 마감일</label>
-                <input type="date" id="newCampSubmissionEnd" class="form-input" onchange="validateCampDateRangesInline('newCamp')">
-                <div class="form-hint">이 날짜 이후 결과물(영수증·게시물 URL) 제출 불가. 비우면 노출 마감일로 폴백</div>
+                <input type="date" id="newCampSubmissionEnd" class="form-input" onchange="syncCampDateMinMax('newCamp');validateCampDateRangesInline('newCamp')">
+                <div class="form-hint">이 날짜 이후 결과물(영수증·게시물 URL) 제출 불가. 비우면 캠페인 노출 마감일로 폴백</div>
                 <div id="newCampSubmissionWarn" class="form-error" style="display:none;margin-top:4px"></div>
               </div>
             </div>
@@ -655,7 +655,7 @@
             </div>
             <div class="form-row" style="grid-template-columns:1fr 1fr">
               <div class="form-group">
-                <label class="form-label">노출 마감일 <span style="background:var(--pink);color:#fff;font-size:9px;font-weight:700;padding:1px 5px;border-radius:3px;margin-left:4px">필수</span></label>
+                <label class="form-label">캠페인 노출 마감일 <span style="background:var(--pink);color:#fff;font-size:9px;font-weight:700;padding:1px 5px;border-radius:3px;margin-left:4px">필수</span></label>
                 <input type="date" id="newCampPostDeadline" class="form-input" onchange="syncCampDateMinMax('newCamp');validateCampDateRangesInline('newCamp')">
                 <div class="form-hint">이 날짜 이후 캠페인이 인플루언서 사이트에서 숨겨집니다</div>
                 <div id="newCampPostDeadlineWarn" class="form-error" style="display:none;margin-top:4px"></div>
@@ -1817,7 +1817,7 @@
   </div>
 </div>
 
-<!-- 노출 마감일 자동 제안 confirm 모달 -->
+<!-- 캠페인 노출 마감일 자동 제안 confirm 모달 -->
 <div class="modal-overlay" id="confirmModal" style="z-index:610">
   <div class="modal" style="max-width:420px;border-radius:24px;margin:auto;text-align:center">
     <div class="modal-body" style="padding:28px 24px 22px">

--- a/dev/js/admin.js
+++ b/dev/js/admin.js
@@ -1421,7 +1421,6 @@ function renderCampPreview(mode) {
           ${camp.slots?`<div class="cp-info-row"><div class="cp-info-key">募集人数</div><div class="cp-info-val">${camp.slots}名</div></div>`:''}
           ${camp.min_followers?`<div class="cp-info-row"><div class="cp-info-key">最小フォロワー</div><div class="cp-info-val">${camp.min_followers.toLocaleString()}</div></div>`:''}
           <div class="cp-info-row"><div class="cp-info-key">当選発表</div><div class="cp-info-val">${esc(camp.winner_announce||'選考後、LINEにてご連絡')}</div></div>
-          <div class="cp-info-row"><div class="cp-info-key">掲載期限</div><div class="cp-info-val" style="font-weight:600">${camp.post_deadline?fmt(camp.post_deadline):'—'}</div></div>
           ${(camp.recruit_type==='monitor'&&(camp.purchase_start||camp.purchase_end))?`<div class="cp-info-row"><div class="cp-info-key">購入期間</div><div class="cp-info-val">${fmt(camp.purchase_start)} 〜 ${fmt(camp.purchase_end)}</div></div>`:''}
           ${(camp.recruit_type==='visit'&&(camp.visit_start||camp.visit_end))?`<div class="cp-info-row"><div class="cp-info-key">訪問期間</div><div class="cp-info-val">${fmt(camp.visit_start)} 〜 ${fmt(camp.visit_end)}</div></div>`:''}
           ${camp.submission_end?`<div class="cp-info-row"><div class="cp-info-key">提出締切</div><div class="cp-info-val" style="font-weight:600">${fmt(camp.submission_end)}</div></div>`:''}

--- a/dev/js/admin.js
+++ b/dev/js/admin.js
@@ -753,7 +753,7 @@ async function loadAdminCampaigns(useCache) {
             </div>
             <strong style="cursor:pointer;color:var(--ink)" onclick="openCampPreviewModal('${c.id}')">${esc(c.title)}</strong>
             <div style="font-size:11px;color:var(--muted);margin-top:2px">${esc(c.brand)}</div>
-            ${c.post_deadline ? `<div style="font-size:10px;color:var(--muted);margin-top:1px">노출: ~${formatDate(c.post_deadline)} ${dDayLabel(c.post_deadline)}</div>` : ''}
+            ${c.post_deadline ? `<div style="font-size:10px;color:var(--muted);margin-top:1px">캠페인 노출: ~${formatDate(c.post_deadline)} ${dDayLabel(c.post_deadline)}</div>` : ''}
           </div>
         </div>
       </td>
@@ -1038,22 +1038,34 @@ async function suggestSubmissionEnd(prefix) {
   }
 }
 
-// 일자 자식 input들의 min/max를 [recruit_start || deadline] ~ post_deadline 으로 동기화 (브라우저 단 차단)
-const CAMP_DATE_FIELDS = ['PurchaseStart','PurchaseEnd','VisitStart','VisitEnd','SubmissionEnd','PostDeadline'];
+// 일자 자식 input들의 min/max 를 운영 흐름에 맞춰 동기화 (브라우저 단 차단)
+//   구매·방문: [recruit_start||deadline] ~ [submission_end || post_deadline]
+//   결과물 제출 마감일: max(recruit_start||deadline, purchase_end, visit_end) ~ post_deadline
+//   캠페인 노출 마감일: deadline ~ (없음)
 function syncCampDateMinMax(prefix) {
   const rs = $(prefix+'RecruitStart')?.value || '';
   const dl = $(prefix+'Deadline')?.value || '';
   const pdl = $(prefix+'PostDeadline')?.value || '';
-  // 자식 일자들은 모집 시작일(없으면 모집 종료일) 이후로만 입력 가능
+  const pe = $(prefix+'PurchaseEnd')?.value || '';
+  const ve = $(prefix+'VisitEnd')?.value || '';
+  const se = $(prefix+'SubmissionEnd')?.value || '';
   const lower = rs || dl || '';
-  CAMP_DATE_FIELDS.forEach(suffix => {
-    if (suffix === 'PostDeadline') return; // post_deadline 은 자식이 아니라 자체 입력
+  const upperPV = se || pdl || '';
+  // 구매·방문: lower ~ upperPV
+  ['PurchaseStart','PurchaseEnd','VisitStart','VisitEnd'].forEach(suffix => {
     const el = $(prefix+suffix);
     if (!el) return;
     if (lower) el.min = lower; else el.removeAttribute('min');
-    if (pdl) el.max = pdl; else el.removeAttribute('max');
+    if (upperPV) el.max = upperPV; else el.removeAttribute('max');
   });
-  // 노출 마감일은 모집 종료일 이후만 (range picker 가 보장하지만 native input 도 강제)
+  // 결과물 제출 마감일: 구매·방문 종료일 이후 (없으면 lower) ~ 캠페인 노출 마감일
+  const seEl = $(prefix+'SubmissionEnd');
+  if (seEl) {
+    const seLower = [lower, pe, ve].filter(Boolean).sort().pop() || '';
+    if (seLower) seEl.min = seLower; else seEl.removeAttribute('min');
+    if (pdl) seEl.max = pdl; else seEl.removeAttribute('max');
+  }
+  // 캠페인 노출 마감일: 모집 종료일 이후
   const postEl = $(prefix+'PostDeadline');
   if (postEl) {
     if (dl) postEl.min = dl; else postEl.removeAttribute('min');
@@ -1062,7 +1074,7 @@ function syncCampDateMinMax(prefix) {
 }
 
 // 입력값 검증 (저장 시 + onchange 인라인 경고). 위반 메시지 배열 반환.
-//   경계: 모집 시작일 ~ 노출 마감일 사이
+//   경계: 모집 시작일 ~ 캠페인 노출 마감일 사이
 function validateCampDateRanges(prefix) {
   const rs = $(prefix+'RecruitStart')?.value || '';
   const dl = $(prefix+'Deadline')?.value || '';
@@ -1080,15 +1092,28 @@ function validateCampDateRanges(prefix) {
     if (pdl && new Date(val) > new Date(pdl)) return false;
     return true;
   };
+  // 구매·방문 일자의 상한은 결과물 제출 마감일(우선) 또는 캠페인 노출 마감일(폴백)
+  const upperPV = se || pdl || '';
+  const inPVRange = (val) => {
+    if (!val) return true;
+    if (lower && new Date(val) < new Date(lower)) return false;
+    if (upperPV && new Date(val) > new Date(upperPV)) return false;
+    return true;
+  };
+  const upperPVLabel = se ? '결과물 제출 마감일' : '캠페인 노출 마감일';
   if (rs && dl && new Date(dl) < new Date(rs)) errs.push({kind:'recruit', msg:'모집 종료일은 모집 시작일 이후여야 합니다'});
-  if (dl && pdl && new Date(pdl) < new Date(dl)) errs.push({kind:'post', msg:'노출 마감일은 모집 종료일 이후여야 합니다'});
-  if (!between(ps)) errs.push({kind:'purchase', msg:'구매 시작일은 모집 시작일~노출 마감일 사이여야 합니다'});
-  if (!between(pe)) errs.push({kind:'purchase', msg:'구매 마감일은 모집 시작일~노출 마감일 사이여야 합니다'});
+  if (dl && pdl && new Date(pdl) < new Date(dl)) errs.push({kind:'post', msg:'캠페인 노출 마감일은 모집 종료일 이후여야 합니다'});
+  if (!inPVRange(ps)) errs.push({kind:'purchase', msg:`구매 시작일은 모집 시작일~${upperPVLabel} 사이여야 합니다`});
+  if (!inPVRange(pe)) errs.push({kind:'purchase', msg:`구매 마감일은 모집 시작일~${upperPVLabel} 사이여야 합니다`});
   if (ps && pe && new Date(pe) < new Date(ps)) errs.push({kind:'purchase', msg:'구매 마감일은 구매 시작일 이후여야 합니다'});
-  if (!between(vs)) errs.push({kind:'visit', msg:'방문 시작일은 모집 시작일~노출 마감일 사이여야 합니다'});
-  if (!between(ve)) errs.push({kind:'visit', msg:'방문 마감일은 모집 시작일~노출 마감일 사이여야 합니다'});
+  if (!inPVRange(vs)) errs.push({kind:'visit', msg:`방문 시작일은 모집 시작일~${upperPVLabel} 사이여야 합니다`});
+  if (!inPVRange(ve)) errs.push({kind:'visit', msg:`방문 마감일은 모집 시작일~${upperPVLabel} 사이여야 합니다`});
   if (vs && ve && new Date(ve) < new Date(vs)) errs.push({kind:'visit', msg:'방문 마감일은 방문 시작일 이후여야 합니다'});
-  if (!between(se)) errs.push({kind:'submission', msg:'결과물 제출 마감일은 모집 시작일~노출 마감일 사이여야 합니다'});
+  // 결과물 제출 마감일: 모집 시작 ~ 캠페인 노출 마감 사이 + 구매·방문 종료일 이후
+  if (se && lower && new Date(se) < new Date(lower)) errs.push({kind:'submission', msg:'결과물 제출 마감일은 모집 시작일 이후여야 합니다'});
+  if (se && pdl && new Date(se) > new Date(pdl)) errs.push({kind:'submission', msg:'결과물 제출 마감일은 캠페인 노출 마감일 이전이어야 합니다'});
+  if (se && pe && new Date(se) < new Date(pe)) errs.push({kind:'submission', msg:'결과물 제출 마감일은 구매 종료일 이후여야 합니다'});
+  if (se && ve && new Date(se) < new Date(ve)) errs.push({kind:'submission', msg:'결과물 제출 마감일은 방문 종료일 이후여야 합니다'});
   return errs;
 }
 
@@ -1242,7 +1267,7 @@ async function saveCampaignEdit() {
     const editDeadline = gv('editCampDeadline');
     const editPostDeadline = gv('editCampPostDeadline');
     if (editPostDeadline && editDeadline && new Date(editPostDeadline) < new Date(editDeadline)) {
-      toast('노출 마감일은 모집 마감일 이후여야 합니다','error');
+      toast('캠페인 노출 마감일은 모집 종료일 이후여야 합니다','error');
       return;
     }
     const editDateErrs = validateCampDateRanges('editCamp');
@@ -2913,7 +2938,7 @@ async function addCampaign() {
   }
   const postDeadline = $('newCampPostDeadline')?.value;
   if (postDeadline && deadline && new Date(postDeadline) < new Date(deadline)) {
-    toast('노출 마감일은 모집 종료일 이후여야 합니다','error');
+    toast('캠페인 노출 마감일은 모집 종료일 이후여야 합니다','error');
     return;
   }
   const newDateErrs = validateCampDateRanges('newCamp');

--- a/dev/js/admin.js
+++ b/dev/js/admin.js
@@ -1038,20 +1038,6 @@ async function suggestSubmissionEnd(prefix) {
   }
 }
 
-// (legacy) 모집 종료일 < 노출 마감일 인라인 경고 — flatpickr range picker 도입 후엔 사실상 미사용. 호출처 호환용 stub.
-function validateDeadlines(deadlineId, postDeadlineId, warnId) {
-  const dl = $(deadlineId)?.value;
-  const pdl = $(postDeadlineId)?.value;
-  const warn = $(warnId);
-  if (!warn) return;
-  if (dl && pdl && new Date(pdl) < new Date(dl)) {
-    warn.textContent = '노출 마감일은 모집 종료일 이후여야 합니다';
-    warn.style.display = 'block';
-  } else {
-    warn.style.display = 'none';
-  }
-}
-
 // 일자 자식 input들의 min/max를 [recruit_start || deadline] ~ post_deadline 으로 동기화 (브라우저 단 차단)
 const CAMP_DATE_FIELDS = ['PurchaseStart','PurchaseEnd','VisitStart','VisitEnd','SubmissionEnd','PostDeadline'];
 function syncCampDateMinMax(prefix) {
@@ -1094,17 +1080,26 @@ function validateCampDateRanges(prefix) {
     if (pdl && new Date(val) > new Date(pdl)) return false;
     return true;
   };
-  if (rs && dl && new Date(dl) < new Date(rs)) errs.push('모집 종료일은 모집 시작일 이후여야 합니다');
-  if (dl && pdl && new Date(pdl) < new Date(dl)) errs.push('노출 마감일은 모집 종료일 이후여야 합니다');
-  if (!between(ps)) errs.push('구매 시작일은 모집 시작일~노출 마감일 사이여야 합니다');
-  if (!between(pe)) errs.push('구매 마감일은 모집 시작일~노출 마감일 사이여야 합니다');
-  if (ps && pe && new Date(pe) < new Date(ps)) errs.push('구매 마감일은 구매 시작일 이후여야 합니다');
-  if (!between(vs)) errs.push('방문 시작일은 모집 시작일~노출 마감일 사이여야 합니다');
-  if (!between(ve)) errs.push('방문 마감일은 모집 시작일~노출 마감일 사이여야 합니다');
-  if (vs && ve && new Date(ve) < new Date(vs)) errs.push('방문 마감일은 방문 시작일 이후여야 합니다');
-  if (!between(se)) errs.push('결과물 제출 마감일은 모집 시작일~노출 마감일 사이여야 합니다');
+  if (rs && dl && new Date(dl) < new Date(rs)) errs.push({kind:'recruit', msg:'모집 종료일은 모집 시작일 이후여야 합니다'});
+  if (dl && pdl && new Date(pdl) < new Date(dl)) errs.push({kind:'post', msg:'노출 마감일은 모집 종료일 이후여야 합니다'});
+  if (!between(ps)) errs.push({kind:'purchase', msg:'구매 시작일은 모집 시작일~노출 마감일 사이여야 합니다'});
+  if (!between(pe)) errs.push({kind:'purchase', msg:'구매 마감일은 모집 시작일~노출 마감일 사이여야 합니다'});
+  if (ps && pe && new Date(pe) < new Date(ps)) errs.push({kind:'purchase', msg:'구매 마감일은 구매 시작일 이후여야 합니다'});
+  if (!between(vs)) errs.push({kind:'visit', msg:'방문 시작일은 모집 시작일~노출 마감일 사이여야 합니다'});
+  if (!between(ve)) errs.push({kind:'visit', msg:'방문 마감일은 모집 시작일~노출 마감일 사이여야 합니다'});
+  if (vs && ve && new Date(ve) < new Date(vs)) errs.push({kind:'visit', msg:'방문 마감일은 방문 시작일 이후여야 합니다'});
+  if (!between(se)) errs.push({kind:'submission', msg:'결과물 제출 마감일은 모집 시작일~노출 마감일 사이여야 합니다'});
   return errs;
 }
+
+// 종류별 row 아래 div 매핑 — 한 row에 여러 위반이 있으면 같은 div에 누적 표시
+const CAMP_DATE_WARN_TARGETS = {
+  recruit:    'RecruitWarn',
+  post:       'PostDeadlineWarn',
+  purchase:   'PurchaseWarn',
+  visit:      'VisitWarn',
+  submission: 'SubmissionWarn',
+};
 
 // ─────────────────────────────────────────────────────────────────
 // flatpickr range picker 통합 (모집·구매·방문 3개 영역)
@@ -1166,6 +1161,8 @@ function setupCampRangePickers() {
       dateFormat: 'Y-m-d',
       altInput: false,
       locale: (typeof flatpickr !== 'undefined' && flatpickr.l10ns && flatpickr.l10ns.ko) ? 'ko' : 'default',
+      static: true,            // 캘린더 popup을 input의 부모(form-group)에 붙여 스크롤 시 따라다님
+      position: 'below',       // 항상 input 아래로 표시 (자동 위/아래 결정 비활성)
       onOpen: (selectedDates, _str, fpInst) => {
         if (kind !== 'recruit') return;
         // 캘린더 열릴 때마다 현재 hidden input의 시작일을 기준으로 경고 평가
@@ -1210,18 +1207,24 @@ function applyCampRangeValues(prefix, values) {
   });
 }
 
-// onchange 인라인 경고 (저장 차단은 별도 체크)
+// onchange 인라인 경고 — 종류별로 분산해서 해당 row 바로 아래 div 에 출력 (저장 차단은 별도 체크)
 function validateCampDateRangesInline(prefix) {
   const errs = validateCampDateRanges(prefix);
-  const warn = $(prefix+'DateRangesWarn');
-  if (!warn) return;
-  if (errs.length === 0) {
-    warn.style.display = 'none';
-    warn.textContent = '';
-  } else {
-    warn.innerHTML = errs.map(e => `· ${e}`).join('<br>');
-    warn.style.display = 'block';
-  }
+  const groups = Object.create(null);
+  Object.keys(CAMP_DATE_WARN_TARGETS).forEach(k => { groups[k] = []; });
+  errs.forEach(e => { if (groups[e.kind]) groups[e.kind].push(e.msg); });
+  Object.keys(CAMP_DATE_WARN_TARGETS).forEach(k => {
+    const div = $(prefix + CAMP_DATE_WARN_TARGETS[k]);
+    if (!div) return;
+    const list = groups[k];
+    if (!list || list.length === 0) {
+      div.style.display = 'none';
+      div.textContent = '';
+    } else {
+      div.innerHTML = list.map(m => `· ${esc(m)}`).join('<br>');
+      div.style.display = 'block';
+    }
+  });
 }
 
 async function saveCampaignEdit() {
@@ -1243,7 +1246,7 @@ async function saveCampaignEdit() {
       return;
     }
     const editDateErrs = validateCampDateRanges('editCamp');
-    if (editDateErrs.length) { toast(editDateErrs[0], 'error'); return; }
+    if (editDateErrs.length) { toast(editDateErrs[0].msg, 'error'); validateCampDateRangesInline('editCamp'); return; }
     const editStatus = gv('editCampStatus');
     if (editDeadline && (editStatus === 'active' || editStatus === 'scheduled')) {
       const dl = new Date(editDeadline); dl.setHours(23,59,59,999);
@@ -2914,7 +2917,7 @@ async function addCampaign() {
     return;
   }
   const newDateErrs = validateCampDateRanges('newCamp');
-  if (newDateErrs.length) { toast(newDateErrs[0], 'error'); return; }
+  if (newDateErrs.length) { toast(newDateErrs[0].msg, 'error'); validateCampDateRangesInline('newCamp'); return; }
   const catEmojiMap = {beauty:'💄',food:'🍜',fashion:'👗',health:'💪',other:'📦'};
   const cat = $('newCampCategory').value;
   const ch = Array.from(document.querySelectorAll('input[name="newChannel"]:checked')).map(c=>c.value).join(',');

--- a/dev/js/admin.js
+++ b/dev/js/admin.js
@@ -749,7 +749,7 @@ async function loadAdminCampaigns(useCache) {
             </div>
             <strong style="cursor:pointer;color:var(--ink)" onclick="openCampPreviewModal('${c.id}')">${esc(c.title)}</strong>
             <div style="font-size:11px;color:var(--muted);margin-top:2px">${esc(c.brand)}</div>
-            ${c.post_deadline ? `<div style="font-size:10px;color:var(--muted);margin-top:1px">게시: ~${formatDate(c.post_deadline)} ${dDayLabel(c.post_deadline)}</div>` : ''}
+            ${c.post_deadline ? `<div style="font-size:10px;color:var(--muted);margin-top:1px">노출: ~${formatDate(c.post_deadline)} ${dDayLabel(c.post_deadline)}</div>` : ''}
           </div>
         </div>
       </td>
@@ -910,6 +910,9 @@ async function openEditCampaign(campId) {
   sv('editCampVisitStart', camp.visit_start||'');
   sv('editCampVisitEnd', camp.visit_end||'');
   sv('editCampSubmissionEnd', camp.submission_end||'');
+  // 일자 입력 min/max 동기화 + 인라인 경고 초기 평가
+  syncCampDateMinMax('editCamp');
+  validateCampDateRangesInline('editCamp');
   sv('editCampWinnerAnnounce', camp.winner_announce || '選考後、LINEにてご連絡');
   sv('editCampDesc', camp.description||'');
   sv('editCampHashtags', camp.hashtags||'');
@@ -1009,7 +1012,7 @@ function resolveConfirmModal(ok) {
   if (_confirmResolver) { _confirmResolver(!!ok); _confirmResolver = null; }
 }
 
-// 모집 마감일 입력 시 게시 마감일을 +14일로 자동 채우기 (확인 모달)
+// 모집 마감일 입력 시 노출 마감일을 +14일로 자동 채우기 (확인 모달)
 async function suggestPostDeadline(deadlineId, postDeadlineId) {
   const dl = $(deadlineId)?.value;
   if (!dl) return;
@@ -1023,7 +1026,7 @@ async function suggestPostDeadline(deadlineId, postDeadlineId) {
   if (!postEl) return;
   // 이미 입력된 값이 같으면 무시
   if (postEl.value === suggested) return;
-  const ok = await showConfirm(`게시 마감일을 ${yyyy}년 ${mm}월 ${dd}일로 입력하시겠습니까?\n(모집 마감일 + 2주)`);
+  const ok = await showConfirm(`노출 마감일을 ${yyyy}년 ${mm}월 ${dd}일로 입력하시겠습니까?\n(모집 마감일 + 2주)`);
   if (ok) postEl.value = suggested;
 }
 
@@ -1033,10 +1036,65 @@ function validateDeadlines(deadlineId, postDeadlineId, warnId) {
   const warn = $(warnId);
   if (!warn) return;
   if (dl && pdl && new Date(pdl) < new Date(dl)) {
-    warn.textContent = '게시 마감일은 모집 마감일 이후여야 합니다';
+    warn.textContent = '노출 마감일은 모집 마감일 이후여야 합니다';
     warn.style.display = 'block';
   } else {
     warn.style.display = 'none';
+  }
+}
+
+// 모집~노출 마감 사이로 구매·방문·결과물제출 일자 강제. prefix = 'newCamp' | 'editCamp'
+const CAMP_DATE_FIELDS = ['PurchaseStart','PurchaseEnd','VisitStart','VisitEnd','SubmissionEnd'];
+
+// HTML5 input min/max 속성을 deadline ~ post_deadline 으로 동기화 (브라우저 단 차단)
+function syncCampDateMinMax(prefix) {
+  const dl = $(prefix+'Deadline')?.value || '';
+  const pdl = $(prefix+'PostDeadline')?.value || '';
+  CAMP_DATE_FIELDS.forEach(suffix => {
+    const el = $(prefix+suffix);
+    if (!el) return;
+    if (dl) el.min = dl; else el.removeAttribute('min');
+    if (pdl) el.max = pdl; else el.removeAttribute('max');
+  });
+}
+
+// 입력값 검증 (저장 시 + onchange 인라인 경고). 위반 메시지 배열 반환.
+function validateCampDateRanges(prefix) {
+  const dl = $(prefix+'Deadline')?.value || '';
+  const pdl = $(prefix+'PostDeadline')?.value || '';
+  const ps = $(prefix+'PurchaseStart')?.value || '';
+  const pe = $(prefix+'PurchaseEnd')?.value || '';
+  const vs = $(prefix+'VisitStart')?.value || '';
+  const ve = $(prefix+'VisitEnd')?.value || '';
+  const se = $(prefix+'SubmissionEnd')?.value || '';
+  const errs = [];
+  const between = (val) => {
+    if (!val) return true;
+    if (dl && new Date(val) < new Date(dl)) return false;
+    if (pdl && new Date(val) > new Date(pdl)) return false;
+    return true;
+  };
+  if (!between(ps)) errs.push('구매 시작일은 모집 마감일~노출 마감일 사이여야 합니다');
+  if (!between(pe)) errs.push('구매 마감일은 모집 마감일~노출 마감일 사이여야 합니다');
+  if (ps && pe && new Date(pe) < new Date(ps)) errs.push('구매 마감일은 구매 시작일 이후여야 합니다');
+  if (!between(vs)) errs.push('방문 시작일은 모집 마감일~노출 마감일 사이여야 합니다');
+  if (!between(ve)) errs.push('방문 마감일은 모집 마감일~노출 마감일 사이여야 합니다');
+  if (vs && ve && new Date(ve) < new Date(vs)) errs.push('방문 마감일은 방문 시작일 이후여야 합니다');
+  if (!between(se)) errs.push('결과물 제출 마감일은 모집 마감일~노출 마감일 사이여야 합니다');
+  return errs;
+}
+
+// onchange 인라인 경고 (저장 차단은 별도 체크)
+function validateCampDateRangesInline(prefix) {
+  const errs = validateCampDateRanges(prefix);
+  const warn = $(prefix+'DateRangesWarn');
+  if (!warn) return;
+  if (errs.length === 0) {
+    warn.style.display = 'none';
+    warn.textContent = '';
+  } else {
+    warn.innerHTML = errs.map(e => `· ${e}`).join('<br>');
+    warn.style.display = 'block';
   }
 }
 
@@ -1055,9 +1113,11 @@ async function saveCampaignEdit() {
     const editDeadline = gv('editCampDeadline');
     const editPostDeadline = gv('editCampPostDeadline');
     if (editPostDeadline && editDeadline && new Date(editPostDeadline) < new Date(editDeadline)) {
-      toast('게시 마감일은 모집 마감일 이후여야 합니다','error');
+      toast('노출 마감일은 모집 마감일 이후여야 합니다','error');
       return;
     }
+    const editDateErrs = validateCampDateRanges('editCamp');
+    if (editDateErrs.length) { toast(editDateErrs[0], 'error'); return; }
     const editStatus = gv('editCampStatus');
     if (editDeadline && (editStatus === 'active' || editStatus === 'scheduled')) {
       const dl = new Date(editDeadline); dl.setHours(23,59,59,999);
@@ -1361,7 +1421,7 @@ function renderCampPreview(mode) {
           ${camp.slots?`<div class="cp-info-row"><div class="cp-info-key">募集人数</div><div class="cp-info-val">${camp.slots}名</div></div>`:''}
           ${camp.min_followers?`<div class="cp-info-row"><div class="cp-info-key">最小フォロワー</div><div class="cp-info-val">${camp.min_followers.toLocaleString()}</div></div>`:''}
           <div class="cp-info-row"><div class="cp-info-key">当選発表</div><div class="cp-info-val">${esc(camp.winner_announce||'選考後、LINEにてご連絡')}</div></div>
-          <div class="cp-info-row"><div class="cp-info-key">投稿締切</div><div class="cp-info-val" style="font-weight:600">${camp.post_deadline?fmt(camp.post_deadline):'—'}</div></div>
+          <div class="cp-info-row"><div class="cp-info-key">掲載期限</div><div class="cp-info-val" style="font-weight:600">${camp.post_deadline?fmt(camp.post_deadline):'—'}</div></div>
           ${(camp.recruit_type==='monitor'&&(camp.purchase_start||camp.purchase_end))?`<div class="cp-info-row"><div class="cp-info-key">購入期間</div><div class="cp-info-val">${fmt(camp.purchase_start)} 〜 ${fmt(camp.purchase_end)}</div></div>`:''}
           ${(camp.recruit_type==='visit'&&(camp.visit_start||camp.visit_end))?`<div class="cp-info-row"><div class="cp-info-key">訪問期間</div><div class="cp-info-val">${fmt(camp.visit_start)} 〜 ${fmt(camp.visit_end)}</div></div>`:''}
           ${camp.submission_end?`<div class="cp-info-row"><div class="cp-info-key">提出締切</div><div class="cp-info-val" style="font-weight:600">${fmt(camp.submission_end)}</div></div>`:''}
@@ -2723,9 +2783,11 @@ async function addCampaign() {
   }
   const postDeadline = $('newCampPostDeadline')?.value;
   if (postDeadline && deadline && new Date(postDeadline) < new Date(deadline)) {
-    toast('게시 마감일은 모집 마감일 이후여야 합니다','error');
+    toast('노출 마감일은 모집 마감일 이후여야 합니다','error');
     return;
   }
+  const newDateErrs = validateCampDateRanges('newCamp');
+  if (newDateErrs.length) { toast(newDateErrs[0], 'error'); return; }
   const catEmojiMap = {beauty:'💄',food:'🍜',fashion:'👗',health:'💪',other:'📦'};
   const cat = $('newCampCategory').value;
   const ch = Array.from(document.querySelectorAll('input[name="newChannel"]:checked')).map(c=>c.value).join(',');

--- a/dev/js/admin.js
+++ b/dev/js/admin.js
@@ -1113,11 +1113,23 @@ function validateCampDateRanges(prefix) {
 //   - 모집 종료일 변경 시 결과물 제출 마감일 자동 제안 + min/max 갱신 + 인라인 검증
 // ─────────────────────────────────────────────────────────────────
 const _campRangePickers = Object.create(null);
+const _pastRecruitStartWarned = Object.create(null); // prefix별 마지막으로 알린 과거 시작일 (중복 방지)
 const RANGE_KIND_HIDDEN_IDS = {
   recruit:  ['RecruitStart', 'Deadline'],
   purchase: ['PurchaseStart', 'PurchaseEnd'],
   visit:    ['VisitStart', 'VisitEnd'],
 };
+
+// 모집 시작일이 오늘 이전이면 의도 확인 알럿 1회 (차단 없음, 같은 값 재호출 안 함)
+async function maybeWarnPastRecruitStart(prefix, startStr) {
+  if (!startStr) return;
+  const today = new Date(); today.setHours(0, 0, 0, 0);
+  const start = new Date(startStr); start.setHours(0, 0, 0, 0);
+  if (start >= today) { _pastRecruitStartWarned[prefix] = null; return; }
+  if (_pastRecruitStartWarned[prefix] === startStr) return;
+  _pastRecruitStartWarned[prefix] = startStr;
+  await showConfirm(`모집 시작일(${startStr})이 오늘보다 이전입니다.\n과거 날짜로 등록하는 것이 맞나요?`);
+}
 function _fpFormatYmd(d) {
   if (!d) return '';
   const yyyy = d.getFullYear();
@@ -1147,9 +1159,11 @@ function setupCampRangePickers() {
         const endEl   = $(prefix + endSuffix);
         if (startEl) startEl.value = _fpFormatYmd(start);
         if (endEl)   endEl.value   = _fpFormatYmd(end);
-        // 모집 기간 종료일이 새로 잡힌 경우 결과물 제출 마감일 자동 제안
-        if (kind === 'recruit' && end) {
-          suggestSubmissionEnd(prefix);
+        if (kind === 'recruit') {
+          // 시작일이 오늘 이전이면 의도 확인 (차단 없음, 같은 값 재호출 안 함)
+          if (start) maybeWarnPastRecruitStart(prefix, _fpFormatYmd(start));
+          // 종료일까지 잡혔으면 결과물 제출 마감일 자동 제안
+          if (end) suggestSubmissionEnd(prefix);
         }
         syncCampDateMinMax(prefix);
         validateCampDateRangesInline(prefix);

--- a/dev/js/admin.js
+++ b/dev/js/admin.js
@@ -135,7 +135,7 @@ function switchAdminPane(pane, el, pushHistory) {
     if (defaultRt) { defaultRt.checked = true; toggleRT(defaultRt); }
     // lookup_values 동적 렌더
     renderChannelCheckboxes('new', 'monitor', []);
-    renderContentTypeCheckboxes('new', []);
+    renderContentTypeCheckboxes('new', [], 'monitor');
     renderCategorySelect('new', '');
     applyMinFollowersVisibility('new', 'monitor');
     applyDeadlineFieldsVisibility('new', 'monitor');
@@ -945,7 +945,7 @@ async function openEditCampaign(campId) {
   const selectedContent = (camp.content_types||'').split(',').map(t=>t.trim()).filter(Boolean);
   await Promise.all([
     renderChannelCheckboxes('edit', rtVal, selectedChannels),
-    renderContentTypeCheckboxes('edit', selectedContent),
+    renderContentTypeCheckboxes('edit', selectedContent, rtVal),
     renderCategorySelect('edit', camp.category||'')
   ]);
   // 기준 채널 선택값 복원 (없으면 첫 번째 채널)
@@ -1065,12 +1065,34 @@ function syncCampDateMinMax(prefix) {
     if (seLower) seEl.min = seLower; else seEl.removeAttribute('min');
     if (pdl) seEl.max = pdl; else seEl.removeAttribute('max');
   }
-  // 캠페인 노출 마감일: 모집 종료일 이후
+  // 캠페인 노출 마감일: 결과물 제출 마감일(우선) 또는 모집 종료일 이후
   const postEl = $(prefix+'PostDeadline');
   if (postEl) {
-    if (dl) postEl.min = dl; else postEl.removeAttribute('min');
+    const postLower = se || dl || '';
+    if (postLower) postEl.min = postLower; else postEl.removeAttribute('min');
     postEl.removeAttribute('max');
   }
+  // flatpickr range picker (구매·방문) 도 같은 경계로 비활성 날짜 처리
+  if (typeof syncCampRangePickerBounds === 'function') syncCampRangePickerBounds(prefix);
+}
+
+// flatpickr range picker 의 minDate/maxDate 를 hidden input 값에 맞춰 동적 갱신
+//   구매·방문: [recruit_start || deadline] ~ [submission_end || post_deadline]
+//   모집: 제한 없음 (관리자가 자유 입력)
+function syncCampRangePickerBounds(prefix) {
+  if (!_campRangePickers) return;
+  const rs = $(prefix+'RecruitStart')?.value || '';
+  const dl = $(prefix+'Deadline')?.value || '';
+  const pdl = $(prefix+'PostDeadline')?.value || '';
+  const se = $(prefix+'SubmissionEnd')?.value || '';
+  const lower = rs || dl || '';
+  const upperPV = se || pdl || '';
+  ['Purchase', 'Visit'].forEach(kind => {
+    const fp = _campRangePickers[prefix + kind + 'Range'];
+    if (!fp) return;
+    fp.set('minDate', lower || null);
+    fp.set('maxDate', upperPV || null);
+  });
 }
 
 // 입력값 검증 (저장 시 + onchange 인라인 경고). 위반 메시지 배열 반환.
@@ -1103,6 +1125,7 @@ function validateCampDateRanges(prefix) {
   const upperPVLabel = se ? '결과물 제출 마감일' : '캠페인 노출 마감일';
   if (rs && dl && new Date(dl) < new Date(rs)) errs.push({kind:'recruit', msg:'모집 종료일은 모집 시작일 이후여야 합니다'});
   if (dl && pdl && new Date(pdl) < new Date(dl)) errs.push({kind:'post', msg:'캠페인 노출 마감일은 모집 종료일 이후여야 합니다'});
+  if (se && pdl && new Date(pdl) < new Date(se)) errs.push({kind:'post', msg:'캠페인 노출 마감일은 결과물 제출 마감일 이후여야 합니다'});
   if (!inPVRange(ps)) errs.push({kind:'purchase', msg:`구매 시작일은 모집 시작일~${upperPVLabel} 사이여야 합니다`});
   if (!inPVRange(pe)) errs.push({kind:'purchase', msg:`구매 마감일은 모집 시작일~${upperPVLabel} 사이여야 합니다`});
   if (ps && pe && new Date(pe) < new Date(ps)) errs.push({kind:'purchase', msg:'구매 마감일은 구매 시작일 이후여야 합니다'});
@@ -3010,7 +3033,7 @@ async function addCampaign() {
   // 동적 영역 재렌더 (체크 해제 + 전체 채널 다시 표시)
   await Promise.all([
     renderChannelCheckboxes('new', null, []),
-    renderContentTypeCheckboxes('new', []),
+    renderContentTypeCheckboxes('new', [], null),
     renderCategorySelect('new', '')
   ]);
   // 주의사항 번들 초기화 (신규 캠페인은 빈 상태로 시작 — 관리자가 번들 선택)
@@ -3288,11 +3311,18 @@ function applyChannelMatchVisibility(formMode) {
   group.style.display = count >= 2 ? 'flex' : 'none';
 }
 
-async function renderContentTypeCheckboxes(formMode, preSelectedLabels) {
+async function renderContentTypeCheckboxes(formMode, preSelectedLabels, recruitType) {
   const cfg = _formCfg[formMode]; if (!cfg) return;
   const wrap = $(cfg.ctWrap); if (!wrap) return;
   let items = [];
   try { items = await fetchLookups('content_type'); } catch(e) { return; }
+  // 리뷰어(monitor) 캠페인은 Qoo10 리뷰 형식상 콘텐츠가 동영상·이미지 위주이므로 옵션 제한.
+  // 기존에 다른 코드(피드/릴스 등)가 저장되어 있다면 옵션 미노출이라 저장 시 자동 폐기됨 (운영 의도).
+  if (recruitType === 'monitor') {
+    const dropped = (preSelectedLabels || []).filter(lbl => !items.some(c => (c.code === 'video' || c.code === 'image') && c.name_ja === lbl));
+    if (dropped.length) console.warn('[renderContentTypeCheckboxes] monitor 캠페인이라 다음 콘텐츠 코드는 폼에서 폐기됨:', dropped);
+    items = items.filter(c => c.code === 'video' || c.code === 'image');
+  }
   const checked = new Set(preSelectedLabels || []);
   wrap.innerHTML = items.map(c =>
     `<label style="display:flex;align-items:center;gap:5px;padding:6px 13px;border:1.5px solid var(--line);border-radius:20px;cursor:pointer;font-size:13px;font-weight:500;transition:.15s" id="${esc(cfg.ctPrefix+c.code)}"><input type="checkbox" name="${esc(cfg.ctName)}" value="${esc(c.name_ja)}" onchange="toggleCT(this)" style="display:none">${esc(c.name_ko)}</label>`
@@ -3321,6 +3351,9 @@ async function filterChannelsByRecruitType(formMode, recruitType) {
   // 현재 체크된 코드 보존
   const checked = Array.from(document.querySelectorAll(`input[name="${cfg.chName}"]:checked`)).map(c => c.value);
   await renderChannelCheckboxes(formMode, recruitType, checked);
+  // 콘텐츠 종류도 모집 타입에 맞춰 재렌더 (monitor=동영상·이미지만, gifting/visit=전체)
+  const checkedCT = Array.from(document.querySelectorAll(`input[name="${cfg.ctName}"]:checked`)).map(c => c.value);
+  await renderContentTypeCheckboxes(formMode, checkedCT, recruitType);
   // 참여방법 번들 드롭다운도 모집 타입에 맞춰 갱신 (선택값은 유지 시도)
   const psetSel = $(formMode === 'edit' ? 'editCampPsetSelect' : 'newCampPsetSelect');
   await populateCampPsetDropdown(formMode, recruitType, psetSel?.value || null);

--- a/dev/js/admin.js
+++ b/dev/js/admin.js
@@ -97,6 +97,10 @@ function switchAdminPane(pane, el, pushHistory) {
   document.querySelectorAll('.admin-si').forEach(s=>s.classList.remove('on'));
   const paneEl = $('adminPane-'+pane);
   if (paneEl) paneEl.classList.add('on');
+  // 캠페인 등록·편집 진입 시 flatpickr range picker mount (idempotent)
+  if (pane === 'add-campaign' || pane === 'edit-campaign') {
+    if (typeof setupCampRangePickers === 'function') setupCampRangePickers();
+  }
   // 사이드바 활성 상태를 data-pane 속성으로 검색
   if (!el) {
     const sidePane = {'add-campaign':'campaigns','edit-campaign':'campaigns',
@@ -903,13 +907,15 @@ async function openEditCampaign(campId) {
   sv('editCampProductPrice', camp.product_price||0);
   sv('editCampReward', camp.reward||0);
   sv('editCampRewardNote', camp.reward_note||'');
-  sv('editCampDeadline', camp.deadline||'');
   sv('editCampPostDeadline', camp.post_deadline||'');
-  sv('editCampPurchaseStart', camp.purchase_start||'');
-  sv('editCampPurchaseEnd', camp.purchase_end||'');
-  sv('editCampVisitStart', camp.visit_start||'');
-  sv('editCampVisitEnd', camp.visit_end||'');
   sv('editCampSubmissionEnd', camp.submission_end||'');
+  // flatpickr range picker mount + 값 주입 (모집·구매·방문 3개)
+  setupCampRangePickers();
+  applyCampRangeValues('editCamp', {
+    recruit:  [camp.recruit_start || '', camp.deadline || ''],
+    purchase: [camp.purchase_start || '', camp.purchase_end || ''],
+    visit:    [camp.visit_start || '', camp.visit_end || ''],
+  });
   // 일자 입력 min/max 동기화 + 인라인 경고 초기 평가
   syncCampDateMinMax('editCamp');
   validateCampDateRangesInline('editCamp');
@@ -1012,54 +1018,67 @@ function resolveConfirmModal(ok) {
   if (_confirmResolver) { _confirmResolver(!!ok); _confirmResolver = null; }
 }
 
-// 모집 마감일 입력 시 노출 마감일을 +14일로 자동 채우기 (확인 모달)
-async function suggestPostDeadline(deadlineId, postDeadlineId) {
-  const dl = $(deadlineId)?.value;
+// 모집 종료일 입력 시 결과물 제출 마감일을 +14일로 자동 제안 (확인 모달)
+async function suggestSubmissionEnd(prefix) {
+  const dl = $(prefix+'Deadline')?.value;
   if (!dl) return;
-  const post = new Date(dl);
-  post.setDate(post.getDate() + 14);
-  const yyyy = post.getFullYear();
-  const mm = String(post.getMonth() + 1).padStart(2, '0');
-  const dd = String(post.getDate()).padStart(2, '0');
+  const target = new Date(dl);
+  target.setDate(target.getDate() + 14);
+  const yyyy = target.getFullYear();
+  const mm = String(target.getMonth() + 1).padStart(2, '0');
+  const dd = String(target.getDate()).padStart(2, '0');
   const suggested = `${yyyy}-${mm}-${dd}`;
-  const postEl = $(postDeadlineId);
-  if (!postEl) return;
-  // 이미 입력된 값이 같으면 무시
-  if (postEl.value === suggested) return;
-  const ok = await showConfirm(`노출 마감일을 ${yyyy}년 ${mm}월 ${dd}일로 입력하시겠습니까?\n(모집 마감일 + 2주)`);
-  if (ok) postEl.value = suggested;
+  const seEl = $(prefix+'SubmissionEnd');
+  if (!seEl || seEl.value === suggested) return;
+  const ok = await showConfirm(`결과물 제출 마감일을 ${yyyy}년 ${mm}월 ${dd}일로 입력하시겠습니까?\n(모집 종료일 + 2주)`);
+  if (ok) {
+    seEl.value = suggested;
+    syncCampDateMinMax(prefix);
+    validateCampDateRangesInline(prefix);
+  }
 }
 
+// (legacy) 모집 종료일 < 노출 마감일 인라인 경고 — flatpickr range picker 도입 후엔 사실상 미사용. 호출처 호환용 stub.
 function validateDeadlines(deadlineId, postDeadlineId, warnId) {
   const dl = $(deadlineId)?.value;
   const pdl = $(postDeadlineId)?.value;
   const warn = $(warnId);
   if (!warn) return;
   if (dl && pdl && new Date(pdl) < new Date(dl)) {
-    warn.textContent = '노출 마감일은 모집 마감일 이후여야 합니다';
+    warn.textContent = '노출 마감일은 모집 종료일 이후여야 합니다';
     warn.style.display = 'block';
   } else {
     warn.style.display = 'none';
   }
 }
 
-// 모집~노출 마감 사이로 구매·방문·결과물제출 일자 강제. prefix = 'newCamp' | 'editCamp'
-const CAMP_DATE_FIELDS = ['PurchaseStart','PurchaseEnd','VisitStart','VisitEnd','SubmissionEnd'];
-
-// HTML5 input min/max 속성을 deadline ~ post_deadline 으로 동기화 (브라우저 단 차단)
+// 일자 자식 input들의 min/max를 [recruit_start || deadline] ~ post_deadline 으로 동기화 (브라우저 단 차단)
+const CAMP_DATE_FIELDS = ['PurchaseStart','PurchaseEnd','VisitStart','VisitEnd','SubmissionEnd','PostDeadline'];
 function syncCampDateMinMax(prefix) {
+  const rs = $(prefix+'RecruitStart')?.value || '';
   const dl = $(prefix+'Deadline')?.value || '';
   const pdl = $(prefix+'PostDeadline')?.value || '';
+  // 자식 일자들은 모집 시작일(없으면 모집 종료일) 이후로만 입력 가능
+  const lower = rs || dl || '';
   CAMP_DATE_FIELDS.forEach(suffix => {
+    if (suffix === 'PostDeadline') return; // post_deadline 은 자식이 아니라 자체 입력
     const el = $(prefix+suffix);
     if (!el) return;
-    if (dl) el.min = dl; else el.removeAttribute('min');
+    if (lower) el.min = lower; else el.removeAttribute('min');
     if (pdl) el.max = pdl; else el.removeAttribute('max');
   });
+  // 노출 마감일은 모집 종료일 이후만 (range picker 가 보장하지만 native input 도 강제)
+  const postEl = $(prefix+'PostDeadline');
+  if (postEl) {
+    if (dl) postEl.min = dl; else postEl.removeAttribute('min');
+    postEl.removeAttribute('max');
+  }
 }
 
 // 입력값 검증 (저장 시 + onchange 인라인 경고). 위반 메시지 배열 반환.
+//   경계: 모집 시작일 ~ 노출 마감일 사이
 function validateCampDateRanges(prefix) {
+  const rs = $(prefix+'RecruitStart')?.value || '';
   const dl = $(prefix+'Deadline')?.value || '';
   const pdl = $(prefix+'PostDeadline')?.value || '';
   const ps = $(prefix+'PurchaseStart')?.value || '';
@@ -1068,20 +1087,93 @@ function validateCampDateRanges(prefix) {
   const ve = $(prefix+'VisitEnd')?.value || '';
   const se = $(prefix+'SubmissionEnd')?.value || '';
   const errs = [];
+  const lower = rs || dl || '';
   const between = (val) => {
     if (!val) return true;
-    if (dl && new Date(val) < new Date(dl)) return false;
+    if (lower && new Date(val) < new Date(lower)) return false;
     if (pdl && new Date(val) > new Date(pdl)) return false;
     return true;
   };
-  if (!between(ps)) errs.push('구매 시작일은 모집 마감일~노출 마감일 사이여야 합니다');
-  if (!between(pe)) errs.push('구매 마감일은 모집 마감일~노출 마감일 사이여야 합니다');
+  if (rs && dl && new Date(dl) < new Date(rs)) errs.push('모집 종료일은 모집 시작일 이후여야 합니다');
+  if (dl && pdl && new Date(pdl) < new Date(dl)) errs.push('노출 마감일은 모집 종료일 이후여야 합니다');
+  if (!between(ps)) errs.push('구매 시작일은 모집 시작일~노출 마감일 사이여야 합니다');
+  if (!between(pe)) errs.push('구매 마감일은 모집 시작일~노출 마감일 사이여야 합니다');
   if (ps && pe && new Date(pe) < new Date(ps)) errs.push('구매 마감일은 구매 시작일 이후여야 합니다');
-  if (!between(vs)) errs.push('방문 시작일은 모집 마감일~노출 마감일 사이여야 합니다');
-  if (!between(ve)) errs.push('방문 마감일은 모집 마감일~노출 마감일 사이여야 합니다');
+  if (!between(vs)) errs.push('방문 시작일은 모집 시작일~노출 마감일 사이여야 합니다');
+  if (!between(ve)) errs.push('방문 마감일은 모집 시작일~노출 마감일 사이여야 합니다');
   if (vs && ve && new Date(ve) < new Date(vs)) errs.push('방문 마감일은 방문 시작일 이후여야 합니다');
-  if (!between(se)) errs.push('결과물 제출 마감일은 모집 마감일~노출 마감일 사이여야 합니다');
+  if (!between(se)) errs.push('결과물 제출 마감일은 모집 시작일~노출 마감일 사이여야 합니다');
   return errs;
+}
+
+// ─────────────────────────────────────────────────────────────────
+// flatpickr range picker 통합 (모집·구매·방문 3개 영역)
+//   - input[data-range-prefix][data-range-kind] 마크업을 mount 대상으로 사용
+//   - hidden start/end input 두 개에 값을 동기화 (저장 로직은 hidden ID 그대로)
+//   - 모집 종료일 변경 시 결과물 제출 마감일 자동 제안 + min/max 갱신 + 인라인 검증
+// ─────────────────────────────────────────────────────────────────
+const _campRangePickers = Object.create(null);
+const RANGE_KIND_HIDDEN_IDS = {
+  recruit:  ['RecruitStart', 'Deadline'],
+  purchase: ['PurchaseStart', 'PurchaseEnd'],
+  visit:    ['VisitStart', 'VisitEnd'],
+};
+function _fpFormatYmd(d) {
+  if (!d) return '';
+  const yyyy = d.getFullYear();
+  const mm = String(d.getMonth() + 1).padStart(2, '0');
+  const dd = String(d.getDate()).padStart(2, '0');
+  return `${yyyy}-${mm}-${dd}`;
+}
+function setupCampRangePickers() {
+  if (typeof flatpickr === 'undefined') return; // CDN 로드 실패 fallback (text input 그대로)
+  const els = document.querySelectorAll('input.fp-range[data-range-prefix]');
+  els.forEach(el => {
+    const id = el.id;
+    if (_campRangePickers[id]) return; // 이미 mount
+    const prefix = el.dataset.rangePrefix;
+    const kind   = el.dataset.rangeKind;
+    const [startSuffix, endSuffix] = RANGE_KIND_HIDDEN_IDS[kind] || [];
+    if (!startSuffix || !endSuffix) return;
+    _campRangePickers[id] = flatpickr(el, {
+      mode: 'range',
+      dateFormat: 'Y-m-d',
+      altInput: false,
+      locale: (typeof flatpickr !== 'undefined' && flatpickr.l10ns && flatpickr.l10ns.ko) ? 'ko' : 'default',
+      onChange: (selectedDates) => {
+        const start = selectedDates[0] || null;
+        const end   = selectedDates[1] || null;
+        const startEl = $(prefix + startSuffix);
+        const endEl   = $(prefix + endSuffix);
+        if (startEl) startEl.value = _fpFormatYmd(start);
+        if (endEl)   endEl.value   = _fpFormatYmd(end);
+        // 모집 기간 종료일이 새로 잡힌 경우 결과물 제출 마감일 자동 제안
+        if (kind === 'recruit' && end) {
+          suggestSubmissionEnd(prefix);
+        }
+        syncCampDateMinMax(prefix);
+        validateCampDateRangesInline(prefix);
+      },
+    });
+  });
+}
+// 편집 모달 열림·신규 폼 진입 시 외부에서 setDate 로 값 주입 (또는 클리어)
+function applyCampRangeValues(prefix, values) {
+  // values = { recruit:[start,end], purchase:[start,end], visit:[start,end] }
+  Object.keys(RANGE_KIND_HIDDEN_IDS).forEach(kind => {
+    const id = prefix + (kind === 'recruit' ? 'RecruitRange' : kind === 'purchase' ? 'PurchaseRange' : 'VisitRange');
+    const fp = _campRangePickers[id];
+    const pair = (values && values[kind]) || [null, null];
+    const [s, e] = pair;
+    const [startSuffix, endSuffix] = RANGE_KIND_HIDDEN_IDS[kind];
+    if ($(prefix + startSuffix)) $(prefix + startSuffix).value = s || '';
+    if ($(prefix + endSuffix))   $(prefix + endSuffix).value   = e || '';
+    if (fp) {
+      if (s && e) fp.setDate([s, e], false);
+      else if (s) fp.setDate([s], false);
+      else fp.clear(false);
+    }
+  });
 }
 
 // onchange 인라인 경고 (저장 차단은 별도 체크)
@@ -1146,6 +1238,7 @@ async function saveCampaignEdit() {
       product_price: parseInt(gv('editCampProductPrice'))||0,
       reward: parseInt(gv('editCampReward'))||0,
       reward_note: gv('editCampRewardNote') || null,
+      recruit_start: gv('editCampRecruitStart')||null,
       deadline: gv('editCampDeadline')||null,
       post_deadline: gv('editCampPostDeadline')||null,
       purchase_start: gv('editCampPurchaseStart')||null,
@@ -1206,7 +1299,7 @@ async function duplicateCampaign(campId) {
       caution_items: Array.isArray(src.caution_items) ? JSON.parse(JSON.stringify(src.caution_items)) : [],
       product_price: src.product_price, reward: src.reward, reward_note: src.reward_note,
       slots: src.slots, applied_count: 0,
-      deadline: src.deadline, post_deadline: src.post_deadline, post_days: src.post_days,
+      recruit_start: src.recruit_start, deadline: src.deadline, post_deadline: src.post_deadline, post_days: src.post_days,
       purchase_start: src.purchase_start, purchase_end: src.purchase_end,
       visit_start: src.visit_start, visit_end: src.visit_end,
       submission_end: src.submission_end,
@@ -1323,6 +1416,7 @@ function buildPreviewCamp(mode) {
     slots: parseInt(val(g+'Slots'))||10,
     min_followers: parseInt(val(g+'MinFollowers'))||0,
     primary_channel: val(g+'PrimaryChannel')||null,
+    recruit_start: val(g+'RecruitStart')||null,
     deadline: val(g+'Deadline')||null,
     post_deadline: val(g+'PostDeadline')||null,
     purchase_start: val(g+'PurchaseStart')||null,
@@ -1417,7 +1511,7 @@ function renderCampPreview(mode) {
           <div class="cp-info-row"><div class="cp-info-key">募集タイプ</div><div class="cp-info-val">${rtBadge?`<span class="cp-rt-badge" style="background:${rtBadge.bg};color:${rtBadge.color}">${rtBadge.label}</span>`:'—'}</div></div>
           ${channelNames.length?`<div class="cp-info-row"><div class="cp-info-key">チャンネル</div><div class="cp-info-val"><div class="cp-chips">${channelNames.map((n,i)=>(i>0?`<span class="cp-chip-sep">${chSep}</span>`:'')+`<span class="cp-chip">${esc(n)}</span>`).join('')}</div></div></div>`:''}
           ${contentTypeNames.length?`<div class="cp-info-row"><div class="cp-info-key">コンテンツ種類</div><div class="cp-info-val"><div class="cp-chips">${contentTypeNames.map(n=>`<span class="cp-chip cp-chip-sm">${esc(n)}</span>`).join('')}</div></div></div>`:''}
-          <div class="cp-info-row"><div class="cp-info-key">募集期間</div><div class="cp-info-val">${fmt(new Date())} 〜 ${fmt(camp.deadline)}</div></div>
+          <div class="cp-info-row"><div class="cp-info-key">募集期間</div><div class="cp-info-val">${fmt(camp.recruit_start || new Date())} 〜 ${fmt(camp.deadline)}</div></div>
           ${camp.slots?`<div class="cp-info-row"><div class="cp-info-key">募集人数</div><div class="cp-info-val">${camp.slots}名</div></div>`:''}
           ${camp.min_followers?`<div class="cp-info-row"><div class="cp-info-key">最小フォロワー</div><div class="cp-info-val">${camp.min_followers.toLocaleString()}</div></div>`:''}
           <div class="cp-info-row"><div class="cp-info-key">当選発表</div><div class="cp-info-val">${esc(camp.winner_announce||'選考後、LINEにてご連絡')}</div></div>
@@ -2782,7 +2876,7 @@ async function addCampaign() {
   }
   const postDeadline = $('newCampPostDeadline')?.value;
   if (postDeadline && deadline && new Date(postDeadline) < new Date(deadline)) {
-    toast('노출 마감일은 모집 마감일 이후여야 합니다','error');
+    toast('노출 마감일은 모집 종료일 이후여야 합니다','error');
     return;
   }
   const newDateErrs = validateCampDateRanges('newCamp');
@@ -2814,6 +2908,7 @@ async function addCampaign() {
     reward: parseInt($('newCampReward').value)||0,
     reward_note: ($('newCampRewardNote')?.value || '').trim() || null,
     slots, applied_count:0,
+    recruit_start: $('newCampRecruitStart')?.value||null,
     deadline: deadline||null,
     post_deadline: $('newCampPostDeadline')?.value||null,
     post_days: $('newCampPostDeadline')?.value
@@ -2840,9 +2935,12 @@ async function addCampaign() {
   renderImgPreview(campImgData, 'campImgPreviewWrap', 'campImgCounter', 'campImgData');
 
   ['newCampTitle','newCampBrand','newCampProduct','newCampProductUrl',
-   'newCampSlots','newCampDeadline','newCampPostDeadline',
-   'newCampHashtags','newCampMentions',
+   'newCampSlots','newCampRecruitStart','newCampDeadline','newCampPostDeadline',
+   'newCampPurchaseStart','newCampPurchaseEnd','newCampVisitStart','newCampVisitEnd',
+   'newCampSubmissionEnd','newCampHashtags','newCampMentions',
    'newCampProductPrice','newCampReward','newCampRewardNote'].forEach(id => { const el=$(id); if(el) el.value=''; });
+  // flatpickr range picker 클리어
+  applyCampRangeValues('newCamp', { recruit:[null,null], purchase:[null,null], visit:[null,null] });
   // 리치 에디터 초기화
   ['newCampDesc','newCampAppeal','newCampGuide','newCampNg'].forEach(id => setRichValue(id, ''));
   document.querySelectorAll('input[name="recruitType"]').forEach(r=>r.checked=false);

--- a/dev/js/admin.js
+++ b/dev/js/admin.js
@@ -1113,22 +1113,36 @@ function validateCampDateRanges(prefix) {
 //   - 모집 종료일 변경 시 결과물 제출 마감일 자동 제안 + min/max 갱신 + 인라인 검증
 // ─────────────────────────────────────────────────────────────────
 const _campRangePickers = Object.create(null);
-const _pastRecruitStartWarned = Object.create(null); // prefix별 마지막으로 알린 과거 시작일 (중복 방지)
 const RANGE_KIND_HIDDEN_IDS = {
   recruit:  ['RecruitStart', 'Deadline'],
   purchase: ['PurchaseStart', 'PurchaseEnd'],
   visit:    ['VisitStart', 'VisitEnd'],
 };
 
-// 모집 시작일이 오늘 이전이면 의도 확인 알럿 1회 (차단 없음, 같은 값 재호출 안 함)
-async function maybeWarnPastRecruitStart(prefix, startStr) {
-  if (!startStr) return;
+// flatpickr 캘린더 popup 하단에 추가하는 인라인 경고 div를 1회만 생성·재사용
+function _ensureFpWarnNode(fp) {
+  if (fp && fp._reverbWarnNode) return fp._reverbWarnNode;
+  if (!fp || !fp.calendarContainer) return null;
+  const node = document.createElement('div');
+  node.className = 'fp-past-warn';
+  node.style.cssText = 'display:none;padding:8px 12px;font-size:11px;font-weight:600;color:#C62828;background:#FFEBEE;border-top:1px solid #FFCDD2;text-align:center;line-height:1.5';
+  fp.calendarContainer.appendChild(node);
+  fp._reverbWarnNode = node;
+  return node;
+}
+// 모집 시작일이 오늘 이전이면 캘린더 popup 하단에 빨간 글씨 표시 (차단·모달 닫힘 없음)
+function updateRecruitPastWarn(fp, startDate) {
+  const node = _ensureFpWarnNode(fp);
+  if (!node) return;
+  if (!startDate) { node.style.display = 'none'; return; }
   const today = new Date(); today.setHours(0, 0, 0, 0);
-  const start = new Date(startStr); start.setHours(0, 0, 0, 0);
-  if (start >= today) { _pastRecruitStartWarned[prefix] = null; return; }
-  if (_pastRecruitStartWarned[prefix] === startStr) return;
-  _pastRecruitStartWarned[prefix] = startStr;
-  await showConfirm(`모집 시작일(${startStr})이 오늘보다 이전입니다.\n과거 날짜로 등록하는 것이 맞나요?`);
+  const start = new Date(startDate); start.setHours(0, 0, 0, 0);
+  if (start < today) {
+    node.textContent = '모집 시작일이 오늘보다 이전입니다. 과거 날짜로 등록하는 것이 맞는지 확인해주세요.';
+    node.style.display = 'block';
+  } else {
+    node.style.display = 'none';
+  }
 }
 function _fpFormatYmd(d) {
   if (!d) return '';
@@ -1152,7 +1166,13 @@ function setupCampRangePickers() {
       dateFormat: 'Y-m-d',
       altInput: false,
       locale: (typeof flatpickr !== 'undefined' && flatpickr.l10ns && flatpickr.l10ns.ko) ? 'ko' : 'default',
-      onChange: (selectedDates) => {
+      onOpen: (selectedDates, _str, fpInst) => {
+        if (kind !== 'recruit') return;
+        // 캘린더 열릴 때마다 현재 hidden input의 시작일을 기준으로 경고 평가
+        const cur = $(prefix + startSuffix)?.value || '';
+        updateRecruitPastWarn(fpInst, cur ? new Date(cur) : null);
+      },
+      onChange: (selectedDates, _str, fpInst) => {
         const start = selectedDates[0] || null;
         const end   = selectedDates[1] || null;
         const startEl = $(prefix + startSuffix);
@@ -1160,8 +1180,8 @@ function setupCampRangePickers() {
         if (startEl) startEl.value = _fpFormatYmd(start);
         if (endEl)   endEl.value   = _fpFormatYmd(end);
         if (kind === 'recruit') {
-          // 시작일이 오늘 이전이면 의도 확인 (차단 없음, 같은 값 재호출 안 함)
-          if (start) maybeWarnPastRecruitStart(prefix, _fpFormatYmd(start));
+          // 캘린더 popup 하단 인라인 경고 갱신 (과거 시작일이면 빨간 글씨 표시, 그 외 숨김)
+          updateRecruitPastWarn(fpInst, start);
           // 종료일까지 잡혔으면 결과물 제출 마감일 자동 제안
           if (end) suggestSubmissionEnd(prefix);
         }

--- a/dev/js/application.js
+++ b/dev/js/application.js
@@ -105,7 +105,7 @@ async function openCampaign(id) {
           </div>`:''}
           <div style="display:flex;border-top:1px solid #faf5f9">
             <div style="width:90px;padding:10px 14px;color:var(--dark-pink);font-weight:600;font-size:11px;background:#fdf5fb;flex-shrink:0">${t('detail.recruitPeriod')}</div>
-            <div style="padding:10px 13px;flex:1;font-size:12px">${formatDate(new Date())} 〜 ${formatDate(camp.deadline)}</div>
+            <div style="padding:10px 13px;flex:1;font-size:12px">${formatDate(camp.recruit_start || new Date())} 〜 ${formatDate(camp.deadline)}</div>
           </div>
           <div style="display:flex;border-top:1px solid #faf5f9">
             <div style="width:90px;padding:10px 14px;color:var(--dark-pink);font-weight:600;font-size:11px;background:#fdf5fb;flex-shrink:0">${t('detail.recruitSlots')}</div>

--- a/dev/js/application.js
+++ b/dev/js/application.js
@@ -115,10 +115,6 @@ async function openCampaign(id) {
             <div style="width:90px;padding:10px 14px;color:var(--dark-pink);font-weight:600;font-size:11px;background:#fdf5fb;flex-shrink:0">${t('detail.winnerAnnounce')}</div>
             <div style="padding:10px 13px;flex:1;font-size:12px">${esc(camp.winner_announce || t('detail.winnerAnnounceValue'))}</div>
           </div>
-          <div style="display:flex;border-top:1px solid #faf5f9">
-            <div style="width:90px;padding:10px 14px;color:var(--dark-pink);font-weight:600;font-size:11px;background:#fdf5fb;flex-shrink:0">${t('detail.postDeadline')}</div>
-            <div style="padding:10px 13px;flex:1;font-size:12px;font-weight:600;color:var(--ink)">${camp.post_deadline ? formatDate(camp.post_deadline) : camp.post_days ? t('detail.postDeadlineRelative').replace('{days}',camp.post_days) : t('detail.noSetting')}</div>
-          </div>
           ${(camp.recruit_type==='monitor' && (camp.purchase_start||camp.purchase_end))?`
           <div style="display:flex;border-top:1px solid #faf5f9">
             <div style="width:90px;padding:10px 14px;color:var(--dark-pink);font-weight:600;font-size:11px;background:#fdf5fb;flex-shrink:0">${t('detail.purchasePeriod')}</div>

--- a/dev/lib/storage.js
+++ b/dev/lib/storage.js
@@ -40,11 +40,39 @@ async function fetchCampaigns() {
     const data = await fetchAllPaged(() =>
       db.from('campaigns').select('*').order('order_index', {ascending: true, nullsFirst: false})
     );
-    if (data.length > 0) { await autoCloseCampaigns(data); return data; }
+    if (data.length > 0) {
+      await autoOpenCampaigns(data);   // scheduled → active (recruit_start 도래)
+      await autoCloseCampaigns(data);  // active → closed (deadline 경과)
+      return data;
+    }
     return DEMO_CAMPAIGNS.slice();
   } catch(e) {
     return DEMO_CAMPAIGNS.slice();
   }
+}
+
+// 모집 시작일 도래 캠페인 자동 활성화 (scheduled → active)
+//   recruit_start 가 오늘(JST 자정 기준) 이하이고 status='scheduled' 면 active 로 전환.
+//   deadline 이 이미 경과한 경우는 autoCloseCampaigns 가 이어서 닫음.
+async function autoOpenCampaigns(camps) {
+  if (!db) return camps;
+  const now = new Date();
+  now.setHours(0, 0, 0, 0);
+  const toOpen = camps.filter(c => {
+    if (c.status !== 'scheduled' || !c.recruit_start) return false;
+    const rs = new Date(c.recruit_start);
+    rs.setHours(0, 0, 0, 0);
+    return now >= rs;
+  });
+  if (!toOpen.length) return camps;
+  const results = await Promise.allSettled(toOpen.map(c => {
+    c.status = 'active';
+    return db.from('campaigns').update({ status: 'active' }).eq('id', c.id);
+  }));
+  results.forEach((r, i) => {
+    if (r.status === 'rejected') console.warn('autoOpenCampaigns 실패:', toOpen[i]?.id, r.reason);
+  });
+  return camps;
 }
 
 // 마감일 경과 캠페인 자동 상태 변경 (병렬 UPDATE)

--- a/index.html
+++ b/index.html
@@ -2610,11 +2610,39 @@ async function fetchCampaigns() {
     const data = await fetchAllPaged(() =>
       db.from('campaigns').select('*').order('order_index', {ascending: true, nullsFirst: false})
     );
-    if (data.length > 0) { await autoCloseCampaigns(data); return data; }
+    if (data.length > 0) {
+      await autoOpenCampaigns(data);   // scheduled → active (recruit_start 도래)
+      await autoCloseCampaigns(data);  // active → closed (deadline 경과)
+      return data;
+    }
     return DEMO_CAMPAIGNS.slice();
   } catch(e) {
     return DEMO_CAMPAIGNS.slice();
   }
+}
+
+// 모집 시작일 도래 캠페인 자동 활성화 (scheduled → active)
+//   recruit_start 가 오늘(JST 자정 기준) 이하이고 status='scheduled' 면 active 로 전환.
+//   deadline 이 이미 경과한 경우는 autoCloseCampaigns 가 이어서 닫음.
+async function autoOpenCampaigns(camps) {
+  if (!db) return camps;
+  const now = new Date();
+  now.setHours(0, 0, 0, 0);
+  const toOpen = camps.filter(c => {
+    if (c.status !== 'scheduled' || !c.recruit_start) return false;
+    const rs = new Date(c.recruit_start);
+    rs.setHours(0, 0, 0, 0);
+    return now >= rs;
+  });
+  if (!toOpen.length) return camps;
+  const results = await Promise.allSettled(toOpen.map(c => {
+    c.status = 'active';
+    return db.from('campaigns').update({ status: 'active' }).eq('id', c.id);
+  }));
+  results.forEach((r, i) => {
+    if (r.status === 'rejected') console.warn('autoOpenCampaigns 실패:', toOpen[i]?.id, r.reason);
+  });
+  return camps;
 }
 
 // 마감일 경과 캠페인 자동 상태 변경 (병렬 UPDATE)
@@ -5337,7 +5365,7 @@ async function openCampaign(id) {
           </div>`:''}
           <div style="display:flex;border-top:1px solid #faf5f9">
             <div style="width:90px;padding:10px 14px;color:var(--dark-pink);font-weight:600;font-size:11px;background:#fdf5fb;flex-shrink:0">${t('detail.recruitPeriod')}</div>
-            <div style="padding:10px 13px;flex:1;font-size:12px">${formatDate(new Date())} 〜 ${formatDate(camp.deadline)}</div>
+            <div style="padding:10px 13px;flex:1;font-size:12px">${formatDate(camp.recruit_start || new Date())} 〜 ${formatDate(camp.deadline)}</div>
           </div>
           <div style="display:flex;border-top:1px solid #faf5f9">
             <div style="width:90px;padding:10px 14px;color:var(--dark-pink);font-weight:600;font-size:11px;background:#fdf5fb;flex-shrink:0">${t('detail.recruitSlots')}</div>

--- a/index.html
+++ b/index.html
@@ -5347,10 +5347,6 @@ async function openCampaign(id) {
             <div style="width:90px;padding:10px 14px;color:var(--dark-pink);font-weight:600;font-size:11px;background:#fdf5fb;flex-shrink:0">${t('detail.winnerAnnounce')}</div>
             <div style="padding:10px 13px;flex:1;font-size:12px">${esc(camp.winner_announce || t('detail.winnerAnnounceValue'))}</div>
           </div>
-          <div style="display:flex;border-top:1px solid #faf5f9">
-            <div style="width:90px;padding:10px 14px;color:var(--dark-pink);font-weight:600;font-size:11px;background:#fdf5fb;flex-shrink:0">${t('detail.postDeadline')}</div>
-            <div style="padding:10px 13px;flex:1;font-size:12px;font-weight:600;color:var(--ink)">${camp.post_deadline ? formatDate(camp.post_deadline) : camp.post_days ? t('detail.postDeadlineRelative').replace('{days}',camp.post_days) : t('detail.noSetting')}</div>
-          </div>
           ${(camp.recruit_type==='monitor' && (camp.purchase_start||camp.purchase_end))?`
           <div style="display:flex;border-top:1px solid #faf5f9">
             <div style="width:90px;padding:10px 14px;color:var(--dark-pink);font-weight:600;font-size:11px;background:#fdf5fb;flex-shrink:0">${t('detail.purchasePeriod')}</div>

--- a/supabase/migrations/072_campaigns_recruit_start.sql
+++ b/supabase/migrations/072_campaigns_recruit_start.sql
@@ -1,0 +1,66 @@
+-- ============================================================
+-- 072_campaigns_recruit_start.sql
+-- 캠페인 모집 시작일 컬럼 추가 (모집 마감일 단일 → 모집 기간 확장)
+-- 작성일: 2026-04-27
+-- ============================================================
+-- 배경:
+--   기존 캠페인 폼은 "모집 마감일(deadline)" 단일 일자만 받았다.
+--   인플루언서 화면의 "募集期間" 표시는 "오늘 ~ deadline" 으로
+--   현재 시점을 시작일처럼 동적 계산했고, 명시적인 모집 시작일은
+--   DB에 저장되지 않았다.
+--
+--   운영 흐름상 캠페인을 미리 등록하고 며칠 뒤에 모집을 시작하는
+--   시나리오가 필요해서, 모집 시작일 컬럼을 추가한다.
+--
+-- 정책:
+--   recruit_start date NULL 추가 (NULL 허용)
+--   - NULL = 즉시 모집 (기존 동작과 동일하게 fallback 처리)
+--   - 신규 캠페인은 폼에서 명시적으로 입력
+--   deadline 의미는 변경 없음 (모집 종료일로 자연 보존)
+--   기존 캠페인 백필 안 함 — recruit_start NULL 그대로 두고 코드에서 fallback
+--
+-- 영향:
+--   - campaigns 테이블에 recruit_start date 컬럼 1개 추가
+--   - RLS 정책 영향 없음 (campaigns SELECT 공개·CUD 관리자 정책 그대로)
+--   - 트리거/함수 영향 없음
+--   - 인덱스 추가 안 함 (조회 빈도 낮음)
+--
+-- 클라이언트 측 후속 작업 (이 마이그레이션과 같은 PR에 포함):
+--   - 캠페인 폼: 모집 마감일 단일 input → flatpickr range picker (시작 ~ 종료)
+--   - autoOpenCampaigns(camps) 신규: status='scheduled' && recruit_start <= now → 'active'
+--   - validateCampDateRanges 경계: deadline ~ post_deadline → recruit_start ~ post_deadline
+--   - 인플루언서 募集期間 표시: recruit_start || new Date() ~ deadline
+--
+-- 롤백:
+--   ALTER TABLE public.campaigns DROP COLUMN IF EXISTS recruit_start;
+-- ============================================================
+
+BEGIN;
+
+ALTER TABLE public.campaigns
+  ADD COLUMN IF NOT EXISTS recruit_start date NULL;
+
+COMMENT ON COLUMN public.campaigns.recruit_start IS
+  '모집 시작일. NULL=즉시 모집 (인플루언서 화면에서 오늘부터로 표시 fallback). deadline(=모집 종료일)과 함께 모집 기간을 구성.';
+
+COMMIT;
+
+-- ============================================================
+-- 검증 쿼리 (실행 후)
+-- ============================================================
+-- [1] 컬럼 추가 확인
+-- SELECT column_name, data_type, is_nullable, column_default
+-- FROM information_schema.columns
+-- WHERE table_schema='public' AND table_name='campaigns' AND column_name='recruit_start';
+--
+-- [2] 기존 캠페인은 모두 NULL
+-- SELECT count(*) FILTER (WHERE recruit_start IS NULL) AS null_count,
+--        count(*) AS total
+-- FROM public.campaigns;
+--
+-- [3] 무결성 (recruit_start 입력된 캠페인은 deadline 이전이어야 함 — 폼 검증으로 보장)
+-- SELECT count(*) FROM public.campaigns
+-- WHERE recruit_start IS NOT NULL AND deadline IS NOT NULL
+--   AND recruit_start::date > deadline::date;
+-- 0 이어야 함
+-- ============================================================


### PR DESCRIPTION
## Summary

캠페인 등록·편집 폼 대규모 정비. 모집 일자를 단일 → "모집 기간(시작 ~ 종료)" 으로 확장 + flatpickr range picker 도입, 모든 일자 input의 검증 경계·라벨·UX를 운영 흐름에 맞춰 재정렬.

### 변경 (10 commits)

**migration 072** (운영 DB 적용 완료, 검증 통과)
- `campaigns.recruit_start date NULL` 추가. 기존 61건 NULL 유지, 무결성 0.

**모집 기간 확장 + range picker (3개 영역)**
- 모집·구매·방문 일자가 각각 flatpickr range picker(시작 ~ 종료 동시 선택, ko locale, static popup)로 통합
- 모집 종료일 입력 시 결과물 제출 마감일 +14일 자동 제안
- 모집 시작일 ≤ 오늘이면 캘린더 popup 하단에 빨간 인라인 경고 (caldenar 닫히지 않음)
- 자동 status 전환: `autoOpenCampaigns` (scheduled + recruit_start 도래 → active)
- 인플루언서 캠페인 상세 募集期間: `recruit_start || new Date() ~ deadline` fallback

**검증 경계 운영 흐름 정렬**
- 모집 시작 → 종료 → 결과물 제출 마감 → 캠페인 노출 마감 (위계)
- 구매·방문 기간: `recruit_start ~ submission_end || post_deadline` 범위. 캘린더에서 범위 밖 비활성
- 결과물 제출 마감일: max(recruit_start, purchase_end, visit_end) 이후 + post_deadline 이전
- 캠페인 노출 마감일: submission_end 이후 (없으면 deadline)
- 검증 메시지를 종류별 row 바로 아래 빨간 글씨로 분산 (이전엔 한 곳에 모임)

**라벨 통일 + 폼 재배치**
- "노출 마감일" → "캠페인 노출 마감일" (의미 명확화: 캠페인이 인플루언서 사이트에서 사라지는 시점)
- 인플루언서 캠페인 상세에서 post_deadline 행 자체 제거 (내부 운영용)
- 모집 타입·인원·카테고리를 모집 조건 → 기본 정보 섹션으로 이동
- 노출 마감일 ↔ 결과물 제출 마감일 row 순서 swap (운영 흐름 = 모집 종료 → 제출 → 노출 종료)
- 모집 기간 hint: "인플루언서를 모집하는 기간을 설정하세요"

**모집 타입별 콘텐츠 종류 옵션 제한**
- 리뷰어(monitor) 캠페인은 콘텐츠 종류를 동영상·이미지 2개로 제한 (Qoo10 리뷰 형식상)
- 기프팅·방문형은 6개 모두 표시 (피드/릴스/스토리/쇼츠/동영상/이미지)

**미리보기 정리**
- 관리자 캠페인 미리보기 모달의 `掲載期限` 행 제거 (인플루언서가 보는 화면과 일치)

### DB 변경 (운영 적용 완료)
- `supabase/migrations/072_campaigns_recruit_start.sql`
- 검증: recruit_start 컬럼 ✓, NULL 61/61 ✓, 무결성 0 ✓

[via reverb-planner] 6축 결정 (DB 설계/picker/자동 채우기/시작 트리거/검증 경계/기본값)
[via reverb-supabase-expert] PASS — ALTER fast-path safe, autoOpenCampaigns mirrors autoCloseCampaigns RLS handling
[via reverb-reviewer] 모든 commit PASS (function defs/call sites match, builds in sync, no stale refs)

## Test plan

- [x] 운영 Supabase migration 072 적용·검증 통과
- [x] dev에서 신규/편집 폼 range picker 정상 동작 확인
- [x] dev에서 검증 경계·인라인 경고 확인
- [ ] 운영 admin/#campaigns 신규 등록 → 모집 기간 캘린더 + 결과물 제출 마감일 자동 +14일
- [ ] 운영 admin 캠페인 편집 → 기존 NULL recruit_start 캠페인은 종료일만 표시, 시작일 입력 가능
- [ ] 운영 인플루언서 캠페인 상세 → 募集期間 표시 (NULL 캠페인은 "오늘 ~ 마감", 입력된 캠페인은 시작일)
- [ ] 운영 monitor 캠페인 신규 등록 → 콘텐츠 종류 동영상·이미지만 표시
- [ ] 운영 리뷰어 → 기프팅 토글 → 콘텐츠 종류 6개로 다시 늘어남

🤖 Generated with [Claude Code](https://claude.com/claude-code)