### PR TITLE
Deploy: multi-entry 내부 메모 (with full history tracking)

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -2951,6 +2951,26 @@ textarea.form-input{resize:vertical;min-height:80px}
 
 <!-- 광고주 신청 상세 모달은 제거됨 — 모든 인라인 편집은 신청 목록 행 안에서 -->
 
+<!-- 광고주 신청 내부 메모 모달 (multi-entry) -->
+<div class="modal-overlay" id="brandAppMemoModal" style="z-index:611">
+  <div class="modal" style="max-width:680px;width:96vw;border-radius:16px;margin:auto;max-height:80vh;display:flex;flex-direction:column">
+    <div class="modal-header" style="padding:16px 20px 12px;border-bottom:1px solid var(--line);display:flex;align-items:center;justify-content:space-between">
+      <div style="font-size:14px;font-weight:700;color:var(--ink)" id="brandAppMemoTitle">내부 메모</div>
+      <button class="btn btn-ghost btn-xs" onclick="closeBrandAppMemoModal()" style="padding:4px 10px">✕</button>
+    </div>
+    <div class="modal-body" style="padding:16px 20px;overflow-y:auto;flex:1" id="brandAppMemoBody">
+      <div style="padding:24px;text-align:center;color:var(--muted);font-size:13px">불러오는 중…</div>
+    </div>
+    <div class="modal-footer" style="padding:14px 20px;border-top:1px solid var(--line);display:flex;flex-direction:column;gap:8px">
+      <textarea id="brandAppMemoNewInput" placeholder="새 메모 입력…" style="width:100%;min-height:60px;padding:8px 10px;border:1px solid var(--line);border-radius:6px;font-size:13px;font-family:inherit;resize:vertical" onkeydown="if((event.metaKey||event.ctrlKey)&&event.key==='Enter'){event.preventDefault();submitNewBrandAppMemo();}"></textarea>
+      <div style="display:flex;justify-content:flex-end;gap:6px">
+        <button class="btn btn-ghost btn-sm" onclick="closeBrandAppMemoModal()">닫기</button>
+        <button class="btn btn-primary btn-sm" onclick="submitNewBrandAppMemo()">메모 추가</button>
+      </div>
+    </div>
+  </div>
+</div>
+
 <!-- 광고주 신청 변경 이력 모달 -->
 <div class="modal-overlay" id="brandAppHistoryModal" style="z-index:610">
   <div class="modal" style="max-width:1100px;width:96vw;border-radius:16px;margin:auto;max-height:80vh;display:flex;flex-direction:column">
