### PR TITLE
Deploy 2026-05-04: brand-survey list overhaul + sidebar polish + multi-filter UX

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -12370,14 +12370,16 @@ function renderBrandApplicationsList() {
         + '<div style="font-size:11px;color:var(--muted);margin-top:2px;font-variant-numeric:tabular-nums">¥ ' + (Number(a.total_jpy) || 0).toLocaleString('ja-JP') + '</div>'
       : '<span style="color:var(--muted)">—</span>';
     var qLocked = (a.status === 'done' || a.status === 'rejected');
-    var quoteSent = '<label class="brand-app-qsent" data-id="' + esc(a.id) + '" style="display:inline-flex;align-items:center;gap:6px;font-size:11px;cursor:' + (qLocked ? 'not-allowed' : 'pointer') + ';color:' + (a.quote_sent_at ? '#16a34a' : 'var(--muted)') + ';font-weight:' + (a.quote_sent_at ? '600' : '400') + '" onclick="event.stopPropagation()">'
-      + '<input type="checkbox" ' + (a.quote_sent_at ? 'checked' : '') + ' ' + (qLocked ? 'disabled' : '') + ' onchange="toggleBrandAppQuoteSent(\'' + esc(a.id) + '\', this)" style="cursor:' + (qLocked ? 'not-allowed' : 'pointer') + '">'
-      + '<span class="qsent-label">' + (a.quote_sent_at ? '전달 ' + fmtDate(a.quote_sent_at) : '미전달') + '</span>'
-    + '</label>';
+    var qDateValue = a.quote_sent_at ? new Date(a.quote_sent_at).toISOString().slice(0,10) : '';
+    var quoteSent = '<div class="brand-app-qsent" data-id="' + esc(a.id) + '" style="display:flex;flex-direction:column;gap:3px;font-size:11px">'
+      + '<label style="display:inline-flex;align-items:center;gap:5px;cursor:' + (qLocked ? 'not-allowed' : 'pointer') + ';color:' + (a.quote_sent_at ? '#16a34a' : 'var(--muted)') + ';font-weight:' + (a.quote_sent_at ? '600' : '400') + '">'
+        + '<input type="checkbox" ' + (a.quote_sent_at ? 'checked' : '') + ' ' + (qLocked ? 'disabled' : '') + ' onchange="toggleBrandAppQuoteSent(\'' + esc(a.id) + '\', this)" style="cursor:' + (qLocked ? 'not-allowed' : 'pointer') + '">'
+        + '<span class="qsent-label">' + (a.quote_sent_at ? '전달' : '미전달') + '</span>'
+      + '</label>'
+      + '<input type="date" class="qsent-date" value="' + qDateValue + '" ' + (a.quote_sent_at && !qLocked ? '' : 'disabled') + ' onchange="updateBrandAppQuoteSentDate(\'' + esc(a.id) + '\', this)" style="font-size:11px;padding:2px 4px;border:1px solid var(--line);border-radius:4px;width:100%;background:' + (a.quote_sent_at && !qLocked ? '#fff' : '#F5F5F5') + '">'
+    + '</div>';
     var memoText = (a.admin_memo || '').trim();
-    var memoCell = memoText
-      ? '<div style="font-size:11px;color:var(--ink);display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;overflow:hidden;line-height:1.4" title="' + esc(memoText) + '">' + esc(memoText) + '</div>'
-      : '<span style="color:var(--muted)">—</span>';
+    var memoCell = '<textarea class="brand-app-memo" data-id="' + esc(a.id) + '" data-original="' + esc(memoText) + '" ' + (qLocked ? 'disabled' : '') + ' onblur="saveBrandAppMemo(\'' + esc(a.id) + '\', this)" placeholder="메모 입력…" style="width:100%;min-height:42px;max-height:80px;font-size:11px;line-height:1.4;padding:4px 6px;border:1px solid var(--line);border-radius:4px;resize:vertical;font-family:inherit;color:var(--ink);background:' + (qLocked ? '#F5F5F5' : '#fff') + '">' + esc(memoText) + '</textarea>';
     return '<tr data-id="' + esc(a.id) + '">'
       + '<td>'
         + '<div style="font-size:11px;font-weight:600;color:var(--ink)">' + esc(a.application_no || '—') + '</div>'
@@ -12616,11 +12618,32 @@ function closeBrandAppDetail() {
   window._brandAppCurrent = null;
 }
 
+function _findBrandApp(id) {
+  var idx = (_brandApps || []).findIndex(function(a){ return a.id === id; });
+  return idx < 0 ? null : _brandApps[idx];
+}
+
+function _refreshQuoteSentCellUI(wrapEl, isoOrNull) {
+  if (!wrapEl) return;
+  var label = wrapEl.querySelector('.qsent-label');
+  var labelWrap = label?.parentElement;
+  var dateInput = wrapEl.querySelector('.qsent-date');
+  if (label) label.textContent = isoOrNull ? '전달' : '미전달';
+  if (labelWrap) {
+    labelWrap.style.color = isoOrNull ? '#16a34a' : 'var(--muted)';
+    labelWrap.style.fontWeight = isoOrNull ? '600' : '400';
+  }
+  if (dateInput) {
+    dateInput.value = isoOrNull ? new Date(isoOrNull).toISOString().slice(0,10) : '';
+    dateInput.disabled = !isoOrNull;
+    dateInput.style.background = isoOrNull ? '#fff' : '#F5F5F5';
+  }
+}
+
 async function toggleBrandAppQuoteSent(id, checkboxEl) {
   if (!currentAdminInfo) { toast('권한이 없습니다','error'); checkboxEl.checked = !checkboxEl.checked; return; }
-  var idx = (_brandApps || []).findIndex(function(a){ return a.id === id; });
-  if (idx < 0) return;
-  var cur = _brandApps[idx];
+  var cur = _findBrandApp(id);
+  if (!cur) return;
   if (cur.status === 'done' || cur.status === 'rejected') {
     checkboxEl.checked = !!cur.quote_sent_at;
     toast('완료/거절된 신청은 변경할 수 없습니다.', 'warn');
@@ -12629,13 +12652,8 @@ async function toggleBrandAppQuoteSent(id, checkboxEl) {
   var prevValue = cur.quote_sent_at;
   var prevVersion = cur.version;
   var nextValue = checkboxEl.checked ? new Date().toISOString() : null;
-  var labelEl = checkboxEl.parentElement?.querySelector('.qsent-label');
-  // 낙관적 UI 갱신
-  if (labelEl) labelEl.textContent = nextValue ? ('전달 ' + fmtDate(nextValue)) : '미전달';
-  if (checkboxEl.parentElement) {
-    checkboxEl.parentElement.style.color = nextValue ? '#16a34a' : 'var(--muted)';
-    checkboxEl.parentElement.style.fontWeight = nextValue ? '600' : '400';
-  }
+  var wrap = checkboxEl.closest('.brand-app-qsent');
+  _refreshQuoteSentCellUI(wrap, nextValue);
   checkboxEl.disabled = true;
   var result = await updateBrandApplication(id, {quote_sent_at: nextValue}, prevVersion);
   checkboxEl.disabled = false;
@@ -12645,19 +12663,84 @@ async function toggleBrandAppQuoteSent(id, checkboxEl) {
     return;
   }
   if (!result.ok) {
-    // 원복
     checkboxEl.checked = !checkboxEl.checked;
-    if (labelEl) labelEl.textContent = prevValue ? ('전달 ' + fmtDate(prevValue)) : '미전달';
-    if (checkboxEl.parentElement) {
-      checkboxEl.parentElement.style.color = prevValue ? '#16a34a' : 'var(--muted)';
-      checkboxEl.parentElement.style.fontWeight = prevValue ? '600' : '400';
-    }
+    _refreshQuoteSentCellUI(wrap, prevValue);
     toast('저장 실패: ' + (result.error || '알 수 없는 오류'), 'error');
     return;
   }
-  // 메모리 갱신
   cur.quote_sent_at = nextValue;
   cur.version = result.data?.version || (prevVersion + 1);
+}
+
+async function updateBrandAppQuoteSentDate(id, dateInput) {
+  if (!currentAdminInfo) { toast('권한이 없습니다','error'); return; }
+  var cur = _findBrandApp(id);
+  if (!cur) return;
+  if (cur.status === 'done' || cur.status === 'rejected') {
+    toast('완료/거절된 신청은 변경할 수 없습니다.', 'warn');
+    dateInput.value = cur.quote_sent_at ? new Date(cur.quote_sent_at).toISOString().slice(0,10) : '';
+    return;
+  }
+  var raw = dateInput.value;
+  if (!raw) {
+    // 날짜를 비우면 견적서 전달 자체를 해제로 간주
+    var wrap = dateInput.closest('.brand-app-qsent');
+    var cb = wrap?.querySelector('input[type="checkbox"]');
+    if (cb) { cb.checked = false; await toggleBrandAppQuoteSent(id, cb); }
+    return;
+  }
+  var prevValue = cur.quote_sent_at;
+  var prevVersion = cur.version;
+  // 입력값(YYYY-MM-DD)을 JST 정오로 저장(타임존 경계 안전)
+  var nextValue = new Date(raw + 'T12:00:00+09:00').toISOString();
+  if (prevValue && new Date(prevValue).toISOString().slice(0,10) === raw) return; // 변동 없음
+  dateInput.disabled = true;
+  var result = await updateBrandApplication(id, {quote_sent_at: nextValue}, prevVersion);
+  dateInput.disabled = false;
+  if (result.conflict) {
+    toast('다른 관리자가 먼저 저장했습니다. 다시 불러옵니다.', 'warn');
+    await loadBrandApplications();
+    return;
+  }
+  if (!result.ok) {
+    dateInput.value = prevValue ? new Date(prevValue).toISOString().slice(0,10) : '';
+    toast('저장 실패: ' + (result.error || '알 수 없는 오류'), 'error');
+    return;
+  }
+  cur.quote_sent_at = nextValue;
+  cur.version = result.data?.version || (prevVersion + 1);
+  toast('전달일이 저장되었습니다.');
+}
+
+async function saveBrandAppMemo(id, textareaEl) {
+  if (!currentAdminInfo) return;
+  var cur = _findBrandApp(id);
+  if (!cur) return;
+  if (cur.status === 'done' || cur.status === 'rejected') {
+    textareaEl.value = cur.admin_memo || '';
+    return;
+  }
+  var nextValue = (textareaEl.value || '').trim();
+  var prevValue = (cur.admin_memo || '').trim();
+  if (nextValue === prevValue) return; // 변동 없음
+  var prevVersion = cur.version;
+  textareaEl.disabled = true;
+  var result = await updateBrandApplication(id, {admin_memo: nextValue || null}, prevVersion);
+  textareaEl.disabled = false;
+  if (result.conflict) {
+    toast('다른 관리자가 먼저 저장했습니다. 다시 불러옵니다.', 'warn');
+    await loadBrandApplications();
+    return;
+  }
+  if (!result.ok) {
+    textareaEl.value = prevValue;
+    toast('저장 실패: ' + (result.error || '알 수 없는 오류'), 'error');
+    return;
+  }
+  cur.admin_memo = nextValue || null;
+  cur.version = result.data?.version || (prevVersion + 1);
+  textareaEl.dataset.original = nextValue;
+  toast('메모가 저장되었습니다.');
 }
 
 async function saveBrandAppChanges(expectedVersion) {

--- a/admin/index.html
+++ b/admin/index.html
@@ -406,7 +406,7 @@ textarea.form-input{resize:vertical;min-height:80px}
 .admin-pane-list .data-table th{position:sticky;top:0;z-index:5;background:var(--surface-dim)}
 /* 브랜드 서베이 페인: 좌우 스크롤 + 첫 두 컬럼 sticky-left */
 #adminPane-brand-applications .admin-table-wrap{overflow-x:auto}
-#adminPane-brand-applications .data-table{min-width:2280px}
+#adminPane-brand-applications .data-table{min-width:3040px}
 /* sticky-left 두 컬럼 폭 강제 (auto 폭이라 left 값과 어긋나서 사이에 갭 생기는 문제 방지) */
 #adminPane-brand-applications .data-table th:nth-child(1),
 #adminPane-brand-applications .data-table td:nth-child(1){width:180px;min-width:180px;max-width:180px;box-sizing:border-box}
@@ -2237,7 +2237,14 @@ textarea.form-input{resize:vertical;min-height:80px}
                 <th style="width:130px">연락처</th>
                 <th style="width:180px">계산서 이메일</th>
                 <th style="width:220px">요청사항</th>
-                <th style="width:180px">제품 요약</th>
+                <th style="width:80px">진행 수량</th>
+                <th style="width:100px">상품 가격(엔)</th>
+                <th style="width:100px">상품 가격(원)</th>
+                <th style="width:130px">상품 최종 금액</th>
+                <th style="width:120px">이체수수료(건)</th>
+                <th style="width:130px">이체수수료(원)</th>
+                <th style="width:130px">최종 견적 금액</th>
+                <th style="width:130px">VAT포함</th>
                 <th style="width:120px">예상 견적 <span class="sort-arrows" data-sort="estimated" onclick="toggleBrandAppSort('estimated')">▲▼</span></th>
                 <th style="width:120px">확정 견적</th>
                 <th style="width:130px">견적서 전달</th>
@@ -2247,7 +2254,7 @@ textarea.form-input{resize:vertical;min-height:80px}
                 <th style="width:110px">신청일 <span class="sort-arrows" data-sort="created" onclick="toggleBrandAppSort('created')">▲▼</span></th>
                 <th style="width:80px">처리</th>
               </tr></thead>
-              <tbody id="brandAppTableBody"><tr><td colspan="15" style="text-align:center;color:var(--muted);padding:24px"><span class="spinner" style="width:20px;height:20px;border-width:2px;border-color:rgba(200,120,163,.2);border-top-color:var(--pink)"></span></td></tr></tbody>
+              <tbody id="brandAppTableBody"><tr><td colspan="22" style="text-align:center;color:var(--muted);padding:24px"><span class="spinner" style="width:20px;height:20px;border-width:2px;border-color:rgba(200,120,163,.2);border-top-color:var(--pink)"></span></td></tr></tbody>
             </table>
             </div>
           </div>
@@ -12284,7 +12291,7 @@ function renderBrandLongPending(apps) {
 
 async function loadBrandApplications() {
   var tbody = $('brandAppTableBody');
-  if (tbody) tbody.innerHTML = '<tr><td colspan="15" style="text-align:center;color:var(--muted);padding:24px"><span class="spinner" style="width:20px;height:20px;border-width:2px;border-color:rgba(200,120,163,.2);border-top-color:var(--pink)"></span></td></tr>';
+  if (tbody) tbody.innerHTML = '<tr><td colspan="22" style="text-align:center;color:var(--muted);padding:24px"><span class="spinner" style="width:20px;height:20px;border-width:2px;border-color:rgba(200,120,163,.2);border-top-color:var(--pink)"></span></td></tr>';
   _brandApps = await fetchBrandApplications();
   renderBrandApplicationsList();
   refreshBrandAppBadge();
@@ -12364,38 +12371,12 @@ function renderBrandApplicationsList() {
   }
 
   var renderBrandAppRow = function(a) {
-    var prodCount = Array.isArray(a.products) ? a.products.length : 0;
-    var prodSummary = prodCount > 0
-      ? esc(prodCount + '종 · ' + (Number(a.total_qty) || 0) + '개')
-        + '<div style="font-size:11px;color:var(--muted);margin-top:2px;font-variant-numeric:tabular-nums">¥ ' + (Number(a.total_jpy) || 0).toLocaleString('ja-JP') + '</div>'
-      : '<span style="color:var(--muted)">—</span>';
-    var qLocked = false; // 잠금 해제 — done/rejected 상태도 인라인 편집 허용 (사용자 요청)
-    var quoteSent = '<div class="brand-app-qsent-cell" data-id="' + esc(a.id) + '" style="position:relative;min-height:36px">' + renderQuoteSentDisplay(a.quote_sent_at, qLocked) + '</div>';
-    var memoText = (a.admin_memo || '').trim();
-    var memoCell = '<div class="brand-app-memo-cell" data-id="' + esc(a.id) + '" style="position:relative;min-height:36px">' + renderMemoDisplay(memoText, qLocked) + '</div>';
-    return '<tr data-id="' + esc(a.id) + '">'
-      + '<td>'
-        + '<div style="font-size:11px;font-weight:600;color:var(--ink)">' + esc(a.application_no || '—') + '</div>'
-        + '<div style="margin-top:3px"><span style="background:#F0F0F0;color:#555;font-size:10px;font-weight:600;padding:2px 7px;border-radius:3px">' + esc(brandAppFormLabel(a.form_type)) + '</span></div>'
-      + '</td>'
-      + '<td style="font-weight:600">' + esc(a.brand_name || '—') + '</td>'
-      + '<td>'
-        + '<div>' + esc(a.contact_name || '—') + '</div>'
-        + (a.email ? '<div style="font-size:11px;color:var(--muted);margin-top:2px;word-break:break-all">' + esc(a.email) + '</div>' : '')
-      + '</td>'
-      + '<td style="font-size:12px">' + esc(formatPhoneDisplay(a.phone) || '—') + '</td>'
-      + '<td style="font-size:12px;color:' + (a.billing_email ? 'var(--ink)' : 'var(--muted)') + ';word-break:break-all">' + esc(a.billing_email || '—') + '</td>'
-      + '<td>' + brandAppNoteCell(a.request_note) + '</td>'
-      + '<td style="font-size:12px">' + prodSummary + '</td>'
-      + '<td style="text-align:right;font-variant-numeric:tabular-nums">' + fmtKrw(a.estimated_krw) + '</td>'
-      + '<td><div class="brand-app-fq-cell" data-id="' + esc(a.id) + '" style="position:relative;min-height:24px">' + renderFinalQuoteDisplay(a.final_quote_krw) + '</div></td>'
-      + '<td>' + quoteSent + '</td>'
-      + '<td>' + memoCell + '</td>'
-      + '<td>' + brandAppStatusSelect(a) + '</td>'
-      + '<td style="font-size:11px;color:var(--muted)">' + fmtDate(a.reviewed_at) + '</td>'
-      + '<td style="font-size:11px;color:var(--muted)">' + fmtDate(a.created_at) + '</td>'
-      + '<td><button class="btn btn-ghost btn-xs" onclick="openBrandAppDetail(\'' + esc(a.id) + '\')">상세</button></td>'
-      + '</tr>';
+    var prods = (Array.isArray(a.products) && a.products.length > 0)
+      ? a.products
+      : [{ name: '', qty: 0, price: 0, transfer_fee_krw: null }];
+    return prods.map(function(p, idx) {
+      return renderBrandAppProductRow(a, p, idx, prods.length);
+    }).join('');
   };
   if (brandAppLazy) brandAppLazy.destroy();
   brandAppLazy = mountLazyList({
@@ -12404,7 +12385,7 @@ function renderBrandApplicationsList() {
     rows: list,
     renderRow: renderBrandAppRow,
     pageSize: BRAND_APP_PAGE_SIZE,
-    emptyHtml: '<tr><td colspan="15" style="text-align:center;color:var(--muted);padding:40px">신청 내역이 없습니다</td></tr>',
+    emptyHtml: '<tr><td colspan="22" style="text-align:center;color:var(--muted);padding:40px">신청 내역이 없습니다</td></tr>',
   });
 }
 
@@ -12614,6 +12595,176 @@ function closeBrandAppDetail() {
 function _findBrandApp(id) {
   var idx = (_brandApps || []).findIndex(function(a){ return a.id === id; });
   return idx < 0 ? null : _brandApps[idx];
+}
+
+// 환율·VAT 상수 (FX_JPY_KRW=10, VAT_RATE=10% — migration 052 트리거와 일치)
+var BRAND_QUOTE_CONST = { FX_JPY_KRW: 10, VAT_RATE: 0.1 };
+
+// 신청 1건의 제품 1개를 1행으로 렌더 (총 22컬럼)
+function renderBrandAppProductRow(a, p, idx, total) {
+  var isFirst = (idx === 0);
+  var qty = Number(p.qty) || 0;
+  var priceJpy = Number(p.price) || 0;
+  var priceKrw = priceJpy * BRAND_QUOTE_CONST.FX_JPY_KRW;
+  var lineTotal = qty * priceKrw;
+  var transferFeeKrw = (p.transfer_fee_krw == null || p.transfer_fee_krw === '') ? null : Number(p.transfer_fee_krw);
+  var feeTotalKrw = transferFeeKrw == null ? 0 : qty * transferFeeKrw;
+  var finalKrw = lineTotal + feeTotalKrw;
+  var vatKrw = Math.floor(finalKrw * (1 + BRAND_QUOTE_CONST.VAT_RATE));
+
+  // 같은 신청 그룹 시각화 — 첫 행에 강조 top border, 마지막 행은 default
+  var trStyle = isFirst ? 'border-top:2px solid rgba(200,120,163,.25)' : '';
+
+  // 신청 단위 셀 (첫 행에만 채움, 나머지는 빈 td)
+  var cellApp = function(html, style) {
+    return '<td' + (style ? ' style="' + style + '"' : '') + '>' + (isFirst ? html : '') + '</td>';
+  };
+
+  var qLocked = false;
+  var memoText = (a.admin_memo || '').trim();
+  var memoCellInner = isFirst ? '<div class="brand-app-memo-cell" data-id="' + esc(a.id) + '" style="position:relative;min-height:36px">' + renderMemoDisplay(memoText, qLocked) + '</div>' : '';
+  var quoteSentInner = isFirst ? '<div class="brand-app-qsent-cell" data-id="' + esc(a.id) + '" style="position:relative;min-height:36px">' + renderQuoteSentDisplay(a.quote_sent_at, qLocked) + '</div>' : '';
+  var fqInner = isFirst ? '<div class="brand-app-fq-cell" data-id="' + esc(a.id) + '" style="position:relative;min-height:24px">' + renderFinalQuoteDisplay(a.final_quote_krw) + '</div>' : '';
+
+  return '<tr data-id="' + esc(a.id) + '" data-product-idx="' + idx + '"' + (trStyle ? ' style="' + trStyle + '"' : '') + '>'
+    // 1. 신청번호
+    + cellApp(
+        '<div style="font-size:11px;font-weight:600;color:var(--ink)">' + esc(a.application_no || '—') + '</div>'
+        + '<div style="margin-top:3px"><span style="background:#F0F0F0;color:#555;font-size:10px;font-weight:600;padding:2px 7px;border-radius:3px">' + esc(brandAppFormLabel(a.form_type)) + '</span></div>'
+      )
+    // 2. 브랜드
+    + cellApp(esc(a.brand_name || '—'), 'font-weight:600')
+    // 3. 담당자
+    + cellApp(
+        '<div>' + esc(a.contact_name || '—') + '</div>'
+        + (a.email ? '<div style="font-size:11px;color:var(--muted);margin-top:2px;word-break:break-all">' + esc(a.email) + '</div>' : '')
+      )
+    // 4. 연락처
+    + cellApp(esc(formatPhoneDisplay(a.phone) || '—'), 'font-size:12px')
+    // 5. 계산서 이메일
+    + cellApp(esc(a.billing_email || '—'), 'font-size:12px;color:' + (a.billing_email ? 'var(--ink)' : 'var(--muted)') + ';word-break:break-all')
+    // 6. 요청사항
+    + cellApp(brandAppNoteCell(a.request_note))
+    // 7-14. 제품별 8컬럼 (모든 행에 표시)
+    + '<td style="text-align:right;font-variant-numeric:tabular-nums;font-size:12px">' + (qty > 0 ? qty.toLocaleString('ja-JP') : '<span style="color:var(--muted)">—</span>') + '</td>'
+    + '<td style="text-align:right;font-variant-numeric:tabular-nums;font-size:12px">' + (priceJpy > 0 ? '¥ ' + priceJpy.toLocaleString('ja-JP') : '<span style="color:var(--muted)">—</span>') + '</td>'
+    + '<td style="text-align:right;font-variant-numeric:tabular-nums;font-size:12px">' + (priceKrw > 0 ? fmtKrw(priceKrw) : '<span style="color:var(--muted)">—</span>') + '</td>'
+    + '<td style="text-align:right;font-variant-numeric:tabular-nums;font-size:12px;font-weight:600">' + (lineTotal > 0 ? fmtKrw(lineTotal) : '<span style="color:var(--muted)">—</span>') + '</td>'
+    + '<td><div class="brand-app-tfee-cell" data-id="' + esc(a.id) + '" data-product-idx="' + idx + '" style="position:relative;min-height:24px">' + renderTransferFeeDisplay(transferFeeKrw) + '</div></td>'
+    + '<td style="text-align:right;font-variant-numeric:tabular-nums;font-size:12px">' + (feeTotalKrw > 0 ? fmtKrw(feeTotalKrw) : '<span style="color:var(--muted)">—</span>') + '</td>'
+    + '<td style="text-align:right;font-variant-numeric:tabular-nums;font-size:12px;font-weight:600">' + (finalKrw > 0 ? fmtKrw(finalKrw) : '<span style="color:var(--muted)">—</span>') + '</td>'
+    + '<td style="text-align:right;font-variant-numeric:tabular-nums;font-size:12px;color:#16a34a;font-weight:600">' + (vatKrw > 0 ? fmtKrw(vatKrw) : '<span style="color:var(--muted)">—</span>') + '</td>'
+    // 15. 예상 견적
+    + cellApp(fmtKrw(a.estimated_krw), 'text-align:right;font-variant-numeric:tabular-nums')
+    // 16. 확정 견적
+    + '<td>' + fqInner + '</td>'
+    // 17. 견적서 전달
+    + '<td>' + quoteSentInner + '</td>'
+    // 18. 내부 메모
+    + '<td>' + memoCellInner + '</td>'
+    // 19. 상태
+    + cellApp(brandAppStatusSelect(a))
+    // 20. 검수일
+    + cellApp(fmtDate(a.reviewed_at), 'font-size:11px;color:var(--muted)')
+    // 21. 신청일
+    + cellApp(fmtDate(a.created_at), 'font-size:11px;color:var(--muted)')
+    // 22. 처리
+    + cellApp('<button class="btn btn-ghost btn-xs" onclick="openBrandAppDetail(\'' + esc(a.id) + '\')">상세</button>')
+    + '</tr>';
+}
+
+// 이체수수료(건) 셀 — display + ✎ 인라인 편집
+function renderTransferFeeDisplay(value) {
+  var hasValue = value != null && isFinite(value);
+  var display = hasValue ? fmtKrw(value) : '<span style="color:var(--muted)">—</span>';
+  return '<div class="tfee-display" style="text-align:right;font-variant-numeric:tabular-nums;font-size:12px;padding-right:22px">' + display + '</div>'
+    + '<button type="button" class="tfee-edit-btn" onclick="enterTransferFeeEdit(this)" title="이체수수료(건) 수정" style="position:absolute;top:0;right:0;background:none;border:none;cursor:pointer;padding:2px;color:var(--muted);display:flex;align-items:center;justify-content:center;border-radius:3px" onmouseover="this.style.background=\'rgba(0,0,0,.05)\'" onmouseout="this.style.background=\'none\'"><span class="material-icons-round notranslate" translate="no" style="font-size:15px">edit</span></button>';
+}
+
+function _restoreTransferFeeDisplay(cell, value) {
+  cell.innerHTML = renderTransferFeeDisplay(value);
+}
+
+function enterTransferFeeEdit(btnEl) {
+  var cell = btnEl.closest('.brand-app-tfee-cell');
+  if (!cell) return;
+  var id = cell.dataset.id;
+  var idx = Number(cell.dataset.productIdx);
+  var cur = _findBrandApp(id);
+  if (!cur || !Array.isArray(cur.products) || !cur.products[idx]) return;
+  var p = cur.products[idx];
+  var original = (p.transfer_fee_krw == null || p.transfer_fee_krw === '') ? '' : String(p.transfer_fee_krw);
+  cell.innerHTML = '<div style="display:flex;flex-direction:column;gap:4px">'
+    + '<input type="number" class="tfee-edit-input" value="' + esc(original) + '" placeholder="0" min="0" step="1" onkeydown="handleTransferFeeEditKey(event, this)" style="width:100%;font-size:11px;padding:3px 6px;border:1px solid var(--pink);border-radius:4px;text-align:right;font-variant-numeric:tabular-nums">'
+    + '<div style="display:flex;gap:4px;justify-content:flex-end">'
+      + '<button type="button" onclick="cancelTransferFeeEdit(this)" style="background:#fff;border:1px solid var(--line);border-radius:4px;padding:3px 8px;cursor:pointer;font-size:11px;color:var(--muted)">취소</button>'
+      + '<button type="button" onclick="confirmTransferFeeEdit(this)" style="background:var(--pink);color:#fff;border:none;border-radius:4px;padding:3px 10px;cursor:pointer;font-size:11px;font-weight:600">저장</button>'
+    + '</div>'
+  + '</div>';
+  var input = cell.querySelector('.tfee-edit-input');
+  if (input) { input.focus(); input.select(); }
+}
+
+function handleTransferFeeEditKey(ev, inputEl) {
+  if (ev.key === 'Escape') { ev.preventDefault(); cancelTransferFeeEdit(inputEl); }
+  else if (ev.key === 'Enter') { ev.preventDefault(); confirmTransferFeeEdit(inputEl); }
+}
+
+function cancelTransferFeeEdit(anyChildEl) {
+  var cell = anyChildEl.closest('.brand-app-tfee-cell');
+  if (!cell) return;
+  var id = cell.dataset.id;
+  var idx = Number(cell.dataset.productIdx);
+  var cur = _findBrandApp(id);
+  if (!cur || !cur.products || !cur.products[idx]) return;
+  _restoreTransferFeeDisplay(cell, cur.products[idx].transfer_fee_krw);
+}
+
+async function confirmTransferFeeEdit(anyChildEl) {
+  var cell = anyChildEl.closest('.brand-app-tfee-cell');
+  if (!cell) return;
+  var input = cell.querySelector('.tfee-edit-input');
+  if (!input) return;
+  var id = cell.dataset.id;
+  var idx = Number(cell.dataset.productIdx);
+  var cur = _findBrandApp(id);
+  if (!cur || !Array.isArray(cur.products) || !cur.products[idx]) return;
+  var raw = (input.value || '').trim();
+  var nextValue = raw === '' ? null : Number(raw);
+  if (nextValue !== null && (!isFinite(nextValue) || nextValue < 0)) {
+    toast('0 이상의 숫자만 입력하세요.', 'warn');
+    return;
+  }
+  var prevValue = cur.products[idx].transfer_fee_krw == null ? null : Number(cur.products[idx].transfer_fee_krw);
+  if (prevValue === nextValue) {
+    _restoreTransferFeeDisplay(cell, prevValue);
+    return;
+  }
+  // 새 products 배열 생성 (immutable patch)
+  var nextProducts = cur.products.map(function(prod, i) {
+    if (i !== idx) return prod;
+    var copy = Object.assign({}, prod);
+    if (nextValue == null) delete copy.transfer_fee_krw; else copy.transfer_fee_krw = nextValue;
+    return copy;
+  });
+  var prevVersion = cur.version;
+  input.disabled = true;
+  var result = await updateBrandApplication(id, {products: nextProducts}, prevVersion);
+  input.disabled = false;
+  if (result.conflict) {
+    toast('다른 관리자가 먼저 저장했습니다. 다시 불러옵니다.', 'warn');
+    await loadBrandApplications();
+    return;
+  }
+  if (!result.ok) {
+    toast('저장 실패: ' + (result.error || '알 수 없는 오류'), 'error');
+    return;
+  }
+  cur.products = nextProducts;
+  cur.version = result.data?.version || (prevVersion + 1);
+  // 같은 신청의 모든 행 재렌더(이체수수료(원)/최종 견적/VAT포함 컬럼이 동기화됨)
+  renderBrandApplicationsList();
+  toast('이체수수료가 저장되었습니다.');
 }
 
 function renderFinalQuoteDisplay(value) {

--- a/admin/index.html
+++ b/admin/index.html
@@ -12372,13 +12372,16 @@ function renderBrandApplicationsList() {
       : '(' + summary + ')';
   }
 
+  // 요약 행만 렌더 (펼치기는 토글로 동적 추가)
   var renderBrandAppRow = function(a) {
-    var prods = (Array.isArray(a.products) && a.products.length > 0)
-      ? a.products
-      : [{ name: '', qty: 0, price: 0, transfer_fee_krw: null }];
-    return prods.map(function(p, idx) {
-      return renderBrandAppProductRow(a, p, idx, prods.length);
-    }).join('');
+    var html = renderBrandAppSummaryRow(a);
+    if (_brandAppExpanded.has(a.id)) {
+      var prods = Array.isArray(a.products) ? a.products : [];
+      html += prods.map(function(p, idx) {
+        return renderBrandAppDetailRow(a, p, idx);
+      }).join('');
+    }
+    return html;
   };
   if (brandAppLazy) brandAppLazy.destroy();
   brandAppLazy = mountLazyList({
@@ -12622,9 +12625,121 @@ function renderProductUrlCell(url) {
   + '</div>';
 }
 
-// 신청 1건의 제품 1개를 1행으로 렌더 (총 22컬럼)
-function renderBrandAppProductRow(a, p, idx, total) {
-  var isFirst = (idx === 0);
+// 펼친 신청 ID 집합 (메모리 — 새로고침 시 초기화)
+var _brandAppExpanded = new Set();
+
+// 모든 제품에서 동일한 값이면 그 값, 다르면 null
+function _uniformProductValue(prods, key) {
+  if (!Array.isArray(prods) || prods.length === 0) return null;
+  var first = prods[0] && prods[0][key];
+  for (var i = 1; i < prods.length; i++) {
+    if (prods[i] && prods[i][key] !== first) return null;
+  }
+  return first;
+}
+
+// 신청 1건 = 1행 (요약 행, 24컬럼). 합산 가능 컬럼은 SUM, 단가는 동일하면 그 값/다르면 "—"
+function renderBrandAppSummaryRow(a) {
+  var prods = Array.isArray(a.products) ? a.products : [];
+  var totalQty = prods.reduce(function(s, p){ return s + (Number(p.qty) || 0); }, 0);
+  var totalLine = prods.reduce(function(s, p){ return s + (Number(p.qty) || 0) * (Number(p.price) || 0) * BRAND_QUOTE_CONST.FX_JPY_KRW; }, 0);
+  var totalFee = prods.reduce(function(s, p){
+    var fee = (p.transfer_fee_krw == null || p.transfer_fee_krw === '') ? 0 : Number(p.transfer_fee_krw);
+    return s + (Number(p.qty) || 0) * fee;
+  }, 0);
+  var totalFinal = totalLine + totalFee;
+  var totalVat = Math.floor(totalFinal * (1 + BRAND_QUOTE_CONST.VAT_RATE));
+  // 단가 — 모든 제품 동일하면 그 값, 다르면 표시 안 함
+  var uPriceJpy = _uniformProductValue(prods, 'price');
+  var uTfee = _uniformProductValue(prods, 'transfer_fee_krw');
+  var uPriceKrw = (uPriceJpy != null && uPriceJpy !== '') ? Number(uPriceJpy) * BRAND_QUOTE_CONST.FX_JPY_KRW : null;
+
+  var dash = '<span style="color:var(--muted)">—</span>';
+  var multi = '<span style="color:var(--muted);font-size:10px">제품별 상이</span>';
+  var renderUnit = function(uniformVal, formatter) {
+    if (prods.length <= 1) {
+      return uniformVal != null && uniformVal !== '' ? formatter(uniformVal) : dash;
+    }
+    return uniformVal != null && uniformVal !== '' ? formatter(uniformVal) : multi;
+  };
+
+  // 펼치기 토글 (제품 2개 이상 또는 항상 표시 — 일관성 위해 항상 표시)
+  var isOpen = _brandAppExpanded.has(a.id);
+  var arrowIcon = isOpen ? 'expand_more' : 'chevron_right';
+  var toggleBtn = '<button type="button" class="brand-app-expand-btn" onclick="toggleBrandAppExpand(\'' + esc(a.id) + '\', this)" title="제품 ' + prods.length + '개 ' + (isOpen ? '접기' : '펼치기') + '" style="background:none;border:none;cursor:pointer;padding:0;margin-right:2px;color:var(--muted);display:inline-flex;align-items:center;vertical-align:middle"><span class="material-icons-round notranslate" translate="no" style="font-size:18px">' + arrowIcon + '</span></button>';
+
+  var qLocked = false;
+  var memoText = (a.admin_memo || '').trim();
+  var memoCellInner = '<div class="brand-app-memo-cell" data-id="' + esc(a.id) + '" style="position:relative;min-height:36px">' + renderMemoDisplay(memoText, qLocked) + '</div>';
+  var quoteSentInner = '<div class="brand-app-qsent-cell" data-id="' + esc(a.id) + '" style="position:relative;min-height:36px">' + renderQuoteSentDisplay(a.quote_sent_at, qLocked) + '</div>';
+  var fqInner = '<div class="brand-app-fq-cell" data-id="' + esc(a.id) + '" style="position:relative;min-height:24px">' + renderFinalQuoteDisplay(a.final_quote_krw) + '</div>';
+
+  return '<tr data-id="' + esc(a.id) + '" data-summary="1">'
+    // 1. 신청번호 + 폼 종류 + 토글 + 제품 N개
+    + '<td>'
+      + '<div style="display:flex;align-items:flex-start;gap:2px">'
+        + toggleBtn
+        + '<div style="flex:1;min-width:0">'
+          + '<div style="font-size:11px;font-weight:600;color:var(--ink)">' + esc(a.application_no || '—') + '</div>'
+          + '<div style="margin-top:3px"><span style="background:#F0F0F0;color:#555;font-size:10px;font-weight:600;padding:2px 7px;border-radius:3px">' + esc(brandAppFormLabel(a.form_type)) + '</span></div>'
+          + '<div style="font-size:10px;color:var(--muted);margin-top:3px">제품 ' + prods.length + '개</div>'
+        + '</div>'
+      + '</div>'
+    + '</td>'
+    // 2. 브랜드
+    + '<td style="font-weight:600">' + esc(a.brand_name || '—') + '</td>'
+    // 3. 담당자
+    + '<td>'
+      + '<div>' + esc(a.contact_name || '—') + '</div>'
+      + (a.email ? '<div style="font-size:11px;color:var(--muted);margin-top:2px;word-break:break-all">' + esc(a.email) + '</div>' : '')
+    + '</td>'
+    // 4. 연락처
+    + '<td style="font-size:12px">' + esc(formatPhoneDisplay(a.phone) || '—') + '</td>'
+    // 5. 계산서 이메일
+    + '<td style="font-size:12px;color:' + (a.billing_email ? 'var(--ink)' : 'var(--muted)') + ';word-break:break-all">' + esc(a.billing_email || '—') + '</td>'
+    // 6. 요청사항
+    + '<td>' + brandAppNoteCell(a.request_note) + '</td>'
+    // 7. 제품명 (요약: 첫 제품 + N개 표시 또는 — )
+    + '<td style="font-size:11px;color:var(--muted)">' + (prods.length > 0 ? esc((prods[0].name || '—') + (prods.length > 1 ? ' 외 ' + (prods.length - 1) + '개' : '')) : '—') + '</td>'
+    // 8. URL (요약 — 첫 URL or "여러 URL")
+    + '<td style="font-size:11px;color:var(--muted)">' + (prods.length > 0 && prods[0].url ? '<span style="word-break:break-all;display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;overflow:hidden;line-height:1.4">' + esc(prods[0].url) + '</span>' + (prods.length > 1 ? '<div style="font-size:10px;color:var(--muted);margin-top:2px">외 ' + (prods.length - 1) + '개</div>' : '') : '—') + '</td>'
+    // 9. 진행 수량 (SUM)
+    + '<td style="text-align:right;font-variant-numeric:tabular-nums;font-size:12px;font-weight:600">' + (totalQty > 0 ? totalQty.toLocaleString('ja-JP') : dash) + '</td>'
+    // 10. 상품 가격(엔) (단가 — 동일하면 값, 아니면 "제품별 상이")
+    + '<td style="text-align:right;font-variant-numeric:tabular-nums;font-size:12px">' + renderUnit(uPriceJpy, function(v){ return '¥ ' + Number(v).toLocaleString('ja-JP'); }) + '</td>'
+    // 11. 상품 가격(원)
+    + '<td style="text-align:right;font-variant-numeric:tabular-nums;font-size:12px">' + renderUnit(uPriceKrw, function(v){ return fmtKrw(v); }) + '</td>'
+    // 12. 상품 최종 금액 (SUM)
+    + '<td style="text-align:right;font-variant-numeric:tabular-nums;font-size:12px;font-weight:600">' + (totalLine > 0 ? fmtKrw(totalLine) : dash) + '</td>'
+    // 13. 이체수수료(건) (단가 — 요약 행에서는 read-only)
+    + '<td style="text-align:right;font-variant-numeric:tabular-nums;font-size:12px">' + renderUnit(uTfee, function(v){ return fmtKrw(v); }) + '</td>'
+    // 14. 이체수수료(원) (SUM)
+    + '<td style="text-align:right;font-variant-numeric:tabular-nums;font-size:12px">' + (totalFee > 0 ? fmtKrw(totalFee) : dash) + '</td>'
+    // 15. 최종 견적 금액 (SUM)
+    + '<td style="text-align:right;font-variant-numeric:tabular-nums;font-size:12px;font-weight:600">' + (totalFinal > 0 ? fmtKrw(totalFinal) : dash) + '</td>'
+    // 16. VAT포함 (SUM)
+    + '<td style="text-align:right;font-variant-numeric:tabular-nums;font-size:12px;color:#16a34a;font-weight:600">' + (totalVat > 0 ? fmtKrw(totalVat) : dash) + '</td>'
+    // 17. 예상 견적
+    + '<td style="text-align:right;font-variant-numeric:tabular-nums">' + fmtKrw(a.estimated_krw) + '</td>'
+    // 18. 확정 견적
+    + '<td>' + fqInner + '</td>'
+    // 19. 견적서 전달
+    + '<td>' + quoteSentInner + '</td>'
+    // 20. 내부 메모
+    + '<td>' + memoCellInner + '</td>'
+    // 21. 상태
+    + '<td>' + brandAppStatusSelect(a) + '</td>'
+    // 22. 검수일
+    + '<td style="font-size:11px;color:var(--muted)">' + fmtDate(a.reviewed_at) + '</td>'
+    // 23. 신청일
+    + '<td style="font-size:11px;color:var(--muted)">' + fmtDate(a.created_at) + '</td>'
+    // 24. 처리
+    + '<td><button class="btn btn-ghost btn-xs" onclick="openBrandAppDetail(\'' + esc(a.id) + '\')">상세</button></td>'
+    + '</tr>';
+}
+
+// 펼친 상태일 때 한 제품별 행 — 신청 단위 셀은 빈 td (좌측 보더로 그룹 표시)
+function renderBrandAppDetailRow(a, p, idx) {
   var qty = Number(p.qty) || 0;
   var priceJpy = Number(p.price) || 0;
   var priceKrw = priceJpy * BRAND_QUOTE_CONST.FX_JPY_KRW;
@@ -12634,69 +12749,49 @@ function renderBrandAppProductRow(a, p, idx, total) {
   var finalKrw = lineTotal + feeTotalKrw;
   var vatKrw = Math.floor(finalKrw * (1 + BRAND_QUOTE_CONST.VAT_RATE));
 
-  // 같은 신청 그룹 시각화 — 첫 행에 강조 top border, 마지막 행은 default
-  var trStyle = isFirst ? 'border-top:2px solid rgba(200,120,163,.25)' : '';
+  var dash = '<span style="color:var(--muted)">—</span>';
+  var emptyApp = '<td></td>'; // 신청 단위 셀 — 펼친 행에서는 비움 (요약 행에 이미 있음)
 
-  // 신청 단위 셀 (첫 행에만 채움, 나머지는 빈 td)
-  var cellApp = function(html, style) {
-    return '<td' + (style ? ' style="' + style + '"' : '') + '>' + (isFirst ? html : '') + '</td>';
-  };
-
-  var qLocked = false;
-  var memoText = (a.admin_memo || '').trim();
-  var memoCellInner = isFirst ? '<div class="brand-app-memo-cell" data-id="' + esc(a.id) + '" style="position:relative;min-height:36px">' + renderMemoDisplay(memoText, qLocked) + '</div>' : '';
-  var quoteSentInner = isFirst ? '<div class="brand-app-qsent-cell" data-id="' + esc(a.id) + '" style="position:relative;min-height:36px">' + renderQuoteSentDisplay(a.quote_sent_at, qLocked) + '</div>' : '';
-  var fqInner = isFirst ? '<div class="brand-app-fq-cell" data-id="' + esc(a.id) + '" style="position:relative;min-height:24px">' + renderFinalQuoteDisplay(a.final_quote_krw) + '</div>' : '';
-
-  return '<tr data-id="' + esc(a.id) + '" data-product-idx="' + idx + '"' + (trStyle ? ' style="' + trStyle + '"' : '') + '>'
-    // 1. 신청번호
-    + cellApp(
-        '<div style="font-size:11px;font-weight:600;color:var(--ink)">' + esc(a.application_no || '—') + '</div>'
-        + '<div style="margin-top:3px"><span style="background:#F0F0F0;color:#555;font-size:10px;font-weight:600;padding:2px 7px;border-radius:3px">' + esc(brandAppFormLabel(a.form_type)) + '</span></div>'
-      )
-    // 2. 브랜드
-    + cellApp(esc(a.brand_name || '—'), 'font-weight:600')
-    // 3. 담당자
-    + cellApp(
-        '<div>' + esc(a.contact_name || '—') + '</div>'
-        + (a.email ? '<div style="font-size:11px;color:var(--muted);margin-top:2px;word-break:break-all">' + esc(a.email) + '</div>' : '')
-      )
-    // 4. 연락처
-    + cellApp(esc(formatPhoneDisplay(a.phone) || '—'), 'font-size:12px')
-    // 5. 계산서 이메일
-    + cellApp(esc(a.billing_email || '—'), 'font-size:12px;color:' + (a.billing_email ? 'var(--ink)' : 'var(--muted)') + ';word-break:break-all')
-    // 6. 요청사항
-    + cellApp(brandAppNoteCell(a.request_note))
-    // 7. 제품명 (제품별 — 모든 행)
-    + '<td style="font-weight:600;color:var(--ink);font-size:11px;word-break:break-word;line-height:1.4">' + (p.name ? esc(p.name) : '<span style="color:var(--muted);font-weight:400">—</span>') + '</td>'
-    // 8. URL (제품별 — 모든 행)
+  return '<tr data-id="' + esc(a.id) + '" data-product-idx="' + idx + '" data-detail="1" style="background:#FBF7FA">'
+    + emptyApp + emptyApp + emptyApp + emptyApp + emptyApp + emptyApp // 1-6 신청 단위 비움
+    // 7. 제품명
+    + '<td style="font-weight:600;color:var(--ink);font-size:11px;word-break:break-word;line-height:1.4;border-left:3px solid rgba(200,120,163,.4);padding-left:8px">' + (p.name ? esc(p.name) : dash) + '</td>'
+    // 8. URL
     + '<td>' + renderProductUrlCell(p.url) + '</td>'
-    // 9-16. 제품별 8컬럼 (모든 행에 표시)
-    + '<td style="text-align:right;font-variant-numeric:tabular-nums;font-size:12px">' + (qty > 0 ? qty.toLocaleString('ja-JP') : '<span style="color:var(--muted)">—</span>') + '</td>'
-    + '<td style="text-align:right;font-variant-numeric:tabular-nums;font-size:12px">' + (priceJpy > 0 ? '¥ ' + priceJpy.toLocaleString('ja-JP') : '<span style="color:var(--muted)">—</span>') + '</td>'
-    + '<td style="text-align:right;font-variant-numeric:tabular-nums;font-size:12px">' + (priceKrw > 0 ? fmtKrw(priceKrw) : '<span style="color:var(--muted)">—</span>') + '</td>'
-    + '<td style="text-align:right;font-variant-numeric:tabular-nums;font-size:12px;font-weight:600">' + (lineTotal > 0 ? fmtKrw(lineTotal) : '<span style="color:var(--muted)">—</span>') + '</td>'
+    // 9-16. 제품별 8컬럼
+    + '<td style="text-align:right;font-variant-numeric:tabular-nums;font-size:12px">' + (qty > 0 ? qty.toLocaleString('ja-JP') : dash) + '</td>'
+    + '<td style="text-align:right;font-variant-numeric:tabular-nums;font-size:12px">' + (priceJpy > 0 ? '¥ ' + priceJpy.toLocaleString('ja-JP') : dash) + '</td>'
+    + '<td style="text-align:right;font-variant-numeric:tabular-nums;font-size:12px">' + (priceKrw > 0 ? fmtKrw(priceKrw) : dash) + '</td>'
+    + '<td style="text-align:right;font-variant-numeric:tabular-nums;font-size:12px;font-weight:600">' + (lineTotal > 0 ? fmtKrw(lineTotal) : dash) + '</td>'
     + '<td><div class="brand-app-tfee-cell" data-id="' + esc(a.id) + '" data-product-idx="' + idx + '" style="position:relative;min-height:24px">' + renderTransferFeeDisplay(transferFeeKrw) + '</div></td>'
-    + '<td style="text-align:right;font-variant-numeric:tabular-nums;font-size:12px">' + (feeTotalKrw > 0 ? fmtKrw(feeTotalKrw) : '<span style="color:var(--muted)">—</span>') + '</td>'
-    + '<td style="text-align:right;font-variant-numeric:tabular-nums;font-size:12px;font-weight:600">' + (finalKrw > 0 ? fmtKrw(finalKrw) : '<span style="color:var(--muted)">—</span>') + '</td>'
-    + '<td style="text-align:right;font-variant-numeric:tabular-nums;font-size:12px;color:#16a34a;font-weight:600">' + (vatKrw > 0 ? fmtKrw(vatKrw) : '<span style="color:var(--muted)">—</span>') + '</td>'
-    // 15. 예상 견적
-    + cellApp(fmtKrw(a.estimated_krw), 'text-align:right;font-variant-numeric:tabular-nums')
-    // 16. 확정 견적
-    + '<td>' + fqInner + '</td>'
-    // 17. 견적서 전달
-    + '<td>' + quoteSentInner + '</td>'
-    // 18. 내부 메모
-    + '<td>' + memoCellInner + '</td>'
-    // 19. 상태
-    + cellApp(brandAppStatusSelect(a))
-    // 20. 검수일
-    + cellApp(fmtDate(a.reviewed_at), 'font-size:11px;color:var(--muted)')
-    // 21. 신청일
-    + cellApp(fmtDate(a.created_at), 'font-size:11px;color:var(--muted)')
-    // 22. 처리
-    + cellApp('<button class="btn btn-ghost btn-xs" onclick="openBrandAppDetail(\'' + esc(a.id) + '\')">상세</button>')
+    + '<td style="text-align:right;font-variant-numeric:tabular-nums;font-size:12px">' + (feeTotalKrw > 0 ? fmtKrw(feeTotalKrw) : dash) + '</td>'
+    + '<td style="text-align:right;font-variant-numeric:tabular-nums;font-size:12px;font-weight:600">' + (finalKrw > 0 ? fmtKrw(finalKrw) : dash) + '</td>'
+    + '<td style="text-align:right;font-variant-numeric:tabular-nums;font-size:12px;color:#16a34a;font-weight:600">' + (vatKrw > 0 ? fmtKrw(vatKrw) : dash) + '</td>'
+    + emptyApp + emptyApp + emptyApp + emptyApp + emptyApp + emptyApp + emptyApp + emptyApp // 17-24 신청 단위 비움
     + '</tr>';
+}
+
+// 토글: 펼침/접힘 — 같은 신청 ID의 detail 행을 동적 추가/제거
+function toggleBrandAppExpand(id, btnEl) {
+  var summaryTr = btnEl.closest('tr');
+  if (!summaryTr) return;
+  if (_brandAppExpanded.has(id)) {
+    _brandAppExpanded.delete(id);
+    var next = summaryTr.nextElementSibling;
+    while (next && next.dataset.id === id && next.dataset.detail === '1') {
+      var rm = next; next = next.nextElementSibling; rm.remove();
+    }
+    var icon = btnEl.querySelector('.material-icons-round'); if (icon) icon.textContent = 'chevron_right';
+    btnEl.title = btnEl.title.replace('접기', '펼치기');
+  } else {
+    _brandAppExpanded.add(id);
+    var cur = _findBrandApp(id);
+    if (!cur || !Array.isArray(cur.products)) return;
+    var html = cur.products.map(function(p, idx){ return renderBrandAppDetailRow(cur, p, idx); }).join('');
+    summaryTr.insertAdjacentHTML('afterend', html);
+    var icon2 = btnEl.querySelector('.material-icons-round'); if (icon2) icon2.textContent = 'expand_more';
+    btnEl.title = btnEl.title.replace('펼치기', '접기');
+  }
 }
 
 // 이체수수료(건) 셀 — display + ✎ 인라인 편집

--- a/admin/index.html
+++ b/admin/index.html
@@ -424,6 +424,12 @@ textarea.form-input{resize:vertical;min-height:80px}
 #adminPane-brand-applications .data-table thead th:nth-child(2){z-index:7}
 #adminPane-brand-applications .data-table tbody td:nth-child(2),
 #adminPane-brand-applications .data-table thead th:nth-child(2){box-shadow:2px 0 4px -2px rgba(0,0,0,.08)}
+/* 헤더 수식 도움말 (?) — CSS-only 툴팁 */
+#adminPane-brand-applications .data-table thead .col-help{display:inline-flex;align-items:center;margin-left:3px;color:var(--muted);cursor:help;position:relative;vertical-align:middle}
+#adminPane-brand-applications .data-table thead .col-help .material-icons-round{font-size:13px}
+#adminPane-brand-applications .data-table thead .col-help:hover{color:var(--pink)}
+#adminPane-brand-applications .data-table thead .col-help:hover::after{content:attr(data-tooltip);position:absolute;top:100%;left:50%;transform:translateX(-50%);margin-top:6px;background:#1A0F18;color:#fff;font-size:11px;font-weight:400;letter-spacing:normal;text-transform:none;line-height:1.5;padding:7px 10px;border-radius:5px;white-space:pre-line;width:max-content;max-width:260px;z-index:100;box-shadow:0 4px 12px rgba(0,0,0,.15);pointer-events:none}
+#adminPane-brand-applications .data-table thead .col-help:hover::before{content:'';position:absolute;top:100%;left:50%;transform:translateX(-50%);margin-top:1px;border:5px solid transparent;border-bottom-color:#1A0F18;pointer-events:none;z-index:101}
 /* 신청 그룹 시각화 — 요약 행 위에 굵은 가로선(다음 그룹 시작 = 이전 그룹 끝) */
 #adminPane-brand-applications .data-table tbody tr[data-summary="1"] td{border-top:2px solid var(--outline)}
 #adminPane-brand-applications .data-table tbody tr[data-summary="1"]:first-child td{border-top:none}
@@ -2248,15 +2254,15 @@ textarea.form-input{resize:vertical;min-height:80px}
                 <th style="width:220px">요청사항</th>
                 <th style="width:200px">제품명</th>
                 <th style="width:180px">URL</th>
-                <th style="width:80px">진행 수량</th>
+                <th style="width:80px">진행 수량 <span class="col-help" data-tooltip="∑ 수량 (전체 제품의 수량 합계)"><span class="material-icons-round notranslate" translate="no">help_outline</span></span></th>
                 <th style="width:100px">상품 가격(엔)</th>
-                <th style="width:100px">상품 가격(원)</th>
-                <th style="width:130px">상품 최종 금액</th>
+                <th style="width:100px">상품 가격(원) <span class="col-help" data-tooltip="상품 가격(엔) × 10  (환율 ¥1 = ₩10)"><span class="material-icons-round notranslate" translate="no">help_outline</span></span></th>
+                <th style="width:130px">상품 최종 금액 <span class="col-help" data-tooltip="진행 수량 × 상품 가격(원)"><span class="material-icons-round notranslate" translate="no">help_outline</span></span></th>
                 <th style="width:120px">이체수수료(건)</th>
-                <th style="width:130px">이체수수료(원)</th>
-                <th style="width:130px">최종 견적 금액</th>
-                <th style="width:130px">VAT포함</th>
-                <th style="width:120px">예상 견적 <span class="sort-arrows" data-sort="estimated" onclick="toggleBrandAppSort('estimated')">▲▼</span></th>
+                <th style="width:130px">이체수수료(원) <span class="col-help" data-tooltip="진행 수량 × 이체수수료(건)"><span class="material-icons-round notranslate" translate="no">help_outline</span></span></th>
+                <th style="width:130px">최종 견적 금액 <span class="col-help" data-tooltip="상품 최종 금액 + 이체수수료(원)"><span class="material-icons-round notranslate" translate="no">help_outline</span></span></th>
+                <th style="width:130px">VAT포함 <span class="col-help" data-tooltip="최종 견적 금액 × 1.1  (VAT 10%)"><span class="material-icons-round notranslate" translate="no">help_outline</span></span></th>
+                <th style="width:120px">예상 견적 <span class="col-help" data-tooltip="DB 트리거 자동 계산 (신청 INSERT 시 고정)&#10;reviewer: (∑ 엔가격×수량×10 + ∑ 수량×₩2,500) × 1.1&#10;seeding: 0 (수동 협의)"><span class="material-icons-round notranslate" translate="no">help_outline</span></span> <span class="sort-arrows" data-sort="estimated" onclick="toggleBrandAppSort('estimated')">▲▼</span></th>
                 <th style="width:120px">확정 견적</th>
                 <th style="width:130px">견적서 전달</th>
                 <th style="width:220px">내부 메모</th>

--- a/admin/index.html
+++ b/admin/index.html
@@ -2099,7 +2099,7 @@ textarea.form-input{resize:vertical;min-height:80px}
               <div style="font-size:10px;color:var(--muted);margin-top:2px">초기 접수 기준 추정치</div>
             </div>
             <div class="admin-card" style="padding:16px">
-              <div style="font-size:11px;color:var(--muted);font-weight:700;letter-spacing:0.05em">확정 견적 합계 (KRW)</div>
+              <div style="font-size:11px;color:var(--muted);font-weight:700;letter-spacing:0.05em">예상 견적 합계 (KRW)</div>
               <div id="brandKpiFinal" style="font-size:20px;font-weight:800;color:var(--pink);margin-top:6px;font-variant-numeric:tabular-nums">—</div>
               <div style="font-size:10px;color:var(--muted);margin-top:2px">quoted 이상 단계 합산</div>
             </div>
@@ -2270,7 +2270,6 @@ textarea.form-input{resize:vertical;min-height:80px}
                 <th style="width:130px">최종 견적 금액 <span class="col-help" data-tooltip="상품 최종 금액 + 이체수수료(원)"><span class="material-icons-round notranslate" translate="no">help_outline</span></span></th>
                 <th style="width:130px">VAT포함 <span class="col-help" data-tooltip="최종 견적 금액 × 1.1  (VAT 10%)"><span class="material-icons-round notranslate" translate="no">help_outline</span></span></th>
                 <th style="width:120px">예상 견적 <span class="col-help" data-tooltip="DB 트리거 자동 계산 (신청 INSERT 시 고정)&#10;reviewer: (∑ 엔가격×수량×10 + ∑ 수량×₩2,500) × 1.1&#10;seeding: 0 (수동 협의)"><span class="material-icons-round notranslate" translate="no">help_outline</span></span> <span class="sort-arrows" data-sort="estimated" onclick="toggleBrandAppSort('estimated')">▲▼</span></th>
-                <th style="width:120px">확정 견적</th>
                 <th style="width:130px">견적서 전달</th>
                 <th style="width:220px">내부 메모</th>
                 <th style="width:120px">상태 <span class="sort-arrows" data-sort="status" onclick="toggleBrandAppSort('status')">▲▼</span></th>
@@ -2278,7 +2277,7 @@ textarea.form-input{resize:vertical;min-height:80px}
                 <th style="width:110px">신청일 <span class="sort-arrows" data-sort="created" onclick="toggleBrandAppSort('created')">▲▼</span></th>
                 <th style="width:80px">처리</th>
               </tr></thead>
-              <tbody id="brandAppTableBody"><tr><td colspan="24" style="text-align:center;color:var(--muted);padding:24px"><span class="spinner" style="width:20px;height:20px;border-width:2px;border-color:rgba(200,120,163,.2);border-top-color:var(--pink)"></span></td></tr></tbody>
+              <tbody id="brandAppTableBody"><tr><td colspan="23" style="text-align:center;color:var(--muted);padding:24px"><span class="spinner" style="width:20px;height:20px;border-width:2px;border-color:rgba(200,120,163,.2);border-top-color:var(--pink)"></span></td></tr></tbody>
             </table>
             </div>
           </div>
@@ -12066,7 +12065,7 @@ function renderBrandKPIs(apps) {
   var estimated = apps.reduce(function(s,a){ return s + (Number(a.estimated_krw) || 0); }, 0);
   var finalSum = apps
     .filter(function(a){ return ['quoted','paid','kakao_room_created','orient_sheet_sent','schedule_sent','campaign_registered','done'].indexOf(a.status) !== -1; })
-    .reduce(function(s,a){ return s + (Number(a.final_quote_krw) || Number(a.estimated_krw) || 0); }, 0);
+    .reduce(function(s,a){ return s + (Number(a.estimated_krw) || 0); }, 0);
 
   var fmtKRW = function(n) { return '₩ ' + Math.round(n).toLocaleString('ko-KR'); };
 
@@ -12315,7 +12314,7 @@ function renderBrandLongPending(apps) {
 
 async function loadBrandApplications() {
   var tbody = $('brandAppTableBody');
-  if (tbody) tbody.innerHTML = '<tr><td colspan="24" style="text-align:center;color:var(--muted);padding:24px"><span class="spinner" style="width:20px;height:20px;border-width:2px;border-color:rgba(200,120,163,.2);border-top-color:var(--pink)"></span></td></tr>';
+  if (tbody) tbody.innerHTML = '<tr><td colspan="23" style="text-align:center;color:var(--muted);padding:24px"><span class="spinner" style="width:20px;height:20px;border-width:2px;border-color:rgba(200,120,163,.2);border-top-color:var(--pink)"></span></td></tr>';
   _brandApps = await fetchBrandApplications();
   renderBrandApplicationsList();
   refreshBrandAppBadge();
@@ -12414,7 +12413,7 @@ function renderBrandApplicationsList() {
     rows: list,
     renderRow: renderBrandAppRow,
     pageSize: BRAND_APP_PAGE_SIZE,
-    emptyHtml: '<tr><td colspan="24" style="text-align:center;color:var(--muted);padding:40px">신청 내역이 없습니다</td></tr>',
+    emptyHtml: '<tr><td colspan="23" style="text-align:center;color:var(--muted);padding:40px">신청 내역이 없습니다</td></tr>',
   });
 }
 
@@ -12591,9 +12590,6 @@ async function openBrandAppDetail(id) {
         + '<div><label style="color:var(--muted);font-size:11px;font-weight:600;display:block;margin-bottom:4px">예상 견적 (자동)</label>'
           + '<input type="text" class="admin-filter" value="' + fmtKrw(a.estimated_krw) + '" readonly style="background:#F7F7F7;color:var(--muted)">'
         + '</div>'
-        + '<div><label style="color:var(--muted);font-size:11px;font-weight:600;display:block;margin-bottom:4px">확정 견적 (₩)</label>'
-          + '<input type="number" id="brandAppEditFinalQuote" class="admin-filter" value="' + (a.final_quote_krw || '') + '" placeholder="0" ' + editableDisabled + '>'
-        + '</div>'
         + '<div style="display:flex;flex-direction:column;justify-content:flex-end">'
           + '<label style="display:flex;align-items:center;gap:6px;color:var(--ink);font-size:13px;cursor:pointer">'
             + '<input type="checkbox" id="brandAppEditQuoteSent" ' + (a.quote_sent_at ? 'checked' : '') + ' ' + editableDisabled + '>'
@@ -12706,7 +12702,6 @@ function renderBrandAppSummaryRow(a) {
   var memoText = (a.admin_memo || '').trim();
   var memoCellInner = '<div class="brand-app-memo-cell" data-id="' + esc(a.id) + '" style="position:relative;min-height:36px">' + renderMemoDisplay(memoText, qLocked) + '</div>';
   var quoteSentInner = '<div class="brand-app-qsent-cell" data-id="' + esc(a.id) + '" style="position:relative;min-height:36px">' + renderQuoteSentDisplay(a.quote_sent_at, qLocked) + '</div>';
-  var fqInner = '<div class="brand-app-fq-cell" data-id="' + esc(a.id) + '" style="position:relative;min-height:24px">' + renderFinalQuoteDisplay(a.final_quote_krw) + '</div>';
 
   return '<tr data-id="' + esc(a.id) + '" data-summary="1">'
     // 1. 신청번호 + 폼 종류 + 토글 + 제품 N개 (셀 전체 클릭으로 토글)
@@ -12755,19 +12750,17 @@ function renderBrandAppSummaryRow(a) {
     + '<td style="text-align:right;font-variant-numeric:tabular-nums;font-size:12px;color:#16a34a;font-weight:600">' + (totalVat > 0 ? fmtKrw(totalVat) : dash) + '</td>'
     // 17. 예상 견적
     + '<td style="text-align:right;font-variant-numeric:tabular-nums">' + fmtKrw(a.estimated_krw) + '</td>'
-    // 18. 확정 견적
-    + '<td>' + fqInner + '</td>'
-    // 19. 견적서 전달
+    // 18. 견적서 전달
     + '<td>' + quoteSentInner + '</td>'
-    // 20. 내부 메모
+    // 19. 내부 메모
     + '<td>' + memoCellInner + '</td>'
-    // 21. 상태
+    // 20. 상태
     + '<td>' + brandAppStatusSelect(a) + '</td>'
-    // 22. 검수일
+    // 21. 검수일
     + '<td style="font-size:11px;color:var(--muted)">' + fmtDate(a.reviewed_at) + '</td>'
-    // 23. 신청일
+    // 22. 신청일
     + '<td style="font-size:11px;color:var(--muted)">' + fmtDate(a.created_at) + '</td>'
-    // 24. 처리
+    // 23. 처리
     + '<td><button class="btn btn-ghost btn-xs" onclick="openBrandAppDetail(\'' + esc(a.id) + '\')">상세</button></td>'
     + '</tr>';
 }
@@ -12801,7 +12794,7 @@ function renderBrandAppDetailRow(a, p, idx) {
     + '<td style="text-align:right;font-variant-numeric:tabular-nums;font-size:12px">' + (feeTotalKrw > 0 ? fmtKrw(feeTotalKrw) : dash) + '</td>'
     + '<td style="text-align:right;font-variant-numeric:tabular-nums;font-size:12px;font-weight:600">' + (finalKrw > 0 ? fmtKrw(finalKrw) : dash) + '</td>'
     + '<td style="text-align:right;font-variant-numeric:tabular-nums;font-size:12px;color:#16a34a;font-weight:600">' + (vatKrw > 0 ? fmtKrw(vatKrw) : dash) + '</td>'
-    + emptyApp + emptyApp + emptyApp + emptyApp + emptyApp + emptyApp + emptyApp + emptyApp // 17-24 신청 단위 비움
+    + emptyApp + emptyApp + emptyApp + emptyApp + emptyApp + emptyApp + emptyApp // 17-23 신청 단위 비움
     + '</tr>';
 }
 
@@ -12933,82 +12926,6 @@ async function confirmTransferFeeEdit(anyChildEl) {
   // 같은 신청의 모든 행 재렌더(이체수수료(원)/최종 견적/VAT포함 컬럼이 동기화됨)
   renderBrandApplicationsList();
   toast('이체수수료가 저장되었습니다.');
-}
-
-function renderFinalQuoteDisplay(value) {
-  return '<div class="fq-display" style="text-align:right;font-variant-numeric:tabular-nums;font-weight:600;padding-right:22px;font-size:12px">' + fmtKrw(value) + '</div>'
-    + '<button type="button" class="fq-edit-btn" onclick="enterFinalQuoteEdit(this)" title="확정 견적 수정" style="position:absolute;top:0;right:0;background:none;border:none;cursor:pointer;padding:2px;color:var(--muted);display:flex;align-items:center;justify-content:center;border-radius:3px" onmouseover="this.style.background=\'rgba(0,0,0,.05)\'" onmouseout="this.style.background=\'none\'"><span class="material-icons-round notranslate" translate="no" style="font-size:15px">edit</span></button>';
-}
-
-function _restoreFinalQuoteDisplay(cell, value) {
-  cell.innerHTML = renderFinalQuoteDisplay(value);
-}
-
-function enterFinalQuoteEdit(btnEl) {
-  var cell = btnEl.closest('.brand-app-fq-cell');
-  if (!cell) return;
-  var cur = _findBrandApp(cell.dataset.id);
-  if (!cur) return;
-  var original = cur.final_quote_krw == null ? '' : String(cur.final_quote_krw);
-  cell.innerHTML = '<div style="display:flex;flex-direction:column;gap:4px">'
-    + '<input type="number" class="fq-edit-input" value="' + esc(original) + '" placeholder="0" min="0" step="1" onkeydown="handleFinalQuoteEditKey(event, this)" style="width:100%;font-size:11px;padding:3px 6px;border:1px solid var(--pink);border-radius:4px;text-align:right;font-variant-numeric:tabular-nums">'
-    + '<div style="display:flex;gap:4px;justify-content:flex-end">'
-      + '<button type="button" onclick="cancelFinalQuoteEdit(this)" style="background:#fff;border:1px solid var(--line);border-radius:4px;padding:3px 8px;cursor:pointer;font-size:11px;color:var(--muted)">취소</button>'
-      + '<button type="button" onclick="confirmFinalQuoteEdit(this)" style="background:var(--pink);color:#fff;border:none;border-radius:4px;padding:3px 10px;cursor:pointer;font-size:11px;font-weight:600">저장</button>'
-    + '</div>'
-  + '</div>';
-  var input = cell.querySelector('.fq-edit-input');
-  if (input) { input.focus(); input.select(); }
-}
-
-function handleFinalQuoteEditKey(ev, inputEl) {
-  if (ev.key === 'Escape') { ev.preventDefault(); cancelFinalQuoteEdit(inputEl); }
-  else if (ev.key === 'Enter') { ev.preventDefault(); confirmFinalQuoteEdit(inputEl); }
-}
-
-function cancelFinalQuoteEdit(anyChildEl) {
-  var cell = anyChildEl.closest('.brand-app-fq-cell');
-  if (!cell) return;
-  var cur = _findBrandApp(cell.dataset.id);
-  _restoreFinalQuoteDisplay(cell, cur?.final_quote_krw);
-}
-
-async function confirmFinalQuoteEdit(anyChildEl) {
-  var cell = anyChildEl.closest('.brand-app-fq-cell');
-  if (!cell) return;
-  var input = cell.querySelector('.fq-edit-input');
-  if (!input) return;
-  var id = cell.dataset.id;
-  var cur = _findBrandApp(id);
-  if (!cur) return;
-  var raw = (input.value || '').trim();
-  var nextValue = raw === '' ? null : Number(raw);
-  if (nextValue !== null && (!isFinite(nextValue) || nextValue < 0)) {
-    toast('0 이상의 숫자만 입력하세요.', 'warn');
-    return;
-  }
-  var prevValue = cur.final_quote_krw == null ? null : Number(cur.final_quote_krw);
-  if (prevValue === nextValue) {
-    _restoreFinalQuoteDisplay(cell, prevValue);
-    return;
-  }
-  var prevVersion = cur.version;
-  input.disabled = true;
-  var result = await updateBrandApplication(id, {final_quote_krw: nextValue}, prevVersion);
-  input.disabled = false;
-  if (result.conflict) {
-    toast('다른 관리자가 먼저 저장했습니다. 다시 불러옵니다.', 'warn');
-    await loadBrandApplications();
-    return;
-  }
-  if (!result.ok) {
-    toast('저장 실패: ' + (result.error || '알 수 없는 오류'), 'error');
-    return;
-  }
-  cur.final_quote_krw = nextValue;
-  cur.version = result.data?.version || (prevVersion + 1);
-  _restoreFinalQuoteDisplay(cell, nextValue);
-  toast('확정 견적이 저장되었습니다.');
 }
 
 function renderQuoteSentDisplay(isoOrNull, locked) {
@@ -13198,13 +13115,11 @@ async function saveBrandAppChanges(expectedVersion) {
   var cur = window._brandAppCurrent;
   if (!cur) return;
   var status = $('brandAppEditStatus')?.value;
-  var finalQuote = $('brandAppEditFinalQuote')?.value;
   var quoteSentChecked = $('brandAppEditQuoteSent')?.checked;
   var memo = $('brandAppEditMemo')?.value || '';
 
   var patch = {
     status: status,
-    final_quote_krw: finalQuote ? Number(finalQuote) : null,
     quote_sent_at: quoteSentChecked ? (cur.quote_sent_at || new Date().toISOString()) : null,
     admin_memo: memo || null
   };

--- a/admin/index.html
+++ b/admin/index.html
@@ -424,6 +424,15 @@ textarea.form-input{resize:vertical;min-height:80px}
 #adminPane-brand-applications .data-table thead th:nth-child(2){z-index:7}
 #adminPane-brand-applications .data-table tbody td:nth-child(2),
 #adminPane-brand-applications .data-table thead th:nth-child(2){box-shadow:2px 0 4px -2px rgba(0,0,0,.08)}
+/* 신청 그룹 시각화 — 요약 행 위에 굵은 가로선(다음 그룹 시작 = 이전 그룹 끝) */
+#adminPane-brand-applications .data-table tbody tr[data-summary="1"] td{border-top:2px solid var(--outline)}
+#adminPane-brand-applications .data-table tbody tr[data-summary="1"]:first-child td{border-top:none}
+/* 펼친 제품 행에서 신청번호 / 브랜드 컬럼은 행 구분선 제거 (그룹 영역으로 보이게) */
+#adminPane-brand-applications .data-table tbody tr[data-detail="1"] td:nth-child(1),
+#adminPane-brand-applications .data-table tbody tr[data-detail="1"] td:nth-child(2){border-bottom:none}
+/* 요약 행의 신청번호 / 브랜드 컬럼도 detail 행이 따라올 때 아래 구분선 제거 — JS로 클래스 부여 대신 :has 사용 */
+#adminPane-brand-applications .data-table tbody tr[data-summary="1"]:has(+ tr[data-detail="1"]) td:nth-child(1),
+#adminPane-brand-applications .data-table tbody tr[data-summary="1"]:has(+ tr[data-detail="1"]) td:nth-child(2){border-bottom:none}
 .kpi-row{display:grid;grid-template-columns:repeat(4,1fr);gap:16px;margin-bottom:24px}
 .kpi-card{background:var(--surface);border:none;border-radius:var(--r16);padding:20px;position:relative;overflow:hidden;box-shadow:var(--elevation-1)}
 .kpi-card::after{content:'';position:absolute;top:0;left:0;right:0;height:3px}

--- a/admin/index.html
+++ b/admin/index.html
@@ -12715,7 +12715,13 @@ function renderMemoDisplay(memoText, locked) {
   var safe = (memoText || '').trim();
   var color = safe ? 'var(--ink)' : 'var(--muted)';
   var content = safe ? esc(safe) : '—';
+  // 요청사항 셀과 동일한 기준: 40자 초과 또는 개행 포함 시 더보기 노출
+  var hasMore = !!safe && (safe.length > 40 || /\n/.test(safe));
+  var moreLink = hasMore
+    ? '<a href="javascript:void(0)" style="font-size:10px;color:var(--pink);text-decoration:underline;cursor:pointer;margin-top:2px;display:inline-block" onclick="event.stopPropagation();openMsgModal(this)" data-msg="' + esc(safe) + '">더보기</a>'
+    : '';
   return '<div class="memo-display" style="font-size:11px;color:' + color + ';display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;overflow:hidden;line-height:1.4;padding-right:22px;white-space:pre-wrap" title="' + esc(safe) + '">' + content + '</div>'
+    + moreLink
     + '<button type="button" class="memo-edit-btn" ' + (locked ? 'disabled' : '') + ' onclick="enterMemoEdit(this)" title="' + (locked ? '완료/거절 신청은 수정 불가' : '메모 수정') + '" style="position:absolute;top:0;right:0;background:none;border:none;cursor:' + (locked ? 'not-allowed' : 'pointer') + ';padding:2px;color:var(--muted);display:flex;align-items:center;justify-content:center;border-radius:3px" onmouseover="if(!this.disabled)this.style.background=\'rgba(0,0,0,.05)\'" onmouseout="this.style.background=\'none\'"><span class="material-icons-round notranslate" translate="no" style="font-size:15px">edit</span></button>';
 }
 

--- a/admin/index.html
+++ b/admin/index.html
@@ -430,6 +430,8 @@ textarea.form-input{resize:vertical;min-height:80px}
 #adminPane-brand-applications .data-table thead .col-help:hover{color:var(--pink)}
 #adminPane-brand-applications .data-table thead .col-help:hover::after{content:attr(data-tooltip);position:absolute;top:100%;left:50%;transform:translateX(-50%);margin-top:6px;background:#1A0F18;color:#fff;font-size:11px;font-weight:400;letter-spacing:normal;text-transform:none;line-height:1.5;padding:7px 10px;border-radius:5px;white-space:pre-line;width:max-content;max-width:260px;z-index:100;box-shadow:0 4px 12px rgba(0,0,0,.15);pointer-events:none}
 #adminPane-brand-applications .data-table thead .col-help:hover::before{content:'';position:absolute;top:100%;left:50%;transform:translateX(-50%);margin-top:1px;border:5px solid transparent;border-bottom-color:#1A0F18;pointer-events:none;z-index:101}
+/* 호버 중인 th의 stacking context를 인접 sticky thead 셀보다 위로 끌어올림 (툴팁 가림 방지) */
+#adminPane-brand-applications .data-table thead th:has(.col-help:hover){z-index:99}
 /* 신청 그룹 시각화 — 요약 행 위에 굵은 가로선(다음 그룹 시작 = 이전 그룹 끝) */
 #adminPane-brand-applications .data-table tbody tr[data-summary="1"] td{border-top:2px solid var(--outline)}
 #adminPane-brand-applications .data-table tbody tr[data-summary="1"]:first-child td{border-top:none}

--- a/admin/index.html
+++ b/admin/index.html
@@ -5908,8 +5908,8 @@ function resetMultiFilter(containerId, allLabel) {
   const btn = wrap.querySelector('.mf-btn');
   const allCb = wrap.querySelector('input[value="all"]');
   const items = wrap.querySelectorAll('.mf-drop input:not([value="all"])');
-  if (allCb) allCb.checked = true;
-  items.forEach(c => c.checked = false);
+  if (allCb) { allCb.checked = true; allCb.indeterminate = false; }
+  items.forEach(c => c.checked = true); // 전체 = 모든 항목 체크 표시
   if (btn) { btn.textContent = allLabel; btn.classList.remove('has-selection'); }
 }
 function updateFilterResetBtn(btnId, multiIds, searchId) {
@@ -5946,22 +5946,14 @@ function syncMultiFilter(containerId, allLabel, options, onChange) {
   createMultiFilter(containerId, allLabel, options, onChange);
   wrap.dataset.optKey = newKey;
   if (prev.length > 0) {
-    const allCb = drop.querySelector('input[value="all"]');
-    let restored = 0;
+    // 일부 선택 상태 복원 — 모두 해제 후 prev 항목만 체크
+    const itemCbs = [...drop.querySelectorAll('input:not([value="all"])')];
+    itemCbs.forEach(c => c.checked = false);
     prev.forEach(v => {
       const cb = drop.querySelector(`input[value="${CSS && CSS.escape ? CSS.escape(v) : v.replace(/"/g,'\\"')}"]`);
-      if (cb) { cb.checked = true; restored++; }
+      if (cb) cb.checked = true;
     });
-    if (restored > 0 && allCb) {
-      allCb.checked = false;
-      const btn = wrap.querySelector('.mf-btn');
-      const itemCbs = [...drop.querySelectorAll('input:not([value="all"])')];
-      const selected = itemCbs.filter(c => c.checked);
-      if (btn) {
-        btn.textContent = selected.map(c => c.parentElement.textContent.trim()).join(', ');
-        btn.classList.add('has-selection');
-      }
-    }
+    if (typeof wrap._mfUpdate === 'function') wrap._mfUpdate();
   }
 }
 
@@ -5975,15 +5967,17 @@ function syncCampMultiFilter(containerId, sortedCamps, onChange) {
 }
 
 // ── 다중 선택 드롭다운 필터 ──
+// "전체" = 모든 항목 체크 표시 (시각). 일부 해제 시 "전체"는 indeterminate.
+// 데이터 모델: 전체(모두 체크) → 빈 배열 반환(=필터 없음). 일부만 체크 → 그 배열 반환.
 function createMultiFilter(containerId, allLabel, options, onChange) {
   const wrap = $(containerId);
   if (!wrap) return;
   const btn = wrap.querySelector('.mf-btn');
   const drop = wrap.querySelector('.mf-drop');
   if (!btn || !drop) return;
-  // 드롭다운 아이템 생성
+  // 드롭다운 아이템 생성 — 초기 상태: 전체 체크 = 모든 항목 체크
   drop.innerHTML = `<label class="mf-item all-item"><input type="checkbox" value="all" checked> ${esc(allLabel)}</label>`
-    + options.map(o => `<label class="mf-item"><input type="checkbox" value="${esc(o.value)}"> ${esc(o.label)}</label>`).join('');
+    + options.map(o => `<label class="mf-item"><input type="checkbox" value="${esc(o.value)}" checked> ${esc(o.label)}</label>`).join('');
   btn.textContent = allLabel;
   // 토글
   btn.onclick = (e) => { e.stopPropagation(); drop.classList.toggle('open'); };
@@ -5992,23 +5986,37 @@ function createMultiFilter(containerId, allLabel, options, onChange) {
   const itemCbs = [...drop.querySelectorAll('input:not([value="all"])')];
   const update = () => {
     const selected = itemCbs.filter(c => c.checked);
-    if (selected.length === 0 || selected.length === itemCbs.length) {
+    if (selected.length === itemCbs.length) {
+      // 모두 체크 = 전체
       allCb.checked = true;
-      itemCbs.forEach(c => c.checked = false);
+      allCb.indeterminate = false;
+      btn.textContent = allLabel;
+      btn.classList.remove('has-selection');
+    } else if (selected.length === 0) {
+      // 모두 해제 — 자동 전체 복귀(시각적으로 모두 체크) — 필터 없음과 동일하게 취급
+      allCb.checked = true;
+      allCb.indeterminate = false;
+      itemCbs.forEach(c => c.checked = true);
       btn.textContent = allLabel;
       btn.classList.remove('has-selection');
     } else {
+      // 일부 — 전체는 indeterminate
       allCb.checked = false;
+      allCb.indeterminate = true;
       btn.textContent = selected.map(c => c.parentElement.textContent.trim()).join(', ');
       btn.classList.add('has-selection');
     }
     onChange(getMultiFilterValues(containerId));
   };
   allCb.onchange = () => {
-    if (allCb.checked) { itemCbs.forEach(c => c.checked = false); }
+    // 전체 토글 — 모든 항목을 같이 체크/해제 (해제 시 update가 자동으로 전체로 복귀)
+    itemCbs.forEach(c => c.checked = allCb.checked);
+    allCb.indeterminate = false;
     update();
   };
-  itemCbs.forEach(c => { c.onchange = () => { if (c.checked) allCb.checked = false; update(); }; });
+  itemCbs.forEach(c => { c.onchange = update; });
+  // 외부에서 prev 복원 후 다시 호출할 수 있도록 노출
+  wrap._mfUpdate = update;
   // 바깥 클릭 닫기 (wrap 당 1회만 등록)
   if (!wrap._mfClickBound) {
     wrap._mfClickBound = true;
@@ -6019,8 +6027,9 @@ function getMultiFilterValues(containerId) {
   const wrap = $(containerId);
   if (!wrap) return [];
   const allCb = wrap.querySelector('input[value="all"]');
-  if (allCb?.checked) return [];
-  return [...wrap.querySelectorAll('.mf-drop input:checked')].map(c => c.value);
+  // 전체(모두 체크) = 필터 없음 → 빈 배열
+  if (allCb?.checked && !allCb.indeterminate) return [];
+  return [...wrap.querySelectorAll('.mf-drop input:not([value="all"]):checked')].map(c => c.value);
 }
 
 function toggleCampSort(key) {

--- a/admin/index.html
+++ b/admin/index.html
@@ -12369,10 +12369,11 @@ function renderBrandApplicationsList() {
       ? esc(prodCount + '종 · ' + (Number(a.total_qty) || 0) + '개')
         + '<div style="font-size:11px;color:var(--muted);margin-top:2px;font-variant-numeric:tabular-nums">¥ ' + (Number(a.total_jpy) || 0).toLocaleString('ja-JP') + '</div>'
       : '<span style="color:var(--muted)">—</span>';
-    var quoteSent = a.quote_sent_at
-      ? '<span style="display:inline-flex;align-items:center;gap:4px;color:#16a34a;font-size:11px;font-weight:600"><span class="material-icons-round notranslate" translate="no" style="font-size:14px">check_circle</span>전달</span>'
-        + '<div style="font-size:10px;color:var(--muted);margin-top:2px">' + fmtDate(a.quote_sent_at) + '</div>'
-      : '<span style="color:var(--muted);font-size:11px">미전달</span>';
+    var qLocked = (a.status === 'done' || a.status === 'rejected');
+    var quoteSent = '<label class="brand-app-qsent" data-id="' + esc(a.id) + '" style="display:inline-flex;align-items:center;gap:6px;font-size:11px;cursor:' + (qLocked ? 'not-allowed' : 'pointer') + ';color:' + (a.quote_sent_at ? '#16a34a' : 'var(--muted)') + ';font-weight:' + (a.quote_sent_at ? '600' : '400') + '" onclick="event.stopPropagation()">'
+      + '<input type="checkbox" ' + (a.quote_sent_at ? 'checked' : '') + ' ' + (qLocked ? 'disabled' : '') + ' onchange="toggleBrandAppQuoteSent(\'' + esc(a.id) + '\', this)" style="cursor:' + (qLocked ? 'not-allowed' : 'pointer') + '">'
+      + '<span class="qsent-label">' + (a.quote_sent_at ? '전달 ' + fmtDate(a.quote_sent_at) : '미전달') + '</span>'
+    + '</label>';
     var memoText = (a.admin_memo || '').trim();
     var memoCell = memoText
       ? '<div style="font-size:11px;color:var(--ink);display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;overflow:hidden;line-height:1.4" title="' + esc(memoText) + '">' + esc(memoText) + '</div>'
@@ -12613,6 +12614,50 @@ function closeBrandAppDetail() {
   if (modal) modal.classList.remove('open');
   _brandAppCurrentId = null;
   window._brandAppCurrent = null;
+}
+
+async function toggleBrandAppQuoteSent(id, checkboxEl) {
+  if (!currentAdminInfo) { toast('권한이 없습니다','error'); checkboxEl.checked = !checkboxEl.checked; return; }
+  var idx = (_brandApps || []).findIndex(function(a){ return a.id === id; });
+  if (idx < 0) return;
+  var cur = _brandApps[idx];
+  if (cur.status === 'done' || cur.status === 'rejected') {
+    checkboxEl.checked = !!cur.quote_sent_at;
+    toast('완료/거절된 신청은 변경할 수 없습니다.', 'warn');
+    return;
+  }
+  var prevValue = cur.quote_sent_at;
+  var prevVersion = cur.version;
+  var nextValue = checkboxEl.checked ? new Date().toISOString() : null;
+  var labelEl = checkboxEl.parentElement?.querySelector('.qsent-label');
+  // 낙관적 UI 갱신
+  if (labelEl) labelEl.textContent = nextValue ? ('전달 ' + fmtDate(nextValue)) : '미전달';
+  if (checkboxEl.parentElement) {
+    checkboxEl.parentElement.style.color = nextValue ? '#16a34a' : 'var(--muted)';
+    checkboxEl.parentElement.style.fontWeight = nextValue ? '600' : '400';
+  }
+  checkboxEl.disabled = true;
+  var result = await updateBrandApplication(id, {quote_sent_at: nextValue}, prevVersion);
+  checkboxEl.disabled = false;
+  if (result.conflict) {
+    toast('다른 관리자가 먼저 저장했습니다. 다시 불러옵니다.', 'warn');
+    await loadBrandApplications();
+    return;
+  }
+  if (!result.ok) {
+    // 원복
+    checkboxEl.checked = !checkboxEl.checked;
+    if (labelEl) labelEl.textContent = prevValue ? ('전달 ' + fmtDate(prevValue)) : '미전달';
+    if (checkboxEl.parentElement) {
+      checkboxEl.parentElement.style.color = prevValue ? '#16a34a' : 'var(--muted)';
+      checkboxEl.parentElement.style.fontWeight = prevValue ? '600' : '400';
+    }
+    toast('저장 실패: ' + (result.error || '알 수 없는 오류'), 'error');
+    return;
+  }
+  // 메모리 갱신
+  cur.quote_sent_at = nextValue;
+  cur.version = result.data?.version || (prevVersion + 1);
 }
 
 async function saveBrandAppChanges(expectedVersion) {

--- a/admin/index.html
+++ b/admin/index.html
@@ -432,8 +432,6 @@ textarea.form-input{resize:vertical;min-height:80px}
 #adminPane-brand-applications .data-table thead .col-help:hover::before{content:'';position:absolute;top:100%;left:50%;transform:translateX(-50%);margin-top:1px;border:5px solid transparent;border-bottom-color:#1A0F18;pointer-events:none;z-index:101}
 /* 호버 중인 th의 stacking context를 인접 sticky thead 셀보다 위로 끌어올림 (툴팁 가림 방지) */
 #adminPane-brand-applications .data-table thead th:has(.col-help:hover){z-index:99}
-/* 신청번호 셀 호버 — 클릭 가능 시각 피드백 (불투명 핑크 톤으로 sticky 뒷면 비침 방지) */
-#adminPane-brand-applications .data-table tbody tr[data-summary="1"] td:nth-child(1):hover{background:#F5E0EA}
 /* 신청 그룹 시각화 — 요약 행 위에 굵은 가로선(다음 그룹 시작 = 이전 그룹 끝) */
 #adminPane-brand-applications .data-table tbody tr[data-summary="1"] td{border-top:2px solid var(--outline)}
 #adminPane-brand-applications .data-table tbody tr[data-summary="1"]:first-child td{border-top:none}

--- a/admin/index.html
+++ b/admin/index.html
@@ -407,6 +407,11 @@ textarea.form-input{resize:vertical;min-height:80px}
 /* 브랜드 서베이 페인: 좌우 스크롤 + 첫 두 컬럼 sticky-left */
 #adminPane-brand-applications .admin-table-wrap{overflow-x:auto}
 #adminPane-brand-applications .data-table{min-width:2280px}
+/* sticky-left 두 컬럼 폭 강제 (auto 폭이라 left 값과 어긋나서 사이에 갭 생기는 문제 방지) */
+#adminPane-brand-applications .data-table th:nth-child(1),
+#adminPane-brand-applications .data-table td:nth-child(1){width:180px;min-width:180px;max-width:180px;box-sizing:border-box}
+#adminPane-brand-applications .data-table th:nth-child(2),
+#adminPane-brand-applications .data-table td:nth-child(2){width:200px;min-width:200px;max-width:200px;box-sizing:border-box;word-break:break-word}
 #adminPane-brand-applications .data-table tbody td:nth-child(1),
 #adminPane-brand-applications .data-table tbody td:nth-child(2){position:sticky;z-index:3;background:var(--surface)}
 #adminPane-brand-applications .data-table tbody tr:hover td:nth-child(1),

--- a/admin/index.html
+++ b/admin/index.html
@@ -432,6 +432,8 @@ textarea.form-input{resize:vertical;min-height:80px}
 #adminPane-brand-applications .data-table thead .col-help:hover::before{content:'';position:absolute;top:100%;left:50%;transform:translateX(-50%);margin-top:1px;border:5px solid transparent;border-bottom-color:#1A0F18;pointer-events:none;z-index:101}
 /* 호버 중인 th의 stacking context를 인접 sticky thead 셀보다 위로 끌어올림 (툴팁 가림 방지) */
 #adminPane-brand-applications .data-table thead th:has(.col-help:hover){z-index:99}
+/* 신청번호 셀 호버 — 클릭 가능 시각 피드백 */
+#adminPane-brand-applications .data-table tbody tr[data-summary="1"] td:nth-child(1):hover{background:rgba(200,120,163,.08)}
 /* 신청 그룹 시각화 — 요약 행 위에 굵은 가로선(다음 그룹 시작 = 이전 그룹 끝) */
 #adminPane-brand-applications .data-table tbody tr[data-summary="1"] td{border-top:2px solid var(--outline)}
 #adminPane-brand-applications .data-table tbody tr[data-summary="1"]:first-child td{border-top:none}
@@ -12698,7 +12700,7 @@ function renderBrandAppSummaryRow(a) {
   // 펼치기 토글 (제품 2개 이상 또는 항상 표시 — 일관성 위해 항상 표시)
   var isOpen = _brandAppExpanded.has(a.id);
   var arrowIcon = isOpen ? 'expand_more' : 'chevron_right';
-  var toggleBtn = '<button type="button" class="brand-app-expand-btn" onclick="toggleBrandAppExpand(\'' + esc(a.id) + '\', this)" title="제품 ' + prods.length + '개 ' + (isOpen ? '접기' : '펼치기') + '" style="background:none;border:none;cursor:pointer;padding:0;margin-right:2px;color:var(--muted);display:inline-flex;align-items:center;vertical-align:middle"><span class="material-icons-round notranslate" translate="no" style="font-size:18px">' + arrowIcon + '</span></button>';
+  var toggleBtn = '<button type="button" class="brand-app-expand-btn" onclick="event.stopPropagation();toggleBrandAppExpand(\'' + esc(a.id) + '\', this)" title="제품 ' + prods.length + '개 ' + (isOpen ? '접기' : '펼치기') + '" style="background:none;border:none;cursor:pointer;padding:0;margin-right:2px;color:var(--muted);display:inline-flex;align-items:center;vertical-align:middle"><span class="material-icons-round notranslate" translate="no" style="font-size:18px">' + arrowIcon + '</span></button>';
 
   var qLocked = false;
   var memoText = (a.admin_memo || '').trim();
@@ -12707,8 +12709,8 @@ function renderBrandAppSummaryRow(a) {
   var fqInner = '<div class="brand-app-fq-cell" data-id="' + esc(a.id) + '" style="position:relative;min-height:24px">' + renderFinalQuoteDisplay(a.final_quote_krw) + '</div>';
 
   return '<tr data-id="' + esc(a.id) + '" data-summary="1">'
-    // 1. 신청번호 + 폼 종류 + 토글 + 제품 N개
-    + '<td>'
+    // 1. 신청번호 + 폼 종류 + 토글 + 제품 N개 (셀 전체 클릭으로 토글)
+    + '<td onclick="handleBrandAppRowClick(event)" style="cursor:pointer" title="클릭하여 ' + (isOpen ? '접기' : '펼치기') + '">'
       + '<div style="display:flex;align-items:flex-start;gap:2px">'
         + toggleBtn
         + '<div style="flex:1;min-width:0">'
@@ -12801,6 +12803,19 @@ function renderBrandAppDetailRow(a, p, idx) {
     + '<td style="text-align:right;font-variant-numeric:tabular-nums;font-size:12px;color:#16a34a;font-weight:600">' + (vatKrw > 0 ? fmtKrw(vatKrw) : dash) + '</td>'
     + emptyApp + emptyApp + emptyApp + emptyApp + emptyApp + emptyApp + emptyApp + emptyApp // 17-24 신청 단위 비움
     + '</tr>';
+}
+
+// 신청번호 셀 클릭으로 토글
+function handleBrandAppRowClick(ev) {
+  // 토글 버튼 자체는 stopPropagation 처리되지만 안전을 위해 한 번 더 가드
+  if (ev.target.closest('button, a, input, select, textarea')) return;
+  var td = ev.currentTarget;
+  var tr = td.closest('tr');
+  if (!tr) return;
+  var id = tr.dataset.id;
+  if (!id) return;
+  var btn = tr.querySelector('.brand-app-expand-btn');
+  if (btn) toggleBrandAppExpand(id, btn);
 }
 
 // 토글: 펼침/접힘 — 같은 신청 ID의 detail 행을 동적 추가/제거

--- a/admin/index.html
+++ b/admin/index.html
@@ -12369,15 +12369,8 @@ function renderBrandApplicationsList() {
       ? esc(prodCount + '종 · ' + (Number(a.total_qty) || 0) + '개')
         + '<div style="font-size:11px;color:var(--muted);margin-top:2px;font-variant-numeric:tabular-nums">¥ ' + (Number(a.total_jpy) || 0).toLocaleString('ja-JP') + '</div>'
       : '<span style="color:var(--muted)">—</span>';
-    var qLocked = (a.status === 'done' || a.status === 'rejected');
-    var qDateValue = a.quote_sent_at ? new Date(a.quote_sent_at).toISOString().slice(0,10) : '';
-    var quoteSent = '<div class="brand-app-qsent" data-id="' + esc(a.id) + '" style="display:flex;flex-direction:column;gap:3px;font-size:11px">'
-      + '<label style="display:inline-flex;align-items:center;gap:5px;cursor:' + (qLocked ? 'not-allowed' : 'pointer') + ';color:' + (a.quote_sent_at ? '#16a34a' : 'var(--muted)') + ';font-weight:' + (a.quote_sent_at ? '600' : '400') + '">'
-        + '<input type="checkbox" ' + (a.quote_sent_at ? 'checked' : '') + ' ' + (qLocked ? 'disabled' : '') + ' onchange="toggleBrandAppQuoteSent(\'' + esc(a.id) + '\', this)" style="cursor:' + (qLocked ? 'not-allowed' : 'pointer') + '">'
-        + '<span class="qsent-label">' + (a.quote_sent_at ? '전달' : '미전달') + '</span>'
-      + '</label>'
-      + '<input type="date" class="qsent-date" value="' + qDateValue + '" ' + (a.quote_sent_at && !qLocked ? '' : 'disabled') + ' onchange="updateBrandAppQuoteSentDate(\'' + esc(a.id) + '\', this)" style="font-size:11px;padding:2px 4px;border:1px solid var(--line);border-radius:4px;width:100%;background:' + (a.quote_sent_at && !qLocked ? '#fff' : '#F5F5F5') + '">'
-    + '</div>';
+    var qLocked = false; // 잠금 해제 — done/rejected 상태도 인라인 편집 허용 (사용자 요청)
+    var quoteSent = '<div class="brand-app-qsent-cell" data-id="' + esc(a.id) + '" style="position:relative;min-height:36px">' + renderQuoteSentDisplay(a.quote_sent_at, qLocked) + '</div>';
     var memoText = (a.admin_memo || '').trim();
     var memoCell = '<div class="brand-app-memo-cell" data-id="' + esc(a.id) + '" style="position:relative;min-height:36px">' + renderMemoDisplay(memoText, qLocked) + '</div>';
     return '<tr data-id="' + esc(a.id) + '">'
@@ -12521,7 +12514,7 @@ async function openBrandAppDetail(id) {
   }
 
   // 편집 가능 여부 — done 또는 rejected면 읽기전용
-  var editableDisabled = (a.status === 'done' || a.status === 'rejected') ? 'disabled' : '';
+  var editableDisabled = ''; // 잠금 해제 — done/rejected 상태도 모달에서 편집 허용 (사용자 요청)
 
   // 섹션 재사용 스타일
   var sectionLabel = function(txt) {
@@ -12623,93 +12616,99 @@ function _findBrandApp(id) {
   return idx < 0 ? null : _brandApps[idx];
 }
 
-function _refreshQuoteSentCellUI(wrapEl, isoOrNull) {
-  if (!wrapEl) return;
-  var label = wrapEl.querySelector('.qsent-label');
-  var labelWrap = label?.parentElement;
-  var dateInput = wrapEl.querySelector('.qsent-date');
-  if (label) label.textContent = isoOrNull ? '전달' : '미전달';
-  if (labelWrap) {
-    labelWrap.style.color = isoOrNull ? '#16a34a' : 'var(--muted)';
-    labelWrap.style.fontWeight = isoOrNull ? '600' : '400';
-  }
-  if (dateInput) {
-    dateInput.value = isoOrNull ? new Date(isoOrNull).toISOString().slice(0,10) : '';
-    dateInput.disabled = !isoOrNull;
-    dateInput.style.background = isoOrNull ? '#fff' : '#F5F5F5';
+function renderQuoteSentDisplay(isoOrNull, locked) {
+  var hasValue = !!isoOrNull;
+  var content = hasValue
+    ? '<span style="display:inline-flex;align-items:center;gap:4px;color:#16a34a;font-size:11px;font-weight:600"><span class="material-icons-round notranslate" translate="no" style="font-size:13px">check_circle</span>전달</span>'
+      + '<div style="font-size:10px;color:var(--muted);margin-top:2px">' + fmtDate(isoOrNull) + '</div>'
+    : '<span style="color:var(--muted);font-size:11px">미전달</span>';
+  return content
+    + '<button type="button" class="qsent-edit-btn" ' + (locked ? 'disabled' : '') + ' onclick="enterQuoteSentEdit(this)" title="' + (locked ? '완료/거절 신청은 수정 불가' : '견적서 전달 수정') + '" style="position:absolute;top:0;right:0;background:none;border:none;cursor:' + (locked ? 'not-allowed' : 'pointer') + ';padding:2px;color:var(--muted);display:flex;align-items:center;justify-content:center;border-radius:3px" onmouseover="if(!this.disabled)this.style.background=\'rgba(0,0,0,.05)\'" onmouseout="this.style.background=\'none\'"><span class="material-icons-round notranslate" translate="no" style="font-size:15px">edit</span></button>';
+}
+
+function _restoreQuoteSentDisplay(cell, isoOrNull, locked) {
+  cell.innerHTML = renderQuoteSentDisplay(isoOrNull, locked);
+}
+
+function enterQuoteSentEdit(btnEl) {
+  var cell = btnEl.closest('.brand-app-qsent-cell');
+  if (!cell) return;
+  var cur = _findBrandApp(cell.dataset.id);
+  if (!cur) return;
+  var hasValue = !!cur.quote_sent_at;
+  var dateValue = hasValue ? new Date(cur.quote_sent_at).toISOString().slice(0,10) : new Date().toISOString().slice(0,10);
+  cell.innerHTML = '<div style="display:flex;flex-direction:column;gap:4px">'
+    + '<label style="display:inline-flex;align-items:center;gap:5px;font-size:11px;cursor:pointer">'
+      + '<input type="checkbox" class="qsent-edit-cb" ' + (hasValue ? 'checked' : '') + ' onchange="syncQsentEditDate(this)">'
+      + '<span>전달 완료</span>'
+    + '</label>'
+    + '<input type="date" class="qsent-edit-date" value="' + dateValue + '" ' + (hasValue ? '' : 'disabled') + ' style="font-size:11px;padding:2px 4px;border:1px solid var(--line);border-radius:4px;width:100%;background:' + (hasValue ? '#fff' : '#F5F5F5') + '">'
+    + '<div style="display:flex;gap:4px;justify-content:flex-end">'
+      + '<button type="button" onclick="cancelQuoteSentEdit(this)" style="background:#fff;border:1px solid var(--line);border-radius:4px;padding:3px 8px;cursor:pointer;font-size:11px;color:var(--muted)">취소</button>'
+      + '<button type="button" onclick="confirmQuoteSentEdit(this)" style="background:var(--pink);color:#fff;border:none;border-radius:4px;padding:3px 10px;cursor:pointer;font-size:11px;font-weight:600">저장</button>'
+    + '</div>'
+  + '</div>';
+}
+
+function syncQsentEditDate(cb) {
+  var cell = cb.closest('.brand-app-qsent-cell');
+  if (!cell) return;
+  var dateInput = cell.querySelector('.qsent-edit-date');
+  if (!dateInput) return;
+  dateInput.disabled = !cb.checked;
+  dateInput.style.background = cb.checked ? '#fff' : '#F5F5F5';
+  if (cb.checked && !dateInput.value) {
+    dateInput.value = new Date().toISOString().slice(0,10);
   }
 }
 
-async function toggleBrandAppQuoteSent(id, checkboxEl) {
-  if (!currentAdminInfo) { toast('권한이 없습니다','error'); checkboxEl.checked = !checkboxEl.checked; return; }
+function cancelQuoteSentEdit(anyChildEl) {
+  var cell = anyChildEl.closest('.brand-app-qsent-cell');
+  if (!cell) return;
+  var cur = _findBrandApp(cell.dataset.id);
+  var locked = cur && (cur.status === 'done' || cur.status === 'rejected');
+  _restoreQuoteSentDisplay(cell, cur?.quote_sent_at || null, !!locked);
+}
+
+async function confirmQuoteSentEdit(anyChildEl) {
+  var cell = anyChildEl.closest('.brand-app-qsent-cell');
+  if (!cell) return;
+  var id = cell.dataset.id;
   var cur = _findBrandApp(id);
   if (!cur) return;
-  if (cur.status === 'done' || cur.status === 'rejected') {
-    checkboxEl.checked = !!cur.quote_sent_at;
-    toast('완료/거절된 신청은 변경할 수 없습니다.', 'warn');
-    return;
+  var cb = cell.querySelector('.qsent-edit-cb');
+  var dateInput = cell.querySelector('.qsent-edit-date');
+  if (!cb || !dateInput) return;
+  var nextValue = null;
+  if (cb.checked) {
+    var raw = dateInput.value;
+    if (!raw) { toast('날짜를 선택하세요.', 'warn'); return; }
+    nextValue = new Date(raw + 'T12:00:00+09:00').toISOString();
   }
   var prevValue = cur.quote_sent_at;
+  var prevDateStr = prevValue ? new Date(prevValue).toISOString().slice(0,10) : null;
+  var nextDateStr = nextValue ? new Date(nextValue).toISOString().slice(0,10) : null;
+  if (prevDateStr === nextDateStr) {
+    _restoreQuoteSentDisplay(cell, prevValue, false);
+    return;
+  }
   var prevVersion = cur.version;
-  var nextValue = checkboxEl.checked ? new Date().toISOString() : null;
-  var wrap = checkboxEl.closest('.brand-app-qsent');
-  _refreshQuoteSentCellUI(wrap, nextValue);
-  checkboxEl.disabled = true;
+  cb.disabled = true; dateInput.disabled = true;
   var result = await updateBrandApplication(id, {quote_sent_at: nextValue}, prevVersion);
-  checkboxEl.disabled = false;
+  cb.disabled = false; dateInput.disabled = false;
   if (result.conflict) {
     toast('다른 관리자가 먼저 저장했습니다. 다시 불러옵니다.', 'warn');
     await loadBrandApplications();
     return;
   }
   if (!result.ok) {
-    checkboxEl.checked = !checkboxEl.checked;
-    _refreshQuoteSentCellUI(wrap, prevValue);
     toast('저장 실패: ' + (result.error || '알 수 없는 오류'), 'error');
     return;
   }
   cur.quote_sent_at = nextValue;
   cur.version = result.data?.version || (prevVersion + 1);
-}
-
-async function updateBrandAppQuoteSentDate(id, dateInput) {
-  if (!currentAdminInfo) { toast('권한이 없습니다','error'); return; }
-  var cur = _findBrandApp(id);
-  if (!cur) return;
-  if (cur.status === 'done' || cur.status === 'rejected') {
-    toast('완료/거절된 신청은 변경할 수 없습니다.', 'warn');
-    dateInput.value = cur.quote_sent_at ? new Date(cur.quote_sent_at).toISOString().slice(0,10) : '';
-    return;
-  }
-  var raw = dateInput.value;
-  if (!raw) {
-    // 날짜를 비우면 견적서 전달 자체를 해제로 간주
-    var wrap = dateInput.closest('.brand-app-qsent');
-    var cb = wrap?.querySelector('input[type="checkbox"]');
-    if (cb) { cb.checked = false; await toggleBrandAppQuoteSent(id, cb); }
-    return;
-  }
-  var prevValue = cur.quote_sent_at;
-  var prevVersion = cur.version;
-  // 입력값(YYYY-MM-DD)을 JST 정오로 저장(타임존 경계 안전)
-  var nextValue = new Date(raw + 'T12:00:00+09:00').toISOString();
-  if (prevValue && new Date(prevValue).toISOString().slice(0,10) === raw) return; // 변동 없음
-  dateInput.disabled = true;
-  var result = await updateBrandApplication(id, {quote_sent_at: nextValue}, prevVersion);
-  dateInput.disabled = false;
-  if (result.conflict) {
-    toast('다른 관리자가 먼저 저장했습니다. 다시 불러옵니다.', 'warn');
-    await loadBrandApplications();
-    return;
-  }
-  if (!result.ok) {
-    dateInput.value = prevValue ? new Date(prevValue).toISOString().slice(0,10) : '';
-    toast('저장 실패: ' + (result.error || '알 수 없는 오류'), 'error');
-    return;
-  }
-  cur.quote_sent_at = nextValue;
-  cur.version = result.data?.version || (prevVersion + 1);
-  toast('전달일이 저장되었습니다.');
+  _restoreQuoteSentDisplay(cell, nextValue, false);
+  toast(nextValue ? '견적서 전달일이 저장되었습니다.' : '견적서 미전달로 변경했습니다.');
 }
 
 function renderMemoDisplay(memoText, locked) {
@@ -12730,8 +12729,6 @@ function enterMemoEdit(btnEl) {
   var id = cell.dataset.id;
   var cur = _findBrandApp(id);
   if (!cur) return;
-  var locked = (cur.status === 'done' || cur.status === 'rejected');
-  if (locked) return;
   var original = (cur.admin_memo || '').trim();
   cell.innerHTML = '<div style="display:flex;flex-direction:column;gap:4px">'
     + '<textarea class="memo-edit-input" data-original="' + esc(original) + '" onkeydown="handleMemoEditKey(event, this)" style="width:100%;min-height:60px;font-size:11px;line-height:1.4;padding:4px 6px;border:1px solid var(--pink);border-radius:4px;resize:vertical;font-family:inherit;color:var(--ink)">' + esc(original) + '</textarea>'

--- a/admin/index.html
+++ b/admin/index.html
@@ -406,7 +406,7 @@ textarea.form-input{resize:vertical;min-height:80px}
 .admin-pane-list .data-table th{position:sticky;top:0;z-index:5;background:var(--surface-dim)}
 /* 브랜드 서베이 페인: 좌우 스크롤 + 첫 두 컬럼 sticky-left */
 #adminPane-brand-applications .admin-table-wrap{overflow-x:auto}
-#adminPane-brand-applications .data-table{min-width:3040px}
+#adminPane-brand-applications .data-table{min-width:3420px}
 /* sticky-left 두 컬럼 폭 강제 (auto 폭이라 left 값과 어긋나서 사이에 갭 생기는 문제 방지) */
 #adminPane-brand-applications .data-table th:nth-child(1),
 #adminPane-brand-applications .data-table td:nth-child(1){width:180px;min-width:180px;max-width:180px;box-sizing:border-box}
@@ -2237,6 +2237,8 @@ textarea.form-input{resize:vertical;min-height:80px}
                 <th style="width:130px">연락처</th>
                 <th style="width:180px">계산서 이메일</th>
                 <th style="width:220px">요청사항</th>
+                <th style="width:200px">제품명</th>
+                <th style="width:180px">URL</th>
                 <th style="width:80px">진행 수량</th>
                 <th style="width:100px">상품 가격(엔)</th>
                 <th style="width:100px">상품 가격(원)</th>
@@ -2254,7 +2256,7 @@ textarea.form-input{resize:vertical;min-height:80px}
                 <th style="width:110px">신청일 <span class="sort-arrows" data-sort="created" onclick="toggleBrandAppSort('created')">▲▼</span></th>
                 <th style="width:80px">처리</th>
               </tr></thead>
-              <tbody id="brandAppTableBody"><tr><td colspan="22" style="text-align:center;color:var(--muted);padding:24px"><span class="spinner" style="width:20px;height:20px;border-width:2px;border-color:rgba(200,120,163,.2);border-top-color:var(--pink)"></span></td></tr></tbody>
+              <tbody id="brandAppTableBody"><tr><td colspan="24" style="text-align:center;color:var(--muted);padding:24px"><span class="spinner" style="width:20px;height:20px;border-width:2px;border-color:rgba(200,120,163,.2);border-top-color:var(--pink)"></span></td></tr></tbody>
             </table>
             </div>
           </div>
@@ -12291,7 +12293,7 @@ function renderBrandLongPending(apps) {
 
 async function loadBrandApplications() {
   var tbody = $('brandAppTableBody');
-  if (tbody) tbody.innerHTML = '<tr><td colspan="22" style="text-align:center;color:var(--muted);padding:24px"><span class="spinner" style="width:20px;height:20px;border-width:2px;border-color:rgba(200,120,163,.2);border-top-color:var(--pink)"></span></td></tr>';
+  if (tbody) tbody.innerHTML = '<tr><td colspan="24" style="text-align:center;color:var(--muted);padding:24px"><span class="spinner" style="width:20px;height:20px;border-width:2px;border-color:rgba(200,120,163,.2);border-top-color:var(--pink)"></span></td></tr>';
   _brandApps = await fetchBrandApplications();
   renderBrandApplicationsList();
   refreshBrandAppBadge();
@@ -12385,7 +12387,7 @@ function renderBrandApplicationsList() {
     rows: list,
     renderRow: renderBrandAppRow,
     pageSize: BRAND_APP_PAGE_SIZE,
-    emptyHtml: '<tr><td colspan="22" style="text-align:center;color:var(--muted);padding:40px">신청 내역이 없습니다</td></tr>',
+    emptyHtml: '<tr><td colspan="24" style="text-align:center;color:var(--muted);padding:40px">신청 내역이 없습니다</td></tr>',
   });
 }
 
@@ -12600,6 +12602,26 @@ function _findBrandApp(id) {
 // 환율·VAT 상수 (FX_JPY_KRW=10, VAT_RATE=10% — migration 052 트리거와 일치)
 var BRAND_QUOTE_CONST = { FX_JPY_KRW: 10, VAT_RATE: 0.1 };
 
+// 제품 URL 셀 — 안전 URL이면 클릭 링크 + 복사 버튼, 아니면 평문 표시
+function renderProductUrlCell(url) {
+  if (!url) return '<span style="color:var(--muted);font-size:11px">—</span>';
+  var safe = (typeof safeBrandUrl === 'function') ? safeBrandUrl(url) : null;
+  if (!safe) {
+    return '<span style="color:var(--muted);word-break:break-all;font-size:11px;display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;overflow:hidden;line-height:1.4">' + esc(url) + '</span>';
+  }
+  var jsSafe = safe.replace(/\\/g, '\\\\').replace(/'/g, "\\'");
+  return '<div style="display:flex;align-items:flex-start;gap:4px;min-width:0">'
+    + '<a href="' + esc(safe) + '" target="_blank" rel="noopener" title="' + esc(url) + '"'
+      + ' style="flex:1;min-width:0;color:var(--pink);word-break:break-all;font-size:11px;'
+      + 'display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;overflow:hidden;line-height:1.4;max-height:2.8em">'
+      + esc(url) + '</a>'
+    + '<button type="button" class="btn btn-ghost btn-xs" onclick="copyBrandProductUrl(\'' + jsSafe + '\')" '
+      + 'title="URL 복사" style="padding:2px 6px;flex-shrink:0">'
+      + '<span class="material-icons-round notranslate" translate="no" style="font-size:13px;vertical-align:middle">content_copy</span>'
+    + '</button>'
+  + '</div>';
+}
+
 // 신청 1건의 제품 1개를 1행으로 렌더 (총 22컬럼)
 function renderBrandAppProductRow(a, p, idx, total) {
   var isFirst = (idx === 0);
@@ -12645,7 +12667,11 @@ function renderBrandAppProductRow(a, p, idx, total) {
     + cellApp(esc(a.billing_email || '—'), 'font-size:12px;color:' + (a.billing_email ? 'var(--ink)' : 'var(--muted)') + ';word-break:break-all')
     // 6. 요청사항
     + cellApp(brandAppNoteCell(a.request_note))
-    // 7-14. 제품별 8컬럼 (모든 행에 표시)
+    // 7. 제품명 (제품별 — 모든 행)
+    + '<td style="font-weight:600;color:var(--ink);font-size:11px;word-break:break-word;line-height:1.4">' + (p.name ? esc(p.name) : '<span style="color:var(--muted);font-weight:400">—</span>') + '</td>'
+    // 8. URL (제품별 — 모든 행)
+    + '<td>' + renderProductUrlCell(p.url) + '</td>'
+    // 9-16. 제품별 8컬럼 (모든 행에 표시)
     + '<td style="text-align:right;font-variant-numeric:tabular-nums;font-size:12px">' + (qty > 0 ? qty.toLocaleString('ja-JP') : '<span style="color:var(--muted)">—</span>') + '</td>'
     + '<td style="text-align:right;font-variant-numeric:tabular-nums;font-size:12px">' + (priceJpy > 0 ? '¥ ' + priceJpy.toLocaleString('ja-JP') : '<span style="color:var(--muted)">—</span>') + '</td>'
     + '<td style="text-align:right;font-variant-numeric:tabular-nums;font-size:12px">' + (priceKrw > 0 ? fmtKrw(priceKrw) : '<span style="color:var(--muted)">—</span>') + '</td>'

--- a/admin/index.html
+++ b/admin/index.html
@@ -432,8 +432,8 @@ textarea.form-input{resize:vertical;min-height:80px}
 #adminPane-brand-applications .data-table thead .col-help:hover::before{content:'';position:absolute;top:100%;left:50%;transform:translateX(-50%);margin-top:1px;border:5px solid transparent;border-bottom-color:#1A0F18;pointer-events:none;z-index:101}
 /* 호버 중인 th의 stacking context를 인접 sticky thead 셀보다 위로 끌어올림 (툴팁 가림 방지) */
 #adminPane-brand-applications .data-table thead th:has(.col-help:hover){z-index:99}
-/* 신청번호 셀 호버 — 클릭 가능 시각 피드백 */
-#adminPane-brand-applications .data-table tbody tr[data-summary="1"] td:nth-child(1):hover{background:rgba(200,120,163,.08)}
+/* 신청번호 셀 호버 — 클릭 가능 시각 피드백 (불투명 핑크 톤으로 sticky 뒷면 비침 방지) */
+#adminPane-brand-applications .data-table tbody tr[data-summary="1"] td:nth-child(1):hover{background:#F5E0EA}
 /* 신청 그룹 시각화 — 요약 행 위에 굵은 가로선(다음 그룹 시작 = 이전 그룹 끝) */
 #adminPane-brand-applications .data-table tbody tr[data-summary="1"] td{border-top:2px solid var(--outline)}
 #adminPane-brand-applications .data-table tbody tr[data-summary="1"]:first-child td{border-top:none}
@@ -12705,7 +12705,7 @@ function renderBrandAppSummaryRow(a) {
 
   return '<tr data-id="' + esc(a.id) + '" data-summary="1">'
     // 1. 신청번호 + 폼 종류 + 토글 + 제품 N개 (셀 전체 클릭으로 토글)
-    + '<td onclick="handleBrandAppRowClick(event)" style="cursor:pointer" title="클릭하여 ' + (isOpen ? '접기' : '펼치기') + '">'
+    + '<td onclick="handleBrandAppRowClick(event)" style="cursor:pointer">'
       + '<div style="display:flex;align-items:flex-start;gap:2px">'
         + toggleBtn
         + '<div style="flex:1;min-width:0">'

--- a/admin/index.html
+++ b/admin/index.html
@@ -12379,7 +12379,7 @@ function renderBrandApplicationsList() {
       + '<input type="date" class="qsent-date" value="' + qDateValue + '" ' + (a.quote_sent_at && !qLocked ? '' : 'disabled') + ' onchange="updateBrandAppQuoteSentDate(\'' + esc(a.id) + '\', this)" style="font-size:11px;padding:2px 4px;border:1px solid var(--line);border-radius:4px;width:100%;background:' + (a.quote_sent_at && !qLocked ? '#fff' : '#F5F5F5') + '">'
     + '</div>';
     var memoText = (a.admin_memo || '').trim();
-    var memoCell = '<textarea class="brand-app-memo" data-id="' + esc(a.id) + '" data-original="' + esc(memoText) + '" ' + (qLocked ? 'disabled' : '') + ' onblur="saveBrandAppMemo(\'' + esc(a.id) + '\', this)" placeholder="메모 입력…" style="width:100%;min-height:42px;max-height:80px;font-size:11px;line-height:1.4;padding:4px 6px;border:1px solid var(--line);border-radius:4px;resize:vertical;font-family:inherit;color:var(--ink);background:' + (qLocked ? '#F5F5F5' : '#fff') + '">' + esc(memoText) + '</textarea>';
+    var memoCell = '<div class="brand-app-memo-cell" data-id="' + esc(a.id) + '" style="position:relative;min-height:36px">' + renderMemoDisplay(memoText, qLocked) + '</div>';
     return '<tr data-id="' + esc(a.id) + '">'
       + '<td>'
         + '<div style="font-size:11px;font-weight:600;color:var(--ink)">' + esc(a.application_no || '—') + '</div>'
@@ -12712,34 +12712,87 @@ async function updateBrandAppQuoteSentDate(id, dateInput) {
   toast('전달일이 저장되었습니다.');
 }
 
-async function saveBrandAppMemo(id, textareaEl) {
-  if (!currentAdminInfo) return;
+function renderMemoDisplay(memoText, locked) {
+  var safe = (memoText || '').trim();
+  var color = safe ? 'var(--ink)' : 'var(--muted)';
+  var content = safe ? esc(safe) : '—';
+  return '<div class="memo-display" style="font-size:11px;color:' + color + ';display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;overflow:hidden;line-height:1.4;padding-right:22px;white-space:pre-wrap" title="' + esc(safe) + '">' + content + '</div>'
+    + '<button type="button" class="memo-edit-btn" ' + (locked ? 'disabled' : '') + ' onclick="enterMemoEdit(this)" title="' + (locked ? '완료/거절 신청은 수정 불가' : '메모 수정') + '" style="position:absolute;top:0;right:0;background:none;border:none;cursor:' + (locked ? 'not-allowed' : 'pointer') + ';padding:2px;color:var(--muted);display:flex;align-items:center;justify-content:center;border-radius:3px" onmouseover="if(!this.disabled)this.style.background=\'rgba(0,0,0,.05)\'" onmouseout="this.style.background=\'none\'"><span class="material-icons-round notranslate" translate="no" style="font-size:15px">edit</span></button>';
+}
+
+function _restoreMemoDisplay(cell, memoText, locked) {
+  cell.innerHTML = renderMemoDisplay(memoText, locked);
+}
+
+function enterMemoEdit(btnEl) {
+  var cell = btnEl.closest('.brand-app-memo-cell');
+  if (!cell) return;
+  var id = cell.dataset.id;
   var cur = _findBrandApp(id);
   if (!cur) return;
-  if (cur.status === 'done' || cur.status === 'rejected') {
-    textareaEl.value = cur.admin_memo || '';
+  var locked = (cur.status === 'done' || cur.status === 'rejected');
+  if (locked) return;
+  var original = (cur.admin_memo || '').trim();
+  cell.innerHTML = '<div style="display:flex;flex-direction:column;gap:4px">'
+    + '<textarea class="memo-edit-input" data-original="' + esc(original) + '" onkeydown="handleMemoEditKey(event, this)" style="width:100%;min-height:60px;font-size:11px;line-height:1.4;padding:4px 6px;border:1px solid var(--pink);border-radius:4px;resize:vertical;font-family:inherit;color:var(--ink)">' + esc(original) + '</textarea>'
+    + '<div style="display:flex;gap:4px;justify-content:flex-end">'
+      + '<button type="button" onclick="cancelMemoEdit(this)" style="background:#fff;border:1px solid var(--line);border-radius:4px;padding:3px 8px;cursor:pointer;font-size:11px;color:var(--muted)">취소</button>'
+      + '<button type="button" onclick="confirmMemoEdit(this)" style="background:var(--pink);color:#fff;border:none;border-radius:4px;padding:3px 10px;cursor:pointer;font-size:11px;font-weight:600">저장</button>'
+    + '</div>'
+  + '</div>';
+  var ta = cell.querySelector('.memo-edit-input');
+  if (ta) { ta.focus(); ta.setSelectionRange(ta.value.length, ta.value.length); }
+}
+
+function handleMemoEditKey(ev, taEl) {
+  if (ev.key === 'Escape') {
+    ev.preventDefault();
+    cancelMemoEdit(taEl);
+  } else if ((ev.metaKey || ev.ctrlKey) && ev.key === 'Enter') {
+    ev.preventDefault();
+    confirmMemoEdit(taEl);
+  }
+}
+
+function cancelMemoEdit(anyChildEl) {
+  var cell = anyChildEl.closest('.brand-app-memo-cell');
+  if (!cell) return;
+  var cur = _findBrandApp(cell.dataset.id);
+  var memoText = (cur?.admin_memo || '').trim();
+  var locked = cur && (cur.status === 'done' || cur.status === 'rejected');
+  _restoreMemoDisplay(cell, memoText, !!locked);
+}
+
+async function confirmMemoEdit(anyChildEl) {
+  var cell = anyChildEl.closest('.brand-app-memo-cell');
+  if (!cell) return;
+  var ta = cell.querySelector('.memo-edit-input');
+  if (!ta) return;
+  var id = cell.dataset.id;
+  var cur = _findBrandApp(id);
+  if (!cur) return;
+  var nextValue = (ta.value || '').trim();
+  var prevValue = (cur.admin_memo || '').trim();
+  if (nextValue === prevValue) {
+    _restoreMemoDisplay(cell, prevValue, false);
     return;
   }
-  var nextValue = (textareaEl.value || '').trim();
-  var prevValue = (cur.admin_memo || '').trim();
-  if (nextValue === prevValue) return; // 변동 없음
   var prevVersion = cur.version;
-  textareaEl.disabled = true;
+  ta.disabled = true;
   var result = await updateBrandApplication(id, {admin_memo: nextValue || null}, prevVersion);
-  textareaEl.disabled = false;
+  ta.disabled = false;
   if (result.conflict) {
     toast('다른 관리자가 먼저 저장했습니다. 다시 불러옵니다.', 'warn');
     await loadBrandApplications();
     return;
   }
   if (!result.ok) {
-    textareaEl.value = prevValue;
     toast('저장 실패: ' + (result.error || '알 수 없는 오류'), 'error');
     return;
   }
   cur.admin_memo = nextValue || null;
   cur.version = result.data?.version || (prevVersion + 1);
-  textareaEl.dataset.original = nextValue;
+  _restoreMemoDisplay(cell, nextValue, false);
   toast('메모가 저장되었습니다.');
 }
 

--- a/admin/index.html
+++ b/admin/index.html
@@ -2226,7 +2226,10 @@ textarea.form-input{resize:vertical;min-height:80px}
               </div>
               <div class="admin-filter-group" style="justify-content:flex-end">
                 <label>&nbsp;</label>
-                <button class="btn btn-ghost btn-xs" id="btnBrandAppFilterReset" onclick="resetBrandAppFilters()" style="display:none">초기화</button>
+                <div style="display:flex;gap:4px">
+                  <button class="btn btn-ghost btn-xs" id="btnBrandAppSortReset" onclick="resetBrandAppSort()" style="display:none">정렬 초기화</button>
+                  <button class="btn btn-ghost btn-xs" id="btnBrandAppFilterReset" onclick="resetBrandAppFilters()" style="display:none">초기화</button>
+                </div>
               </div>
               <div class="admin-filter-group" style="flex:1;min-width:200px;margin-left:auto">
                 <label>검색</label>
@@ -12377,6 +12380,8 @@ function renderBrandApplicationsList() {
   var filterActive = res.filterActive;
   var resetBtn = $('btnBrandAppFilterReset');
   if (resetBtn) resetBtn.style.display = filterActive ? 'inline-block' : 'none';
+  var sortResetBtn = $('btnBrandAppSortReset');
+  if (sortResetBtn) sortResetBtn.style.display = _brandAppSortIsDefault() ? 'none' : 'inline-block';
 
   var count = $('brandAppTotalCount');
   if (count) {
@@ -12429,6 +12434,16 @@ function toggleBrandAppSort(field) {
   } else {
     _brandAppSort = {field: field, dir: 'desc'};
   }
+  updateBrandAppSortIndicators();
+  renderBrandApplicationsList();
+}
+
+function _brandAppSortIsDefault() {
+  return _brandAppSort.field === 'created' && _brandAppSort.dir === 'desc';
+}
+
+function resetBrandAppSort() {
+  _brandAppSort = {field: 'created', dir: 'desc'};
   updateBrandAppSortIndicators();
   renderBrandApplicationsList();
 }

--- a/admin/index.html
+++ b/admin/index.html
@@ -12388,7 +12388,7 @@ function renderBrandApplicationsList() {
       + '<td>' + brandAppNoteCell(a.request_note) + '</td>'
       + '<td style="font-size:12px">' + prodSummary + '</td>'
       + '<td style="text-align:right;font-variant-numeric:tabular-nums">' + fmtKrw(a.estimated_krw) + '</td>'
-      + '<td style="text-align:right;font-variant-numeric:tabular-nums;font-weight:600">' + fmtKrw(a.final_quote_krw) + '</td>'
+      + '<td><div class="brand-app-fq-cell" data-id="' + esc(a.id) + '" style="position:relative;min-height:24px">' + renderFinalQuoteDisplay(a.final_quote_krw) + '</div></td>'
       + '<td>' + quoteSent + '</td>'
       + '<td>' + memoCell + '</td>'
       + '<td>' + brandAppStatusSelect(a) + '</td>'
@@ -12614,6 +12614,82 @@ function closeBrandAppDetail() {
 function _findBrandApp(id) {
   var idx = (_brandApps || []).findIndex(function(a){ return a.id === id; });
   return idx < 0 ? null : _brandApps[idx];
+}
+
+function renderFinalQuoteDisplay(value) {
+  return '<div class="fq-display" style="text-align:right;font-variant-numeric:tabular-nums;font-weight:600;padding-right:22px;font-size:12px">' + fmtKrw(value) + '</div>'
+    + '<button type="button" class="fq-edit-btn" onclick="enterFinalQuoteEdit(this)" title="확정 견적 수정" style="position:absolute;top:0;right:0;background:none;border:none;cursor:pointer;padding:2px;color:var(--muted);display:flex;align-items:center;justify-content:center;border-radius:3px" onmouseover="this.style.background=\'rgba(0,0,0,.05)\'" onmouseout="this.style.background=\'none\'"><span class="material-icons-round notranslate" translate="no" style="font-size:15px">edit</span></button>';
+}
+
+function _restoreFinalQuoteDisplay(cell, value) {
+  cell.innerHTML = renderFinalQuoteDisplay(value);
+}
+
+function enterFinalQuoteEdit(btnEl) {
+  var cell = btnEl.closest('.brand-app-fq-cell');
+  if (!cell) return;
+  var cur = _findBrandApp(cell.dataset.id);
+  if (!cur) return;
+  var original = cur.final_quote_krw == null ? '' : String(cur.final_quote_krw);
+  cell.innerHTML = '<div style="display:flex;flex-direction:column;gap:4px">'
+    + '<input type="number" class="fq-edit-input" value="' + esc(original) + '" placeholder="0" min="0" step="1" onkeydown="handleFinalQuoteEditKey(event, this)" style="width:100%;font-size:11px;padding:3px 6px;border:1px solid var(--pink);border-radius:4px;text-align:right;font-variant-numeric:tabular-nums">'
+    + '<div style="display:flex;gap:4px;justify-content:flex-end">'
+      + '<button type="button" onclick="cancelFinalQuoteEdit(this)" style="background:#fff;border:1px solid var(--line);border-radius:4px;padding:3px 8px;cursor:pointer;font-size:11px;color:var(--muted)">취소</button>'
+      + '<button type="button" onclick="confirmFinalQuoteEdit(this)" style="background:var(--pink);color:#fff;border:none;border-radius:4px;padding:3px 10px;cursor:pointer;font-size:11px;font-weight:600">저장</button>'
+    + '</div>'
+  + '</div>';
+  var input = cell.querySelector('.fq-edit-input');
+  if (input) { input.focus(); input.select(); }
+}
+
+function handleFinalQuoteEditKey(ev, inputEl) {
+  if (ev.key === 'Escape') { ev.preventDefault(); cancelFinalQuoteEdit(inputEl); }
+  else if (ev.key === 'Enter') { ev.preventDefault(); confirmFinalQuoteEdit(inputEl); }
+}
+
+function cancelFinalQuoteEdit(anyChildEl) {
+  var cell = anyChildEl.closest('.brand-app-fq-cell');
+  if (!cell) return;
+  var cur = _findBrandApp(cell.dataset.id);
+  _restoreFinalQuoteDisplay(cell, cur?.final_quote_krw);
+}
+
+async function confirmFinalQuoteEdit(anyChildEl) {
+  var cell = anyChildEl.closest('.brand-app-fq-cell');
+  if (!cell) return;
+  var input = cell.querySelector('.fq-edit-input');
+  if (!input) return;
+  var id = cell.dataset.id;
+  var cur = _findBrandApp(id);
+  if (!cur) return;
+  var raw = (input.value || '').trim();
+  var nextValue = raw === '' ? null : Number(raw);
+  if (nextValue !== null && (!isFinite(nextValue) || nextValue < 0)) {
+    toast('0 이상의 숫자만 입력하세요.', 'warn');
+    return;
+  }
+  var prevValue = cur.final_quote_krw == null ? null : Number(cur.final_quote_krw);
+  if (prevValue === nextValue) {
+    _restoreFinalQuoteDisplay(cell, prevValue);
+    return;
+  }
+  var prevVersion = cur.version;
+  input.disabled = true;
+  var result = await updateBrandApplication(id, {final_quote_krw: nextValue}, prevVersion);
+  input.disabled = false;
+  if (result.conflict) {
+    toast('다른 관리자가 먼저 저장했습니다. 다시 불러옵니다.', 'warn');
+    await loadBrandApplications();
+    return;
+  }
+  if (!result.ok) {
+    toast('저장 실패: ' + (result.error || '알 수 없는 오류'), 'error');
+    return;
+  }
+  cur.final_quote_krw = nextValue;
+  cur.version = result.data?.version || (prevVersion + 1);
+  _restoreFinalQuoteDisplay(cell, nextValue);
+  toast('확정 견적이 저장되었습니다.');
 }
 
 function renderQuoteSentDisplay(isoOrNull, locked) {

--- a/dev/admin/index.html
+++ b/dev/admin/index.html
@@ -1199,15 +1199,15 @@
                 <th style="width:220px">요청사항</th>
                 <th style="width:200px">제품명</th>
                 <th style="width:180px">URL</th>
-                <th style="width:80px">진행 수량</th>
+                <th style="width:80px">진행 수량 <span class="col-help" data-tooltip="∑ 수량 (전체 제품의 수량 합계)"><span class="material-icons-round notranslate" translate="no">help_outline</span></span></th>
                 <th style="width:100px">상품 가격(엔)</th>
-                <th style="width:100px">상품 가격(원)</th>
-                <th style="width:130px">상품 최종 금액</th>
+                <th style="width:100px">상품 가격(원) <span class="col-help" data-tooltip="상품 가격(엔) × 10  (환율 ¥1 = ₩10)"><span class="material-icons-round notranslate" translate="no">help_outline</span></span></th>
+                <th style="width:130px">상품 최종 금액 <span class="col-help" data-tooltip="진행 수량 × 상품 가격(원)"><span class="material-icons-round notranslate" translate="no">help_outline</span></span></th>
                 <th style="width:120px">이체수수료(건)</th>
-                <th style="width:130px">이체수수료(원)</th>
-                <th style="width:130px">최종 견적 금액</th>
-                <th style="width:130px">VAT포함</th>
-                <th style="width:120px">예상 견적 <span class="sort-arrows" data-sort="estimated" onclick="toggleBrandAppSort('estimated')">▲▼</span></th>
+                <th style="width:130px">이체수수료(원) <span class="col-help" data-tooltip="진행 수량 × 이체수수료(건)"><span class="material-icons-round notranslate" translate="no">help_outline</span></span></th>
+                <th style="width:130px">최종 견적 금액 <span class="col-help" data-tooltip="상품 최종 금액 + 이체수수료(원)"><span class="material-icons-round notranslate" translate="no">help_outline</span></span></th>
+                <th style="width:130px">VAT포함 <span class="col-help" data-tooltip="최종 견적 금액 × 1.1  (VAT 10%)"><span class="material-icons-round notranslate" translate="no">help_outline</span></span></th>
+                <th style="width:120px">예상 견적 <span class="col-help" data-tooltip="DB 트리거 자동 계산 (신청 INSERT 시 고정)&#10;reviewer: (∑ 엔가격×수량×10 + ∑ 수량×₩2,500) × 1.1&#10;seeding: 0 (수동 협의)"><span class="material-icons-round notranslate" translate="no">help_outline</span></span> <span class="sort-arrows" data-sort="estimated" onclick="toggleBrandAppSort('estimated')">▲▼</span></th>
                 <th style="width:120px">확정 견적</th>
                 <th style="width:130px">견적서 전달</th>
                 <th style="width:220px">내부 메모</th>

--- a/dev/admin/index.html
+++ b/dev/admin/index.html
@@ -1169,7 +1169,10 @@
               </div>
               <div class="admin-filter-group" style="justify-content:flex-end">
                 <label>&nbsp;</label>
-                <button class="btn btn-ghost btn-xs" id="btnBrandAppFilterReset" onclick="resetBrandAppFilters()" style="display:none">초기화</button>
+                <div style="display:flex;gap:4px">
+                  <button class="btn btn-ghost btn-xs" id="btnBrandAppSortReset" onclick="resetBrandAppSort()" style="display:none">정렬 초기화</button>
+                  <button class="btn btn-ghost btn-xs" id="btnBrandAppFilterReset" onclick="resetBrandAppFilters()" style="display:none">초기화</button>
+                </div>
               </div>
               <div class="admin-filter-group" style="flex:1;min-width:200px;margin-left:auto">
                 <label>검색</label>

--- a/dev/admin/index.html
+++ b/dev/admin/index.html
@@ -1197,7 +1197,14 @@
                 <th style="width:130px">연락처</th>
                 <th style="width:180px">계산서 이메일</th>
                 <th style="width:220px">요청사항</th>
-                <th style="width:180px">제품 요약</th>
+                <th style="width:80px">진행 수량</th>
+                <th style="width:100px">상품 가격(엔)</th>
+                <th style="width:100px">상품 가격(원)</th>
+                <th style="width:130px">상품 최종 금액</th>
+                <th style="width:120px">이체수수료(건)</th>
+                <th style="width:130px">이체수수료(원)</th>
+                <th style="width:130px">최종 견적 금액</th>
+                <th style="width:130px">VAT포함</th>
                 <th style="width:120px">예상 견적 <span class="sort-arrows" data-sort="estimated" onclick="toggleBrandAppSort('estimated')">▲▼</span></th>
                 <th style="width:120px">확정 견적</th>
                 <th style="width:130px">견적서 전달</th>
@@ -1207,7 +1214,7 @@
                 <th style="width:110px">신청일 <span class="sort-arrows" data-sort="created" onclick="toggleBrandAppSort('created')">▲▼</span></th>
                 <th style="width:80px">처리</th>
               </tr></thead>
-              <tbody id="brandAppTableBody"><tr><td colspan="15" style="text-align:center;color:var(--muted);padding:24px"><span class="spinner" style="width:20px;height:20px;border-width:2px;border-color:rgba(200,120,163,.2);border-top-color:var(--pink)"></span></td></tr></tbody>
+              <tbody id="brandAppTableBody"><tr><td colspan="22" style="text-align:center;color:var(--muted);padding:24px"><span class="spinner" style="width:20px;height:20px;border-width:2px;border-color:rgba(200,120,163,.2);border-top-color:var(--pink)"></span></td></tr></tbody>
             </table>
             </div>
           </div>

--- a/dev/admin/index.html
+++ b/dev/admin/index.html
@@ -1040,7 +1040,7 @@
               <div style="font-size:10px;color:var(--muted);margin-top:2px">초기 접수 기준 추정치</div>
             </div>
             <div class="admin-card" style="padding:16px">
-              <div style="font-size:11px;color:var(--muted);font-weight:700;letter-spacing:0.05em">확정 견적 합계 (KRW)</div>
+              <div style="font-size:11px;color:var(--muted);font-weight:700;letter-spacing:0.05em">예상 견적 합계 (KRW)</div>
               <div id="brandKpiFinal" style="font-size:20px;font-weight:800;color:var(--pink);margin-top:6px;font-variant-numeric:tabular-nums">—</div>
               <div style="font-size:10px;color:var(--muted);margin-top:2px">quoted 이상 단계 합산</div>
             </div>
@@ -1211,7 +1211,6 @@
                 <th style="width:130px">최종 견적 금액 <span class="col-help" data-tooltip="상품 최종 금액 + 이체수수료(원)"><span class="material-icons-round notranslate" translate="no">help_outline</span></span></th>
                 <th style="width:130px">VAT포함 <span class="col-help" data-tooltip="최종 견적 금액 × 1.1  (VAT 10%)"><span class="material-icons-round notranslate" translate="no">help_outline</span></span></th>
                 <th style="width:120px">예상 견적 <span class="col-help" data-tooltip="DB 트리거 자동 계산 (신청 INSERT 시 고정)&#10;reviewer: (∑ 엔가격×수량×10 + ∑ 수량×₩2,500) × 1.1&#10;seeding: 0 (수동 협의)"><span class="material-icons-round notranslate" translate="no">help_outline</span></span> <span class="sort-arrows" data-sort="estimated" onclick="toggleBrandAppSort('estimated')">▲▼</span></th>
-                <th style="width:120px">확정 견적</th>
                 <th style="width:130px">견적서 전달</th>
                 <th style="width:220px">내부 메모</th>
                 <th style="width:120px">상태 <span class="sort-arrows" data-sort="status" onclick="toggleBrandAppSort('status')">▲▼</span></th>
@@ -1219,7 +1218,7 @@
                 <th style="width:110px">신청일 <span class="sort-arrows" data-sort="created" onclick="toggleBrandAppSort('created')">▲▼</span></th>
                 <th style="width:80px">처리</th>
               </tr></thead>
-              <tbody id="brandAppTableBody"><tr><td colspan="24" style="text-align:center;color:var(--muted);padding:24px"><span class="spinner" style="width:20px;height:20px;border-width:2px;border-color:rgba(200,120,163,.2);border-top-color:var(--pink)"></span></td></tr></tbody>
+              <tbody id="brandAppTableBody"><tr><td colspan="23" style="text-align:center;color:var(--muted);padding:24px"><span class="spinner" style="width:20px;height:20px;border-width:2px;border-color:rgba(200,120,163,.2);border-top-color:var(--pink)"></span></td></tr></tbody>
             </table>
             </div>
           </div>

--- a/dev/admin/index.html
+++ b/dev/admin/index.html
@@ -1197,6 +1197,8 @@
                 <th style="width:130px">연락처</th>
                 <th style="width:180px">계산서 이메일</th>
                 <th style="width:220px">요청사항</th>
+                <th style="width:200px">제품명</th>
+                <th style="width:180px">URL</th>
                 <th style="width:80px">진행 수량</th>
                 <th style="width:100px">상품 가격(엔)</th>
                 <th style="width:100px">상품 가격(원)</th>
@@ -1214,7 +1216,7 @@
                 <th style="width:110px">신청일 <span class="sort-arrows" data-sort="created" onclick="toggleBrandAppSort('created')">▲▼</span></th>
                 <th style="width:80px">처리</th>
               </tr></thead>
-              <tbody id="brandAppTableBody"><tr><td colspan="22" style="text-align:center;color:var(--muted);padding:24px"><span class="spinner" style="width:20px;height:20px;border-width:2px;border-color:rgba(200,120,163,.2);border-top-color:var(--pink)"></span></td></tr></tbody>
+              <tbody id="brandAppTableBody"><tr><td colspan="24" style="text-align:center;color:var(--muted);padding:24px"><span class="spinner" style="width:20px;height:20px;border-width:2px;border-color:rgba(200,120,163,.2);border-top-color:var(--pink)"></span></td></tr></tbody>
             </table>
             </div>
           </div>

--- a/dev/css/admin.css
+++ b/dev/css/admin.css
@@ -67,7 +67,7 @@
 .admin-pane-list .data-table th{position:sticky;top:0;z-index:5;background:var(--surface-dim)}
 /* 브랜드 서베이 페인: 좌우 스크롤 + 첫 두 컬럼 sticky-left */
 #adminPane-brand-applications .admin-table-wrap{overflow-x:auto}
-#adminPane-brand-applications .data-table{min-width:3040px}
+#adminPane-brand-applications .data-table{min-width:3420px}
 /* sticky-left 두 컬럼 폭 강제 (auto 폭이라 left 값과 어긋나서 사이에 갭 생기는 문제 방지) */
 #adminPane-brand-applications .data-table th:nth-child(1),
 #adminPane-brand-applications .data-table td:nth-child(1){width:180px;min-width:180px;max-width:180px;box-sizing:border-box}

--- a/dev/css/admin.css
+++ b/dev/css/admin.css
@@ -91,6 +91,8 @@
 #adminPane-brand-applications .data-table thead .col-help:hover{color:var(--pink)}
 #adminPane-brand-applications .data-table thead .col-help:hover::after{content:attr(data-tooltip);position:absolute;top:100%;left:50%;transform:translateX(-50%);margin-top:6px;background:#1A0F18;color:#fff;font-size:11px;font-weight:400;letter-spacing:normal;text-transform:none;line-height:1.5;padding:7px 10px;border-radius:5px;white-space:pre-line;width:max-content;max-width:260px;z-index:100;box-shadow:0 4px 12px rgba(0,0,0,.15);pointer-events:none}
 #adminPane-brand-applications .data-table thead .col-help:hover::before{content:'';position:absolute;top:100%;left:50%;transform:translateX(-50%);margin-top:1px;border:5px solid transparent;border-bottom-color:#1A0F18;pointer-events:none;z-index:101}
+/* 호버 중인 th의 stacking context를 인접 sticky thead 셀보다 위로 끌어올림 (툴팁 가림 방지) */
+#adminPane-brand-applications .data-table thead th:has(.col-help:hover){z-index:99}
 /* 신청 그룹 시각화 — 요약 행 위에 굵은 가로선(다음 그룹 시작 = 이전 그룹 끝) */
 #adminPane-brand-applications .data-table tbody tr[data-summary="1"] td{border-top:2px solid var(--outline)}
 #adminPane-brand-applications .data-table tbody tr[data-summary="1"]:first-child td{border-top:none}

--- a/dev/css/admin.css
+++ b/dev/css/admin.css
@@ -67,7 +67,7 @@
 .admin-pane-list .data-table th{position:sticky;top:0;z-index:5;background:var(--surface-dim)}
 /* 브랜드 서베이 페인: 좌우 스크롤 + 첫 두 컬럼 sticky-left */
 #adminPane-brand-applications .admin-table-wrap{overflow-x:auto}
-#adminPane-brand-applications .data-table{min-width:2280px}
+#adminPane-brand-applications .data-table{min-width:3040px}
 /* sticky-left 두 컬럼 폭 강제 (auto 폭이라 left 값과 어긋나서 사이에 갭 생기는 문제 방지) */
 #adminPane-brand-applications .data-table th:nth-child(1),
 #adminPane-brand-applications .data-table td:nth-child(1){width:180px;min-width:180px;max-width:180px;box-sizing:border-box}

--- a/dev/css/admin.css
+++ b/dev/css/admin.css
@@ -68,6 +68,11 @@
 /* 브랜드 서베이 페인: 좌우 스크롤 + 첫 두 컬럼 sticky-left */
 #adminPane-brand-applications .admin-table-wrap{overflow-x:auto}
 #adminPane-brand-applications .data-table{min-width:2280px}
+/* sticky-left 두 컬럼 폭 강제 (auto 폭이라 left 값과 어긋나서 사이에 갭 생기는 문제 방지) */
+#adminPane-brand-applications .data-table th:nth-child(1),
+#adminPane-brand-applications .data-table td:nth-child(1){width:180px;min-width:180px;max-width:180px;box-sizing:border-box}
+#adminPane-brand-applications .data-table th:nth-child(2),
+#adminPane-brand-applications .data-table td:nth-child(2){width:200px;min-width:200px;max-width:200px;box-sizing:border-box;word-break:break-word}
 #adminPane-brand-applications .data-table tbody td:nth-child(1),
 #adminPane-brand-applications .data-table tbody td:nth-child(2){position:sticky;z-index:3;background:var(--surface)}
 #adminPane-brand-applications .data-table tbody tr:hover td:nth-child(1),

--- a/dev/css/admin.css
+++ b/dev/css/admin.css
@@ -85,6 +85,12 @@
 #adminPane-brand-applications .data-table thead th:nth-child(2){z-index:7}
 #adminPane-brand-applications .data-table tbody td:nth-child(2),
 #adminPane-brand-applications .data-table thead th:nth-child(2){box-shadow:2px 0 4px -2px rgba(0,0,0,.08)}
+/* 헤더 수식 도움말 (?) — CSS-only 툴팁 */
+#adminPane-brand-applications .data-table thead .col-help{display:inline-flex;align-items:center;margin-left:3px;color:var(--muted);cursor:help;position:relative;vertical-align:middle}
+#adminPane-brand-applications .data-table thead .col-help .material-icons-round{font-size:13px}
+#adminPane-brand-applications .data-table thead .col-help:hover{color:var(--pink)}
+#adminPane-brand-applications .data-table thead .col-help:hover::after{content:attr(data-tooltip);position:absolute;top:100%;left:50%;transform:translateX(-50%);margin-top:6px;background:#1A0F18;color:#fff;font-size:11px;font-weight:400;letter-spacing:normal;text-transform:none;line-height:1.5;padding:7px 10px;border-radius:5px;white-space:pre-line;width:max-content;max-width:260px;z-index:100;box-shadow:0 4px 12px rgba(0,0,0,.15);pointer-events:none}
+#adminPane-brand-applications .data-table thead .col-help:hover::before{content:'';position:absolute;top:100%;left:50%;transform:translateX(-50%);margin-top:1px;border:5px solid transparent;border-bottom-color:#1A0F18;pointer-events:none;z-index:101}
 /* 신청 그룹 시각화 — 요약 행 위에 굵은 가로선(다음 그룹 시작 = 이전 그룹 끝) */
 #adminPane-brand-applications .data-table tbody tr[data-summary="1"] td{border-top:2px solid var(--outline)}
 #adminPane-brand-applications .data-table tbody tr[data-summary="1"]:first-child td{border-top:none}

--- a/dev/css/admin.css
+++ b/dev/css/admin.css
@@ -93,8 +93,6 @@
 #adminPane-brand-applications .data-table thead .col-help:hover::before{content:'';position:absolute;top:100%;left:50%;transform:translateX(-50%);margin-top:1px;border:5px solid transparent;border-bottom-color:#1A0F18;pointer-events:none;z-index:101}
 /* 호버 중인 th의 stacking context를 인접 sticky thead 셀보다 위로 끌어올림 (툴팁 가림 방지) */
 #adminPane-brand-applications .data-table thead th:has(.col-help:hover){z-index:99}
-/* 신청번호 셀 호버 — 클릭 가능 시각 피드백 (불투명 핑크 톤으로 sticky 뒷면 비침 방지) */
-#adminPane-brand-applications .data-table tbody tr[data-summary="1"] td:nth-child(1):hover{background:#F5E0EA}
 /* 신청 그룹 시각화 — 요약 행 위에 굵은 가로선(다음 그룹 시작 = 이전 그룹 끝) */
 #adminPane-brand-applications .data-table tbody tr[data-summary="1"] td{border-top:2px solid var(--outline)}
 #adminPane-brand-applications .data-table tbody tr[data-summary="1"]:first-child td{border-top:none}

--- a/dev/css/admin.css
+++ b/dev/css/admin.css
@@ -85,6 +85,15 @@
 #adminPane-brand-applications .data-table thead th:nth-child(2){z-index:7}
 #adminPane-brand-applications .data-table tbody td:nth-child(2),
 #adminPane-brand-applications .data-table thead th:nth-child(2){box-shadow:2px 0 4px -2px rgba(0,0,0,.08)}
+/* 신청 그룹 시각화 — 요약 행 위에 굵은 가로선(다음 그룹 시작 = 이전 그룹 끝) */
+#adminPane-brand-applications .data-table tbody tr[data-summary="1"] td{border-top:2px solid var(--outline)}
+#adminPane-brand-applications .data-table tbody tr[data-summary="1"]:first-child td{border-top:none}
+/* 펼친 제품 행에서 신청번호 / 브랜드 컬럼은 행 구분선 제거 (그룹 영역으로 보이게) */
+#adminPane-brand-applications .data-table tbody tr[data-detail="1"] td:nth-child(1),
+#adminPane-brand-applications .data-table tbody tr[data-detail="1"] td:nth-child(2){border-bottom:none}
+/* 요약 행의 신청번호 / 브랜드 컬럼도 detail 행이 따라올 때 아래 구분선 제거 — JS로 클래스 부여 대신 :has 사용 */
+#adminPane-brand-applications .data-table tbody tr[data-summary="1"]:has(+ tr[data-detail="1"]) td:nth-child(1),
+#adminPane-brand-applications .data-table tbody tr[data-summary="1"]:has(+ tr[data-detail="1"]) td:nth-child(2){border-bottom:none}
 .kpi-row{display:grid;grid-template-columns:repeat(4,1fr);gap:16px;margin-bottom:24px}
 .kpi-card{background:var(--surface);border:none;border-radius:var(--r16);padding:20px;position:relative;overflow:hidden;box-shadow:var(--elevation-1)}
 .kpi-card::after{content:'';position:absolute;top:0;left:0;right:0;height:3px}

--- a/dev/css/admin.css
+++ b/dev/css/admin.css
@@ -93,8 +93,8 @@
 #adminPane-brand-applications .data-table thead .col-help:hover::before{content:'';position:absolute;top:100%;left:50%;transform:translateX(-50%);margin-top:1px;border:5px solid transparent;border-bottom-color:#1A0F18;pointer-events:none;z-index:101}
 /* 호버 중인 th의 stacking context를 인접 sticky thead 셀보다 위로 끌어올림 (툴팁 가림 방지) */
 #adminPane-brand-applications .data-table thead th:has(.col-help:hover){z-index:99}
-/* 신청번호 셀 호버 — 클릭 가능 시각 피드백 */
-#adminPane-brand-applications .data-table tbody tr[data-summary="1"] td:nth-child(1):hover{background:rgba(200,120,163,.08)}
+/* 신청번호 셀 호버 — 클릭 가능 시각 피드백 (불투명 핑크 톤으로 sticky 뒷면 비침 방지) */
+#adminPane-brand-applications .data-table tbody tr[data-summary="1"] td:nth-child(1):hover{background:#F5E0EA}
 /* 신청 그룹 시각화 — 요약 행 위에 굵은 가로선(다음 그룹 시작 = 이전 그룹 끝) */
 #adminPane-brand-applications .data-table tbody tr[data-summary="1"] td{border-top:2px solid var(--outline)}
 #adminPane-brand-applications .data-table tbody tr[data-summary="1"]:first-child td{border-top:none}

--- a/dev/css/admin.css
+++ b/dev/css/admin.css
@@ -93,6 +93,8 @@
 #adminPane-brand-applications .data-table thead .col-help:hover::before{content:'';position:absolute;top:100%;left:50%;transform:translateX(-50%);margin-top:1px;border:5px solid transparent;border-bottom-color:#1A0F18;pointer-events:none;z-index:101}
 /* 호버 중인 th의 stacking context를 인접 sticky thead 셀보다 위로 끌어올림 (툴팁 가림 방지) */
 #adminPane-brand-applications .data-table thead th:has(.col-help:hover){z-index:99}
+/* 신청번호 셀 호버 — 클릭 가능 시각 피드백 */
+#adminPane-brand-applications .data-table tbody tr[data-summary="1"] td:nth-child(1):hover{background:rgba(200,120,163,.08)}
 /* 신청 그룹 시각화 — 요약 행 위에 굵은 가로선(다음 그룹 시작 = 이전 그룹 끝) */
 #adminPane-brand-applications .data-table tbody tr[data-summary="1"] td{border-top:2px solid var(--outline)}
 #adminPane-brand-applications .data-table tbody tr[data-summary="1"]:first-child td{border-top:none}

--- a/dev/js/admin.js
+++ b/dev/js/admin.js
@@ -7265,7 +7265,7 @@ function renderBrandAppSummaryRow(a) {
 
   return '<tr data-id="' + esc(a.id) + '" data-summary="1">'
     // 1. 신청번호 + 폼 종류 + 토글 + 제품 N개 (셀 전체 클릭으로 토글)
-    + '<td onclick="handleBrandAppRowClick(event)" style="cursor:pointer" title="클릭하여 ' + (isOpen ? '접기' : '펼치기') + '">'
+    + '<td onclick="handleBrandAppRowClick(event)" style="cursor:pointer">'
       + '<div style="display:flex;align-items:flex-start;gap:2px">'
         + toggleBtn
         + '<div style="flex:1;min-width:0">'

--- a/dev/js/admin.js
+++ b/dev/js/admin.js
@@ -6959,15 +6959,8 @@ function renderBrandApplicationsList() {
       ? esc(prodCount + '종 · ' + (Number(a.total_qty) || 0) + '개')
         + '<div style="font-size:11px;color:var(--muted);margin-top:2px;font-variant-numeric:tabular-nums">¥ ' + (Number(a.total_jpy) || 0).toLocaleString('ja-JP') + '</div>'
       : '<span style="color:var(--muted)">—</span>';
-    var qLocked = (a.status === 'done' || a.status === 'rejected');
-    var qDateValue = a.quote_sent_at ? new Date(a.quote_sent_at).toISOString().slice(0,10) : '';
-    var quoteSent = '<div class="brand-app-qsent" data-id="' + esc(a.id) + '" style="display:flex;flex-direction:column;gap:3px;font-size:11px">'
-      + '<label style="display:inline-flex;align-items:center;gap:5px;cursor:' + (qLocked ? 'not-allowed' : 'pointer') + ';color:' + (a.quote_sent_at ? '#16a34a' : 'var(--muted)') + ';font-weight:' + (a.quote_sent_at ? '600' : '400') + '">'
-        + '<input type="checkbox" ' + (a.quote_sent_at ? 'checked' : '') + ' ' + (qLocked ? 'disabled' : '') + ' onchange="toggleBrandAppQuoteSent(\'' + esc(a.id) + '\', this)" style="cursor:' + (qLocked ? 'not-allowed' : 'pointer') + '">'
-        + '<span class="qsent-label">' + (a.quote_sent_at ? '전달' : '미전달') + '</span>'
-      + '</label>'
-      + '<input type="date" class="qsent-date" value="' + qDateValue + '" ' + (a.quote_sent_at && !qLocked ? '' : 'disabled') + ' onchange="updateBrandAppQuoteSentDate(\'' + esc(a.id) + '\', this)" style="font-size:11px;padding:2px 4px;border:1px solid var(--line);border-radius:4px;width:100%;background:' + (a.quote_sent_at && !qLocked ? '#fff' : '#F5F5F5') + '">'
-    + '</div>';
+    var qLocked = false; // 잠금 해제 — done/rejected 상태도 인라인 편집 허용 (사용자 요청)
+    var quoteSent = '<div class="brand-app-qsent-cell" data-id="' + esc(a.id) + '" style="position:relative;min-height:36px">' + renderQuoteSentDisplay(a.quote_sent_at, qLocked) + '</div>';
     var memoText = (a.admin_memo || '').trim();
     var memoCell = '<div class="brand-app-memo-cell" data-id="' + esc(a.id) + '" style="position:relative;min-height:36px">' + renderMemoDisplay(memoText, qLocked) + '</div>';
     return '<tr data-id="' + esc(a.id) + '">'
@@ -7111,7 +7104,7 @@ async function openBrandAppDetail(id) {
   }
 
   // 편집 가능 여부 — done 또는 rejected면 읽기전용
-  var editableDisabled = (a.status === 'done' || a.status === 'rejected') ? 'disabled' : '';
+  var editableDisabled = ''; // 잠금 해제 — done/rejected 상태도 모달에서 편집 허용 (사용자 요청)
 
   // 섹션 재사용 스타일
   var sectionLabel = function(txt) {
@@ -7213,93 +7206,99 @@ function _findBrandApp(id) {
   return idx < 0 ? null : _brandApps[idx];
 }
 
-function _refreshQuoteSentCellUI(wrapEl, isoOrNull) {
-  if (!wrapEl) return;
-  var label = wrapEl.querySelector('.qsent-label');
-  var labelWrap = label?.parentElement;
-  var dateInput = wrapEl.querySelector('.qsent-date');
-  if (label) label.textContent = isoOrNull ? '전달' : '미전달';
-  if (labelWrap) {
-    labelWrap.style.color = isoOrNull ? '#16a34a' : 'var(--muted)';
-    labelWrap.style.fontWeight = isoOrNull ? '600' : '400';
-  }
-  if (dateInput) {
-    dateInput.value = isoOrNull ? new Date(isoOrNull).toISOString().slice(0,10) : '';
-    dateInput.disabled = !isoOrNull;
-    dateInput.style.background = isoOrNull ? '#fff' : '#F5F5F5';
+function renderQuoteSentDisplay(isoOrNull, locked) {
+  var hasValue = !!isoOrNull;
+  var content = hasValue
+    ? '<span style="display:inline-flex;align-items:center;gap:4px;color:#16a34a;font-size:11px;font-weight:600"><span class="material-icons-round notranslate" translate="no" style="font-size:13px">check_circle</span>전달</span>'
+      + '<div style="font-size:10px;color:var(--muted);margin-top:2px">' + fmtDate(isoOrNull) + '</div>'
+    : '<span style="color:var(--muted);font-size:11px">미전달</span>';
+  return content
+    + '<button type="button" class="qsent-edit-btn" ' + (locked ? 'disabled' : '') + ' onclick="enterQuoteSentEdit(this)" title="' + (locked ? '완료/거절 신청은 수정 불가' : '견적서 전달 수정') + '" style="position:absolute;top:0;right:0;background:none;border:none;cursor:' + (locked ? 'not-allowed' : 'pointer') + ';padding:2px;color:var(--muted);display:flex;align-items:center;justify-content:center;border-radius:3px" onmouseover="if(!this.disabled)this.style.background=\'rgba(0,0,0,.05)\'" onmouseout="this.style.background=\'none\'"><span class="material-icons-round notranslate" translate="no" style="font-size:15px">edit</span></button>';
+}
+
+function _restoreQuoteSentDisplay(cell, isoOrNull, locked) {
+  cell.innerHTML = renderQuoteSentDisplay(isoOrNull, locked);
+}
+
+function enterQuoteSentEdit(btnEl) {
+  var cell = btnEl.closest('.brand-app-qsent-cell');
+  if (!cell) return;
+  var cur = _findBrandApp(cell.dataset.id);
+  if (!cur) return;
+  var hasValue = !!cur.quote_sent_at;
+  var dateValue = hasValue ? new Date(cur.quote_sent_at).toISOString().slice(0,10) : new Date().toISOString().slice(0,10);
+  cell.innerHTML = '<div style="display:flex;flex-direction:column;gap:4px">'
+    + '<label style="display:inline-flex;align-items:center;gap:5px;font-size:11px;cursor:pointer">'
+      + '<input type="checkbox" class="qsent-edit-cb" ' + (hasValue ? 'checked' : '') + ' onchange="syncQsentEditDate(this)">'
+      + '<span>전달 완료</span>'
+    + '</label>'
+    + '<input type="date" class="qsent-edit-date" value="' + dateValue + '" ' + (hasValue ? '' : 'disabled') + ' style="font-size:11px;padding:2px 4px;border:1px solid var(--line);border-radius:4px;width:100%;background:' + (hasValue ? '#fff' : '#F5F5F5') + '">'
+    + '<div style="display:flex;gap:4px;justify-content:flex-end">'
+      + '<button type="button" onclick="cancelQuoteSentEdit(this)" style="background:#fff;border:1px solid var(--line);border-radius:4px;padding:3px 8px;cursor:pointer;font-size:11px;color:var(--muted)">취소</button>'
+      + '<button type="button" onclick="confirmQuoteSentEdit(this)" style="background:var(--pink);color:#fff;border:none;border-radius:4px;padding:3px 10px;cursor:pointer;font-size:11px;font-weight:600">저장</button>'
+    + '</div>'
+  + '</div>';
+}
+
+function syncQsentEditDate(cb) {
+  var cell = cb.closest('.brand-app-qsent-cell');
+  if (!cell) return;
+  var dateInput = cell.querySelector('.qsent-edit-date');
+  if (!dateInput) return;
+  dateInput.disabled = !cb.checked;
+  dateInput.style.background = cb.checked ? '#fff' : '#F5F5F5';
+  if (cb.checked && !dateInput.value) {
+    dateInput.value = new Date().toISOString().slice(0,10);
   }
 }
 
-async function toggleBrandAppQuoteSent(id, checkboxEl) {
-  if (!currentAdminInfo) { toast('권한이 없습니다','error'); checkboxEl.checked = !checkboxEl.checked; return; }
+function cancelQuoteSentEdit(anyChildEl) {
+  var cell = anyChildEl.closest('.brand-app-qsent-cell');
+  if (!cell) return;
+  var cur = _findBrandApp(cell.dataset.id);
+  var locked = cur && (cur.status === 'done' || cur.status === 'rejected');
+  _restoreQuoteSentDisplay(cell, cur?.quote_sent_at || null, !!locked);
+}
+
+async function confirmQuoteSentEdit(anyChildEl) {
+  var cell = anyChildEl.closest('.brand-app-qsent-cell');
+  if (!cell) return;
+  var id = cell.dataset.id;
   var cur = _findBrandApp(id);
   if (!cur) return;
-  if (cur.status === 'done' || cur.status === 'rejected') {
-    checkboxEl.checked = !!cur.quote_sent_at;
-    toast('완료/거절된 신청은 변경할 수 없습니다.', 'warn');
-    return;
+  var cb = cell.querySelector('.qsent-edit-cb');
+  var dateInput = cell.querySelector('.qsent-edit-date');
+  if (!cb || !dateInput) return;
+  var nextValue = null;
+  if (cb.checked) {
+    var raw = dateInput.value;
+    if (!raw) { toast('날짜를 선택하세요.', 'warn'); return; }
+    nextValue = new Date(raw + 'T12:00:00+09:00').toISOString();
   }
   var prevValue = cur.quote_sent_at;
+  var prevDateStr = prevValue ? new Date(prevValue).toISOString().slice(0,10) : null;
+  var nextDateStr = nextValue ? new Date(nextValue).toISOString().slice(0,10) : null;
+  if (prevDateStr === nextDateStr) {
+    _restoreQuoteSentDisplay(cell, prevValue, false);
+    return;
+  }
   var prevVersion = cur.version;
-  var nextValue = checkboxEl.checked ? new Date().toISOString() : null;
-  var wrap = checkboxEl.closest('.brand-app-qsent');
-  _refreshQuoteSentCellUI(wrap, nextValue);
-  checkboxEl.disabled = true;
+  cb.disabled = true; dateInput.disabled = true;
   var result = await updateBrandApplication(id, {quote_sent_at: nextValue}, prevVersion);
-  checkboxEl.disabled = false;
+  cb.disabled = false; dateInput.disabled = false;
   if (result.conflict) {
     toast('다른 관리자가 먼저 저장했습니다. 다시 불러옵니다.', 'warn');
     await loadBrandApplications();
     return;
   }
   if (!result.ok) {
-    checkboxEl.checked = !checkboxEl.checked;
-    _refreshQuoteSentCellUI(wrap, prevValue);
     toast('저장 실패: ' + (result.error || '알 수 없는 오류'), 'error');
     return;
   }
   cur.quote_sent_at = nextValue;
   cur.version = result.data?.version || (prevVersion + 1);
-}
-
-async function updateBrandAppQuoteSentDate(id, dateInput) {
-  if (!currentAdminInfo) { toast('권한이 없습니다','error'); return; }
-  var cur = _findBrandApp(id);
-  if (!cur) return;
-  if (cur.status === 'done' || cur.status === 'rejected') {
-    toast('완료/거절된 신청은 변경할 수 없습니다.', 'warn');
-    dateInput.value = cur.quote_sent_at ? new Date(cur.quote_sent_at).toISOString().slice(0,10) : '';
-    return;
-  }
-  var raw = dateInput.value;
-  if (!raw) {
-    // 날짜를 비우면 견적서 전달 자체를 해제로 간주
-    var wrap = dateInput.closest('.brand-app-qsent');
-    var cb = wrap?.querySelector('input[type="checkbox"]');
-    if (cb) { cb.checked = false; await toggleBrandAppQuoteSent(id, cb); }
-    return;
-  }
-  var prevValue = cur.quote_sent_at;
-  var prevVersion = cur.version;
-  // 입력값(YYYY-MM-DD)을 JST 정오로 저장(타임존 경계 안전)
-  var nextValue = new Date(raw + 'T12:00:00+09:00').toISOString();
-  if (prevValue && new Date(prevValue).toISOString().slice(0,10) === raw) return; // 변동 없음
-  dateInput.disabled = true;
-  var result = await updateBrandApplication(id, {quote_sent_at: nextValue}, prevVersion);
-  dateInput.disabled = false;
-  if (result.conflict) {
-    toast('다른 관리자가 먼저 저장했습니다. 다시 불러옵니다.', 'warn');
-    await loadBrandApplications();
-    return;
-  }
-  if (!result.ok) {
-    dateInput.value = prevValue ? new Date(prevValue).toISOString().slice(0,10) : '';
-    toast('저장 실패: ' + (result.error || '알 수 없는 오류'), 'error');
-    return;
-  }
-  cur.quote_sent_at = nextValue;
-  cur.version = result.data?.version || (prevVersion + 1);
-  toast('전달일이 저장되었습니다.');
+  _restoreQuoteSentDisplay(cell, nextValue, false);
+  toast(nextValue ? '견적서 전달일이 저장되었습니다.' : '견적서 미전달로 변경했습니다.');
 }
 
 function renderMemoDisplay(memoText, locked) {
@@ -7320,8 +7319,6 @@ function enterMemoEdit(btnEl) {
   var id = cell.dataset.id;
   var cur = _findBrandApp(id);
   if (!cur) return;
-  var locked = (cur.status === 'done' || cur.status === 'rejected');
-  if (locked) return;
   var original = (cur.admin_memo || '').trim();
   cell.innerHTML = '<div style="display:flex;flex-direction:column;gap:4px">'
     + '<textarea class="memo-edit-input" data-original="' + esc(original) + '" onkeydown="handleMemoEditKey(event, this)" style="width:100%;min-height:60px;font-size:11px;line-height:1.4;padding:4px 6px;border:1px solid var(--pink);border-radius:4px;resize:vertical;font-family:inherit;color:var(--ink)">' + esc(original) + '</textarea>'

--- a/dev/js/admin.js
+++ b/dev/js/admin.js
@@ -6874,7 +6874,7 @@ function renderBrandLongPending(apps) {
 
 async function loadBrandApplications() {
   var tbody = $('brandAppTableBody');
-  if (tbody) tbody.innerHTML = '<tr><td colspan="15" style="text-align:center;color:var(--muted);padding:24px"><span class="spinner" style="width:20px;height:20px;border-width:2px;border-color:rgba(200,120,163,.2);border-top-color:var(--pink)"></span></td></tr>';
+  if (tbody) tbody.innerHTML = '<tr><td colspan="22" style="text-align:center;color:var(--muted);padding:24px"><span class="spinner" style="width:20px;height:20px;border-width:2px;border-color:rgba(200,120,163,.2);border-top-color:var(--pink)"></span></td></tr>';
   _brandApps = await fetchBrandApplications();
   renderBrandApplicationsList();
   refreshBrandAppBadge();
@@ -6954,38 +6954,12 @@ function renderBrandApplicationsList() {
   }
 
   var renderBrandAppRow = function(a) {
-    var prodCount = Array.isArray(a.products) ? a.products.length : 0;
-    var prodSummary = prodCount > 0
-      ? esc(prodCount + '종 · ' + (Number(a.total_qty) || 0) + '개')
-        + '<div style="font-size:11px;color:var(--muted);margin-top:2px;font-variant-numeric:tabular-nums">¥ ' + (Number(a.total_jpy) || 0).toLocaleString('ja-JP') + '</div>'
-      : '<span style="color:var(--muted)">—</span>';
-    var qLocked = false; // 잠금 해제 — done/rejected 상태도 인라인 편집 허용 (사용자 요청)
-    var quoteSent = '<div class="brand-app-qsent-cell" data-id="' + esc(a.id) + '" style="position:relative;min-height:36px">' + renderQuoteSentDisplay(a.quote_sent_at, qLocked) + '</div>';
-    var memoText = (a.admin_memo || '').trim();
-    var memoCell = '<div class="brand-app-memo-cell" data-id="' + esc(a.id) + '" style="position:relative;min-height:36px">' + renderMemoDisplay(memoText, qLocked) + '</div>';
-    return '<tr data-id="' + esc(a.id) + '">'
-      + '<td>'
-        + '<div style="font-size:11px;font-weight:600;color:var(--ink)">' + esc(a.application_no || '—') + '</div>'
-        + '<div style="margin-top:3px"><span style="background:#F0F0F0;color:#555;font-size:10px;font-weight:600;padding:2px 7px;border-radius:3px">' + esc(brandAppFormLabel(a.form_type)) + '</span></div>'
-      + '</td>'
-      + '<td style="font-weight:600">' + esc(a.brand_name || '—') + '</td>'
-      + '<td>'
-        + '<div>' + esc(a.contact_name || '—') + '</div>'
-        + (a.email ? '<div style="font-size:11px;color:var(--muted);margin-top:2px;word-break:break-all">' + esc(a.email) + '</div>' : '')
-      + '</td>'
-      + '<td style="font-size:12px">' + esc(formatPhoneDisplay(a.phone) || '—') + '</td>'
-      + '<td style="font-size:12px;color:' + (a.billing_email ? 'var(--ink)' : 'var(--muted)') + ';word-break:break-all">' + esc(a.billing_email || '—') + '</td>'
-      + '<td>' + brandAppNoteCell(a.request_note) + '</td>'
-      + '<td style="font-size:12px">' + prodSummary + '</td>'
-      + '<td style="text-align:right;font-variant-numeric:tabular-nums">' + fmtKrw(a.estimated_krw) + '</td>'
-      + '<td><div class="brand-app-fq-cell" data-id="' + esc(a.id) + '" style="position:relative;min-height:24px">' + renderFinalQuoteDisplay(a.final_quote_krw) + '</div></td>'
-      + '<td>' + quoteSent + '</td>'
-      + '<td>' + memoCell + '</td>'
-      + '<td>' + brandAppStatusSelect(a) + '</td>'
-      + '<td style="font-size:11px;color:var(--muted)">' + fmtDate(a.reviewed_at) + '</td>'
-      + '<td style="font-size:11px;color:var(--muted)">' + fmtDate(a.created_at) + '</td>'
-      + '<td><button class="btn btn-ghost btn-xs" onclick="openBrandAppDetail(\'' + esc(a.id) + '\')">상세</button></td>'
-      + '</tr>';
+    var prods = (Array.isArray(a.products) && a.products.length > 0)
+      ? a.products
+      : [{ name: '', qty: 0, price: 0, transfer_fee_krw: null }];
+    return prods.map(function(p, idx) {
+      return renderBrandAppProductRow(a, p, idx, prods.length);
+    }).join('');
   };
   if (brandAppLazy) brandAppLazy.destroy();
   brandAppLazy = mountLazyList({
@@ -6994,7 +6968,7 @@ function renderBrandApplicationsList() {
     rows: list,
     renderRow: renderBrandAppRow,
     pageSize: BRAND_APP_PAGE_SIZE,
-    emptyHtml: '<tr><td colspan="15" style="text-align:center;color:var(--muted);padding:40px">신청 내역이 없습니다</td></tr>',
+    emptyHtml: '<tr><td colspan="22" style="text-align:center;color:var(--muted);padding:40px">신청 내역이 없습니다</td></tr>',
   });
 }
 
@@ -7204,6 +7178,176 @@ function closeBrandAppDetail() {
 function _findBrandApp(id) {
   var idx = (_brandApps || []).findIndex(function(a){ return a.id === id; });
   return idx < 0 ? null : _brandApps[idx];
+}
+
+// 환율·VAT 상수 (FX_JPY_KRW=10, VAT_RATE=10% — migration 052 트리거와 일치)
+var BRAND_QUOTE_CONST = { FX_JPY_KRW: 10, VAT_RATE: 0.1 };
+
+// 신청 1건의 제품 1개를 1행으로 렌더 (총 22컬럼)
+function renderBrandAppProductRow(a, p, idx, total) {
+  var isFirst = (idx === 0);
+  var qty = Number(p.qty) || 0;
+  var priceJpy = Number(p.price) || 0;
+  var priceKrw = priceJpy * BRAND_QUOTE_CONST.FX_JPY_KRW;
+  var lineTotal = qty * priceKrw;
+  var transferFeeKrw = (p.transfer_fee_krw == null || p.transfer_fee_krw === '') ? null : Number(p.transfer_fee_krw);
+  var feeTotalKrw = transferFeeKrw == null ? 0 : qty * transferFeeKrw;
+  var finalKrw = lineTotal + feeTotalKrw;
+  var vatKrw = Math.floor(finalKrw * (1 + BRAND_QUOTE_CONST.VAT_RATE));
+
+  // 같은 신청 그룹 시각화 — 첫 행에 강조 top border, 마지막 행은 default
+  var trStyle = isFirst ? 'border-top:2px solid rgba(200,120,163,.25)' : '';
+
+  // 신청 단위 셀 (첫 행에만 채움, 나머지는 빈 td)
+  var cellApp = function(html, style) {
+    return '<td' + (style ? ' style="' + style + '"' : '') + '>' + (isFirst ? html : '') + '</td>';
+  };
+
+  var qLocked = false;
+  var memoText = (a.admin_memo || '').trim();
+  var memoCellInner = isFirst ? '<div class="brand-app-memo-cell" data-id="' + esc(a.id) + '" style="position:relative;min-height:36px">' + renderMemoDisplay(memoText, qLocked) + '</div>' : '';
+  var quoteSentInner = isFirst ? '<div class="brand-app-qsent-cell" data-id="' + esc(a.id) + '" style="position:relative;min-height:36px">' + renderQuoteSentDisplay(a.quote_sent_at, qLocked) + '</div>' : '';
+  var fqInner = isFirst ? '<div class="brand-app-fq-cell" data-id="' + esc(a.id) + '" style="position:relative;min-height:24px">' + renderFinalQuoteDisplay(a.final_quote_krw) + '</div>' : '';
+
+  return '<tr data-id="' + esc(a.id) + '" data-product-idx="' + idx + '"' + (trStyle ? ' style="' + trStyle + '"' : '') + '>'
+    // 1. 신청번호
+    + cellApp(
+        '<div style="font-size:11px;font-weight:600;color:var(--ink)">' + esc(a.application_no || '—') + '</div>'
+        + '<div style="margin-top:3px"><span style="background:#F0F0F0;color:#555;font-size:10px;font-weight:600;padding:2px 7px;border-radius:3px">' + esc(brandAppFormLabel(a.form_type)) + '</span></div>'
+      )
+    // 2. 브랜드
+    + cellApp(esc(a.brand_name || '—'), 'font-weight:600')
+    // 3. 담당자
+    + cellApp(
+        '<div>' + esc(a.contact_name || '—') + '</div>'
+        + (a.email ? '<div style="font-size:11px;color:var(--muted);margin-top:2px;word-break:break-all">' + esc(a.email) + '</div>' : '')
+      )
+    // 4. 연락처
+    + cellApp(esc(formatPhoneDisplay(a.phone) || '—'), 'font-size:12px')
+    // 5. 계산서 이메일
+    + cellApp(esc(a.billing_email || '—'), 'font-size:12px;color:' + (a.billing_email ? 'var(--ink)' : 'var(--muted)') + ';word-break:break-all')
+    // 6. 요청사항
+    + cellApp(brandAppNoteCell(a.request_note))
+    // 7-14. 제품별 8컬럼 (모든 행에 표시)
+    + '<td style="text-align:right;font-variant-numeric:tabular-nums;font-size:12px">' + (qty > 0 ? qty.toLocaleString('ja-JP') : '<span style="color:var(--muted)">—</span>') + '</td>'
+    + '<td style="text-align:right;font-variant-numeric:tabular-nums;font-size:12px">' + (priceJpy > 0 ? '¥ ' + priceJpy.toLocaleString('ja-JP') : '<span style="color:var(--muted)">—</span>') + '</td>'
+    + '<td style="text-align:right;font-variant-numeric:tabular-nums;font-size:12px">' + (priceKrw > 0 ? fmtKrw(priceKrw) : '<span style="color:var(--muted)">—</span>') + '</td>'
+    + '<td style="text-align:right;font-variant-numeric:tabular-nums;font-size:12px;font-weight:600">' + (lineTotal > 0 ? fmtKrw(lineTotal) : '<span style="color:var(--muted)">—</span>') + '</td>'
+    + '<td><div class="brand-app-tfee-cell" data-id="' + esc(a.id) + '" data-product-idx="' + idx + '" style="position:relative;min-height:24px">' + renderTransferFeeDisplay(transferFeeKrw) + '</div></td>'
+    + '<td style="text-align:right;font-variant-numeric:tabular-nums;font-size:12px">' + (feeTotalKrw > 0 ? fmtKrw(feeTotalKrw) : '<span style="color:var(--muted)">—</span>') + '</td>'
+    + '<td style="text-align:right;font-variant-numeric:tabular-nums;font-size:12px;font-weight:600">' + (finalKrw > 0 ? fmtKrw(finalKrw) : '<span style="color:var(--muted)">—</span>') + '</td>'
+    + '<td style="text-align:right;font-variant-numeric:tabular-nums;font-size:12px;color:#16a34a;font-weight:600">' + (vatKrw > 0 ? fmtKrw(vatKrw) : '<span style="color:var(--muted)">—</span>') + '</td>'
+    // 15. 예상 견적
+    + cellApp(fmtKrw(a.estimated_krw), 'text-align:right;font-variant-numeric:tabular-nums')
+    // 16. 확정 견적
+    + '<td>' + fqInner + '</td>'
+    // 17. 견적서 전달
+    + '<td>' + quoteSentInner + '</td>'
+    // 18. 내부 메모
+    + '<td>' + memoCellInner + '</td>'
+    // 19. 상태
+    + cellApp(brandAppStatusSelect(a))
+    // 20. 검수일
+    + cellApp(fmtDate(a.reviewed_at), 'font-size:11px;color:var(--muted)')
+    // 21. 신청일
+    + cellApp(fmtDate(a.created_at), 'font-size:11px;color:var(--muted)')
+    // 22. 처리
+    + cellApp('<button class="btn btn-ghost btn-xs" onclick="openBrandAppDetail(\'' + esc(a.id) + '\')">상세</button>')
+    + '</tr>';
+}
+
+// 이체수수료(건) 셀 — display + ✎ 인라인 편집
+function renderTransferFeeDisplay(value) {
+  var hasValue = value != null && isFinite(value);
+  var display = hasValue ? fmtKrw(value) : '<span style="color:var(--muted)">—</span>';
+  return '<div class="tfee-display" style="text-align:right;font-variant-numeric:tabular-nums;font-size:12px;padding-right:22px">' + display + '</div>'
+    + '<button type="button" class="tfee-edit-btn" onclick="enterTransferFeeEdit(this)" title="이체수수료(건) 수정" style="position:absolute;top:0;right:0;background:none;border:none;cursor:pointer;padding:2px;color:var(--muted);display:flex;align-items:center;justify-content:center;border-radius:3px" onmouseover="this.style.background=\'rgba(0,0,0,.05)\'" onmouseout="this.style.background=\'none\'"><span class="material-icons-round notranslate" translate="no" style="font-size:15px">edit</span></button>';
+}
+
+function _restoreTransferFeeDisplay(cell, value) {
+  cell.innerHTML = renderTransferFeeDisplay(value);
+}
+
+function enterTransferFeeEdit(btnEl) {
+  var cell = btnEl.closest('.brand-app-tfee-cell');
+  if (!cell) return;
+  var id = cell.dataset.id;
+  var idx = Number(cell.dataset.productIdx);
+  var cur = _findBrandApp(id);
+  if (!cur || !Array.isArray(cur.products) || !cur.products[idx]) return;
+  var p = cur.products[idx];
+  var original = (p.transfer_fee_krw == null || p.transfer_fee_krw === '') ? '' : String(p.transfer_fee_krw);
+  cell.innerHTML = '<div style="display:flex;flex-direction:column;gap:4px">'
+    + '<input type="number" class="tfee-edit-input" value="' + esc(original) + '" placeholder="0" min="0" step="1" onkeydown="handleTransferFeeEditKey(event, this)" style="width:100%;font-size:11px;padding:3px 6px;border:1px solid var(--pink);border-radius:4px;text-align:right;font-variant-numeric:tabular-nums">'
+    + '<div style="display:flex;gap:4px;justify-content:flex-end">'
+      + '<button type="button" onclick="cancelTransferFeeEdit(this)" style="background:#fff;border:1px solid var(--line);border-radius:4px;padding:3px 8px;cursor:pointer;font-size:11px;color:var(--muted)">취소</button>'
+      + '<button type="button" onclick="confirmTransferFeeEdit(this)" style="background:var(--pink);color:#fff;border:none;border-radius:4px;padding:3px 10px;cursor:pointer;font-size:11px;font-weight:600">저장</button>'
+    + '</div>'
+  + '</div>';
+  var input = cell.querySelector('.tfee-edit-input');
+  if (input) { input.focus(); input.select(); }
+}
+
+function handleTransferFeeEditKey(ev, inputEl) {
+  if (ev.key === 'Escape') { ev.preventDefault(); cancelTransferFeeEdit(inputEl); }
+  else if (ev.key === 'Enter') { ev.preventDefault(); confirmTransferFeeEdit(inputEl); }
+}
+
+function cancelTransferFeeEdit(anyChildEl) {
+  var cell = anyChildEl.closest('.brand-app-tfee-cell');
+  if (!cell) return;
+  var id = cell.dataset.id;
+  var idx = Number(cell.dataset.productIdx);
+  var cur = _findBrandApp(id);
+  if (!cur || !cur.products || !cur.products[idx]) return;
+  _restoreTransferFeeDisplay(cell, cur.products[idx].transfer_fee_krw);
+}
+
+async function confirmTransferFeeEdit(anyChildEl) {
+  var cell = anyChildEl.closest('.brand-app-tfee-cell');
+  if (!cell) return;
+  var input = cell.querySelector('.tfee-edit-input');
+  if (!input) return;
+  var id = cell.dataset.id;
+  var idx = Number(cell.dataset.productIdx);
+  var cur = _findBrandApp(id);
+  if (!cur || !Array.isArray(cur.products) || !cur.products[idx]) return;
+  var raw = (input.value || '').trim();
+  var nextValue = raw === '' ? null : Number(raw);
+  if (nextValue !== null && (!isFinite(nextValue) || nextValue < 0)) {
+    toast('0 이상의 숫자만 입력하세요.', 'warn');
+    return;
+  }
+  var prevValue = cur.products[idx].transfer_fee_krw == null ? null : Number(cur.products[idx].transfer_fee_krw);
+  if (prevValue === nextValue) {
+    _restoreTransferFeeDisplay(cell, prevValue);
+    return;
+  }
+  // 새 products 배열 생성 (immutable patch)
+  var nextProducts = cur.products.map(function(prod, i) {
+    if (i !== idx) return prod;
+    var copy = Object.assign({}, prod);
+    if (nextValue == null) delete copy.transfer_fee_krw; else copy.transfer_fee_krw = nextValue;
+    return copy;
+  });
+  var prevVersion = cur.version;
+  input.disabled = true;
+  var result = await updateBrandApplication(id, {products: nextProducts}, prevVersion);
+  input.disabled = false;
+  if (result.conflict) {
+    toast('다른 관리자가 먼저 저장했습니다. 다시 불러옵니다.', 'warn');
+    await loadBrandApplications();
+    return;
+  }
+  if (!result.ok) {
+    toast('저장 실패: ' + (result.error || '알 수 없는 오류'), 'error');
+    return;
+  }
+  cur.products = nextProducts;
+  cur.version = result.data?.version || (prevVersion + 1);
+  // 같은 신청의 모든 행 재렌더(이체수수료(원)/최종 견적/VAT포함 컬럼이 동기화됨)
+  renderBrandApplicationsList();
+  toast('이체수수료가 저장되었습니다.');
 }
 
 function renderFinalQuoteDisplay(value) {

--- a/dev/js/admin.js
+++ b/dev/js/admin.js
@@ -6941,6 +6941,8 @@ function renderBrandApplicationsList() {
   var filterActive = res.filterActive;
   var resetBtn = $('btnBrandAppFilterReset');
   if (resetBtn) resetBtn.style.display = filterActive ? 'inline-block' : 'none';
+  var sortResetBtn = $('btnBrandAppSortReset');
+  if (sortResetBtn) sortResetBtn.style.display = _brandAppSortIsDefault() ? 'none' : 'inline-block';
 
   var count = $('brandAppTotalCount');
   if (count) {
@@ -6993,6 +6995,16 @@ function toggleBrandAppSort(field) {
   } else {
     _brandAppSort = {field: field, dir: 'desc'};
   }
+  updateBrandAppSortIndicators();
+  renderBrandApplicationsList();
+}
+
+function _brandAppSortIsDefault() {
+  return _brandAppSort.field === 'created' && _brandAppSort.dir === 'desc';
+}
+
+function resetBrandAppSort() {
+  _brandAppSort = {field: 'created', dir: 'desc'};
   updateBrandAppSortIndicators();
   renderBrandApplicationsList();
 }

--- a/dev/js/admin.js
+++ b/dev/js/admin.js
@@ -6959,10 +6959,11 @@ function renderBrandApplicationsList() {
       ? esc(prodCount + '종 · ' + (Number(a.total_qty) || 0) + '개')
         + '<div style="font-size:11px;color:var(--muted);margin-top:2px;font-variant-numeric:tabular-nums">¥ ' + (Number(a.total_jpy) || 0).toLocaleString('ja-JP') + '</div>'
       : '<span style="color:var(--muted)">—</span>';
-    var quoteSent = a.quote_sent_at
-      ? '<span style="display:inline-flex;align-items:center;gap:4px;color:#16a34a;font-size:11px;font-weight:600"><span class="material-icons-round notranslate" translate="no" style="font-size:14px">check_circle</span>전달</span>'
-        + '<div style="font-size:10px;color:var(--muted);margin-top:2px">' + fmtDate(a.quote_sent_at) + '</div>'
-      : '<span style="color:var(--muted);font-size:11px">미전달</span>';
+    var qLocked = (a.status === 'done' || a.status === 'rejected');
+    var quoteSent = '<label class="brand-app-qsent" data-id="' + esc(a.id) + '" style="display:inline-flex;align-items:center;gap:6px;font-size:11px;cursor:' + (qLocked ? 'not-allowed' : 'pointer') + ';color:' + (a.quote_sent_at ? '#16a34a' : 'var(--muted)') + ';font-weight:' + (a.quote_sent_at ? '600' : '400') + '" onclick="event.stopPropagation()">'
+      + '<input type="checkbox" ' + (a.quote_sent_at ? 'checked' : '') + ' ' + (qLocked ? 'disabled' : '') + ' onchange="toggleBrandAppQuoteSent(\'' + esc(a.id) + '\', this)" style="cursor:' + (qLocked ? 'not-allowed' : 'pointer') + '">'
+      + '<span class="qsent-label">' + (a.quote_sent_at ? '전달 ' + fmtDate(a.quote_sent_at) : '미전달') + '</span>'
+    + '</label>';
     var memoText = (a.admin_memo || '').trim();
     var memoCell = memoText
       ? '<div style="font-size:11px;color:var(--ink);display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;overflow:hidden;line-height:1.4" title="' + esc(memoText) + '">' + esc(memoText) + '</div>'
@@ -7203,6 +7204,50 @@ function closeBrandAppDetail() {
   if (modal) modal.classList.remove('open');
   _brandAppCurrentId = null;
   window._brandAppCurrent = null;
+}
+
+async function toggleBrandAppQuoteSent(id, checkboxEl) {
+  if (!currentAdminInfo) { toast('권한이 없습니다','error'); checkboxEl.checked = !checkboxEl.checked; return; }
+  var idx = (_brandApps || []).findIndex(function(a){ return a.id === id; });
+  if (idx < 0) return;
+  var cur = _brandApps[idx];
+  if (cur.status === 'done' || cur.status === 'rejected') {
+    checkboxEl.checked = !!cur.quote_sent_at;
+    toast('완료/거절된 신청은 변경할 수 없습니다.', 'warn');
+    return;
+  }
+  var prevValue = cur.quote_sent_at;
+  var prevVersion = cur.version;
+  var nextValue = checkboxEl.checked ? new Date().toISOString() : null;
+  var labelEl = checkboxEl.parentElement?.querySelector('.qsent-label');
+  // 낙관적 UI 갱신
+  if (labelEl) labelEl.textContent = nextValue ? ('전달 ' + fmtDate(nextValue)) : '미전달';
+  if (checkboxEl.parentElement) {
+    checkboxEl.parentElement.style.color = nextValue ? '#16a34a' : 'var(--muted)';
+    checkboxEl.parentElement.style.fontWeight = nextValue ? '600' : '400';
+  }
+  checkboxEl.disabled = true;
+  var result = await updateBrandApplication(id, {quote_sent_at: nextValue}, prevVersion);
+  checkboxEl.disabled = false;
+  if (result.conflict) {
+    toast('다른 관리자가 먼저 저장했습니다. 다시 불러옵니다.', 'warn');
+    await loadBrandApplications();
+    return;
+  }
+  if (!result.ok) {
+    // 원복
+    checkboxEl.checked = !checkboxEl.checked;
+    if (labelEl) labelEl.textContent = prevValue ? ('전달 ' + fmtDate(prevValue)) : '미전달';
+    if (checkboxEl.parentElement) {
+      checkboxEl.parentElement.style.color = prevValue ? '#16a34a' : 'var(--muted)';
+      checkboxEl.parentElement.style.fontWeight = prevValue ? '600' : '400';
+    }
+    toast('저장 실패: ' + (result.error || '알 수 없는 오류'), 'error');
+    return;
+  }
+  // 메모리 갱신
+  cur.quote_sent_at = nextValue;
+  cur.version = result.data?.version || (prevVersion + 1);
 }
 
 async function saveBrandAppChanges(expectedVersion) {

--- a/dev/js/admin.js
+++ b/dev/js/admin.js
@@ -470,8 +470,8 @@ function resetMultiFilter(containerId, allLabel) {
   const btn = wrap.querySelector('.mf-btn');
   const allCb = wrap.querySelector('input[value="all"]');
   const items = wrap.querySelectorAll('.mf-drop input:not([value="all"])');
-  if (allCb) allCb.checked = true;
-  items.forEach(c => c.checked = false);
+  if (allCb) { allCb.checked = true; allCb.indeterminate = false; }
+  items.forEach(c => c.checked = true); // 전체 = 모든 항목 체크 표시
   if (btn) { btn.textContent = allLabel; btn.classList.remove('has-selection'); }
 }
 function updateFilterResetBtn(btnId, multiIds, searchId) {
@@ -508,22 +508,14 @@ function syncMultiFilter(containerId, allLabel, options, onChange) {
   createMultiFilter(containerId, allLabel, options, onChange);
   wrap.dataset.optKey = newKey;
   if (prev.length > 0) {
-    const allCb = drop.querySelector('input[value="all"]');
-    let restored = 0;
+    // 일부 선택 상태 복원 — 모두 해제 후 prev 항목만 체크
+    const itemCbs = [...drop.querySelectorAll('input:not([value="all"])')];
+    itemCbs.forEach(c => c.checked = false);
     prev.forEach(v => {
       const cb = drop.querySelector(`input[value="${CSS && CSS.escape ? CSS.escape(v) : v.replace(/"/g,'\\"')}"]`);
-      if (cb) { cb.checked = true; restored++; }
+      if (cb) cb.checked = true;
     });
-    if (restored > 0 && allCb) {
-      allCb.checked = false;
-      const btn = wrap.querySelector('.mf-btn');
-      const itemCbs = [...drop.querySelectorAll('input:not([value="all"])')];
-      const selected = itemCbs.filter(c => c.checked);
-      if (btn) {
-        btn.textContent = selected.map(c => c.parentElement.textContent.trim()).join(', ');
-        btn.classList.add('has-selection');
-      }
-    }
+    if (typeof wrap._mfUpdate === 'function') wrap._mfUpdate();
   }
 }
 
@@ -537,15 +529,17 @@ function syncCampMultiFilter(containerId, sortedCamps, onChange) {
 }
 
 // ── 다중 선택 드롭다운 필터 ──
+// "전체" = 모든 항목 체크 표시 (시각). 일부 해제 시 "전체"는 indeterminate.
+// 데이터 모델: 전체(모두 체크) → 빈 배열 반환(=필터 없음). 일부만 체크 → 그 배열 반환.
 function createMultiFilter(containerId, allLabel, options, onChange) {
   const wrap = $(containerId);
   if (!wrap) return;
   const btn = wrap.querySelector('.mf-btn');
   const drop = wrap.querySelector('.mf-drop');
   if (!btn || !drop) return;
-  // 드롭다운 아이템 생성
+  // 드롭다운 아이템 생성 — 초기 상태: 전체 체크 = 모든 항목 체크
   drop.innerHTML = `<label class="mf-item all-item"><input type="checkbox" value="all" checked> ${esc(allLabel)}</label>`
-    + options.map(o => `<label class="mf-item"><input type="checkbox" value="${esc(o.value)}"> ${esc(o.label)}</label>`).join('');
+    + options.map(o => `<label class="mf-item"><input type="checkbox" value="${esc(o.value)}" checked> ${esc(o.label)}</label>`).join('');
   btn.textContent = allLabel;
   // 토글
   btn.onclick = (e) => { e.stopPropagation(); drop.classList.toggle('open'); };
@@ -554,23 +548,37 @@ function createMultiFilter(containerId, allLabel, options, onChange) {
   const itemCbs = [...drop.querySelectorAll('input:not([value="all"])')];
   const update = () => {
     const selected = itemCbs.filter(c => c.checked);
-    if (selected.length === 0 || selected.length === itemCbs.length) {
+    if (selected.length === itemCbs.length) {
+      // 모두 체크 = 전체
       allCb.checked = true;
-      itemCbs.forEach(c => c.checked = false);
+      allCb.indeterminate = false;
+      btn.textContent = allLabel;
+      btn.classList.remove('has-selection');
+    } else if (selected.length === 0) {
+      // 모두 해제 — 자동 전체 복귀(시각적으로 모두 체크) — 필터 없음과 동일하게 취급
+      allCb.checked = true;
+      allCb.indeterminate = false;
+      itemCbs.forEach(c => c.checked = true);
       btn.textContent = allLabel;
       btn.classList.remove('has-selection');
     } else {
+      // 일부 — 전체는 indeterminate
       allCb.checked = false;
+      allCb.indeterminate = true;
       btn.textContent = selected.map(c => c.parentElement.textContent.trim()).join(', ');
       btn.classList.add('has-selection');
     }
     onChange(getMultiFilterValues(containerId));
   };
   allCb.onchange = () => {
-    if (allCb.checked) { itemCbs.forEach(c => c.checked = false); }
+    // 전체 토글 — 모든 항목을 같이 체크/해제 (해제 시 update가 자동으로 전체로 복귀)
+    itemCbs.forEach(c => c.checked = allCb.checked);
+    allCb.indeterminate = false;
     update();
   };
-  itemCbs.forEach(c => { c.onchange = () => { if (c.checked) allCb.checked = false; update(); }; });
+  itemCbs.forEach(c => { c.onchange = update; });
+  // 외부에서 prev 복원 후 다시 호출할 수 있도록 노출
+  wrap._mfUpdate = update;
   // 바깥 클릭 닫기 (wrap 당 1회만 등록)
   if (!wrap._mfClickBound) {
     wrap._mfClickBound = true;
@@ -581,8 +589,9 @@ function getMultiFilterValues(containerId) {
   const wrap = $(containerId);
   if (!wrap) return [];
   const allCb = wrap.querySelector('input[value="all"]');
-  if (allCb?.checked) return [];
-  return [...wrap.querySelectorAll('.mf-drop input:checked')].map(c => c.value);
+  // 전체(모두 체크) = 필터 없음 → 빈 배열
+  if (allCb?.checked && !allCb.indeterminate) return [];
+  return [...wrap.querySelectorAll('.mf-drop input:not([value="all"]):checked')].map(c => c.value);
 }
 
 function toggleCampSort(key) {

--- a/dev/js/admin.js
+++ b/dev/js/admin.js
@@ -7305,7 +7305,13 @@ function renderMemoDisplay(memoText, locked) {
   var safe = (memoText || '').trim();
   var color = safe ? 'var(--ink)' : 'var(--muted)';
   var content = safe ? esc(safe) : '—';
+  // 요청사항 셀과 동일한 기준: 40자 초과 또는 개행 포함 시 더보기 노출
+  var hasMore = !!safe && (safe.length > 40 || /\n/.test(safe));
+  var moreLink = hasMore
+    ? '<a href="javascript:void(0)" style="font-size:10px;color:var(--pink);text-decoration:underline;cursor:pointer;margin-top:2px;display:inline-block" onclick="event.stopPropagation();openMsgModal(this)" data-msg="' + esc(safe) + '">더보기</a>'
+    : '';
   return '<div class="memo-display" style="font-size:11px;color:' + color + ';display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;overflow:hidden;line-height:1.4;padding-right:22px;white-space:pre-wrap" title="' + esc(safe) + '">' + content + '</div>'
+    + moreLink
     + '<button type="button" class="memo-edit-btn" ' + (locked ? 'disabled' : '') + ' onclick="enterMemoEdit(this)" title="' + (locked ? '완료/거절 신청은 수정 불가' : '메모 수정') + '" style="position:absolute;top:0;right:0;background:none;border:none;cursor:' + (locked ? 'not-allowed' : 'pointer') + ';padding:2px;color:var(--muted);display:flex;align-items:center;justify-content:center;border-radius:3px" onmouseover="if(!this.disabled)this.style.background=\'rgba(0,0,0,.05)\'" onmouseout="this.style.background=\'none\'"><span class="material-icons-round notranslate" translate="no" style="font-size:15px">edit</span></button>';
 }
 

--- a/dev/js/admin.js
+++ b/dev/js/admin.js
@@ -6960,14 +6960,16 @@ function renderBrandApplicationsList() {
         + '<div style="font-size:11px;color:var(--muted);margin-top:2px;font-variant-numeric:tabular-nums">¥ ' + (Number(a.total_jpy) || 0).toLocaleString('ja-JP') + '</div>'
       : '<span style="color:var(--muted)">—</span>';
     var qLocked = (a.status === 'done' || a.status === 'rejected');
-    var quoteSent = '<label class="brand-app-qsent" data-id="' + esc(a.id) + '" style="display:inline-flex;align-items:center;gap:6px;font-size:11px;cursor:' + (qLocked ? 'not-allowed' : 'pointer') + ';color:' + (a.quote_sent_at ? '#16a34a' : 'var(--muted)') + ';font-weight:' + (a.quote_sent_at ? '600' : '400') + '" onclick="event.stopPropagation()">'
-      + '<input type="checkbox" ' + (a.quote_sent_at ? 'checked' : '') + ' ' + (qLocked ? 'disabled' : '') + ' onchange="toggleBrandAppQuoteSent(\'' + esc(a.id) + '\', this)" style="cursor:' + (qLocked ? 'not-allowed' : 'pointer') + '">'
-      + '<span class="qsent-label">' + (a.quote_sent_at ? '전달 ' + fmtDate(a.quote_sent_at) : '미전달') + '</span>'
-    + '</label>';
+    var qDateValue = a.quote_sent_at ? new Date(a.quote_sent_at).toISOString().slice(0,10) : '';
+    var quoteSent = '<div class="brand-app-qsent" data-id="' + esc(a.id) + '" style="display:flex;flex-direction:column;gap:3px;font-size:11px">'
+      + '<label style="display:inline-flex;align-items:center;gap:5px;cursor:' + (qLocked ? 'not-allowed' : 'pointer') + ';color:' + (a.quote_sent_at ? '#16a34a' : 'var(--muted)') + ';font-weight:' + (a.quote_sent_at ? '600' : '400') + '">'
+        + '<input type="checkbox" ' + (a.quote_sent_at ? 'checked' : '') + ' ' + (qLocked ? 'disabled' : '') + ' onchange="toggleBrandAppQuoteSent(\'' + esc(a.id) + '\', this)" style="cursor:' + (qLocked ? 'not-allowed' : 'pointer') + '">'
+        + '<span class="qsent-label">' + (a.quote_sent_at ? '전달' : '미전달') + '</span>'
+      + '</label>'
+      + '<input type="date" class="qsent-date" value="' + qDateValue + '" ' + (a.quote_sent_at && !qLocked ? '' : 'disabled') + ' onchange="updateBrandAppQuoteSentDate(\'' + esc(a.id) + '\', this)" style="font-size:11px;padding:2px 4px;border:1px solid var(--line);border-radius:4px;width:100%;background:' + (a.quote_sent_at && !qLocked ? '#fff' : '#F5F5F5') + '">'
+    + '</div>';
     var memoText = (a.admin_memo || '').trim();
-    var memoCell = memoText
-      ? '<div style="font-size:11px;color:var(--ink);display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;overflow:hidden;line-height:1.4" title="' + esc(memoText) + '">' + esc(memoText) + '</div>'
-      : '<span style="color:var(--muted)">—</span>';
+    var memoCell = '<textarea class="brand-app-memo" data-id="' + esc(a.id) + '" data-original="' + esc(memoText) + '" ' + (qLocked ? 'disabled' : '') + ' onblur="saveBrandAppMemo(\'' + esc(a.id) + '\', this)" placeholder="메모 입력…" style="width:100%;min-height:42px;max-height:80px;font-size:11px;line-height:1.4;padding:4px 6px;border:1px solid var(--line);border-radius:4px;resize:vertical;font-family:inherit;color:var(--ink);background:' + (qLocked ? '#F5F5F5' : '#fff') + '">' + esc(memoText) + '</textarea>';
     return '<tr data-id="' + esc(a.id) + '">'
       + '<td>'
         + '<div style="font-size:11px;font-weight:600;color:var(--ink)">' + esc(a.application_no || '—') + '</div>'
@@ -7206,11 +7208,32 @@ function closeBrandAppDetail() {
   window._brandAppCurrent = null;
 }
 
+function _findBrandApp(id) {
+  var idx = (_brandApps || []).findIndex(function(a){ return a.id === id; });
+  return idx < 0 ? null : _brandApps[idx];
+}
+
+function _refreshQuoteSentCellUI(wrapEl, isoOrNull) {
+  if (!wrapEl) return;
+  var label = wrapEl.querySelector('.qsent-label');
+  var labelWrap = label?.parentElement;
+  var dateInput = wrapEl.querySelector('.qsent-date');
+  if (label) label.textContent = isoOrNull ? '전달' : '미전달';
+  if (labelWrap) {
+    labelWrap.style.color = isoOrNull ? '#16a34a' : 'var(--muted)';
+    labelWrap.style.fontWeight = isoOrNull ? '600' : '400';
+  }
+  if (dateInput) {
+    dateInput.value = isoOrNull ? new Date(isoOrNull).toISOString().slice(0,10) : '';
+    dateInput.disabled = !isoOrNull;
+    dateInput.style.background = isoOrNull ? '#fff' : '#F5F5F5';
+  }
+}
+
 async function toggleBrandAppQuoteSent(id, checkboxEl) {
   if (!currentAdminInfo) { toast('권한이 없습니다','error'); checkboxEl.checked = !checkboxEl.checked; return; }
-  var idx = (_brandApps || []).findIndex(function(a){ return a.id === id; });
-  if (idx < 0) return;
-  var cur = _brandApps[idx];
+  var cur = _findBrandApp(id);
+  if (!cur) return;
   if (cur.status === 'done' || cur.status === 'rejected') {
     checkboxEl.checked = !!cur.quote_sent_at;
     toast('완료/거절된 신청은 변경할 수 없습니다.', 'warn');
@@ -7219,13 +7242,8 @@ async function toggleBrandAppQuoteSent(id, checkboxEl) {
   var prevValue = cur.quote_sent_at;
   var prevVersion = cur.version;
   var nextValue = checkboxEl.checked ? new Date().toISOString() : null;
-  var labelEl = checkboxEl.parentElement?.querySelector('.qsent-label');
-  // 낙관적 UI 갱신
-  if (labelEl) labelEl.textContent = nextValue ? ('전달 ' + fmtDate(nextValue)) : '미전달';
-  if (checkboxEl.parentElement) {
-    checkboxEl.parentElement.style.color = nextValue ? '#16a34a' : 'var(--muted)';
-    checkboxEl.parentElement.style.fontWeight = nextValue ? '600' : '400';
-  }
+  var wrap = checkboxEl.closest('.brand-app-qsent');
+  _refreshQuoteSentCellUI(wrap, nextValue);
   checkboxEl.disabled = true;
   var result = await updateBrandApplication(id, {quote_sent_at: nextValue}, prevVersion);
   checkboxEl.disabled = false;
@@ -7235,19 +7253,84 @@ async function toggleBrandAppQuoteSent(id, checkboxEl) {
     return;
   }
   if (!result.ok) {
-    // 원복
     checkboxEl.checked = !checkboxEl.checked;
-    if (labelEl) labelEl.textContent = prevValue ? ('전달 ' + fmtDate(prevValue)) : '미전달';
-    if (checkboxEl.parentElement) {
-      checkboxEl.parentElement.style.color = prevValue ? '#16a34a' : 'var(--muted)';
-      checkboxEl.parentElement.style.fontWeight = prevValue ? '600' : '400';
-    }
+    _refreshQuoteSentCellUI(wrap, prevValue);
     toast('저장 실패: ' + (result.error || '알 수 없는 오류'), 'error');
     return;
   }
-  // 메모리 갱신
   cur.quote_sent_at = nextValue;
   cur.version = result.data?.version || (prevVersion + 1);
+}
+
+async function updateBrandAppQuoteSentDate(id, dateInput) {
+  if (!currentAdminInfo) { toast('권한이 없습니다','error'); return; }
+  var cur = _findBrandApp(id);
+  if (!cur) return;
+  if (cur.status === 'done' || cur.status === 'rejected') {
+    toast('완료/거절된 신청은 변경할 수 없습니다.', 'warn');
+    dateInput.value = cur.quote_sent_at ? new Date(cur.quote_sent_at).toISOString().slice(0,10) : '';
+    return;
+  }
+  var raw = dateInput.value;
+  if (!raw) {
+    // 날짜를 비우면 견적서 전달 자체를 해제로 간주
+    var wrap = dateInput.closest('.brand-app-qsent');
+    var cb = wrap?.querySelector('input[type="checkbox"]');
+    if (cb) { cb.checked = false; await toggleBrandAppQuoteSent(id, cb); }
+    return;
+  }
+  var prevValue = cur.quote_sent_at;
+  var prevVersion = cur.version;
+  // 입력값(YYYY-MM-DD)을 JST 정오로 저장(타임존 경계 안전)
+  var nextValue = new Date(raw + 'T12:00:00+09:00').toISOString();
+  if (prevValue && new Date(prevValue).toISOString().slice(0,10) === raw) return; // 변동 없음
+  dateInput.disabled = true;
+  var result = await updateBrandApplication(id, {quote_sent_at: nextValue}, prevVersion);
+  dateInput.disabled = false;
+  if (result.conflict) {
+    toast('다른 관리자가 먼저 저장했습니다. 다시 불러옵니다.', 'warn');
+    await loadBrandApplications();
+    return;
+  }
+  if (!result.ok) {
+    dateInput.value = prevValue ? new Date(prevValue).toISOString().slice(0,10) : '';
+    toast('저장 실패: ' + (result.error || '알 수 없는 오류'), 'error');
+    return;
+  }
+  cur.quote_sent_at = nextValue;
+  cur.version = result.data?.version || (prevVersion + 1);
+  toast('전달일이 저장되었습니다.');
+}
+
+async function saveBrandAppMemo(id, textareaEl) {
+  if (!currentAdminInfo) return;
+  var cur = _findBrandApp(id);
+  if (!cur) return;
+  if (cur.status === 'done' || cur.status === 'rejected') {
+    textareaEl.value = cur.admin_memo || '';
+    return;
+  }
+  var nextValue = (textareaEl.value || '').trim();
+  var prevValue = (cur.admin_memo || '').trim();
+  if (nextValue === prevValue) return; // 변동 없음
+  var prevVersion = cur.version;
+  textareaEl.disabled = true;
+  var result = await updateBrandApplication(id, {admin_memo: nextValue || null}, prevVersion);
+  textareaEl.disabled = false;
+  if (result.conflict) {
+    toast('다른 관리자가 먼저 저장했습니다. 다시 불러옵니다.', 'warn');
+    await loadBrandApplications();
+    return;
+  }
+  if (!result.ok) {
+    textareaEl.value = prevValue;
+    toast('저장 실패: ' + (result.error || '알 수 없는 오류'), 'error');
+    return;
+  }
+  cur.admin_memo = nextValue || null;
+  cur.version = result.data?.version || (prevVersion + 1);
+  textareaEl.dataset.original = nextValue;
+  toast('메모가 저장되었습니다.');
 }
 
 async function saveBrandAppChanges(expectedVersion) {

--- a/dev/js/admin.js
+++ b/dev/js/admin.js
@@ -6625,7 +6625,7 @@ function renderBrandKPIs(apps) {
   var estimated = apps.reduce(function(s,a){ return s + (Number(a.estimated_krw) || 0); }, 0);
   var finalSum = apps
     .filter(function(a){ return ['quoted','paid','kakao_room_created','orient_sheet_sent','schedule_sent','campaign_registered','done'].indexOf(a.status) !== -1; })
-    .reduce(function(s,a){ return s + (Number(a.final_quote_krw) || Number(a.estimated_krw) || 0); }, 0);
+    .reduce(function(s,a){ return s + (Number(a.estimated_krw) || 0); }, 0);
 
   var fmtKRW = function(n) { return '₩ ' + Math.round(n).toLocaleString('ko-KR'); };
 
@@ -6874,7 +6874,7 @@ function renderBrandLongPending(apps) {
 
 async function loadBrandApplications() {
   var tbody = $('brandAppTableBody');
-  if (tbody) tbody.innerHTML = '<tr><td colspan="24" style="text-align:center;color:var(--muted);padding:24px"><span class="spinner" style="width:20px;height:20px;border-width:2px;border-color:rgba(200,120,163,.2);border-top-color:var(--pink)"></span></td></tr>';
+  if (tbody) tbody.innerHTML = '<tr><td colspan="23" style="text-align:center;color:var(--muted);padding:24px"><span class="spinner" style="width:20px;height:20px;border-width:2px;border-color:rgba(200,120,163,.2);border-top-color:var(--pink)"></span></td></tr>';
   _brandApps = await fetchBrandApplications();
   renderBrandApplicationsList();
   refreshBrandAppBadge();
@@ -6973,7 +6973,7 @@ function renderBrandApplicationsList() {
     rows: list,
     renderRow: renderBrandAppRow,
     pageSize: BRAND_APP_PAGE_SIZE,
-    emptyHtml: '<tr><td colspan="24" style="text-align:center;color:var(--muted);padding:40px">신청 내역이 없습니다</td></tr>',
+    emptyHtml: '<tr><td colspan="23" style="text-align:center;color:var(--muted);padding:40px">신청 내역이 없습니다</td></tr>',
   });
 }
 
@@ -7150,9 +7150,6 @@ async function openBrandAppDetail(id) {
         + '<div><label style="color:var(--muted);font-size:11px;font-weight:600;display:block;margin-bottom:4px">예상 견적 (자동)</label>'
           + '<input type="text" class="admin-filter" value="' + fmtKrw(a.estimated_krw) + '" readonly style="background:#F7F7F7;color:var(--muted)">'
         + '</div>'
-        + '<div><label style="color:var(--muted);font-size:11px;font-weight:600;display:block;margin-bottom:4px">확정 견적 (₩)</label>'
-          + '<input type="number" id="brandAppEditFinalQuote" class="admin-filter" value="' + (a.final_quote_krw || '') + '" placeholder="0" ' + editableDisabled + '>'
-        + '</div>'
         + '<div style="display:flex;flex-direction:column;justify-content:flex-end">'
           + '<label style="display:flex;align-items:center;gap:6px;color:var(--ink);font-size:13px;cursor:pointer">'
             + '<input type="checkbox" id="brandAppEditQuoteSent" ' + (a.quote_sent_at ? 'checked' : '') + ' ' + editableDisabled + '>'
@@ -7265,7 +7262,6 @@ function renderBrandAppSummaryRow(a) {
   var memoText = (a.admin_memo || '').trim();
   var memoCellInner = '<div class="brand-app-memo-cell" data-id="' + esc(a.id) + '" style="position:relative;min-height:36px">' + renderMemoDisplay(memoText, qLocked) + '</div>';
   var quoteSentInner = '<div class="brand-app-qsent-cell" data-id="' + esc(a.id) + '" style="position:relative;min-height:36px">' + renderQuoteSentDisplay(a.quote_sent_at, qLocked) + '</div>';
-  var fqInner = '<div class="brand-app-fq-cell" data-id="' + esc(a.id) + '" style="position:relative;min-height:24px">' + renderFinalQuoteDisplay(a.final_quote_krw) + '</div>';
 
   return '<tr data-id="' + esc(a.id) + '" data-summary="1">'
     // 1. 신청번호 + 폼 종류 + 토글 + 제품 N개 (셀 전체 클릭으로 토글)
@@ -7314,19 +7310,17 @@ function renderBrandAppSummaryRow(a) {
     + '<td style="text-align:right;font-variant-numeric:tabular-nums;font-size:12px;color:#16a34a;font-weight:600">' + (totalVat > 0 ? fmtKrw(totalVat) : dash) + '</td>'
     // 17. 예상 견적
     + '<td style="text-align:right;font-variant-numeric:tabular-nums">' + fmtKrw(a.estimated_krw) + '</td>'
-    // 18. 확정 견적
-    + '<td>' + fqInner + '</td>'
-    // 19. 견적서 전달
+    // 18. 견적서 전달
     + '<td>' + quoteSentInner + '</td>'
-    // 20. 내부 메모
+    // 19. 내부 메모
     + '<td>' + memoCellInner + '</td>'
-    // 21. 상태
+    // 20. 상태
     + '<td>' + brandAppStatusSelect(a) + '</td>'
-    // 22. 검수일
+    // 21. 검수일
     + '<td style="font-size:11px;color:var(--muted)">' + fmtDate(a.reviewed_at) + '</td>'
-    // 23. 신청일
+    // 22. 신청일
     + '<td style="font-size:11px;color:var(--muted)">' + fmtDate(a.created_at) + '</td>'
-    // 24. 처리
+    // 23. 처리
     + '<td><button class="btn btn-ghost btn-xs" onclick="openBrandAppDetail(\'' + esc(a.id) + '\')">상세</button></td>'
     + '</tr>';
 }
@@ -7360,7 +7354,7 @@ function renderBrandAppDetailRow(a, p, idx) {
     + '<td style="text-align:right;font-variant-numeric:tabular-nums;font-size:12px">' + (feeTotalKrw > 0 ? fmtKrw(feeTotalKrw) : dash) + '</td>'
     + '<td style="text-align:right;font-variant-numeric:tabular-nums;font-size:12px;font-weight:600">' + (finalKrw > 0 ? fmtKrw(finalKrw) : dash) + '</td>'
     + '<td style="text-align:right;font-variant-numeric:tabular-nums;font-size:12px;color:#16a34a;font-weight:600">' + (vatKrw > 0 ? fmtKrw(vatKrw) : dash) + '</td>'
-    + emptyApp + emptyApp + emptyApp + emptyApp + emptyApp + emptyApp + emptyApp + emptyApp // 17-24 신청 단위 비움
+    + emptyApp + emptyApp + emptyApp + emptyApp + emptyApp + emptyApp + emptyApp // 17-23 신청 단위 비움
     + '</tr>';
 }
 
@@ -7492,82 +7486,6 @@ async function confirmTransferFeeEdit(anyChildEl) {
   // 같은 신청의 모든 행 재렌더(이체수수료(원)/최종 견적/VAT포함 컬럼이 동기화됨)
   renderBrandApplicationsList();
   toast('이체수수료가 저장되었습니다.');
-}
-
-function renderFinalQuoteDisplay(value) {
-  return '<div class="fq-display" style="text-align:right;font-variant-numeric:tabular-nums;font-weight:600;padding-right:22px;font-size:12px">' + fmtKrw(value) + '</div>'
-    + '<button type="button" class="fq-edit-btn" onclick="enterFinalQuoteEdit(this)" title="확정 견적 수정" style="position:absolute;top:0;right:0;background:none;border:none;cursor:pointer;padding:2px;color:var(--muted);display:flex;align-items:center;justify-content:center;border-radius:3px" onmouseover="this.style.background=\'rgba(0,0,0,.05)\'" onmouseout="this.style.background=\'none\'"><span class="material-icons-round notranslate" translate="no" style="font-size:15px">edit</span></button>';
-}
-
-function _restoreFinalQuoteDisplay(cell, value) {
-  cell.innerHTML = renderFinalQuoteDisplay(value);
-}
-
-function enterFinalQuoteEdit(btnEl) {
-  var cell = btnEl.closest('.brand-app-fq-cell');
-  if (!cell) return;
-  var cur = _findBrandApp(cell.dataset.id);
-  if (!cur) return;
-  var original = cur.final_quote_krw == null ? '' : String(cur.final_quote_krw);
-  cell.innerHTML = '<div style="display:flex;flex-direction:column;gap:4px">'
-    + '<input type="number" class="fq-edit-input" value="' + esc(original) + '" placeholder="0" min="0" step="1" onkeydown="handleFinalQuoteEditKey(event, this)" style="width:100%;font-size:11px;padding:3px 6px;border:1px solid var(--pink);border-radius:4px;text-align:right;font-variant-numeric:tabular-nums">'
-    + '<div style="display:flex;gap:4px;justify-content:flex-end">'
-      + '<button type="button" onclick="cancelFinalQuoteEdit(this)" style="background:#fff;border:1px solid var(--line);border-radius:4px;padding:3px 8px;cursor:pointer;font-size:11px;color:var(--muted)">취소</button>'
-      + '<button type="button" onclick="confirmFinalQuoteEdit(this)" style="background:var(--pink);color:#fff;border:none;border-radius:4px;padding:3px 10px;cursor:pointer;font-size:11px;font-weight:600">저장</button>'
-    + '</div>'
-  + '</div>';
-  var input = cell.querySelector('.fq-edit-input');
-  if (input) { input.focus(); input.select(); }
-}
-
-function handleFinalQuoteEditKey(ev, inputEl) {
-  if (ev.key === 'Escape') { ev.preventDefault(); cancelFinalQuoteEdit(inputEl); }
-  else if (ev.key === 'Enter') { ev.preventDefault(); confirmFinalQuoteEdit(inputEl); }
-}
-
-function cancelFinalQuoteEdit(anyChildEl) {
-  var cell = anyChildEl.closest('.brand-app-fq-cell');
-  if (!cell) return;
-  var cur = _findBrandApp(cell.dataset.id);
-  _restoreFinalQuoteDisplay(cell, cur?.final_quote_krw);
-}
-
-async function confirmFinalQuoteEdit(anyChildEl) {
-  var cell = anyChildEl.closest('.brand-app-fq-cell');
-  if (!cell) return;
-  var input = cell.querySelector('.fq-edit-input');
-  if (!input) return;
-  var id = cell.dataset.id;
-  var cur = _findBrandApp(id);
-  if (!cur) return;
-  var raw = (input.value || '').trim();
-  var nextValue = raw === '' ? null : Number(raw);
-  if (nextValue !== null && (!isFinite(nextValue) || nextValue < 0)) {
-    toast('0 이상의 숫자만 입력하세요.', 'warn');
-    return;
-  }
-  var prevValue = cur.final_quote_krw == null ? null : Number(cur.final_quote_krw);
-  if (prevValue === nextValue) {
-    _restoreFinalQuoteDisplay(cell, prevValue);
-    return;
-  }
-  var prevVersion = cur.version;
-  input.disabled = true;
-  var result = await updateBrandApplication(id, {final_quote_krw: nextValue}, prevVersion);
-  input.disabled = false;
-  if (result.conflict) {
-    toast('다른 관리자가 먼저 저장했습니다. 다시 불러옵니다.', 'warn');
-    await loadBrandApplications();
-    return;
-  }
-  if (!result.ok) {
-    toast('저장 실패: ' + (result.error || '알 수 없는 오류'), 'error');
-    return;
-  }
-  cur.final_quote_krw = nextValue;
-  cur.version = result.data?.version || (prevVersion + 1);
-  _restoreFinalQuoteDisplay(cell, nextValue);
-  toast('확정 견적이 저장되었습니다.');
 }
 
 function renderQuoteSentDisplay(isoOrNull, locked) {
@@ -7757,13 +7675,11 @@ async function saveBrandAppChanges(expectedVersion) {
   var cur = window._brandAppCurrent;
   if (!cur) return;
   var status = $('brandAppEditStatus')?.value;
-  var finalQuote = $('brandAppEditFinalQuote')?.value;
   var quoteSentChecked = $('brandAppEditQuoteSent')?.checked;
   var memo = $('brandAppEditMemo')?.value || '';
 
   var patch = {
     status: status,
-    final_quote_krw: finalQuote ? Number(finalQuote) : null,
     quote_sent_at: quoteSentChecked ? (cur.quote_sent_at || new Date().toISOString()) : null,
     admin_memo: memo || null
   };

--- a/dev/js/admin.js
+++ b/dev/js/admin.js
@@ -6953,13 +6953,16 @@ function renderBrandApplicationsList() {
       : '(' + summary + ')';
   }
 
+  // 요약 행만 렌더 (펼치기는 토글로 동적 추가)
   var renderBrandAppRow = function(a) {
-    var prods = (Array.isArray(a.products) && a.products.length > 0)
-      ? a.products
-      : [{ name: '', qty: 0, price: 0, transfer_fee_krw: null }];
-    return prods.map(function(p, idx) {
-      return renderBrandAppProductRow(a, p, idx, prods.length);
-    }).join('');
+    var html = renderBrandAppSummaryRow(a);
+    if (_brandAppExpanded.has(a.id)) {
+      var prods = Array.isArray(a.products) ? a.products : [];
+      html += prods.map(function(p, idx) {
+        return renderBrandAppDetailRow(a, p, idx);
+      }).join('');
+    }
+    return html;
   };
   if (brandAppLazy) brandAppLazy.destroy();
   brandAppLazy = mountLazyList({
@@ -7203,9 +7206,121 @@ function renderProductUrlCell(url) {
   + '</div>';
 }
 
-// 신청 1건의 제품 1개를 1행으로 렌더 (총 22컬럼)
-function renderBrandAppProductRow(a, p, idx, total) {
-  var isFirst = (idx === 0);
+// 펼친 신청 ID 집합 (메모리 — 새로고침 시 초기화)
+var _brandAppExpanded = new Set();
+
+// 모든 제품에서 동일한 값이면 그 값, 다르면 null
+function _uniformProductValue(prods, key) {
+  if (!Array.isArray(prods) || prods.length === 0) return null;
+  var first = prods[0] && prods[0][key];
+  for (var i = 1; i < prods.length; i++) {
+    if (prods[i] && prods[i][key] !== first) return null;
+  }
+  return first;
+}
+
+// 신청 1건 = 1행 (요약 행, 24컬럼). 합산 가능 컬럼은 SUM, 단가는 동일하면 그 값/다르면 "—"
+function renderBrandAppSummaryRow(a) {
+  var prods = Array.isArray(a.products) ? a.products : [];
+  var totalQty = prods.reduce(function(s, p){ return s + (Number(p.qty) || 0); }, 0);
+  var totalLine = prods.reduce(function(s, p){ return s + (Number(p.qty) || 0) * (Number(p.price) || 0) * BRAND_QUOTE_CONST.FX_JPY_KRW; }, 0);
+  var totalFee = prods.reduce(function(s, p){
+    var fee = (p.transfer_fee_krw == null || p.transfer_fee_krw === '') ? 0 : Number(p.transfer_fee_krw);
+    return s + (Number(p.qty) || 0) * fee;
+  }, 0);
+  var totalFinal = totalLine + totalFee;
+  var totalVat = Math.floor(totalFinal * (1 + BRAND_QUOTE_CONST.VAT_RATE));
+  // 단가 — 모든 제품 동일하면 그 값, 다르면 표시 안 함
+  var uPriceJpy = _uniformProductValue(prods, 'price');
+  var uTfee = _uniformProductValue(prods, 'transfer_fee_krw');
+  var uPriceKrw = (uPriceJpy != null && uPriceJpy !== '') ? Number(uPriceJpy) * BRAND_QUOTE_CONST.FX_JPY_KRW : null;
+
+  var dash = '<span style="color:var(--muted)">—</span>';
+  var multi = '<span style="color:var(--muted);font-size:10px">제품별 상이</span>';
+  var renderUnit = function(uniformVal, formatter) {
+    if (prods.length <= 1) {
+      return uniformVal != null && uniformVal !== '' ? formatter(uniformVal) : dash;
+    }
+    return uniformVal != null && uniformVal !== '' ? formatter(uniformVal) : multi;
+  };
+
+  // 펼치기 토글 (제품 2개 이상 또는 항상 표시 — 일관성 위해 항상 표시)
+  var isOpen = _brandAppExpanded.has(a.id);
+  var arrowIcon = isOpen ? 'expand_more' : 'chevron_right';
+  var toggleBtn = '<button type="button" class="brand-app-expand-btn" onclick="toggleBrandAppExpand(\'' + esc(a.id) + '\', this)" title="제품 ' + prods.length + '개 ' + (isOpen ? '접기' : '펼치기') + '" style="background:none;border:none;cursor:pointer;padding:0;margin-right:2px;color:var(--muted);display:inline-flex;align-items:center;vertical-align:middle"><span class="material-icons-round notranslate" translate="no" style="font-size:18px">' + arrowIcon + '</span></button>';
+
+  var qLocked = false;
+  var memoText = (a.admin_memo || '').trim();
+  var memoCellInner = '<div class="brand-app-memo-cell" data-id="' + esc(a.id) + '" style="position:relative;min-height:36px">' + renderMemoDisplay(memoText, qLocked) + '</div>';
+  var quoteSentInner = '<div class="brand-app-qsent-cell" data-id="' + esc(a.id) + '" style="position:relative;min-height:36px">' + renderQuoteSentDisplay(a.quote_sent_at, qLocked) + '</div>';
+  var fqInner = '<div class="brand-app-fq-cell" data-id="' + esc(a.id) + '" style="position:relative;min-height:24px">' + renderFinalQuoteDisplay(a.final_quote_krw) + '</div>';
+
+  return '<tr data-id="' + esc(a.id) + '" data-summary="1">'
+    // 1. 신청번호 + 폼 종류 + 토글 + 제품 N개
+    + '<td>'
+      + '<div style="display:flex;align-items:flex-start;gap:2px">'
+        + toggleBtn
+        + '<div style="flex:1;min-width:0">'
+          + '<div style="font-size:11px;font-weight:600;color:var(--ink)">' + esc(a.application_no || '—') + '</div>'
+          + '<div style="margin-top:3px"><span style="background:#F0F0F0;color:#555;font-size:10px;font-weight:600;padding:2px 7px;border-radius:3px">' + esc(brandAppFormLabel(a.form_type)) + '</span></div>'
+          + '<div style="font-size:10px;color:var(--muted);margin-top:3px">제품 ' + prods.length + '개</div>'
+        + '</div>'
+      + '</div>'
+    + '</td>'
+    // 2. 브랜드
+    + '<td style="font-weight:600">' + esc(a.brand_name || '—') + '</td>'
+    // 3. 담당자
+    + '<td>'
+      + '<div>' + esc(a.contact_name || '—') + '</div>'
+      + (a.email ? '<div style="font-size:11px;color:var(--muted);margin-top:2px;word-break:break-all">' + esc(a.email) + '</div>' : '')
+    + '</td>'
+    // 4. 연락처
+    + '<td style="font-size:12px">' + esc(formatPhoneDisplay(a.phone) || '—') + '</td>'
+    // 5. 계산서 이메일
+    + '<td style="font-size:12px;color:' + (a.billing_email ? 'var(--ink)' : 'var(--muted)') + ';word-break:break-all">' + esc(a.billing_email || '—') + '</td>'
+    // 6. 요청사항
+    + '<td>' + brandAppNoteCell(a.request_note) + '</td>'
+    // 7. 제품명 (요약: 첫 제품 + N개 표시 또는 — )
+    + '<td style="font-size:11px;color:var(--muted)">' + (prods.length > 0 ? esc((prods[0].name || '—') + (prods.length > 1 ? ' 외 ' + (prods.length - 1) + '개' : '')) : '—') + '</td>'
+    // 8. URL (요약 — 첫 URL or "여러 URL")
+    + '<td style="font-size:11px;color:var(--muted)">' + (prods.length > 0 && prods[0].url ? '<span style="word-break:break-all;display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;overflow:hidden;line-height:1.4">' + esc(prods[0].url) + '</span>' + (prods.length > 1 ? '<div style="font-size:10px;color:var(--muted);margin-top:2px">외 ' + (prods.length - 1) + '개</div>' : '') : '—') + '</td>'
+    // 9. 진행 수량 (SUM)
+    + '<td style="text-align:right;font-variant-numeric:tabular-nums;font-size:12px;font-weight:600">' + (totalQty > 0 ? totalQty.toLocaleString('ja-JP') : dash) + '</td>'
+    // 10. 상품 가격(엔) (단가 — 동일하면 값, 아니면 "제품별 상이")
+    + '<td style="text-align:right;font-variant-numeric:tabular-nums;font-size:12px">' + renderUnit(uPriceJpy, function(v){ return '¥ ' + Number(v).toLocaleString('ja-JP'); }) + '</td>'
+    // 11. 상품 가격(원)
+    + '<td style="text-align:right;font-variant-numeric:tabular-nums;font-size:12px">' + renderUnit(uPriceKrw, function(v){ return fmtKrw(v); }) + '</td>'
+    // 12. 상품 최종 금액 (SUM)
+    + '<td style="text-align:right;font-variant-numeric:tabular-nums;font-size:12px;font-weight:600">' + (totalLine > 0 ? fmtKrw(totalLine) : dash) + '</td>'
+    // 13. 이체수수료(건) (단가 — 요약 행에서는 read-only)
+    + '<td style="text-align:right;font-variant-numeric:tabular-nums;font-size:12px">' + renderUnit(uTfee, function(v){ return fmtKrw(v); }) + '</td>'
+    // 14. 이체수수료(원) (SUM)
+    + '<td style="text-align:right;font-variant-numeric:tabular-nums;font-size:12px">' + (totalFee > 0 ? fmtKrw(totalFee) : dash) + '</td>'
+    // 15. 최종 견적 금액 (SUM)
+    + '<td style="text-align:right;font-variant-numeric:tabular-nums;font-size:12px;font-weight:600">' + (totalFinal > 0 ? fmtKrw(totalFinal) : dash) + '</td>'
+    // 16. VAT포함 (SUM)
+    + '<td style="text-align:right;font-variant-numeric:tabular-nums;font-size:12px;color:#16a34a;font-weight:600">' + (totalVat > 0 ? fmtKrw(totalVat) : dash) + '</td>'
+    // 17. 예상 견적
+    + '<td style="text-align:right;font-variant-numeric:tabular-nums">' + fmtKrw(a.estimated_krw) + '</td>'
+    // 18. 확정 견적
+    + '<td>' + fqInner + '</td>'
+    // 19. 견적서 전달
+    + '<td>' + quoteSentInner + '</td>'
+    // 20. 내부 메모
+    + '<td>' + memoCellInner + '</td>'
+    // 21. 상태
+    + '<td>' + brandAppStatusSelect(a) + '</td>'
+    // 22. 검수일
+    + '<td style="font-size:11px;color:var(--muted)">' + fmtDate(a.reviewed_at) + '</td>'
+    // 23. 신청일
+    + '<td style="font-size:11px;color:var(--muted)">' + fmtDate(a.created_at) + '</td>'
+    // 24. 처리
+    + '<td><button class="btn btn-ghost btn-xs" onclick="openBrandAppDetail(\'' + esc(a.id) + '\')">상세</button></td>'
+    + '</tr>';
+}
+
+// 펼친 상태일 때 한 제품별 행 — 신청 단위 셀은 빈 td (좌측 보더로 그룹 표시)
+function renderBrandAppDetailRow(a, p, idx) {
   var qty = Number(p.qty) || 0;
   var priceJpy = Number(p.price) || 0;
   var priceKrw = priceJpy * BRAND_QUOTE_CONST.FX_JPY_KRW;
@@ -7215,69 +7330,49 @@ function renderBrandAppProductRow(a, p, idx, total) {
   var finalKrw = lineTotal + feeTotalKrw;
   var vatKrw = Math.floor(finalKrw * (1 + BRAND_QUOTE_CONST.VAT_RATE));
 
-  // 같은 신청 그룹 시각화 — 첫 행에 강조 top border, 마지막 행은 default
-  var trStyle = isFirst ? 'border-top:2px solid rgba(200,120,163,.25)' : '';
+  var dash = '<span style="color:var(--muted)">—</span>';
+  var emptyApp = '<td></td>'; // 신청 단위 셀 — 펼친 행에서는 비움 (요약 행에 이미 있음)
 
-  // 신청 단위 셀 (첫 행에만 채움, 나머지는 빈 td)
-  var cellApp = function(html, style) {
-    return '<td' + (style ? ' style="' + style + '"' : '') + '>' + (isFirst ? html : '') + '</td>';
-  };
-
-  var qLocked = false;
-  var memoText = (a.admin_memo || '').trim();
-  var memoCellInner = isFirst ? '<div class="brand-app-memo-cell" data-id="' + esc(a.id) + '" style="position:relative;min-height:36px">' + renderMemoDisplay(memoText, qLocked) + '</div>' : '';
-  var quoteSentInner = isFirst ? '<div class="brand-app-qsent-cell" data-id="' + esc(a.id) + '" style="position:relative;min-height:36px">' + renderQuoteSentDisplay(a.quote_sent_at, qLocked) + '</div>' : '';
-  var fqInner = isFirst ? '<div class="brand-app-fq-cell" data-id="' + esc(a.id) + '" style="position:relative;min-height:24px">' + renderFinalQuoteDisplay(a.final_quote_krw) + '</div>' : '';
-
-  return '<tr data-id="' + esc(a.id) + '" data-product-idx="' + idx + '"' + (trStyle ? ' style="' + trStyle + '"' : '') + '>'
-    // 1. 신청번호
-    + cellApp(
-        '<div style="font-size:11px;font-weight:600;color:var(--ink)">' + esc(a.application_no || '—') + '</div>'
-        + '<div style="margin-top:3px"><span style="background:#F0F0F0;color:#555;font-size:10px;font-weight:600;padding:2px 7px;border-radius:3px">' + esc(brandAppFormLabel(a.form_type)) + '</span></div>'
-      )
-    // 2. 브랜드
-    + cellApp(esc(a.brand_name || '—'), 'font-weight:600')
-    // 3. 담당자
-    + cellApp(
-        '<div>' + esc(a.contact_name || '—') + '</div>'
-        + (a.email ? '<div style="font-size:11px;color:var(--muted);margin-top:2px;word-break:break-all">' + esc(a.email) + '</div>' : '')
-      )
-    // 4. 연락처
-    + cellApp(esc(formatPhoneDisplay(a.phone) || '—'), 'font-size:12px')
-    // 5. 계산서 이메일
-    + cellApp(esc(a.billing_email || '—'), 'font-size:12px;color:' + (a.billing_email ? 'var(--ink)' : 'var(--muted)') + ';word-break:break-all')
-    // 6. 요청사항
-    + cellApp(brandAppNoteCell(a.request_note))
-    // 7. 제품명 (제품별 — 모든 행)
-    + '<td style="font-weight:600;color:var(--ink);font-size:11px;word-break:break-word;line-height:1.4">' + (p.name ? esc(p.name) : '<span style="color:var(--muted);font-weight:400">—</span>') + '</td>'
-    // 8. URL (제품별 — 모든 행)
+  return '<tr data-id="' + esc(a.id) + '" data-product-idx="' + idx + '" data-detail="1" style="background:#FBF7FA">'
+    + emptyApp + emptyApp + emptyApp + emptyApp + emptyApp + emptyApp // 1-6 신청 단위 비움
+    // 7. 제품명
+    + '<td style="font-weight:600;color:var(--ink);font-size:11px;word-break:break-word;line-height:1.4;border-left:3px solid rgba(200,120,163,.4);padding-left:8px">' + (p.name ? esc(p.name) : dash) + '</td>'
+    // 8. URL
     + '<td>' + renderProductUrlCell(p.url) + '</td>'
-    // 9-16. 제품별 8컬럼 (모든 행에 표시)
-    + '<td style="text-align:right;font-variant-numeric:tabular-nums;font-size:12px">' + (qty > 0 ? qty.toLocaleString('ja-JP') : '<span style="color:var(--muted)">—</span>') + '</td>'
-    + '<td style="text-align:right;font-variant-numeric:tabular-nums;font-size:12px">' + (priceJpy > 0 ? '¥ ' + priceJpy.toLocaleString('ja-JP') : '<span style="color:var(--muted)">—</span>') + '</td>'
-    + '<td style="text-align:right;font-variant-numeric:tabular-nums;font-size:12px">' + (priceKrw > 0 ? fmtKrw(priceKrw) : '<span style="color:var(--muted)">—</span>') + '</td>'
-    + '<td style="text-align:right;font-variant-numeric:tabular-nums;font-size:12px;font-weight:600">' + (lineTotal > 0 ? fmtKrw(lineTotal) : '<span style="color:var(--muted)">—</span>') + '</td>'
+    // 9-16. 제품별 8컬럼
+    + '<td style="text-align:right;font-variant-numeric:tabular-nums;font-size:12px">' + (qty > 0 ? qty.toLocaleString('ja-JP') : dash) + '</td>'
+    + '<td style="text-align:right;font-variant-numeric:tabular-nums;font-size:12px">' + (priceJpy > 0 ? '¥ ' + priceJpy.toLocaleString('ja-JP') : dash) + '</td>'
+    + '<td style="text-align:right;font-variant-numeric:tabular-nums;font-size:12px">' + (priceKrw > 0 ? fmtKrw(priceKrw) : dash) + '</td>'
+    + '<td style="text-align:right;font-variant-numeric:tabular-nums;font-size:12px;font-weight:600">' + (lineTotal > 0 ? fmtKrw(lineTotal) : dash) + '</td>'
     + '<td><div class="brand-app-tfee-cell" data-id="' + esc(a.id) + '" data-product-idx="' + idx + '" style="position:relative;min-height:24px">' + renderTransferFeeDisplay(transferFeeKrw) + '</div></td>'
-    + '<td style="text-align:right;font-variant-numeric:tabular-nums;font-size:12px">' + (feeTotalKrw > 0 ? fmtKrw(feeTotalKrw) : '<span style="color:var(--muted)">—</span>') + '</td>'
-    + '<td style="text-align:right;font-variant-numeric:tabular-nums;font-size:12px;font-weight:600">' + (finalKrw > 0 ? fmtKrw(finalKrw) : '<span style="color:var(--muted)">—</span>') + '</td>'
-    + '<td style="text-align:right;font-variant-numeric:tabular-nums;font-size:12px;color:#16a34a;font-weight:600">' + (vatKrw > 0 ? fmtKrw(vatKrw) : '<span style="color:var(--muted)">—</span>') + '</td>'
-    // 15. 예상 견적
-    + cellApp(fmtKrw(a.estimated_krw), 'text-align:right;font-variant-numeric:tabular-nums')
-    // 16. 확정 견적
-    + '<td>' + fqInner + '</td>'
-    // 17. 견적서 전달
-    + '<td>' + quoteSentInner + '</td>'
-    // 18. 내부 메모
-    + '<td>' + memoCellInner + '</td>'
-    // 19. 상태
-    + cellApp(brandAppStatusSelect(a))
-    // 20. 검수일
-    + cellApp(fmtDate(a.reviewed_at), 'font-size:11px;color:var(--muted)')
-    // 21. 신청일
-    + cellApp(fmtDate(a.created_at), 'font-size:11px;color:var(--muted)')
-    // 22. 처리
-    + cellApp('<button class="btn btn-ghost btn-xs" onclick="openBrandAppDetail(\'' + esc(a.id) + '\')">상세</button>')
+    + '<td style="text-align:right;font-variant-numeric:tabular-nums;font-size:12px">' + (feeTotalKrw > 0 ? fmtKrw(feeTotalKrw) : dash) + '</td>'
+    + '<td style="text-align:right;font-variant-numeric:tabular-nums;font-size:12px;font-weight:600">' + (finalKrw > 0 ? fmtKrw(finalKrw) : dash) + '</td>'
+    + '<td style="text-align:right;font-variant-numeric:tabular-nums;font-size:12px;color:#16a34a;font-weight:600">' + (vatKrw > 0 ? fmtKrw(vatKrw) : dash) + '</td>'
+    + emptyApp + emptyApp + emptyApp + emptyApp + emptyApp + emptyApp + emptyApp + emptyApp // 17-24 신청 단위 비움
     + '</tr>';
+}
+
+// 토글: 펼침/접힘 — 같은 신청 ID의 detail 행을 동적 추가/제거
+function toggleBrandAppExpand(id, btnEl) {
+  var summaryTr = btnEl.closest('tr');
+  if (!summaryTr) return;
+  if (_brandAppExpanded.has(id)) {
+    _brandAppExpanded.delete(id);
+    var next = summaryTr.nextElementSibling;
+    while (next && next.dataset.id === id && next.dataset.detail === '1') {
+      var rm = next; next = next.nextElementSibling; rm.remove();
+    }
+    var icon = btnEl.querySelector('.material-icons-round'); if (icon) icon.textContent = 'chevron_right';
+    btnEl.title = btnEl.title.replace('접기', '펼치기');
+  } else {
+    _brandAppExpanded.add(id);
+    var cur = _findBrandApp(id);
+    if (!cur || !Array.isArray(cur.products)) return;
+    var html = cur.products.map(function(p, idx){ return renderBrandAppDetailRow(cur, p, idx); }).join('');
+    summaryTr.insertAdjacentHTML('afterend', html);
+    var icon2 = btnEl.querySelector('.material-icons-round'); if (icon2) icon2.textContent = 'expand_more';
+    btnEl.title = btnEl.title.replace('펼치기', '접기');
+  }
 }
 
 // 이체수수료(건) 셀 — display + ✎ 인라인 편집

--- a/dev/js/admin.js
+++ b/dev/js/admin.js
@@ -6969,7 +6969,7 @@ function renderBrandApplicationsList() {
       + '<input type="date" class="qsent-date" value="' + qDateValue + '" ' + (a.quote_sent_at && !qLocked ? '' : 'disabled') + ' onchange="updateBrandAppQuoteSentDate(\'' + esc(a.id) + '\', this)" style="font-size:11px;padding:2px 4px;border:1px solid var(--line);border-radius:4px;width:100%;background:' + (a.quote_sent_at && !qLocked ? '#fff' : '#F5F5F5') + '">'
     + '</div>';
     var memoText = (a.admin_memo || '').trim();
-    var memoCell = '<textarea class="brand-app-memo" data-id="' + esc(a.id) + '" data-original="' + esc(memoText) + '" ' + (qLocked ? 'disabled' : '') + ' onblur="saveBrandAppMemo(\'' + esc(a.id) + '\', this)" placeholder="메모 입력…" style="width:100%;min-height:42px;max-height:80px;font-size:11px;line-height:1.4;padding:4px 6px;border:1px solid var(--line);border-radius:4px;resize:vertical;font-family:inherit;color:var(--ink);background:' + (qLocked ? '#F5F5F5' : '#fff') + '">' + esc(memoText) + '</textarea>';
+    var memoCell = '<div class="brand-app-memo-cell" data-id="' + esc(a.id) + '" style="position:relative;min-height:36px">' + renderMemoDisplay(memoText, qLocked) + '</div>';
     return '<tr data-id="' + esc(a.id) + '">'
       + '<td>'
         + '<div style="font-size:11px;font-weight:600;color:var(--ink)">' + esc(a.application_no || '—') + '</div>'
@@ -7302,34 +7302,87 @@ async function updateBrandAppQuoteSentDate(id, dateInput) {
   toast('전달일이 저장되었습니다.');
 }
 
-async function saveBrandAppMemo(id, textareaEl) {
-  if (!currentAdminInfo) return;
+function renderMemoDisplay(memoText, locked) {
+  var safe = (memoText || '').trim();
+  var color = safe ? 'var(--ink)' : 'var(--muted)';
+  var content = safe ? esc(safe) : '—';
+  return '<div class="memo-display" style="font-size:11px;color:' + color + ';display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;overflow:hidden;line-height:1.4;padding-right:22px;white-space:pre-wrap" title="' + esc(safe) + '">' + content + '</div>'
+    + '<button type="button" class="memo-edit-btn" ' + (locked ? 'disabled' : '') + ' onclick="enterMemoEdit(this)" title="' + (locked ? '완료/거절 신청은 수정 불가' : '메모 수정') + '" style="position:absolute;top:0;right:0;background:none;border:none;cursor:' + (locked ? 'not-allowed' : 'pointer') + ';padding:2px;color:var(--muted);display:flex;align-items:center;justify-content:center;border-radius:3px" onmouseover="if(!this.disabled)this.style.background=\'rgba(0,0,0,.05)\'" onmouseout="this.style.background=\'none\'"><span class="material-icons-round notranslate" translate="no" style="font-size:15px">edit</span></button>';
+}
+
+function _restoreMemoDisplay(cell, memoText, locked) {
+  cell.innerHTML = renderMemoDisplay(memoText, locked);
+}
+
+function enterMemoEdit(btnEl) {
+  var cell = btnEl.closest('.brand-app-memo-cell');
+  if (!cell) return;
+  var id = cell.dataset.id;
   var cur = _findBrandApp(id);
   if (!cur) return;
-  if (cur.status === 'done' || cur.status === 'rejected') {
-    textareaEl.value = cur.admin_memo || '';
+  var locked = (cur.status === 'done' || cur.status === 'rejected');
+  if (locked) return;
+  var original = (cur.admin_memo || '').trim();
+  cell.innerHTML = '<div style="display:flex;flex-direction:column;gap:4px">'
+    + '<textarea class="memo-edit-input" data-original="' + esc(original) + '" onkeydown="handleMemoEditKey(event, this)" style="width:100%;min-height:60px;font-size:11px;line-height:1.4;padding:4px 6px;border:1px solid var(--pink);border-radius:4px;resize:vertical;font-family:inherit;color:var(--ink)">' + esc(original) + '</textarea>'
+    + '<div style="display:flex;gap:4px;justify-content:flex-end">'
+      + '<button type="button" onclick="cancelMemoEdit(this)" style="background:#fff;border:1px solid var(--line);border-radius:4px;padding:3px 8px;cursor:pointer;font-size:11px;color:var(--muted)">취소</button>'
+      + '<button type="button" onclick="confirmMemoEdit(this)" style="background:var(--pink);color:#fff;border:none;border-radius:4px;padding:3px 10px;cursor:pointer;font-size:11px;font-weight:600">저장</button>'
+    + '</div>'
+  + '</div>';
+  var ta = cell.querySelector('.memo-edit-input');
+  if (ta) { ta.focus(); ta.setSelectionRange(ta.value.length, ta.value.length); }
+}
+
+function handleMemoEditKey(ev, taEl) {
+  if (ev.key === 'Escape') {
+    ev.preventDefault();
+    cancelMemoEdit(taEl);
+  } else if ((ev.metaKey || ev.ctrlKey) && ev.key === 'Enter') {
+    ev.preventDefault();
+    confirmMemoEdit(taEl);
+  }
+}
+
+function cancelMemoEdit(anyChildEl) {
+  var cell = anyChildEl.closest('.brand-app-memo-cell');
+  if (!cell) return;
+  var cur = _findBrandApp(cell.dataset.id);
+  var memoText = (cur?.admin_memo || '').trim();
+  var locked = cur && (cur.status === 'done' || cur.status === 'rejected');
+  _restoreMemoDisplay(cell, memoText, !!locked);
+}
+
+async function confirmMemoEdit(anyChildEl) {
+  var cell = anyChildEl.closest('.brand-app-memo-cell');
+  if (!cell) return;
+  var ta = cell.querySelector('.memo-edit-input');
+  if (!ta) return;
+  var id = cell.dataset.id;
+  var cur = _findBrandApp(id);
+  if (!cur) return;
+  var nextValue = (ta.value || '').trim();
+  var prevValue = (cur.admin_memo || '').trim();
+  if (nextValue === prevValue) {
+    _restoreMemoDisplay(cell, prevValue, false);
     return;
   }
-  var nextValue = (textareaEl.value || '').trim();
-  var prevValue = (cur.admin_memo || '').trim();
-  if (nextValue === prevValue) return; // 변동 없음
   var prevVersion = cur.version;
-  textareaEl.disabled = true;
+  ta.disabled = true;
   var result = await updateBrandApplication(id, {admin_memo: nextValue || null}, prevVersion);
-  textareaEl.disabled = false;
+  ta.disabled = false;
   if (result.conflict) {
     toast('다른 관리자가 먼저 저장했습니다. 다시 불러옵니다.', 'warn');
     await loadBrandApplications();
     return;
   }
   if (!result.ok) {
-    textareaEl.value = prevValue;
     toast('저장 실패: ' + (result.error || '알 수 없는 오류'), 'error');
     return;
   }
   cur.admin_memo = nextValue || null;
   cur.version = result.data?.version || (prevVersion + 1);
-  textareaEl.dataset.original = nextValue;
+  _restoreMemoDisplay(cell, nextValue, false);
   toast('메모가 저장되었습니다.');
 }
 

--- a/dev/js/admin.js
+++ b/dev/js/admin.js
@@ -7259,7 +7259,7 @@ function renderBrandAppSummaryRow(a) {
   // 펼치기 토글 (제품 2개 이상 또는 항상 표시 — 일관성 위해 항상 표시)
   var isOpen = _brandAppExpanded.has(a.id);
   var arrowIcon = isOpen ? 'expand_more' : 'chevron_right';
-  var toggleBtn = '<button type="button" class="brand-app-expand-btn" onclick="toggleBrandAppExpand(\'' + esc(a.id) + '\', this)" title="제품 ' + prods.length + '개 ' + (isOpen ? '접기' : '펼치기') + '" style="background:none;border:none;cursor:pointer;padding:0;margin-right:2px;color:var(--muted);display:inline-flex;align-items:center;vertical-align:middle"><span class="material-icons-round notranslate" translate="no" style="font-size:18px">' + arrowIcon + '</span></button>';
+  var toggleBtn = '<button type="button" class="brand-app-expand-btn" onclick="event.stopPropagation();toggleBrandAppExpand(\'' + esc(a.id) + '\', this)" title="제품 ' + prods.length + '개 ' + (isOpen ? '접기' : '펼치기') + '" style="background:none;border:none;cursor:pointer;padding:0;margin-right:2px;color:var(--muted);display:inline-flex;align-items:center;vertical-align:middle"><span class="material-icons-round notranslate" translate="no" style="font-size:18px">' + arrowIcon + '</span></button>';
 
   var qLocked = false;
   var memoText = (a.admin_memo || '').trim();
@@ -7268,8 +7268,8 @@ function renderBrandAppSummaryRow(a) {
   var fqInner = '<div class="brand-app-fq-cell" data-id="' + esc(a.id) + '" style="position:relative;min-height:24px">' + renderFinalQuoteDisplay(a.final_quote_krw) + '</div>';
 
   return '<tr data-id="' + esc(a.id) + '" data-summary="1">'
-    // 1. 신청번호 + 폼 종류 + 토글 + 제품 N개
-    + '<td>'
+    // 1. 신청번호 + 폼 종류 + 토글 + 제품 N개 (셀 전체 클릭으로 토글)
+    + '<td onclick="handleBrandAppRowClick(event)" style="cursor:pointer" title="클릭하여 ' + (isOpen ? '접기' : '펼치기') + '">'
       + '<div style="display:flex;align-items:flex-start;gap:2px">'
         + toggleBtn
         + '<div style="flex:1;min-width:0">'
@@ -7362,6 +7362,19 @@ function renderBrandAppDetailRow(a, p, idx) {
     + '<td style="text-align:right;font-variant-numeric:tabular-nums;font-size:12px;color:#16a34a;font-weight:600">' + (vatKrw > 0 ? fmtKrw(vatKrw) : dash) + '</td>'
     + emptyApp + emptyApp + emptyApp + emptyApp + emptyApp + emptyApp + emptyApp + emptyApp // 17-24 신청 단위 비움
     + '</tr>';
+}
+
+// 신청번호 셀 클릭으로 토글
+function handleBrandAppRowClick(ev) {
+  // 토글 버튼 자체는 stopPropagation 처리되지만 안전을 위해 한 번 더 가드
+  if (ev.target.closest('button, a, input, select, textarea')) return;
+  var td = ev.currentTarget;
+  var tr = td.closest('tr');
+  if (!tr) return;
+  var id = tr.dataset.id;
+  if (!id) return;
+  var btn = tr.querySelector('.brand-app-expand-btn');
+  if (btn) toggleBrandAppExpand(id, btn);
 }
 
 // 토글: 펼침/접힘 — 같은 신청 ID의 detail 행을 동적 추가/제거

--- a/dev/js/admin.js
+++ b/dev/js/admin.js
@@ -6874,7 +6874,7 @@ function renderBrandLongPending(apps) {
 
 async function loadBrandApplications() {
   var tbody = $('brandAppTableBody');
-  if (tbody) tbody.innerHTML = '<tr><td colspan="22" style="text-align:center;color:var(--muted);padding:24px"><span class="spinner" style="width:20px;height:20px;border-width:2px;border-color:rgba(200,120,163,.2);border-top-color:var(--pink)"></span></td></tr>';
+  if (tbody) tbody.innerHTML = '<tr><td colspan="24" style="text-align:center;color:var(--muted);padding:24px"><span class="spinner" style="width:20px;height:20px;border-width:2px;border-color:rgba(200,120,163,.2);border-top-color:var(--pink)"></span></td></tr>';
   _brandApps = await fetchBrandApplications();
   renderBrandApplicationsList();
   refreshBrandAppBadge();
@@ -6968,7 +6968,7 @@ function renderBrandApplicationsList() {
     rows: list,
     renderRow: renderBrandAppRow,
     pageSize: BRAND_APP_PAGE_SIZE,
-    emptyHtml: '<tr><td colspan="22" style="text-align:center;color:var(--muted);padding:40px">신청 내역이 없습니다</td></tr>',
+    emptyHtml: '<tr><td colspan="24" style="text-align:center;color:var(--muted);padding:40px">신청 내역이 없습니다</td></tr>',
   });
 }
 
@@ -7183,6 +7183,26 @@ function _findBrandApp(id) {
 // 환율·VAT 상수 (FX_JPY_KRW=10, VAT_RATE=10% — migration 052 트리거와 일치)
 var BRAND_QUOTE_CONST = { FX_JPY_KRW: 10, VAT_RATE: 0.1 };
 
+// 제품 URL 셀 — 안전 URL이면 클릭 링크 + 복사 버튼, 아니면 평문 표시
+function renderProductUrlCell(url) {
+  if (!url) return '<span style="color:var(--muted);font-size:11px">—</span>';
+  var safe = (typeof safeBrandUrl === 'function') ? safeBrandUrl(url) : null;
+  if (!safe) {
+    return '<span style="color:var(--muted);word-break:break-all;font-size:11px;display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;overflow:hidden;line-height:1.4">' + esc(url) + '</span>';
+  }
+  var jsSafe = safe.replace(/\\/g, '\\\\').replace(/'/g, "\\'");
+  return '<div style="display:flex;align-items:flex-start;gap:4px;min-width:0">'
+    + '<a href="' + esc(safe) + '" target="_blank" rel="noopener" title="' + esc(url) + '"'
+      + ' style="flex:1;min-width:0;color:var(--pink);word-break:break-all;font-size:11px;'
+      + 'display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;overflow:hidden;line-height:1.4;max-height:2.8em">'
+      + esc(url) + '</a>'
+    + '<button type="button" class="btn btn-ghost btn-xs" onclick="copyBrandProductUrl(\'' + jsSafe + '\')" '
+      + 'title="URL 복사" style="padding:2px 6px;flex-shrink:0">'
+      + '<span class="material-icons-round notranslate" translate="no" style="font-size:13px;vertical-align:middle">content_copy</span>'
+    + '</button>'
+  + '</div>';
+}
+
 // 신청 1건의 제품 1개를 1행으로 렌더 (총 22컬럼)
 function renderBrandAppProductRow(a, p, idx, total) {
   var isFirst = (idx === 0);
@@ -7228,7 +7248,11 @@ function renderBrandAppProductRow(a, p, idx, total) {
     + cellApp(esc(a.billing_email || '—'), 'font-size:12px;color:' + (a.billing_email ? 'var(--ink)' : 'var(--muted)') + ';word-break:break-all')
     // 6. 요청사항
     + cellApp(brandAppNoteCell(a.request_note))
-    // 7-14. 제품별 8컬럼 (모든 행에 표시)
+    // 7. 제품명 (제품별 — 모든 행)
+    + '<td style="font-weight:600;color:var(--ink);font-size:11px;word-break:break-word;line-height:1.4">' + (p.name ? esc(p.name) : '<span style="color:var(--muted);font-weight:400">—</span>') + '</td>'
+    // 8. URL (제품별 — 모든 행)
+    + '<td>' + renderProductUrlCell(p.url) + '</td>'
+    // 9-16. 제품별 8컬럼 (모든 행에 표시)
     + '<td style="text-align:right;font-variant-numeric:tabular-nums;font-size:12px">' + (qty > 0 ? qty.toLocaleString('ja-JP') : '<span style="color:var(--muted)">—</span>') + '</td>'
     + '<td style="text-align:right;font-variant-numeric:tabular-nums;font-size:12px">' + (priceJpy > 0 ? '¥ ' + priceJpy.toLocaleString('ja-JP') : '<span style="color:var(--muted)">—</span>') + '</td>'
     + '<td style="text-align:right;font-variant-numeric:tabular-nums;font-size:12px">' + (priceKrw > 0 ? fmtKrw(priceKrw) : '<span style="color:var(--muted)">—</span>') + '</td>'

--- a/dev/js/admin.js
+++ b/dev/js/admin.js
@@ -6978,7 +6978,7 @@ function renderBrandApplicationsList() {
       + '<td>' + brandAppNoteCell(a.request_note) + '</td>'
       + '<td style="font-size:12px">' + prodSummary + '</td>'
       + '<td style="text-align:right;font-variant-numeric:tabular-nums">' + fmtKrw(a.estimated_krw) + '</td>'
-      + '<td style="text-align:right;font-variant-numeric:tabular-nums;font-weight:600">' + fmtKrw(a.final_quote_krw) + '</td>'
+      + '<td><div class="brand-app-fq-cell" data-id="' + esc(a.id) + '" style="position:relative;min-height:24px">' + renderFinalQuoteDisplay(a.final_quote_krw) + '</div></td>'
       + '<td>' + quoteSent + '</td>'
       + '<td>' + memoCell + '</td>'
       + '<td>' + brandAppStatusSelect(a) + '</td>'
@@ -7204,6 +7204,82 @@ function closeBrandAppDetail() {
 function _findBrandApp(id) {
   var idx = (_brandApps || []).findIndex(function(a){ return a.id === id; });
   return idx < 0 ? null : _brandApps[idx];
+}
+
+function renderFinalQuoteDisplay(value) {
+  return '<div class="fq-display" style="text-align:right;font-variant-numeric:tabular-nums;font-weight:600;padding-right:22px;font-size:12px">' + fmtKrw(value) + '</div>'
+    + '<button type="button" class="fq-edit-btn" onclick="enterFinalQuoteEdit(this)" title="확정 견적 수정" style="position:absolute;top:0;right:0;background:none;border:none;cursor:pointer;padding:2px;color:var(--muted);display:flex;align-items:center;justify-content:center;border-radius:3px" onmouseover="this.style.background=\'rgba(0,0,0,.05)\'" onmouseout="this.style.background=\'none\'"><span class="material-icons-round notranslate" translate="no" style="font-size:15px">edit</span></button>';
+}
+
+function _restoreFinalQuoteDisplay(cell, value) {
+  cell.innerHTML = renderFinalQuoteDisplay(value);
+}
+
+function enterFinalQuoteEdit(btnEl) {
+  var cell = btnEl.closest('.brand-app-fq-cell');
+  if (!cell) return;
+  var cur = _findBrandApp(cell.dataset.id);
+  if (!cur) return;
+  var original = cur.final_quote_krw == null ? '' : String(cur.final_quote_krw);
+  cell.innerHTML = '<div style="display:flex;flex-direction:column;gap:4px">'
+    + '<input type="number" class="fq-edit-input" value="' + esc(original) + '" placeholder="0" min="0" step="1" onkeydown="handleFinalQuoteEditKey(event, this)" style="width:100%;font-size:11px;padding:3px 6px;border:1px solid var(--pink);border-radius:4px;text-align:right;font-variant-numeric:tabular-nums">'
+    + '<div style="display:flex;gap:4px;justify-content:flex-end">'
+      + '<button type="button" onclick="cancelFinalQuoteEdit(this)" style="background:#fff;border:1px solid var(--line);border-radius:4px;padding:3px 8px;cursor:pointer;font-size:11px;color:var(--muted)">취소</button>'
+      + '<button type="button" onclick="confirmFinalQuoteEdit(this)" style="background:var(--pink);color:#fff;border:none;border-radius:4px;padding:3px 10px;cursor:pointer;font-size:11px;font-weight:600">저장</button>'
+    + '</div>'
+  + '</div>';
+  var input = cell.querySelector('.fq-edit-input');
+  if (input) { input.focus(); input.select(); }
+}
+
+function handleFinalQuoteEditKey(ev, inputEl) {
+  if (ev.key === 'Escape') { ev.preventDefault(); cancelFinalQuoteEdit(inputEl); }
+  else if (ev.key === 'Enter') { ev.preventDefault(); confirmFinalQuoteEdit(inputEl); }
+}
+
+function cancelFinalQuoteEdit(anyChildEl) {
+  var cell = anyChildEl.closest('.brand-app-fq-cell');
+  if (!cell) return;
+  var cur = _findBrandApp(cell.dataset.id);
+  _restoreFinalQuoteDisplay(cell, cur?.final_quote_krw);
+}
+
+async function confirmFinalQuoteEdit(anyChildEl) {
+  var cell = anyChildEl.closest('.brand-app-fq-cell');
+  if (!cell) return;
+  var input = cell.querySelector('.fq-edit-input');
+  if (!input) return;
+  var id = cell.dataset.id;
+  var cur = _findBrandApp(id);
+  if (!cur) return;
+  var raw = (input.value || '').trim();
+  var nextValue = raw === '' ? null : Number(raw);
+  if (nextValue !== null && (!isFinite(nextValue) || nextValue < 0)) {
+    toast('0 이상의 숫자만 입력하세요.', 'warn');
+    return;
+  }
+  var prevValue = cur.final_quote_krw == null ? null : Number(cur.final_quote_krw);
+  if (prevValue === nextValue) {
+    _restoreFinalQuoteDisplay(cell, prevValue);
+    return;
+  }
+  var prevVersion = cur.version;
+  input.disabled = true;
+  var result = await updateBrandApplication(id, {final_quote_krw: nextValue}, prevVersion);
+  input.disabled = false;
+  if (result.conflict) {
+    toast('다른 관리자가 먼저 저장했습니다. 다시 불러옵니다.', 'warn');
+    await loadBrandApplications();
+    return;
+  }
+  if (!result.ok) {
+    toast('저장 실패: ' + (result.error || '알 수 없는 오류'), 'error');
+    return;
+  }
+  cur.final_quote_krw = nextValue;
+  cur.version = result.data?.version || (prevVersion + 1);
+  _restoreFinalQuoteDisplay(cell, nextValue);
+  toast('확정 견적이 저장되었습니다.');
 }
 
 function renderQuoteSentDisplay(isoOrNull, locked) {

--- a/supabase/seed/dev_brand_app_dummy.sql
+++ b/supabase/seed/dev_brand_app_dummy.sql
@@ -1,0 +1,171 @@
+-- ============================================================
+-- dev_brand_app_dummy.sql
+-- 브랜드 서베이 신청 목록 UI 검증용 더미 데이터 (15건)
+--
+-- 대상 DB: 개발(qysmxtipobomefudyixw) 전용. 운영 DB 실행 금지!
+-- 사용법: Supabase SQL Editor에 전체 붙여넣기 → Run
+--
+-- 채번 트리거가 application_no를 자동 생성하므로 명시 불필요.
+-- 다양성 커버:
+--   - form_type: reviewer 9건 / seeding 6건
+--   - products 갯수: 1, 1, 2, 3, 5, 1, 2, 8, 1, 3, 4, 1, 1, 6, 2 (1~8개 분포)
+--   - status: new(3) / reviewing(2) / quoted(2) / orient_sheet_sent(1) /
+--             schedule_sent(1) / campaign_registered(1) / paid(2) / done(2) / rejected(1)
+--   - 가격 폭: ¥500 ~ ¥25,000
+--   - 수량 폭: 3 ~ 500개
+--   - transfer_fee_krw: 3000, 5000, 7500, null 혼합
+--   - 브랜드명 언어: 한국어 / 영문 / 일본어 / 한일 혼용
+--   - admin_memo / quote_sent_at / request_note 길이 다양 (짧음/중간/매우 김 + 개행 포함)
+-- ============================================================
+
+INSERT INTO public.brand_applications (
+  form_type, brand_name, contact_name, phone, email, billing_email,
+  products, request_note, status, admin_memo, final_quote_krw, quote_sent_at
+) VALUES
+
+-- 1. reviewer · 1개 · new · 평균값
+('reviewer', '뷰티스킨 코리아', '김지우', '010-1234-5678', 'kim.jiwoo@beautyskin.kr', 'tax@beautyskin.kr',
+ '[{"name":"하이드라 부스터 세럼 50ml","url":"https://qoo10.jp/g/sample-001","qty":50,"price":2800,"transfer_fee_krw":5000}]'::jsonb,
+ '리뷰어 분들께 자세한 사용법 동영상 가이드 함께 제공 부탁드립니다. 일본어 패키지 라벨 제공 가능합니다.',
+ 'new', NULL, NULL, NULL),
+
+-- 2. reviewer · 2개 · reviewing
+('reviewer', '오가닉 푸드 스토리', '박서연', '02-555-1234', 'park@organicfood.kr', NULL,
+ '[{"name":"유기농 견과류 믹스 200g","url":"https://qoo10.jp/g/sample-002a","qty":30,"price":1500,"transfer_fee_krw":5000},
+   {"name":"수제 그래놀라 250g","url":"https://qoo10.jp/g/sample-002b","qty":30,"price":1800,"transfer_fee_krw":5000}]'::jsonb,
+ NULL,
+ 'reviewing', '담당자 휴가 중. 5월 6일 견적 전달 예정.', NULL, NULL),
+
+-- 3. seeding · 1개 · quoted
+('seeding', '내추럴 코스메틱', '이수민', '+82-10-9999-8888', 'sumin@naturalcos.com', 'billing@naturalcos.com',
+ '[{"name":"아이크림 30ml","url":"","qty":20,"price":3500,"transfer_fee_krw":null}]'::jsonb,
+ '나노 인플루언서 30명 정도 매칭 희망합니다. 30대 여성 타깃.',
+ 'quoted', '예상 견적 전달. 클라이언트 확인 대기 중. 5/3 후속 연락 예정.', 1100000,
+ '2026-05-01 14:30:00+09'::timestamptz),
+
+-- 4. reviewer · 3개 · paid
+('reviewer', '주방의 마법', '최민준', '031-789-0123', 'choi@kitchenmagic.kr', 'finance@kitchenmagic.kr',
+ '[{"name":"실리콘 주걱 3종 세트","url":"https://qoo10.jp/g/sample-004a","qty":15,"price":1200,"transfer_fee_krw":5000},
+   {"name":"논스틱 프라이팬 24cm","url":"https://qoo10.jp/g/sample-004b","qty":15,"price":4800,"transfer_fee_krw":5000},
+   {"name":"수제 우드 도마 L","url":"https://qoo10.jp/g/sample-004c","qty":15,"price":2500,"transfer_fee_krw":5000}]'::jsonb,
+ '주방 카테고리 인플루언서 우선. 요리 콘텐츠 제작 가능자로 매칭 부탁드립니다.',
+ 'paid', '입금 확인 완료. 5/2 카톡방 생성 예정. 오리엔테이션 5/4.',
+ 1850000, '2026-04-25 10:00:00+09'::timestamptz),
+
+-- 5. reviewer · 5개 · done · 캠페인 완료
+('reviewer', '슈퍼키즈', '정하린', '010-2222-3333', 'jung@superkids.kr', 'tax@superkids.kr',
+ '[{"name":"유아 스토리북 세트 (5권)","url":"https://qoo10.jp/g/sample-005a","qty":40,"price":2200,"transfer_fee_krw":5000},
+   {"name":"한글 학습 카드 100종","url":"https://qoo10.jp/g/sample-005b","qty":40,"price":1500,"transfer_fee_krw":5000},
+   {"name":"수학 워크북 미취학용","url":"https://qoo10.jp/g/sample-005c","qty":40,"price":1800,"transfer_fee_krw":5000},
+   {"name":"색칠공부 키트 24색","url":"https://qoo10.jp/g/sample-005d","qty":40,"price":1200,"transfer_fee_krw":5000},
+   {"name":"스티커 보상판 세트","url":"https://qoo10.jp/g/sample-005e","qty":40,"price":800,"transfer_fee_krw":5000}]'::jsonb,
+ '주부맘 인플루언서 위주. 자녀 등장 시 모자이크 처리 필수 안내 부탁드립니다. 일본 가정 대상.',
+ 'done', '캠페인 완료. 결과 보고서 5/15까지 정리 예정. 재의뢰 가능성 있음.',
+ 3520000, '2026-04-10 09:00:00+09'::timestamptz),
+
+-- 6. seeding · 2개 · rejected
+('seeding', '글로우 스킨케어', '강민지', '010-7777-8888', 'kang@glowskin.kr', NULL,
+ '[{"name":"비타민C 세럼 30ml","url":"","qty":25,"price":3200,"transfer_fee_krw":null},
+   {"name":"리프팅 크림 50ml","url":"","qty":25,"price":4500,"transfer_fee_krw":null}]'::jsonb,
+ '20대 여성 인플루언서 매칭. 광고 표기 가이드 사전 안내 필요.',
+ 'rejected', '2025년 컴플라이언스 이슈로 보류 결정. 재신청 가능.', NULL, NULL),
+
+-- 7. reviewer · 2개 · orient_sheet_sent
+('reviewer', '홈데코 라운지', '윤도현', '010-5555-6666', 'yoon@homedeco.kr', 'tax@homedeco.kr',
+ '[{"name":"인테리어 우드 액자 A4","url":"https://qoo10.jp/g/sample-007a","qty":20,"price":2800,"transfer_fee_krw":5000},
+   {"name":"향초 3종 세트 (라벤더/우드/시트러스)","url":"https://qoo10.jp/g/sample-007b","qty":20,"price":3500,"transfer_fee_krw":5000}]'::jsonb,
+ NULL,
+ 'orient_sheet_sent', '오리엔테이션 5/2 발송. 응답 대기 중.', 1450000,
+ '2026-04-30 16:00:00+09'::timestamptz),
+
+-- 8. reviewer · 8개 · schedule_sent · 대형 신청
+('reviewer', 'Beauty Glow Inc.', '서민호', '010-3344-5566', 'seo@beautyglow.com', 'finance@beautyglow.com',
+ '[{"name":"스킨토너 200ml","url":"https://qoo10.jp/g/sample-008a","qty":100,"price":1800,"transfer_fee_krw":5000},
+   {"name":"클렌징 폼 150ml","url":"https://qoo10.jp/g/sample-008b","qty":100,"price":1500,"transfer_fee_krw":5000},
+   {"name":"에센스 50ml","url":"https://qoo10.jp/g/sample-008c","qty":100,"price":3500,"transfer_fee_krw":5000},
+   {"name":"세럼 30ml","url":"https://qoo10.jp/g/sample-008d","qty":100,"price":4200,"transfer_fee_krw":5000},
+   {"name":"아이크림 25ml","url":"https://qoo10.jp/g/sample-008e","qty":100,"price":3800,"transfer_fee_krw":5000},
+   {"name":"수면팩 80g","url":"https://qoo10.jp/g/sample-008f","qty":100,"price":2200,"transfer_fee_krw":5000},
+   {"name":"마스크팩 5매입","url":"https://qoo10.jp/g/sample-008g","qty":100,"price":1200,"transfer_fee_krw":5000},
+   {"name":"클렌징 오일 200ml","url":"https://qoo10.jp/g/sample-008h","qty":100,"price":2800,"transfer_fee_krw":5000}]'::jsonb,
+ '대규모 캠페인이라 진행 일정 사전 협의 필요합니다.\n관련 일정표는 별도 메일 첨부 예정입니다.',
+ 'schedule_sent', '일정표 5/3 발송. 클라이언트 확인 후 견적 확정 예정.', NULL, NULL),
+
+-- 9. reviewer · 1개 · campaign_registered · 캠페인 등록 단계
+('reviewer', 'Q10 글로벌 유통', '한유진', '02-3344-5566', 'han.yujin@q10global.kr', 'tax@q10global.kr',
+ '[{"name":"프리미엄 홍삼 스틱 30포","url":"https://qoo10.jp/g/sample-009","qty":80,"price":4500,"transfer_fee_krw":5000}]'::jsonb,
+ '40~50대 건강관심층 인플루언서 우선.',
+ 'campaign_registered', '캠페인 #2026-04-22 등록 완료. 모집 시작 5/5.', 4290000,
+ '2026-04-20 11:00:00+09'::timestamptz),
+
+-- 10. seeding · 3개 · new · 매우 짧은 정보
+('seeding', 'F&B 스튜디오', '오지훈', '+82-10-1111-2222', 'oh@fnb.kr', NULL,
+ '[{"name":"수제 잼 200g","url":"","qty":15,"price":1800,"transfer_fee_krw":null},
+   {"name":"꿀 250g","url":"","qty":15,"price":2500,"transfer_fee_krw":null},
+   {"name":"드립백 커피 10개입","url":"","qty":15,"price":1200,"transfer_fee_krw":null}]'::jsonb,
+ NULL,
+ 'new', NULL, NULL, NULL),
+
+-- 11. reviewer · 4개 · paid · 매우 긴 메모 (더보기 검증)
+('reviewer', '스타일 클로젯', '임채원', '010-8899-7766', 'lim@styleclo.kr', 'finance@styleclo.kr',
+ '[{"name":"베이직 티셔츠 (화이트)","url":"https://qoo10.jp/g/sample-011a","qty":25,"price":2800,"transfer_fee_krw":5000},
+   {"name":"베이직 티셔츠 (블랙)","url":"https://qoo10.jp/g/sample-011b","qty":25,"price":2800,"transfer_fee_krw":5000},
+   {"name":"슬랙스 (베이지)","url":"https://qoo10.jp/g/sample-011c","qty":25,"price":4500,"transfer_fee_krw":5000},
+   {"name":"가디건 (네이비)","url":"https://qoo10.jp/g/sample-011d","qty":25,"price":5800,"transfer_fee_krw":5000}]'::jsonb,
+ '20~30대 여성 패션 인플루언서로 매칭 부탁드립니다.\n착용샷 + 코디 제안 콘텐츠 가능자 우선이며,\n계절 트렌드 반영해주시면 좋겠습니다.',
+ 'paid', '입금 5/1 확인 완료. 카톡방 생성 5/2.\n\n[중요 협의사항]\n- 사이즈 표기는 일본 기준(S/M/L)으로 통일\n- 컬러는 영문(white/black/beige/navy)+한글 병기\n- 배송 추적은 EMS 송장번호 공유\n- 결과물은 2026-05-20까지 제출 마감\n- VAT 포함 견적이며 추가 수수료 없음 확인됨\n\n클라이언트 측 요청으로 인플루언서 모집 시 패션 카테고리 팔로워 5천 이상 우선 고려.',
+ 2780000, '2026-04-28 09:30:00+09'::timestamptz),
+
+-- 12. reviewer · 1개 · done · 럭셔리 (가격 매우 높음)
+('reviewer', '프리미엄 워치 갤러리', '강시현', '02-777-8888', 'kang@premiumwatch.kr', 'tax@premiumwatch.kr',
+ '[{"name":"오토매틱 손목시계 (스테인리스)","url":"https://qoo10.jp/g/sample-012","qty":5,"price":25000,"transfer_fee_krw":7500}]'::jsonb,
+ '럭셔리 카테고리 메가 인플루언서 5명 한정 매칭. 30대 남성 우선.',
+ 'done', '캠페인 완료. ROAS 320% 달성. 재진행 협의 중.', 1450000,
+ '2026-04-05 14:00:00+09'::timestamptz),
+
+-- 13. seeding · 1개 · reviewing · 저가 (가격 매우 낮음)
+('seeding', '데일리 스낵 코리아', '김다현', '010-4455-6677', 'kim@dailysnack.kr', NULL,
+ '[{"name":"미니 초콜릿 5개입","url":"","qty":200,"price":500,"transfer_fee_krw":null}]'::jsonb,
+ '대량 시딩 (200명). MZ세대 푸드 인플루언서 위주.',
+ 'reviewing', '단가 낮은 대량 시딩 건. 견적 검토 중.', NULL, NULL),
+
+-- 14. reviewer · 6개 · quoted · 매우 긴 요청사항 (개행 포함)
+('reviewer', '株式会社グリーンライフ (한국법인)', '中村 美優', '+81-90-1234-5678', 'nakamura@greenlife.jp', 'tax@greenlife.jp',
+ '[{"name":"식물 키우기 키트 (선인장)","url":"https://qoo10.jp/g/sample-014a","qty":35,"price":1500,"transfer_fee_krw":5000},
+   {"name":"식물 키우기 키트 (다육이)","url":"https://qoo10.jp/g/sample-014b","qty":35,"price":1800,"transfer_fee_krw":5000},
+   {"name":"미니 화분 3종","url":"https://qoo10.jp/g/sample-014c","qty":35,"price":2200,"transfer_fee_krw":5000},
+   {"name":"식물영양제","url":"https://qoo10.jp/g/sample-014d","qty":35,"price":1200,"transfer_fee_krw":5000},
+   {"name":"가드닝 도구 4종 세트","url":"https://qoo10.jp/g/sample-014e","qty":35,"price":3500,"transfer_fee_krw":5000},
+   {"name":"식물 라벨 스티커","url":"https://qoo10.jp/g/sample-014f","qty":35,"price":600,"transfer_fee_krw":5000}]'::jsonb,
+ '【 진행 조건 】\n1. 식물/가드닝 카테고리 인플루언서 한정\n2. 20~40대 여성 우선\n3. 키우는 과정 동영상 콘텐츠 가능자\n\n【 콘텐츠 가이드 】\n- 발아부터 성장까지 주 1회 업로드 (총 4주)\n- 마지막 영상에 #PR #광고 표기 필수\n- 제품 패키지 노출 1회 이상\n\n【 기타 】\n- 일본어 안내문 별도 동봉\n- 배송 지연 시 사전 공지\n- 문제 발생 시 24시간 내 응대 원칙',
+ 'quoted', '클라이언트 측 견적 확인 대기. 5/4 회신 예정.', 1620000,
+ '2026-04-29 10:30:00+09'::timestamptz),
+
+-- 15. reviewer · 2개 · new · 영문 + 한일 혼용
+('reviewer', 'Korea-Japan Cosmetics', 'Lee Min Ho', '010-9988-7766', 'lee@kjcosmetics.com', NULL,
+ '[{"name":"BB Cushion 15g","url":"https://qoo10.jp/g/sample-015a","qty":60,"price":3200,"transfer_fee_krw":3000},
+   {"name":"Lip Tint Set (3종)","url":"https://qoo10.jp/g/sample-015b","qty":60,"price":2800,"transfer_fee_krw":3000}]'::jsonb,
+ 'K-Beauty 인플루언서 위주. JP→KR 트래픽 유도 목적.',
+ 'new', NULL, NULL, NULL);
+
+
+-- ============================================================
+-- 검증 SQL (선택)
+-- ============================================================
+/*
+SELECT application_no, form_type, brand_name, status,
+       jsonb_array_length(products) AS prod_cnt,
+       total_qty, total_jpy, estimated_krw, final_quote_krw,
+       quote_sent_at IS NOT NULL AS quote_sent,
+       admin_memo IS NOT NULL AS has_memo,
+       (length(coalesce(admin_memo, '')) > 40 OR admin_memo LIKE '%' || E'\n' || '%') AS memo_long
+FROM public.brand_applications
+ORDER BY created_at DESC
+LIMIT 20;
+
+-- 상태별 분포
+SELECT status, COUNT(*) FROM public.brand_applications GROUP BY status ORDER BY status;
+
+-- 폼 종류별 분포
+SELECT form_type, COUNT(*) FROM public.brand_applications GROUP BY form_type;
+*/


### PR DESCRIPTION
## Summary
26 dev commits ready for production. All verified — reviewer PASS on 8 regression checks.

### Highlights
- **Brand-survey list overhaul** — collapsed by default (1 row per app with SUM aggregates), click 신청번호 to expand into per-product rows. 3 inline edit fields with ✎ icon (메모 / 견적서 전달 / 이체수수료(건)), 7 formula tooltips on calculated columns, 정렬 초기화 button. 확정 견적 column dropped (replaced by client-side 최종 견적 SUM).
- **Sidebar polish** — header/footer fixed, scroll only the menu, dark scrollbar, label readability.
- **application_no v2** — JFUN-{R|S}-YYMMDD-NNN (Q→R, N→S, 2-digit year). Migration 078 already applied to production DB in PR #132.
- **Multi-filter UX** — "전체" now shows all child checkboxes ✓ and supports indeterminate state when partially selected. Data semantics unchanged.
- **2 carry-over commits** — campaign-edit Phase 2 audit + brand-app product table 모집비용/이체수수료 columns.

## Reviewer notes
- transfer_fee_krw is a new key in products jsonb — DB triggers ignore it (read-only client computation)
- Removed 6 unused FinalQuote handlers, no stale references
- dev/seed/dev_brand_app_dummy.sql is dev-only (no auto-apply path)
- Sidebar collapsed mode unaffected by 3-zone layout

## Test plan (post-deploy)
- [ ] https://globalreverb.com/admin/#brand-applications — 23 columns, expand/collapse, formula tooltips
- [ ] Sidebar at narrow viewport
- [ ] Multi-filter: 전체 체크 → 모든 항목 ✓, 1개 해제 → 전체 indeterminate