@@ -4507,6 +4527,74 @@ async function markAdminNoticeRead(noticeId) {
 // ══════════════════════════════════════
 
 // 광고주 신청 목록 조회 (관리자 RLS로 전체 조회)
+// 광고주 신청 메모 (multi-entry, migration 080)
+async function fetchBrandAppMemos(applicationId) {
+  if (!db || !applicationId) return [];
+  try {
+    const {data, error} = await db?.from('brand_application_memos')
+      .select('id, application_id, author_id, author_name, text, created_at, updated_at')
+      .eq('application_id', applicationId)
+      .order('created_at', {ascending: false});
+    if (error) throw error;
+    return data || [];
+  } catch(e) { console.error('[fetchBrandAppMemos]', e); return []; }
+}
+async function insertBrandAppMemo(applicationId, text, authorId, authorName) {
+  if (!db) return {ok:false, error:'no_db'};
+  try {
+    const result = await retryWithRefresh(async () => {
+      const {data, error} = await db?.from('brand_application_memos')
+        .insert({application_id: applicationId, text: text, author_id: authorId || null, author_name: authorName || null})
+        .select('*').maybeSingle();
+      if (error) throw error;
+      return data;
+    });
+    return {ok: true, data: result};
+  } catch(e) { console.error('[insertBrandAppMemo]', e); return {ok:false, error: e?.message || 'unknown'}; }
+}
+async function updateBrandAppMemo(memoId, text) {
+  if (!db) return {ok:false, error:'no_db'};
+  try {
+    const result = await retryWithRefresh(async () => {
+      const {data, error} = await db?.from('brand_application_memos')
+        .update({text: text, updated_at: new Date().toISOString()})
+        .eq('id', memoId)
+        .select('*').maybeSingle();
+      if (error) throw error;
+      return data;
+    });
+    return {ok: true, data: result};
+  } catch(e) { console.error('[updateBrandAppMemo]', e); return {ok:false, error: e?.message || 'unknown'}; }
+}
+async function deleteBrandAppMemo(memoId) {
+  if (!db) return {ok:false, error:'no_db'};
+  try {
+    await retryWithRefresh(async () => {
+      const {error} = await db?.from('brand_application_memos').delete().eq('id', memoId);
+      if (error) throw error;
+    });
+    return {ok: true};
+  } catch(e) { console.error('[deleteBrandAppMemo]', e); return {ok:false, error: e?.message || 'unknown'}; }
+}
+// 신청별 메모 카운트 + latest 텍스트 (목록 셀 표시용)
+async function fetchBrandAppMemoSummaries() {
+  if (!db) return {};
+  try {
+    const {data, error} = await db?.from('brand_application_memos')
+      .select('application_id, text, created_at')
+      .order('created_at', {ascending: false})
+      .limit(100000);
+    if (error) throw error;
+    const summary = {};
+    (data || []).forEach(r => {
+      if (!summary[r.application_id]) summary[r.application_id] = {count: 0, latest: null};
+      summary[r.application_id].count++;
+      if (!summary[r.application_id].latest) summary[r.application_id].latest = r.text;
+    });
+    return summary;
+  } catch(e) { console.error('[fetchBrandAppMemoSummaries]', e); return {}; }
+}
+
 // 신청별 history 건수 조회 (작은 카운트 쿼리 — 1회 호출)
 async function fetchBrandAppHistoryCounts() {
   if (!db) return {};
@@ -12400,6 +12488,9 @@ function renderBrandLongPending(apps) {
 }
 
 var _brandAppHistoryCounts = {};
+var _brandAppMemoSummaries = {};      // {appId: {count, latest}}
+var _brandAppMemoModalCurrentId = null;
+var _brandAppMemoModalCache = [];     // open된 신청의 메모 배열 (memory)
 
 // 인라인 편집 성공 후 카운트 즉시 +1 + 해당 row의 이력 버튼 셀만 outerHTML 갱신
 function _refreshBrandAppHistoryButton(id) {
@@ -12416,13 +12507,15 @@ function _refreshBrandAppHistoryButton(id) {
 async function loadBrandApplications() {
   var tbody = $('brandAppTableBody');
   if (tbody) tbody.innerHTML = '<tr><td colspan="23" style="text-align:center;color:var(--muted);padding:24px"><span class="spinner" style="width:20px;height:20px;border-width:2px;border-color:rgba(200,120,163,.2);border-top-color:var(--pink)"></span></td></tr>';
-  // 신청 본문 + history 카운트 동시 fetch
-  var [apps, counts] = await Promise.all([
+  // 신청 본문 + history 카운트 + 메모 요약 동시 fetch
+  var [apps, counts, memoSummaries] = await Promise.all([
     fetchBrandApplications(),
-    fetchBrandAppHistoryCounts()
+    fetchBrandAppHistoryCounts(),
+    fetchBrandAppMemoSummaries()
   ]);
   _brandApps = apps;
   _brandAppHistoryCounts = counts || {};
+  _brandAppMemoSummaries = memoSummaries || {};
   renderBrandApplicationsList();
   refreshBrandAppBadge();
 }
@@ -12730,7 +12823,7 @@ function renderBrandAppSummaryRow(a) {
 
   var qLocked = false;
   var memoText = (a.admin_memo || '').trim();
-  var memoCellInner = '<div class="brand-app-memo-cell" data-id="' + esc(a.id) + '" style="position:relative;min-height:36px">' + renderMemoDisplay(memoText, qLocked) + '</div>';
+  var memoCellInner = '<div class="brand-app-memo-cell" data-id="' + esc(a.id) + '" style="position:relative;min-height:36px">' + renderMemoCellInner(a.id) + '</div>';
   var quoteSentInner = '<div class="brand-app-qsent-cell" data-id="' + esc(a.id) + '" style="position:relative;min-height:36px">' + renderQuoteSentDisplay(a.quote_sent_at, qLocked) + '</div>';
 
   return '<tr data-id="' + esc(a.id) + '" data-summary="1">'
@@ -12893,6 +12986,155 @@ async function openBrandAppHistoryModal(id) {
 function closeBrandAppHistoryModal() {
   var modal = document.getElementById('brandAppHistoryModal');
   if (modal) modal.classList.remove('open');
+}
+
+// ─── 내부 메모 (multi-entry) 모달 ────────────────────────────
+async function openBrandAppMemoModal(id) {
+  _brandAppMemoModalCurrentId = id;
+  var cur = _findBrandApp(id);
+  var modal = document.getElementById('brandAppMemoModal');
+  var titleEl = document.getElementById('brandAppMemoTitle');
+  var bodyEl  = document.getElementById('brandAppMemoBody');
+  var newInput = document.getElementById('brandAppMemoNewInput');
+  if (!modal || !titleEl || !bodyEl) return;
+  titleEl.textContent = (cur ? (cur.application_no || '') + ' · ' + (cur.brand_name || '') : '신청') + ' — 내부 메모';
+  bodyEl.innerHTML = '<div style="padding:24px;text-align:center;color:var(--muted);font-size:13px"><span class="spinner" style="width:16px;height:16px;border-width:2px;border-color:rgba(200,120,163,.2);border-top-color:var(--pink);display:inline-block;vertical-align:middle;margin-right:6px"></span>불러오는 중…</div>';
+  if (newInput) newInput.value = '';
+  modal.classList.add('open');
+  await loadBrandAppMemoList();
+  if (newInput) newInput.focus();
+}
+
+function closeBrandAppMemoModal() {
+  var modal = document.getElementById('brandAppMemoModal');
+  if (modal) modal.classList.remove('open');
+  _brandAppMemoModalCurrentId = null;
+}
+
+async function loadBrandAppMemoList() {
+  if (!_brandAppMemoModalCurrentId) return;
+  var rows = await fetchBrandAppMemos(_brandAppMemoModalCurrentId);
+  _brandAppMemoModalCache = rows || [];
+  renderBrandAppMemoList();
+  // 목록 셀 카운트 동기화
+  _brandAppMemoSummaries[_brandAppMemoModalCurrentId] = {
+    count: _brandAppMemoModalCache.length,
+    latest: _brandAppMemoModalCache.length > 0 ? _brandAppMemoModalCache[0].text : null
+  };
+  _refreshBrandAppMemoCell(_brandAppMemoModalCurrentId);
+}
+
+function renderBrandAppMemoList() {
+  var bodyEl = document.getElementById('brandAppMemoBody');
+  if (!bodyEl) return;
+  if (_brandAppMemoModalCache.length === 0) {
+    bodyEl.innerHTML = '<div style="padding:24px;text-align:center;color:var(--muted);font-size:13px">메모가 없습니다. 아래에 새 메모를 입력하세요.</div>';
+    return;
+  }
+  bodyEl.innerHTML = _brandAppMemoModalCache.map(function(m){
+    var when = m.created_at ? new Date(m.created_at).toLocaleString('ko-KR', {timeZone:'Asia/Seoul'}) : '';
+    var edited = (m.updated_at && m.created_at && m.updated_at !== m.created_at)
+      ? '<span style="color:var(--muted);font-size:10px;margin-left:6px">(수정됨 ' + esc(new Date(m.updated_at).toLocaleString('ko-KR', {timeZone:'Asia/Seoul'})) + ')</span>'
+      : '';
+    return '<div class="bam-row" data-memo-id="' + esc(m.id) + '" style="padding:10px 12px;margin-bottom:8px;border:1px solid var(--line);border-radius:8px;background:#fff">'
+      + '<div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:6px;font-size:11px;color:var(--muted)">'
+        + '<div><span style="font-weight:600;color:var(--ink)">' + esc(m.author_name || '시스템') + '</span> · ' + esc(when) + edited + '</div>'
+        + '<div style="display:flex;gap:4px">'
+          + '<button class="btn btn-ghost btn-xs" onclick="enterBrandAppMemoEdit(\'' + esc(m.id) + '\')" style="padding:2px 8px" title="수정"><span class="material-icons-round notranslate" translate="no" style="font-size:14px">edit</span></button>'
+          + '<button class="btn btn-ghost btn-xs" onclick="deleteBrandAppMemoConfirm(\'' + esc(m.id) + '\')" style="padding:2px 8px;color:#c0392b" title="삭제"><span class="material-icons-round notranslate" translate="no" style="font-size:14px">delete_outline</span></button>'
+        + '</div>'
+      + '</div>'
+      + '<div class="bam-text" style="font-size:13px;color:var(--ink);white-space:pre-wrap;word-break:break-word;line-height:1.5">' + esc(m.text) + '</div>'
+    + '</div>';
+  }).join('');
+}
+
+function enterBrandAppMemoEdit(memoId) {
+  var row = document.querySelector('.bam-row[data-memo-id="' + (CSS.escape ? CSS.escape(memoId) : memoId) + '"]');
+  if (!row) return;
+  var memo = _brandAppMemoModalCache.find(function(m){ return m.id === memoId; });
+  if (!memo) return;
+  var textDiv = row.querySelector('.bam-text');
+  if (!textDiv) return;
+  textDiv.outerHTML = '<div style="display:flex;flex-direction:column;gap:6px">'
+    + '<textarea class="bam-edit-input" style="width:100%;min-height:60px;padding:6px 8px;border:1px solid var(--pink);border-radius:6px;font-size:13px;font-family:inherit;resize:vertical">' + esc(memo.text) + '</textarea>'
+    + '<div style="display:flex;gap:4px;justify-content:flex-end">'
+      + '<button class="btn btn-ghost btn-xs" onclick="cancelBrandAppMemoEdit(\'' + esc(memoId) + '\')" style="padding:3px 10px">취소</button>'
+      + '<button class="btn btn-primary btn-xs" onclick="confirmBrandAppMemoEdit(\'' + esc(memoId) + '\')" style="padding:3px 12px">저장</button>'
+    + '</div>'
+  + '</div>';
+  var input = row.querySelector('.bam-edit-input');
+  if (input) { input.focus(); input.setSelectionRange(input.value.length, input.value.length); }
+}
+
+function cancelBrandAppMemoEdit(memoId) {
+  // 단순히 다시 렌더 (캐시에서)
+  renderBrandAppMemoList();
+}
+
+async function confirmBrandAppMemoEdit(memoId) {
+  var row = document.querySelector('.bam-row[data-memo-id="' + (CSS.escape ? CSS.escape(memoId) : memoId) + '"]');
+  if (!row) return;
+  var input = row.querySelector('.bam-edit-input');
+  if (!input) return;
+  var newText = (input.value || '').trim();
+  if (!newText) { toast('메모 내용을 입력하세요.', 'warn'); return; }
+  input.disabled = true;
+  var result = await updateBrandAppMemo(memoId, newText);
+  if (!result.ok) { toast('저장 실패: ' + (result.error || '알 수 없는 오류'), 'error'); input.disabled = false; return; }
+  toast('메모가 저장되었습니다.');
+  await loadBrandAppMemoList();
+}
+
+async function deleteBrandAppMemoConfirm(memoId) {
+  if (!confirm('이 메모를 삭제할까요?')) return;
+  var result = await deleteBrandAppMemo(memoId);
+  if (!result.ok) { toast('삭제 실패: ' + (result.error || '알 수 없는 오류'), 'error'); return; }
+  toast('메모가 삭제되었습니다.');
+  await loadBrandAppMemoList();
+}
+
+async function submitNewBrandAppMemo() {
+  if (!_brandAppMemoModalCurrentId) return;
+  var input = document.getElementById('brandAppMemoNewInput');
+  if (!input) return;
+  var text = (input.value || '').trim();
+  if (!text) { toast('메모 내용을 입력하세요.', 'warn'); return; }
+  input.disabled = true;
+  var name = currentAdminInfo?.name || currentUser?.email || '관리자';
+  var authorId = currentUser?.id || null;
+  var result = await insertBrandAppMemo(_brandAppMemoModalCurrentId, text, authorId, name);
+  input.disabled = false;
+  if (!result.ok) { toast('추가 실패: ' + (result.error || '알 수 없는 오류'), 'error'); return; }
+  input.value = '';
+  toast('메모가 추가되었습니다.');
+  await loadBrandAppMemoList();
+}
+
+// 메모 셀(목록의 내부 메모 컬럼)에서 latest 메모 + 카운트 표시 갱신 (인라인)
+function _refreshBrandAppMemoCell(applicationId) {
+  var row = document.querySelector('#brandAppTableBody tr[data-id="' + (CSS && CSS.escape ? CSS.escape(applicationId) : applicationId) + '"][data-summary="1"]');
+  if (!row) return;
+  var cell = row.querySelector('.brand-app-memo-cell');
+  if (!cell) return;
+  cell.innerHTML = renderMemoCellInner(applicationId);
+}
+
+// 메모 셀 inner HTML — latest 메모 1줄 + "외 N개" + ✎(모달 진입)
+function renderMemoCellInner(applicationId) {
+  var sum = _brandAppMemoSummaries[applicationId];
+  var count = sum ? sum.count : 0;
+  var latest = sum ? (sum.latest || '') : '';
+  var contentHtml;
+  if (count === 0) {
+    contentHtml = '<span style="color:var(--muted)">—</span>';
+  } else {
+    var safe = esc(latest);
+    var moreLabel = count > 1 ? '<div style="font-size:10px;color:var(--muted);margin-top:2px">외 ' + (count - 1) + '개</div>' : '';
+    contentHtml = '<div style="font-size:11px;color:var(--ink);display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;overflow:hidden;line-height:1.4;padding-right:22px;white-space:pre-wrap" title="' + safe + '">' + safe + '</div>' + moreLabel;
+  }
+  return contentHtml
+    + '<button type="button" onclick="event.stopPropagation();openBrandAppMemoModal(\'' + esc(applicationId) + '\')" title="메모 보기/추가" style="position:absolute;top:0;right:0;background:none;border:none;cursor:pointer;padding:2px;color:var(--muted);display:flex;align-items:center;justify-content:center;border-radius:3px" onmouseover="this.style.background=\'rgba(0,0,0,.05)\'" onmouseout="this.style.background=\'none\'"><span class="material-icons-round notranslate" translate="no" style="font-size:15px">edit</span></button>';
 }
 
 // 제품 jsonb 변경을 sub-field 단위로 풀어서 가상 history rows 반환

--- a/admin/index.html
+++ b/admin/index.html
@@ -12750,7 +12750,10 @@ var BRAND_APP_HISTORY_FIELD_LABELS = {
   admin_memo: '내부 메모',
   quote_sent_at: '견적서 전달일',
   final_quote_krw: '확정 견적',
-  products: '제품 정보'
+  products: '제품 정보',
+  memo_added: '메모 추가',
+  memo_edited: '메모 수정',
+  memo_deleted: '메모 삭제'
 };
 function _brandAppHistoryFieldLabel(f) { return BRAND_APP_HISTORY_FIELD_LABELS[f] || f; }
 function _brandAppHistoryFormatValue(field, val) {
@@ -12774,6 +12777,17 @@ function _brandAppHistoryFormatValue(field, val) {
     var prods = Array.isArray(val) ? val : [];
     var totalQty = prods.reduce(function(s, p){ return s + (Number(p.qty) || 0); }, 0);
     return esc(prods.length + '종 · ' + totalQty + '개');
+  }
+  // 메모 추가/수정/삭제 (val은 jsonb 객체 또는 문자열)
+  if (field === 'memo_added' || field === 'memo_edited' || field === 'memo_deleted') {
+    var memoText = '';
+    if (typeof val === 'object' && val !== null) {
+      memoText = val.text || '';
+    } else {
+      memoText = String(val);
+    }
+    if (memoText.length > 80) memoText = memoText.slice(0, 80) + '…';
+    return esc(memoText);
   }
   return esc(String(val));
 }
@@ -13083,6 +13097,7 @@ async function confirmBrandAppMemoEdit(memoId) {
   var result = await updateBrandAppMemo(memoId, newText);
   if (!result.ok) { toast('저장 실패: ' + (result.error || '알 수 없는 오류'), 'error'); input.disabled = false; return; }
   toast('메모가 저장되었습니다.');
+  if (_brandAppMemoModalCurrentId) _refreshBrandAppHistoryButton(_brandAppMemoModalCurrentId);
   await loadBrandAppMemoList();
 }
 
@@ -13091,6 +13106,7 @@ async function deleteBrandAppMemoConfirm(memoId) {
   var result = await deleteBrandAppMemo(memoId);
   if (!result.ok) { toast('삭제 실패: ' + (result.error || '알 수 없는 오류'), 'error'); return; }
   toast('메모가 삭제되었습니다.');
+  if (_brandAppMemoModalCurrentId) _refreshBrandAppHistoryButton(_brandAppMemoModalCurrentId);
   await loadBrandAppMemoList();
 }
 
@@ -13108,6 +13124,7 @@ async function submitNewBrandAppMemo() {
   if (!result.ok) { toast('추가 실패: ' + (result.error || '알 수 없는 오류'), 'error'); return; }
   input.value = '';
   toast('메모가 추가되었습니다.');
+  _refreshBrandAppHistoryButton(_brandAppMemoModalCurrentId);
   await loadBrandAppMemoList();
 }
 

--- a/dev/admin/index.html
+++ b/dev/admin/index.html
@@ -1894,6 +1894,26 @@
 
 <!-- 광고주 신청 상세 모달은 제거됨 — 모든 인라인 편집은 신청 목록 행 안에서 -->
 
+<!-- 광고주 신청 내부 메모 모달 (multi-entry) -->
+<div class="modal-overlay" id="brandAppMemoModal" style="z-index:611">
+  <div class="modal" style="max-width:680px;width:96vw;border-radius:16px;margin:auto;max-height:80vh;display:flex;flex-direction:column">
+    <div class="modal-header" style="padding:16px 20px 12px;border-bottom:1px solid var(--line);display:flex;align-items:center;justify-content:space-between">
+      <div style="font-size:14px;font-weight:700;color:var(--ink)" id="brandAppMemoTitle">내부 메모</div>
+      <button class="btn btn-ghost btn-xs" onclick="closeBrandAppMemoModal()" style="padding:4px 10px">✕</button>
+    </div>
+    <div class="modal-body" style="padding:16px 20px;overflow-y:auto;flex:1" id="brandAppMemoBody">
+      <div style="padding:24px;text-align:center;color:var(--muted);font-size:13px">불러오는 중…</div>
+    </div>
+    <div class="modal-footer" style="padding:14px 20px;border-top:1px solid var(--line);display:flex;flex-direction:column;gap:8px">
+      <textarea id="brandAppMemoNewInput" placeholder="새 메모 입력…" style="width:100%;min-height:60px;padding:8px 10px;border:1px solid var(--line);border-radius:6px;font-size:13px;font-family:inherit;resize:vertical" onkeydown="if((event.metaKey||event.ctrlKey)&&event.key==='Enter'){event.preventDefault();submitNewBrandAppMemo();}"></textarea>
+      <div style="display:flex;justify-content:flex-end;gap:6px">
+        <button class="btn btn-ghost btn-sm" onclick="closeBrandAppMemoModal()">닫기</button>
+        <button class="btn btn-primary btn-sm" onclick="submitNewBrandAppMemo()">메모 추가</button>
+      </div>
+    </div>
+  </div>
+</div>
+
 <!-- 광고주 신청 변경 이력 모달 -->
 <div class="modal-overlay" id="brandAppHistoryModal" style="z-index:610">
   <div class="modal" style="max-width:1100px;width:96vw;border-radius:16px;margin:auto;max-height:80vh;display:flex;flex-direction:column">

--- a/dev/js/admin.js
+++ b/dev/js/admin.js
@@ -6933,6 +6933,9 @@ function renderBrandLongPending(apps) {
 }
 
 var _brandAppHistoryCounts = {};
+var _brandAppMemoSummaries = {};      // {appId: {count, latest}}
+var _brandAppMemoModalCurrentId = null;
+var _brandAppMemoModalCache = [];     // open된 신청의 메모 배열 (memory)
 
 // 인라인 편집 성공 후 카운트 즉시 +1 + 해당 row의 이력 버튼 셀만 outerHTML 갱신
 function _refreshBrandAppHistoryButton(id) {
@@ -6949,13 +6952,15 @@ function _refreshBrandAppHistoryButton(id) {
 async function loadBrandApplications() {
   var tbody = $('brandAppTableBody');
   if (tbody) tbody.innerHTML = '<tr><td colspan="23" style="text-align:center;color:var(--muted);padding:24px"><span class="spinner" style="width:20px;height:20px;border-width:2px;border-color:rgba(200,120,163,.2);border-top-color:var(--pink)"></span></td></tr>';
-  // 신청 본문 + history 카운트 동시 fetch
-  var [apps, counts] = await Promise.all([
+  // 신청 본문 + history 카운트 + 메모 요약 동시 fetch
+  var [apps, counts, memoSummaries] = await Promise.all([
     fetchBrandApplications(),
-    fetchBrandAppHistoryCounts()
+    fetchBrandAppHistoryCounts(),
+    fetchBrandAppMemoSummaries()
   ]);
   _brandApps = apps;
   _brandAppHistoryCounts = counts || {};
+  _brandAppMemoSummaries = memoSummaries || {};
   renderBrandApplicationsList();
   refreshBrandAppBadge();
 }
@@ -7263,7 +7268,7 @@ function renderBrandAppSummaryRow(a) {
 
   var qLocked = false;
   var memoText = (a.admin_memo || '').trim();
-  var memoCellInner = '<div class="brand-app-memo-cell" data-id="' + esc(a.id) + '" style="position:relative;min-height:36px">' + renderMemoDisplay(memoText, qLocked) + '</div>';
+  var memoCellInner = '<div class="brand-app-memo-cell" data-id="' + esc(a.id) + '" style="position:relative;min-height:36px">' + renderMemoCellInner(a.id) + '</div>';
   var quoteSentInner = '<div class="brand-app-qsent-cell" data-id="' + esc(a.id) + '" style="position:relative;min-height:36px">' + renderQuoteSentDisplay(a.quote_sent_at, qLocked) + '</div>';
 
   return '<tr data-id="' + esc(a.id) + '" data-summary="1">'
@@ -7426,6 +7431,155 @@ async function openBrandAppHistoryModal(id) {
 function closeBrandAppHistoryModal() {
   var modal = document.getElementById('brandAppHistoryModal');
   if (modal) modal.classList.remove('open');
+}
+
+// ─── 내부 메모 (multi-entry) 모달 ────────────────────────────
+async function openBrandAppMemoModal(id) {
+  _brandAppMemoModalCurrentId = id;
+  var cur = _findBrandApp(id);
+  var modal = document.getElementById('brandAppMemoModal');
+  var titleEl = document.getElementById('brandAppMemoTitle');
+  var bodyEl  = document.getElementById('brandAppMemoBody');
+  var newInput = document.getElementById('brandAppMemoNewInput');
+  if (!modal || !titleEl || !bodyEl) return;
+  titleEl.textContent = (cur ? (cur.application_no || '') + ' · ' + (cur.brand_name || '') : '신청') + ' — 내부 메모';
+  bodyEl.innerHTML = '<div style="padding:24px;text-align:center;color:var(--muted);font-size:13px"><span class="spinner" style="width:16px;height:16px;border-width:2px;border-color:rgba(200,120,163,.2);border-top-color:var(--pink);display:inline-block;vertical-align:middle;margin-right:6px"></span>불러오는 중…</div>';
+  if (newInput) newInput.value = '';
+  modal.classList.add('open');
+  await loadBrandAppMemoList();
+  if (newInput) newInput.focus();
+}
+
+function closeBrandAppMemoModal() {
+  var modal = document.getElementById('brandAppMemoModal');
+  if (modal) modal.classList.remove('open');
+  _brandAppMemoModalCurrentId = null;
+}
+
+async function loadBrandAppMemoList() {
+  if (!_brandAppMemoModalCurrentId) return;
+  var rows = await fetchBrandAppMemos(_brandAppMemoModalCurrentId);
+  _brandAppMemoModalCache = rows || [];
+  renderBrandAppMemoList();
+  // 목록 셀 카운트 동기화
+  _brandAppMemoSummaries[_brandAppMemoModalCurrentId] = {
+    count: _brandAppMemoModalCache.length,
+    latest: _brandAppMemoModalCache.length > 0 ? _brandAppMemoModalCache[0].text : null
+  };
+  _refreshBrandAppMemoCell(_brandAppMemoModalCurrentId);
+}
+
+function renderBrandAppMemoList() {
+  var bodyEl = document.getElementById('brandAppMemoBody');
+  if (!bodyEl) return;
+  if (_brandAppMemoModalCache.length === 0) {
+    bodyEl.innerHTML = '<div style="padding:24px;text-align:center;color:var(--muted);font-size:13px">메모가 없습니다. 아래에 새 메모를 입력하세요.</div>';
+    return;
+  }
+  bodyEl.innerHTML = _brandAppMemoModalCache.map(function(m){
+    var when = m.created_at ? new Date(m.created_at).toLocaleString('ko-KR', {timeZone:'Asia/Seoul'}) : '';
+    var edited = (m.updated_at && m.created_at && m.updated_at !== m.created_at)
+      ? '<span style="color:var(--muted);font-size:10px;margin-left:6px">(수정됨 ' + esc(new Date(m.updated_at).toLocaleString('ko-KR', {timeZone:'Asia/Seoul'})) + ')</span>'
+      : '';
+    return '<div class="bam-row" data-memo-id="' + esc(m.id) + '" style="padding:10px 12px;margin-bottom:8px;border:1px solid var(--line);border-radius:8px;background:#fff">'
+      + '<div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:6px;font-size:11px;color:var(--muted)">'
+        + '<div><span style="font-weight:600;color:var(--ink)">' + esc(m.author_name || '시스템') + '</span> · ' + esc(when) + edited + '</div>'
+        + '<div style="display:flex;gap:4px">'
+          + '<button class="btn btn-ghost btn-xs" onclick="enterBrandAppMemoEdit(\'' + esc(m.id) + '\')" style="padding:2px 8px" title="수정"><span class="material-icons-round notranslate" translate="no" style="font-size:14px">edit</span></button>'
+          + '<button class="btn btn-ghost btn-xs" onclick="deleteBrandAppMemoConfirm(\'' + esc(m.id) + '\')" style="padding:2px 8px;color:#c0392b" title="삭제"><span class="material-icons-round notranslate" translate="no" style="font-size:14px">delete_outline</span></button>'
+        + '</div>'
+      + '</div>'
+      + '<div class="bam-text" style="font-size:13px;color:var(--ink);white-space:pre-wrap;word-break:break-word;line-height:1.5">' + esc(m.text) + '</div>'
+    + '</div>';
+  }).join('');
+}
+
+function enterBrandAppMemoEdit(memoId) {
+  var row = document.querySelector('.bam-row[data-memo-id="' + (CSS.escape ? CSS.escape(memoId) : memoId) + '"]');
+  if (!row) return;
+  var memo = _brandAppMemoModalCache.find(function(m){ return m.id === memoId; });
+  if (!memo) return;
+  var textDiv = row.querySelector('.bam-text');
+  if (!textDiv) return;
+  textDiv.outerHTML = '<div style="display:flex;flex-direction:column;gap:6px">'
+    + '<textarea class="bam-edit-input" style="width:100%;min-height:60px;padding:6px 8px;border:1px solid var(--pink);border-radius:6px;font-size:13px;font-family:inherit;resize:vertical">' + esc(memo.text) + '</textarea>'
+    + '<div style="display:flex;gap:4px;justify-content:flex-end">'
+      + '<button class="btn btn-ghost btn-xs" onclick="cancelBrandAppMemoEdit(\'' + esc(memoId) + '\')" style="padding:3px 10px">취소</button>'
+      + '<button class="btn btn-primary btn-xs" onclick="confirmBrandAppMemoEdit(\'' + esc(memoId) + '\')" style="padding:3px 12px">저장</button>'
+    + '</div>'
+  + '</div>';
+  var input = row.querySelector('.bam-edit-input');
+  if (input) { input.focus(); input.setSelectionRange(input.value.length, input.value.length); }
+}
+
+function cancelBrandAppMemoEdit(memoId) {
+  // 단순히 다시 렌더 (캐시에서)
+  renderBrandAppMemoList();
+}
+
+async function confirmBrandAppMemoEdit(memoId) {
+  var row = document.querySelector('.bam-row[data-memo-id="' + (CSS.escape ? CSS.escape(memoId) : memoId) + '"]');
+  if (!row) return;
+  var input = row.querySelector('.bam-edit-input');
+  if (!input) return;
+  var newText = (input.value || '').trim();
+  if (!newText) { toast('메모 내용을 입력하세요.', 'warn'); return; }
+  input.disabled = true;
+  var result = await updateBrandAppMemo(memoId, newText);
+  if (!result.ok) { toast('저장 실패: ' + (result.error || '알 수 없는 오류'), 'error'); input.disabled = false; return; }
+  toast('메모가 저장되었습니다.');
+  await loadBrandAppMemoList();
+}
+
+async function deleteBrandAppMemoConfirm(memoId) {
+  if (!confirm('이 메모를 삭제할까요?')) return;
+  var result = await deleteBrandAppMemo(memoId);
+  if (!result.ok) { toast('삭제 실패: ' + (result.error || '알 수 없는 오류'), 'error'); return; }
+  toast('메모가 삭제되었습니다.');
+  await loadBrandAppMemoList();
+}
+
+async function submitNewBrandAppMemo() {
+  if (!_brandAppMemoModalCurrentId) return;
+  var input = document.getElementById('brandAppMemoNewInput');
+  if (!input) return;
+  var text = (input.value || '').trim();
+  if (!text) { toast('메모 내용을 입력하세요.', 'warn'); return; }
+  input.disabled = true;
+  var name = currentAdminInfo?.name || currentUser?.email || '관리자';
+  var authorId = currentUser?.id || null;
+  var result = await insertBrandAppMemo(_brandAppMemoModalCurrentId, text, authorId, name);
+  input.disabled = false;
+  if (!result.ok) { toast('추가 실패: ' + (result.error || '알 수 없는 오류'), 'error'); return; }
+  input.value = '';
+  toast('메모가 추가되었습니다.');
+  await loadBrandAppMemoList();
+}
+
+// 메모 셀(목록의 내부 메모 컬럼)에서 latest 메모 + 카운트 표시 갱신 (인라인)
+function _refreshBrandAppMemoCell(applicationId) {
+  var row = document.querySelector('#brandAppTableBody tr[data-id="' + (CSS && CSS.escape ? CSS.escape(applicationId) : applicationId) + '"][data-summary="1"]');
+  if (!row) return;
+  var cell = row.querySelector('.brand-app-memo-cell');
+  if (!cell) return;
+  cell.innerHTML = renderMemoCellInner(applicationId);
+}
+
+// 메모 셀 inner HTML — latest 메모 1줄 + "외 N개" + ✎(모달 진입)
+function renderMemoCellInner(applicationId) {
+  var sum = _brandAppMemoSummaries[applicationId];
+  var count = sum ? sum.count : 0;
+  var latest = sum ? (sum.latest || '') : '';
+  var contentHtml;
+  if (count === 0) {
+    contentHtml = '<span style="color:var(--muted)">—</span>';
+  } else {
+    var safe = esc(latest);
+    var moreLabel = count > 1 ? '<div style="font-size:10px;color:var(--muted);margin-top:2px">외 ' + (count - 1) + '개</div>' : '';
+    contentHtml = '<div style="font-size:11px;color:var(--ink);display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;overflow:hidden;line-height:1.4;padding-right:22px;white-space:pre-wrap" title="' + safe + '">' + safe + '</div>' + moreLabel;
+  }
+  return contentHtml
+    + '<button type="button" onclick="event.stopPropagation();openBrandAppMemoModal(\'' + esc(applicationId) + '\')" title="메모 보기/추가" style="position:absolute;top:0;right:0;background:none;border:none;cursor:pointer;padding:2px;color:var(--muted);display:flex;align-items:center;justify-content:center;border-radius:3px" onmouseover="this.style.background=\'rgba(0,0,0,.05)\'" onmouseout="this.style.background=\'none\'"><span class="material-icons-round notranslate" translate="no" style="font-size:15px">edit</span></button>';
 }
 
 // 제품 jsonb 변경을 sub-field 단위로 풀어서 가상 history rows 반환

--- a/dev/js/admin.js
+++ b/dev/js/admin.js
@@ -7195,7 +7195,10 @@ var BRAND_APP_HISTORY_FIELD_LABELS = {
   admin_memo: '내부 메모',
   quote_sent_at: '견적서 전달일',
   final_quote_krw: '확정 견적',
-  products: '제품 정보'
+  products: '제품 정보',
+  memo_added: '메모 추가',
+  memo_edited: '메모 수정',
+  memo_deleted: '메모 삭제'
 };
 function _brandAppHistoryFieldLabel(f) { return BRAND_APP_HISTORY_FIELD_LABELS[f] || f; }
 function _brandAppHistoryFormatValue(field, val) {
@@ -7219,6 +7222,17 @@ function _brandAppHistoryFormatValue(field, val) {
     var prods = Array.isArray(val) ? val : [];
     var totalQty = prods.reduce(function(s, p){ return s + (Number(p.qty) || 0); }, 0);
     return esc(prods.length + '종 · ' + totalQty + '개');
+  }
+  // 메모 추가/수정/삭제 (val은 jsonb 객체 또는 문자열)
+  if (field === 'memo_added' || field === 'memo_edited' || field === 'memo_deleted') {
+    var memoText = '';
+    if (typeof val === 'object' && val !== null) {
+      memoText = val.text || '';
+    } else {
+      memoText = String(val);
+    }
+    if (memoText.length > 80) memoText = memoText.slice(0, 80) + '…';
+    return esc(memoText);
   }
   return esc(String(val));
 }
@@ -7528,6 +7542,7 @@ async function confirmBrandAppMemoEdit(memoId) {
   var result = await updateBrandAppMemo(memoId, newText);
   if (!result.ok) { toast('저장 실패: ' + (result.error || '알 수 없는 오류'), 'error'); input.disabled = false; return; }
   toast('메모가 저장되었습니다.');
+  if (_brandAppMemoModalCurrentId) _refreshBrandAppHistoryButton(_brandAppMemoModalCurrentId);
   await loadBrandAppMemoList();
 }
 
@@ -7536,6 +7551,7 @@ async function deleteBrandAppMemoConfirm(memoId) {
   var result = await deleteBrandAppMemo(memoId);
   if (!result.ok) { toast('삭제 실패: ' + (result.error || '알 수 없는 오류'), 'error'); return; }
   toast('메모가 삭제되었습니다.');
+  if (_brandAppMemoModalCurrentId) _refreshBrandAppHistoryButton(_brandAppMemoModalCurrentId);
   await loadBrandAppMemoList();
 }
 
@@ -7553,6 +7569,7 @@ async function submitNewBrandAppMemo() {
   if (!result.ok) { toast('추가 실패: ' + (result.error || '알 수 없는 오류'), 'error'); return; }
   input.value = '';
   toast('메모가 추가되었습니다.');
+  _refreshBrandAppHistoryButton(_brandAppMemoModalCurrentId);
   await loadBrandAppMemoList();
 }
 

--- a/dev/lib/storage.js
+++ b/dev/lib/storage.js
@@ -1210,6 +1210,74 @@ async function markAdminNoticeRead(noticeId) {
 // ══════════════════════════════════════
 
 // 광고주 신청 목록 조회 (관리자 RLS로 전체 조회)
+// 광고주 신청 메모 (multi-entry, migration 080)
+async function fetchBrandAppMemos(applicationId) {
+  if (!db || !applicationId) return [];
+  try {
+    const {data, error} = await db?.from('brand_application_memos')
+      .select('id, application_id, author_id, author_name, text, created_at, updated_at')
+      .eq('application_id', applicationId)
+      .order('created_at', {ascending: false});
+    if (error) throw error;
+    return data || [];
+  } catch(e) { console.error('[fetchBrandAppMemos]', e); return []; }
+}
+async function insertBrandAppMemo(applicationId, text, authorId, authorName) {
+  if (!db) return {ok:false, error:'no_db'};
+  try {
+    const result = await retryWithRefresh(async () => {
+      const {data, error} = await db?.from('brand_application_memos')
+        .insert({application_id: applicationId, text: text, author_id: authorId || null, author_name: authorName || null})
+        .select('*').maybeSingle();
+      if (error) throw error;
+      return data;
+    });
+    return {ok: true, data: result};
+  } catch(e) { console.error('[insertBrandAppMemo]', e); return {ok:false, error: e?.message || 'unknown'}; }
+}
+async function updateBrandAppMemo(memoId, text) {
+  if (!db) return {ok:false, error:'no_db'};
+  try {
+    const result = await retryWithRefresh(async () => {
+      const {data, error} = await db?.from('brand_application_memos')
+        .update({text: text, updated_at: new Date().toISOString()})
+        .eq('id', memoId)
+        .select('*').maybeSingle();
+      if (error) throw error;
+      return data;
+    });
+    return {ok: true, data: result};
+  } catch(e) { console.error('[updateBrandAppMemo]', e); return {ok:false, error: e?.message || 'unknown'}; }
+}
+async function deleteBrandAppMemo(memoId) {
+  if (!db) return {ok:false, error:'no_db'};
+  try {
+    await retryWithRefresh(async () => {
+      const {error} = await db?.from('brand_application_memos').delete().eq('id', memoId);
+      if (error) throw error;
+    });
+    return {ok: true};
+  } catch(e) { console.error('[deleteBrandAppMemo]', e); return {ok:false, error: e?.message || 'unknown'}; }
+}
+// 신청별 메모 카운트 + latest 텍스트 (목록 셀 표시용)
+async function fetchBrandAppMemoSummaries() {
+  if (!db) return {};
+  try {
+    const {data, error} = await db?.from('brand_application_memos')
+      .select('application_id, text, created_at')
+      .order('created_at', {ascending: false})
+      .limit(100000);
+    if (error) throw error;
+    const summary = {};
+    (data || []).forEach(r => {
+      if (!summary[r.application_id]) summary[r.application_id] = {count: 0, latest: null};
+      summary[r.application_id].count++;
+      if (!summary[r.application_id].latest) summary[r.application_id].latest = r.text;
+    });
+    return summary;
+  } catch(e) { console.error('[fetchBrandAppMemoSummaries]', e); return {}; }
+}
+
 // 신청별 history 건수 조회 (작은 카운트 쿼리 — 1회 호출)
 async function fetchBrandAppHistoryCounts() {
   if (!db) return {};

--- a/supabase/migrations/080_brand_application_memos.sql
+++ b/supabase/migrations/080_brand_application_memos.sql
@@ -1,0 +1,257 @@
+-- ============================================================
+-- 080_brand_application_memos.sql
+-- 브랜드 서베이 신청별 다중 메모 테이블
+--
+-- 배경: brand_applications.admin_memo (단일 text) → 다중 메모 테이블로 확장
+-- - 메모마다 row 1개, 작성자/시간 기록, 수정·삭제 가능 (모든 관리자)
+-- - 기존 admin_memo 데이터는 첫 메모 row로 마이그레이션 (legacy row)
+-- - admin_memo 컬럼은 즉시 DROP하지 않음 (추후 별도 PR에서 제거)
+-- - 079의 brand_application_history 트리거는 admin_memo 변경을 추적 중이나
+--   새 brand_application_memos 테이블은 별도 INSERT라 history에 기록 안 됨
+--   → 메모 history 추적 필요 시 다음 PR에서 별도 트리거 추가
+-- ============================================================
+
+-- ────────────────────────────────────────────────────────────
+-- 1. 테이블 생성
+-- ────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS public.brand_application_memos (
+  id              uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  application_id  uuid        NOT NULL
+                    REFERENCES public.brand_applications(id) ON DELETE CASCADE,
+  author_id       uuid        REFERENCES auth.users(id) ON DELETE SET NULL,
+  author_name     text,                              -- 삭제된 관리자 이름 보존용 스냅샷
+  text            text        NOT NULL CHECK (length(trim(text)) > 0),
+  created_at      timestamptz NOT NULL DEFAULT now(),
+  updated_at      timestamptz NOT NULL DEFAULT now()
+);
+
+COMMENT ON TABLE public.brand_application_memos IS
+  '[080] 브랜드 서베이 신청별 다중 메모. 메모마다 row 1개. admin_memo(legacy) 대체.';
+
+COMMENT ON COLUMN public.brand_application_memos.author_name IS
+  '작성 시점 관리자 이름 스냅샷. author_id(auth.users)가 삭제돼도 이름 보존.';
+
+COMMENT ON COLUMN public.brand_application_memos.text IS
+  '메모 본문. 공백만으로 구성된 내용은 CHECK 제약으로 차단(trim 적용).';
+
+-- ────────────────────────────────────────────────────────────
+-- 2. 인덱스 (application_id + 최신순)
+-- ────────────────────────────────────────────────────────────
+CREATE INDEX IF NOT EXISTS brand_application_memos_app_created_idx
+  ON public.brand_application_memos (application_id, created_at DESC);
+
+-- ────────────────────────────────────────────────────────────
+-- 3. RLS
+-- ────────────────────────────────────────────────────────────
+ALTER TABLE public.brand_application_memos ENABLE ROW LEVEL SECURITY;
+
+-- SELECT: 관리자만
+CREATE POLICY "admin_select_brand_application_memos"
+  ON public.brand_application_memos
+  FOR SELECT
+  TO authenticated
+  USING (public.is_admin());
+
+-- INSERT: 관리자만 (모든 관리자가 타인 신청에도 메모 작성 가능)
+CREATE POLICY "admin_insert_brand_application_memos"
+  ON public.brand_application_memos
+  FOR INSERT
+  TO authenticated
+  WITH CHECK (public.is_admin());
+
+-- UPDATE: 관리자만 (단순 정책 — 모든 관리자가 모든 메모 수정 가능)
+CREATE POLICY "admin_update_brand_application_memos"
+  ON public.brand_application_memos
+  FOR UPDATE
+  TO authenticated
+  USING (public.is_admin())
+  WITH CHECK (public.is_admin());
+
+-- DELETE: 관리자만 (단순 정책 — 모든 관리자가 모든 메모 삭제 가능)
+CREATE POLICY "admin_delete_brand_application_memos"
+  ON public.brand_application_memos
+  FOR DELETE
+  TO authenticated
+  USING (public.is_admin());
+
+-- ────────────────────────────────────────────────────────────
+-- 4. updated_at 자동 갱신 트리거
+-- ────────────────────────────────────────────────────────────
+CREATE OR REPLACE FUNCTION public.touch_brand_application_memos_updated_at()
+  RETURNS trigger
+  LANGUAGE plpgsql
+  SECURITY DEFINER
+  SET search_path = ''
+AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$;
+
+COMMENT ON FUNCTION public.touch_brand_application_memos_updated_at IS
+  '[080] brand_application_memos BEFORE UPDATE 트리거. updated_at 자동 갱신.';
+
+DROP TRIGGER IF EXISTS trg_brand_app_memos_updated_at ON public.brand_application_memos;
+
+CREATE TRIGGER trg_brand_app_memos_updated_at
+  BEFORE UPDATE ON public.brand_application_memos
+  FOR EACH ROW
+  EXECUTE FUNCTION public.touch_brand_application_memos_updated_at();
+
+-- ────────────────────────────────────────────────────────────
+-- 5. 기존 admin_memo 데이터 마이그레이션
+--    조건: admin_memo IS NOT NULL AND trim(admin_memo) <> ''
+--    author_id = NULL (legacy 데이터는 작성자 불명)
+--    author_name = '(legacy)'
+--    created_at = brand_applications.updated_at (최종 수정 시점 근사)
+--      → updated_at이 NULL이면 created_at 폴백 (방어적 처리)
+-- ────────────────────────────────────────────────────────────
+INSERT INTO public.brand_application_memos
+  (application_id, author_id, author_name, text, created_at, updated_at)
+SELECT
+  id,
+  NULL,
+  '(legacy)',
+  admin_memo,
+  COALESCE(updated_at, created_at, now()),
+  COALESCE(updated_at, created_at, now())
+FROM public.brand_applications
+WHERE admin_memo IS NOT NULL
+  AND trim(admin_memo) <> '';
+
+-- admin_memo 컬럼은 legacy 유지 (추후 PR에서 DROP 예정)
+-- DROP COLUMN 시 brand_application_history 트리거의 admin_memo 추적도 함께 정리 필요
+
+
+-- ════════════════════════════════════════════════════════════
+-- [클라이언트 영향 분석]
+-- • brand_application_memos 테이블은 RLS 정책만으로 직접 CRUD 가능
+--   (RPC 불필요 — is_admin() 인증된 authenticated 사용자가 .from() 직접 호출)
+-- • storage.js에 아래 함수 추가 권장:
+--   - fetchBrandAppMemos(applicationId)
+--       → SELECT * FROM brand_application_memos
+--         WHERE application_id = $1 ORDER BY created_at DESC
+--   - insertBrandAppMemo(applicationId, text, authorId, authorName)
+--       → INSERT INTO brand_application_memos ...
+--   - updateBrandAppMemo(memoId, text)
+--       → UPDATE brand_application_memos SET text = $2 WHERE id = $1
+--   - deleteBrandAppMemo(memoId)
+--       → DELETE FROM brand_application_memos WHERE id = $1
+-- • 기존 updateBrandApplication() 호출 시 admin_memo 필드 패치는 계속 동작
+--   (legacy 컬럼 유지 중이므로 기존 코드 변경 불필요)
+-- • brand_application_history 트리거: admin_memo 컬럼 UPDATE 여전히 추적 중
+--   새 brand_application_memos INSERT는 history에 기록되지 않음
+--   → 메모 변경 이력이 필요하면 별도 트리거를 다음 PR에서 추가
+-- ════════════════════════════════════════════════════════════
+
+
+-- ════════════════════════════════════════════════════════════
+-- [검증 SQL] — 개발 DB에서 마이그레이션 적용 후 SQL Editor에서 직접 실행
+-- ════════════════════════════════════════════════════════════
+/*
+-- 1. 테이블 및 인덱스 존재 확인
+SELECT tablename
+FROM pg_tables
+WHERE schemaname = 'public' AND tablename = 'brand_application_memos';
+
+SELECT indexname
+FROM pg_indexes
+WHERE tablename = 'brand_application_memos';
+
+-- 2. RLS 정책 확인 (4개 기대: select/insert/update/delete)
+SELECT policyname, cmd
+FROM pg_policies
+WHERE tablename = 'brand_application_memos'
+ORDER BY cmd;
+
+-- 3. 트리거 확인
+SELECT tgname, tgtype, tgenabled
+FROM pg_trigger
+WHERE tgrelid = 'public.brand_application_memos'::regclass;
+
+-- 4. 기존 admin_memo 보유 row 수 vs 신규 테이블 count 일치 확인
+SELECT COUNT(*) AS legacy_memo_count
+FROM public.brand_applications
+WHERE admin_memo IS NOT NULL AND trim(admin_memo) <> '';
+
+SELECT COUNT(*) AS migrated_memo_count
+FROM public.brand_application_memos
+WHERE author_name = '(legacy)';
+
+-- → legacy_memo_count = migrated_memo_count 이어야 함
+
+-- 5. legacy 메모 내용 샘플 확인
+SELECT
+  m.application_id,
+  m.text,
+  m.author_name,
+  m.created_at,
+  b.admin_memo AS original_admin_memo
+FROM public.brand_application_memos m
+JOIN public.brand_applications b ON b.id = m.application_id
+WHERE m.author_name = '(legacy)'
+LIMIT 5;
+
+-- 6. updated_at 트리거 동작 확인
+-- (검증용 메모 INSERT 후 UPDATE하여 updated_at 변경 확인)
+DO $$
+DECLARE
+  v_app_id uuid;
+  v_memo_id uuid;
+  v_created_at timestamptz;
+  v_updated_at timestamptz;
+BEGIN
+  -- 첫 번째 신청 ID 확보
+  SELECT id INTO v_app_id FROM public.brand_applications LIMIT 1;
+  IF v_app_id IS NULL THEN
+    RAISE NOTICE '신청 데이터가 없어 트리거 검증 스킵';
+    RETURN;
+  END IF;
+
+  -- 검증용 메모 INSERT
+  INSERT INTO public.brand_application_memos (application_id, text, author_name)
+  VALUES (v_app_id, '트리거 검증용 메모', '(test)')
+  RETURNING id, created_at, updated_at INTO v_memo_id, v_created_at, v_updated_at;
+
+  RAISE NOTICE 'INSERT: created_at=%, updated_at=%', v_created_at, v_updated_at;
+
+  -- 1초 대기 후 UPDATE (updated_at 변경 확인)
+  PERFORM pg_sleep(1);
+  UPDATE public.brand_application_memos SET text = '트리거 검증용 메모 (수정됨)' WHERE id = v_memo_id;
+  SELECT updated_at INTO v_updated_at FROM public.brand_application_memos WHERE id = v_memo_id;
+
+  RAISE NOTICE 'UPDATE: updated_at=% (원본 created_at=%보다 커야 함)', v_updated_at, v_created_at;
+
+  -- 검증 데이터 정리
+  DELETE FROM public.brand_application_memos WHERE id = v_memo_id;
+  RAISE NOTICE '검증 메모 삭제 완료: %', v_memo_id;
+END;
+$$;
+
+-- 7. RLS 검증 (클라이언트 측 — SQL Editor는 service_role이라 직접 확인 불가)
+--    관리자 로그인 상태:
+--      const { data } = await db.from('brand_application_memos').select('*').limit(5);
+--      → N건 반환 (is_admin() true)
+--    비관리자(인플루언서) 로그인 상태:
+--      → 0건 반환 (is_admin() false)
+--    비로그인(anon):
+--      → 0건 또는 error (authenticated 정책만 있으므로 anon 차단)
+*/
+
+
+-- ════════════════════════════════════════════════════════════
+-- [롤백 SQL] — 운영 적용 후 문제 발생 시 순서대로 실행
+-- admin_memo 컬럼은 DROP하지 않았으므로 롤백 후 기존 단일 메모 기능 즉시 복구
+-- ════════════════════════════════════════════════════════════
+/*
+-- STEP 1. 트리거 제거
+DROP TRIGGER IF EXISTS trg_brand_app_memos_updated_at ON public.brand_application_memos;
+
+-- STEP 2. 트리거 함수 제거
+DROP FUNCTION IF EXISTS public.touch_brand_application_memos_updated_at();
+
+-- STEP 3. 테이블 DROP (마이그레이션된 legacy 메모 포함 영구 삭제 — 주의)
+-- admin_memo 컬럼은 brand_applications에 그대로 남아있어 데이터 유실 없음
+DROP TABLE IF EXISTS public.brand_application_memos;
+*/

--- a/supabase/migrations/081_brand_application_memos_history.sql
+++ b/supabase/migrations/081_brand_application_memos_history.sql
@@ -1,0 +1,288 @@
+-- ============================================================
+-- 081_brand_application_memos_history.sql
+-- brand_application_memos 변경 이력 자동 기록
+--
+-- 1. brand_application_history.field_name CHECK 제약 확장
+--    추가값: memo_added / memo_edited / memo_deleted
+-- 2. 트리거 함수 record_brand_application_memo_history()
+--    AFTER INSERT/UPDATE/DELETE on brand_application_memos
+-- 3. 트리거 trg_brand_app_memo_history 바인딩
+-- ============================================================
+
+-- ────────────────────────────────────────────────────────────
+-- 1. field_name CHECK 제약 확장
+--    기존: ('status', 'admin_memo', 'quote_sent_at', 'final_quote_krw', 'products')
+--    추가: 'memo_added', 'memo_edited', 'memo_deleted'
+-- ────────────────────────────────────────────────────────────
+
+-- 제약 이름 조회 후 DROP (이름이 자동 생성된 경우 대비, 테이블 정의 기준으로 명칭 확인)
+DO $$
+DECLARE
+  v_constraint_name text;
+BEGIN
+  SELECT conname INTO v_constraint_name
+  FROM pg_constraint
+  WHERE conrelid = 'public.brand_application_history'::regclass
+    AND contype = 'c'
+    AND pg_get_constraintdef(oid) LIKE '%field_name%';
+
+  IF v_constraint_name IS NOT NULL THEN
+    EXECUTE format(
+      'ALTER TABLE public.brand_application_history DROP CONSTRAINT %I',
+      v_constraint_name
+    );
+    RAISE NOTICE '기존 CHECK 제약 제거: %', v_constraint_name;
+  ELSE
+    RAISE NOTICE 'field_name CHECK 제약 없음 — 신규 추가만 진행';
+  END IF;
+END;
+$$;
+
+ALTER TABLE public.brand_application_history
+  ADD CONSTRAINT brand_application_history_field_name_check
+  CHECK (field_name IN (
+    'status', 'admin_memo', 'quote_sent_at', 'final_quote_krw', 'products',
+    'memo_added', 'memo_edited', 'memo_deleted'
+  ));
+
+COMMENT ON CONSTRAINT brand_application_history_field_name_check
+  ON public.brand_application_history IS
+  '[081] field_name 허용값. 079 5개 + 081 memo_added/memo_edited/memo_deleted 3개.';
+
+-- ────────────────────────────────────────────────────────────
+-- 2. 트리거 함수
+-- ────────────────────────────────────────────────────────────
+CREATE OR REPLACE FUNCTION public.record_brand_application_memo_history()
+  RETURNS trigger
+  LANGUAGE plpgsql
+  SECURITY DEFINER
+  SET search_path = ''
+AS $$
+DECLARE
+  v_actor_id    uuid;
+  v_actor_name  text;
+  v_app_id      uuid;
+BEGIN
+  -- 행위자: auth.uid() (NULL 허용 — 서비스롤/시스템 호출 대비)
+  v_actor_id := auth.uid();
+
+  IF v_actor_id IS NOT NULL THEN
+    SELECT name INTO v_actor_name
+    FROM public.admins
+    WHERE auth_id = v_actor_id
+    LIMIT 1;
+  END IF;
+
+  -- application_id: DELETE는 OLD에서, 그 외 NEW에서 취득
+  IF TG_OP = 'DELETE' THEN
+    v_app_id := OLD.application_id;
+  ELSE
+    v_app_id := NEW.application_id;
+  END IF;
+
+  -- INSERT: 메모 신규 추가 → memo_added
+  IF TG_OP = 'INSERT' THEN
+    INSERT INTO public.brand_application_history
+      (application_id, changed_by, changed_by_name, field_name, old_value, new_value)
+    VALUES (
+      v_app_id,
+      v_actor_id,
+      v_actor_name,
+      'memo_added',
+      NULL,
+      jsonb_build_object(
+        'id',          NEW.id,
+        'text',        NEW.text,
+        'author_id',   NEW.author_id,
+        'author_name', NEW.author_name,
+        'created_at',  NEW.created_at
+      )
+    );
+
+  -- UPDATE: text 변경 있을 때만 → memo_edited
+  ELSIF TG_OP = 'UPDATE' THEN
+    IF NEW.text IS DISTINCT FROM OLD.text THEN
+      INSERT INTO public.brand_application_history
+        (application_id, changed_by, changed_by_name, field_name, old_value, new_value)
+      VALUES (
+        v_app_id,
+        v_actor_id,
+        v_actor_name,
+        'memo_edited',
+        jsonb_build_object(
+          'id',          OLD.id,
+          'text',        OLD.text,
+          'author_id',   OLD.author_id,
+          'author_name', OLD.author_name,
+          'updated_at',  OLD.updated_at
+        ),
+        jsonb_build_object(
+          'id',          NEW.id,
+          'text',        NEW.text,
+          'author_id',   NEW.author_id,
+          'author_name', NEW.author_name,
+          'updated_at',  NEW.updated_at
+        )
+      );
+    END IF;
+
+  -- DELETE: 메모 삭제 → memo_deleted
+  ELSIF TG_OP = 'DELETE' THEN
+    INSERT INTO public.brand_application_history
+      (application_id, changed_by, changed_by_name, field_name, old_value, new_value)
+    VALUES (
+      v_app_id,
+      v_actor_id,
+      v_actor_name,
+      'memo_deleted',
+      jsonb_build_object(
+        'id',          OLD.id,
+        'text',        OLD.text,
+        'author_id',   OLD.author_id,
+        'author_name', OLD.author_name,
+        'created_at',  OLD.created_at,
+        'updated_at',  OLD.updated_at
+      ),
+      NULL
+    );
+  END IF;
+
+  -- DELETE 트리거는 OLD를 반환해야 함, 나머지는 NEW
+  IF TG_OP = 'DELETE' THEN
+    RETURN OLD;
+  ELSE
+    RETURN NEW;
+  END IF;
+END;
+$$;
+
+COMMENT ON FUNCTION public.record_brand_application_memo_history IS
+  '[081] brand_application_memos AFTER INSERT/UPDATE/DELETE 트리거. '
+  'INSERT→memo_added, UPDATE(text 변경 시)→memo_edited, DELETE→memo_deleted 로 '
+  'brand_application_history에 기록. SECURITY DEFINER — 클라이언트 RLS 우회하여 이력 기록.';
+
+-- ────────────────────────────────────────────────────────────
+-- 3. 트리거 바인딩
+-- ────────────────────────────────────────────────────────────
+DROP TRIGGER IF EXISTS trg_brand_app_memo_history ON public.brand_application_memos;
+
+CREATE TRIGGER trg_brand_app_memo_history
+  AFTER INSERT OR UPDATE OR DELETE ON public.brand_application_memos
+  FOR EACH ROW
+  EXECUTE FUNCTION public.record_brand_application_memo_history();
+
+
+-- ════════════════════════════════════════════════════════════
+-- [클라이언트 영향 분석]
+-- • brand_application_memos CRUD 호출(insertBrandAppMemo 등)은 변경 불필요
+--   트리거가 AFTER INSERT/UPDATE/DELETE로 자동 기록
+-- • fetchBrandApplicationHistory(id) 는 기존대로 brand_application_history 조회
+--   field_name IN ('memo_added','memo_edited','memo_deleted') 필터 추가로
+--   메모 이력만 별도 표시 가능 (선택적 UI 개선)
+-- ════════════════════════════════════════════════════════════
+
+
+-- ════════════════════════════════════════════════════════════
+-- [검증 SQL] — 개발 DB SQL Editor에서 직접 실행
+-- ════════════════════════════════════════════════════════════
+/*
+-- 0. CHECK 제약 확장 확인
+SELECT conname, pg_get_constraintdef(oid) AS def
+FROM pg_constraint
+WHERE conrelid = 'public.brand_application_history'::regclass
+  AND contype = 'c';
+-- memo_added / memo_edited / memo_deleted 포함 여부 확인
+
+-- 1. 트리거 존재 확인
+SELECT tgname, tgtype, tgenabled
+FROM pg_trigger
+WHERE tgrelid = 'public.brand_application_memos'::regclass
+  AND tgname = 'trg_brand_app_memo_history';
+
+-- 2. 검증용 신청 ID 확보
+SELECT id FROM public.brand_applications ORDER BY created_at DESC LIMIT 1;
+-- 이하 <app_id> 를 실제 UUID로 교체하여 실행
+
+-- 3. INSERT 검증 → history에 memo_added 1행 기대
+INSERT INTO public.brand_application_memos (application_id, text, author_name)
+VALUES ('<app_id>', '검증용 메모 - 최초', '(test)');
+
+SELECT field_name, old_value, new_value, changed_by_name, changed_at
+FROM public.brand_application_history
+WHERE application_id = '<app_id>'
+  AND field_name = 'memo_added'
+ORDER BY changed_at DESC
+LIMIT 1;
+-- new_value.text = '검증용 메모 - 최초', old_value IS NULL 확인
+
+-- 4. UPDATE text 변경 → history에 memo_edited 1행 기대
+UPDATE public.brand_application_memos
+SET text = '검증용 메모 - 수정됨'
+WHERE application_id = '<app_id>'
+  AND author_name = '(test)';
+
+SELECT field_name, old_value, new_value, changed_at
+FROM public.brand_application_history
+WHERE application_id = '<app_id>'
+  AND field_name = 'memo_edited'
+ORDER BY changed_at DESC
+LIMIT 1;
+-- old_value.text = '검증용 메모 - 최초', new_value.text = '검증용 메모 - 수정됨' 확인
+
+-- 5. UPDATE text 미변경(author_name만 변경) → history row 추가 없음 확인
+SELECT COUNT(*) AS cnt_before
+FROM public.brand_application_history
+WHERE application_id = '<app_id>' AND field_name = 'memo_edited';
+
+UPDATE public.brand_application_memos
+SET author_name = '(test-renamed)'
+WHERE application_id = '<app_id>'
+  AND author_name = '(test)';
+
+SELECT COUNT(*) AS cnt_after
+FROM public.brand_application_history
+WHERE application_id = '<app_id>' AND field_name = 'memo_edited';
+-- cnt_before = cnt_after 이어야 함 (text 미변경이므로 기록 없음)
+
+-- 6. DELETE 검증 → history에 memo_deleted 1행 기대
+DELETE FROM public.brand_application_memos
+WHERE application_id = '<app_id>'
+  AND author_name IN ('(test)', '(test-renamed)');
+
+SELECT field_name, old_value, new_value, changed_at
+FROM public.brand_application_history
+WHERE application_id = '<app_id>'
+  AND field_name = 'memo_deleted'
+ORDER BY changed_at DESC
+LIMIT 1;
+-- old_value.text = '검증용 메모 - 수정됨', new_value IS NULL 확인
+
+-- 7. 검증 이력 정리 (선택)
+-- DELETE FROM public.brand_application_history WHERE application_id = '<app_id>';
+*/
+
+
+-- ════════════════════════════════════════════════════════════
+-- [롤백 SQL] — 운영 적용 후 문제 발생 시 순서대로 실행
+-- ════════════════════════════════════════════════════════════
+/*
+-- STEP 1. 트리거 제거 (brand_application_memos 테이블 영향 없어짐)
+DROP TRIGGER IF EXISTS trg_brand_app_memo_history ON public.brand_application_memos;
+
+-- STEP 2. 트리거 함수 제거
+DROP FUNCTION IF EXISTS public.record_brand_application_memo_history();
+
+-- STEP 3. field_name CHECK 제약을 079 원본으로 복원
+ALTER TABLE public.brand_application_history
+  DROP CONSTRAINT IF EXISTS brand_application_history_field_name_check;
+
+ALTER TABLE public.brand_application_history
+  ADD CONSTRAINT brand_application_history_field_name_check
+  CHECK (field_name IN (
+    'status', 'admin_memo', 'quote_sent_at', 'final_quote_krw', 'products'
+  ));
+
+-- STEP 4. memo_added/edited/deleted 이력 데이터 제거 (선택 — 불필요 시 생략)
+-- DELETE FROM public.brand_application_history
+-- WHERE field_name IN ('memo_added', 'memo_edited', 'memo_deleted');
+*/


### PR DESCRIPTION
## Summary
2 commits + 2 migrations. 운영 DB에 080 + 081 이미 적용 완료(트리거 활성 확인).

### Changes
- **migration 080** — `brand_application_memos` 테이블 신규 (admin CRUD via RLS), 기존 `brand_applications.admin_memo` 데이터를 첫 메모 row로 이전 (운영 0건). admin_memo 컬럼은 legacy 보존.
- **migration 081** — `brand_application_history.field_name` CHECK 확장(memo_added/memo_edited/memo_deleted) + AFTER INSERT/UPDATE/DELETE 트리거가 메모 변경을 history에 자동 기록.
- **Multi-entry memo modal** — 신청별 메모 셀의 ✎ 클릭 → 모달에서 메모 목록 + 각 항목 수정/삭제 + 새 메모 추가 (Cmd/Ctrl+Enter 빠른 저장)
- **List cell** — latest 메모 1줄 + "외 N개" 힌트 표시
- **History modal** — 메모 추가/수정/삭제 행이 작성자 이름과 함께 노출
- **이력 카운트 즉시 갱신** — 메모 변경 시 `_refreshBrandAppHistoryButton` 호출로 새로고침 없이 +1

## Test plan
- [ ] 운영 신청 메모 추가/수정/삭제 → 이력 버튼 카운트 즉시 +1
- [ ] 이력 모달에 본인 이름 + 메모 변경 행 노출
- [ ] 다른 관리자 메모도 수정/삭제 가능 (RLS = is_admin 단순 정책)