### PR TITLE
Deploy 2026-05-07 #2: 캠페인 폼 날짜 레이아웃 + 상태 재설계 (paused→expired)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,7 +115,7 @@
 - **콘텐츠 가이드 4개 필드(설명/어필 포인트/촬영 가이드/NG사항) 리치 텍스트 에디터** (Quill v2) — 볼드/이탤릭/리스트/링크/헤더/인용 지원. Notion 복사·붙여넣기로 서식 유지. 이미지 태그는 저장 시 제거(base64 폭증 방지). 저장 포맷은 sanitize된 HTML 문자열, 기존 `text` 컬럼 그대로 사용. 평문(legacy) 데이터는 렌더 시 자동 `<br>` 변환으로 하위호환. XSS 방어: DOMPurify 저장+렌더 이중 sanitize. 공통 헬퍼는 `dev/lib/shared.js`의 `sanitizeRich/richHtml/renderRich`
 - 캠페인 목록: 썸네일+이미지수 표시, 상태/타입 드롭다운 필터, 검색(캠페인명+브랜드), 헤더 정렬(조회/신청/등록일/수정일 ▲▼), D-day 라벨(게시마감/모집마감), 타입 라벨 통일([타입] 제목 형식), 승인수/모집수 표시 + 대기 배지
 - 캠페인 미리보기: 캠페인 제목 클릭 시 모바일 크기 프리뷰 모달 (편집 버튼 포함)
-- 캠페인 상태: draft(준비) → scheduled(모집예정) → active(모집중) → paused(일시정지) → closed(종료), 드롭다운으로 변경
+- 캠페인 상태: draft(준비) → scheduled(모집예정) → active(모집중) → closed(종료) → expired(노출마감), 드롭다운으로 변경. **migration 097(2026-05-07)에서 paused 제거 + expired 신규**. closed = 모집 종료지만 post_deadline까지 인플루언서 화면에 카드 노출(募集締切 오버레이) / expired = post_deadline 경과로 완전 비노출. 시각 분류: 노출 그룹(scheduled/active/closed)은 컬러 배지(파랑/초록/핑크), 비노출 그룹(draft/expired)은 회색·점선
 - 캠페인 자동 종료: deadline 경과 시 active → closed 자동 변경 (클라이언트 체크)
 - **캠페인 자동 시작**(2026-04-27 migration 072): scheduled 캠페인의 `recruit_start` 가 도래하면 active 로 자동 전환. `fetchCampaigns` 호출 시 `autoOpenCampaigns()` → `autoCloseCampaigns()` 순서로 실행되어 시작·종료를 한 번에 처리
 - 마감일 검증: post_deadline >= deadline 필수, 인라인 경고 + 저장 차단
@@ -152,7 +152,7 @@
 - **캠페인 신청자 목록 SNS 전체 표시**(2026-04-22): `renderAppCampList` 행에 IG/TT/X/YT 4개 채널 핸들+팔로워 모두 표시(이전: primary_channel만)
 - **전화번호 표시 포맷 정규화**(`formatPhoneDisplay` in ui.js, 2026-04-22): KR/JP 번호 정규화(11자리 3-4-4, 10자리 02/03/06 → 2-4-4 else 3-3-4, `+81`/`+82` 지원). 적용처: 인플루언서 상세 모달·브랜드 앱 리스트·상세. 매칭 실패 시 원문 폴백
 - **캠페인·신청·결과물 표 brand_ko/product_ko 컬럼 분리**(2026-04-30, 02c432f / 56dcfd4 / 231a638): 기존 단일 "브랜드/상품" 라인이었던 캠페인 관리·신청 관리·캠페인별 신청자 페인 표가 `brand_ko`(브랜드 한국어명)·`product_ko`(상품 한국어명) 컬럼으로 분리. 검색창은 두 컬럼 모두 매칭. 컬럼 폭은 다른 컬럼이 좁아지지 않게 일정 너비 캡 적용. dynamic thead 도 분리 컬럼으로 갱신
-- **캠페인 상태 도움말 모달**(2026-04-30, cdaa146): 캠페인 관리 표 헤더 「상태」 옆 `info` Material Icon 클릭 시 5단계(`draft`/`scheduled`/`active`/`paused`/`closed`) 의미와 자동 전이 규칙(예: `recruit_start` 도래 시 `scheduled→active`, `deadline` 경과 시 `active→closed`)을 모달로 안내. 담당자가 상태 의미를 헷갈리던 문제 해결
+- **캠페인 상태 도움말 모달**(2026-04-30, cdaa146): 캠페인 관리 표 헤더 「상태」 옆 `info` Material Icon 클릭 시 5단계(`draft`/`scheduled`/`active`/`closed`/`expired`, **migration 097에서 paused 제거 + expired 추가**) 의미와 자동 전이 규칙(`recruit_start` 도래 시 `scheduled→active`, `deadline` 경과 시 `active→closed`, `post_deadline` 경과 시 `closed→expired`)을 모달로 안내. 담당자가 상태 의미를 헷갈리던 문제 해결
 - **민감 항목 변경 모달 + 변경 이력 추적**(2026-04-29 migration 077, d79ad39): 캠페인 편집 폼에서 `caution_items`/`participation_steps` 같은 민감 항목 변경 시 신청자에게 영향이 있을 수 있다는 경고 모달(`#sensitiveChangeModal`)을 dev 소스에 정식 연결. 변경은 `campaign_caution_history` 테이블에 audit 트리거로 자동 기록(누가/언제/어느 필드/이전·이후 값). SELECT는 super_admin 한정 (`is_super_admin()` RLS), INSERT는 트리거만. 함께 도입된 DB 잠금 마이그레이션은 동시 편집 시 마지막 쓰기가 이전 변경을 덮어쓰는 사고 방지
 - **참여방법/주의사항 편집 모달 분리**(2026-04-26, eb78c98 / c5e2cef / 6be9c19): 기존 캠페인 폼 inline 편집을 별도 편집 모달로 분리. 카드 헤더에 「편집」 버튼 1개로 정리, bundle summary 카드는 한·일 양언어 풀 노출, 미리보기는 `注意事項` 한·일 토글 추가
 - **결과물 영수증 구매정보 마스킹**(2026-04-30, 0d2b599): 관리자 결과물 검수 모달에서 영수증의 `purchase_date`(구매일)·`purchase_amount`(구매금액) 노출 제거. 인플루언서 본인 화면(재제출 폼)에서는 그대로 유지. 개인정보 최소 노출 정책에 부합

--- a/admin/index.html
+++ b/admin/index.html
@@ -135,6 +135,10 @@ img{display:block;max-width:100%}
 .badge-gold{background:var(--gold-l);color:var(--gold)}
 .badge-blue{background:var(--blue-l);color:var(--blue)}
 .badge-gray{background:var(--surface-dim);color:var(--muted);border:1px solid var(--outline)}
+/* 캠페인 상태 노출 그룹용 — closed(모집 끝났지만 게시 기간 살아있어 인플루언서 화면에 노출 중) */
+.badge-pink{background:#FFE4EC;color:#B91C5C;border:1px solid #FFB8D0}
+/* 캠페인 상태 비노출 강조 — expired(노출마감, 영구 비노출) */
+.badge-expired{background:#EEEEEE;color:#666666;border:1.5px dashed #999999;opacity:.85}
 .badge-new{background:var(--primary);color:#fff}
 
 /* ── FORMS (Material Text Field - Outlined) ── */
@@ -1417,7 +1421,7 @@ textarea.form-input{resize:vertical;min-height:80px}
               </div>
               <div class="form-group"><label class="form-label">상태</label>
                 <select id="editCampStatus" class="form-input">
-                  <option value="draft">준비</option><option value="scheduled">모집예정</option><option value="active">모집중</option><option value="paused">일시정지</option><option value="closed">종료</option>
+                  <option value="draft">준비</option><option value="scheduled">모집예정</option><option value="active">모집중</option><option value="closed">종료</option><option value="expired">노출마감</option>
                 </select>
               </div>
             </div>
@@ -2905,16 +2909,16 @@ textarea.form-input{resize:vertical;min-height:80px}
             <td style="padding:8px 10px">「모집중」 / 「募集中」 배지</td>
           </tr>
           <tr>
-            <td style="padding:8px 10px"><span style="background:#F2E6F0;color:#735;font-size:11px;font-weight:700;padding:2px 8px;border-radius:4px">paused</span></td>
-            <td style="padding:8px 10px">일시정지</td>
-            <td style="padding:8px 10px;color:var(--red);font-weight:600">노출 안 됨</td>
-            <td style="padding:8px 10px;color:var(--muted)">—</td>
-          </tr>
-          <tr>
             <td style="padding:8px 10px"><span style="background:#F5F5F5;color:#999;font-size:11px;font-weight:700;padding:2px 8px;border-radius:4px">closed</span></td>
             <td style="padding:8px 10px">모집 종료</td>
             <td style="padding:8px 10px;color:var(--gold);font-weight:600">캠페인 노출 마감일까지 노출</td>
             <td style="padding:8px 10px">「募集締切」 오버레이 + 신청 버튼 비활성</td>
+          </tr>
+          <tr>
+            <td style="padding:8px 10px"><span style="background:#EFEFEF;color:#888;font-size:11px;font-weight:700;padding:2px 8px;border-radius:4px">expired</span></td>
+            <td style="padding:8px 10px">노출 마감 (캠페인 노출 마감일 경과)</td>
+            <td style="padding:8px 10px;color:var(--red);font-weight:600">노출 안 됨</td>
+            <td style="padding:8px 10px;color:var(--muted)">—</td>
           </tr>
         </tbody>
       </table>
@@ -2922,14 +2926,15 @@ textarea.form-input{resize:vertical;min-height:80px}
         <div style="font-weight:700;color:var(--dark-pink);margin-bottom:6px">자동 전이 규칙</div>
         <ul style="margin:0;padding-left:18px;color:var(--ink)">
           <li><strong>모집 마감일(deadline) 경과</strong>하면 active → closed 로 자동 변경됩니다 (인플루언서 페이지 접속 시 클라이언트 측에서 처리).</li>
+          <li><strong>캠페인 노출 마감일(post_deadline) 경과</strong>하면 closed → expired 로 자동 변경됩니다. expired 상태는 사이트에서 완전히 숨겨집니다.</li>
           <li>모집 마감일이 지난 캠페인은 active / scheduled 상태로 저장·변경할 수 없습니다.</li>
-          <li>closed 라도 <strong>캠페인 노출 마감일(post_deadline)</strong>이 남아 있으면 사이트에서 보입니다 (이미 응모한 인플루언서가 캠페인 정보·결과물 제출 페이지를 열 수 있도록).</li>
+          <li>closed / expired 캠페인의 주의사항·참여방법은 수정할 수 없습니다 (DB에서 이중 차단).</li>
         </ul>
       </div>
       <div style="margin-top:14px;padding:14px;background:var(--surface-dim);border-radius:10px;font-size:12px;line-height:1.6">
-        <div style="font-weight:700;color:var(--ink);margin-bottom:6px">전이 흐름 예시</div>
-        <div style="font-family:monospace;font-size:11px;color:var(--ink)">draft → scheduled → active → closed → (post_deadline 경과 후 비노출)</div>
-        <div style="margin-top:6px;color:var(--muted)">paused 는 임시 중단용 — 작업 끝나면 active 로 복귀</div>
+        <div style="font-weight:700;color:var(--ink);margin-bottom:6px">전이 흐름</div>
+        <div style="font-family:monospace;font-size:11px;color:var(--ink)">draft → scheduled → active → closed → expired</div>
+        <div style="margin-top:6px;color:var(--muted)">closed 는 post_deadline 까지 인플루언서에게 노출(募集締切 표시). expired 는 완전 비노출.</div>
       </div>
     </div>
     <div style="padding:14px 20px;border-top:1px solid var(--line);text-align:right">
@@ -3700,6 +3705,7 @@ async function fetchCampaigns() {
     if (data.length > 0) {
       await autoOpenCampaigns(data);   // scheduled → active (recruit_start 도래)
       await autoCloseCampaigns(data);  // active → closed (deadline 경과)
+      await autoExpireCampaigns(data); // closed → expired (post_deadline 경과)
       return data;
     }
     return DEMO_CAMPAIGNS.slice();
@@ -3750,6 +3756,30 @@ async function autoCloseCampaigns(camps) {
   }));
   results.forEach((r, i) => {
     if (r.status === 'rejected') console.warn('autoCloseCampaigns 실패:', toClose[i]?.id, r.reason);
+  });
+  return camps;
+}
+
+// post_deadline 경과 캠페인 자동 노출마감 전환 (closed → expired)
+//   post_deadline 당일 자정(JST) 이후 접속 시 expired로 전환.
+//   expired 캠페인은 인플루언서 화면에서 완전히 숨겨짐 (closed는 post_deadline까지 표시).
+async function autoExpireCampaigns(camps) {
+  if (!db) return camps;
+  const now = new Date();
+  now.setHours(0, 0, 0, 0);
+  const toExpire = camps.filter(c => {
+    if (c.status !== 'closed' || !c.post_deadline) return false;
+    const pd = new Date(c.post_deadline);
+    pd.setHours(23, 59, 59, 999);
+    return now > pd;
+  });
+  if (!toExpire.length) return camps;
+  const results = await Promise.allSettled(toExpire.map(c => {
+    c.status = 'expired';
+    return db.from('campaigns').update({ status: 'expired' }).eq('id', c.id);
+  }));
+  results.forEach((r, i) => {
+    if (r.status === 'rejected') console.warn('autoExpireCampaigns 실패:', toExpire[i]?.id, r.reason);
   });
   return camps;
 }
@@ -6222,7 +6252,7 @@ function initMultiFilters() {
     {value:'monitor',label:'리뷰어'},{value:'gifting',label:'기프팅'},{value:'visit',label:'방문형'}
   ], () => filterAdminCampaigns());
   createMultiFilter('campStatusMulti', '전체 상태', [
-    {value:'draft',label:'준비'},{value:'scheduled',label:'모집예정'},{value:'active',label:'모집중'},{value:'paused',label:'일시정지'},{value:'closed',label:'종료'}
+    {value:'draft',label:'준비'},{value:'scheduled',label:'모집예정'},{value:'active',label:'모집중'},{value:'closed',label:'종료'},{value:'expired',label:'노출마감'}
   ], () => filterAdminCampaigns());
   // 신청관리
   createMultiFilter('appTypeMulti', '전체 타입', [
@@ -6338,11 +6368,11 @@ function renderCampaignBreakdown(camps) {
   if (!statusEl || !chEl) return;
 
   const statusDef = [
-    {key:'draft', label:'준비', color:'#9aa0a6', bg:'#F1F3F4'},
+    {key:'draft',     label:'준비',     color:'#9aa0a6', bg:'#F1F3F4'},
     {key:'scheduled', label:'모집예정', color:'#5B7CFF', bg:'#EEF2FF'},
-    {key:'active', label:'모집중', color:'#0E7E4A', bg:'#E8F7EF'},
-    {key:'paused', label:'일시정지', color:'#B26A00', bg:'#FFF4E5'},
-    {key:'closed', label:'종료', color:'#6B6B6B', bg:'#EEEEEE'},
+    {key:'active',    label:'모집중',   color:'#0E7E4A', bg:'#E8F7EF'},
+    {key:'closed',    label:'종료',     color:'#B91C5C', bg:'#FFE4EC'},
+    {key:'expired',   label:'노출마감', color:'#666666', bg:'#EEEEEE'},
   ];
   const statusCount = {};
   camps.forEach(c => { const s=c.status||'draft'; statusCount[s]=(statusCount[s]||0)+1; });
@@ -6753,11 +6783,12 @@ async function loadAdminCampaigns(useCache) {
     {value:'draft',     label:'준비',     count: stCounts.draft || 0},
     {value:'scheduled', label:'모집예정', count: stCounts.scheduled || 0},
     {value:'active',    label:'모집중',   count: stCounts.active || 0},
-    {value:'paused',    label:'일시정지', count: stCounts.paused || 0},
     {value:'closed',    label:'종료',     count: stCounts.closed || 0},
+    {value:'expired',   label:'노출마감', count: stCounts.expired || 0},
   ], () => filterAdminCampaigns());
-  const stLabels = {active:'모집중',scheduled:'모집예정',draft:'준비',paused:'일시정지',closed:'종료'};
-  const stColors = {active:'var(--green)',scheduled:'#5B7CFF',draft:'var(--muted)',paused:'var(--gold)',closed:'var(--muted)'};
+  const stLabels = {active:'모집중',scheduled:'모집예정',draft:'준비',closed:'종료',expired:'노출마감'};
+  // 노출 그룹(scheduled/active/closed)은 컬러, 비노출(draft/expired)은 회색·점선으로 시각 구분
+  const stColors = {active:'var(--green)',scheduled:'#5B7CFF',draft:'var(--muted)',closed:'#B91C5C',expired:'#666666'};
   const el = $('adminCampStatusCounts');
   if (el) el.innerHTML = Object.keys(stLabels).filter(k=>stCounts[k]).map(k =>
     `<span style="color:${stColors[k]};font-weight:600">${stLabels[k]} ${stCounts[k]}</span>`
@@ -6788,7 +6819,7 @@ async function loadAdminCampaigns(useCache) {
     });
   } else if (adminCampSortKey) {
     const dir = adminCampSortDir === 'asc' ? 1 : -1;
-    const statusOrder = {draft:0,scheduled:1,active:2,paused:3,closed:4};
+    const statusOrder = {draft:0,scheduled:1,active:2,closed:3,expired:4};
     const getVal = {
       status: c => statusOrder[c.status]??99,
       created: c => new Date(c.created_at).getTime(),
@@ -6806,10 +6837,14 @@ async function loadAdminCampaigns(useCache) {
   const isFiltered = searchVal || typeVals.length > 0 || statusVals.length > 0 || !!adminCampSortKey;
 
   const typeLabel = t => getRecruitTypeBadgeKoSm(t);
-  const statusLabel = {draft:'준비',scheduled:'모집예정',active:'모집중',paused:'일시정지',closed:'종료'};
-  const statusBadgeClass = {draft:'badge-gray',scheduled:'badge-blue',active:'badge-green',paused:'badge-gold',closed:'badge-gray'};
+  const statusLabel = {draft:'준비',scheduled:'모집예정',active:'모집중',closed:'종료',expired:'노출마감'};
+  // 노출 그룹(scheduled/active/closed)과 비노출 그룹(draft/expired)을 색·점선으로 구분
+  //   scheduled=파랑, active=초록, closed=핑크(게시 기간 살아있는 동안 노출 중)
+  //   draft=회색+점선, expired=비노출 강조 회색+점선
+  const statusBadgeClass = {draft:'badge-gray',scheduled:'badge-blue',active:'badge-green',closed:'badge-pink',expired:'badge-expired'};
   const statusBadge = s => {
     const cls = statusBadgeClass[s]||'badge-gray';
+    // draft만 점선 인라인 — expired는 .badge-expired 자체에 dashed 정의되어 있어 인라인 불필요
     const dashed = s==='draft' ? 'border:1.5px dashed var(--muted);' : '';
     return `<div style="position:relative;display:inline-block">
       <span class="badge ${cls}" style="cursor:pointer;${dashed}display:inline-flex;align-items:center;gap:3px" onclick="toggleStatusDropdown(this)">${statusLabel[s]||s}<span style="font-size:10px;opacity:.7">▾</span></span>
@@ -7119,28 +7154,29 @@ async function openEditCampaign(campId) {
 
 // 캠페인 편집 폼: 신청 동의 영향 영역 readonly 토글
 //   대상: 주의사항(caution) / 참여방법(participation) 요약 카드의 「편집」 버튼
-//   조건: status === 'closed' 일 때 비활성화 + 잠금 메시지 노출
+//   조건: status === 'closed' 또는 'expired' 일 때 비활성화 + 잠금 메시지 노출
 function applyEditFormSensitiveLocks(status) {
-  const isClosed = status === 'closed';
+  const isLocked = status === 'closed' || status === 'expired';
+  const lockLabel = status === 'expired' ? '노출마감' : '종료';
   ['Pset', 'Cset'].forEach(kind => {
     const card = $('editCamp' + kind + 'Summary');
     if (!card) return;
     const editBtn = card.querySelector('button[onclick*="openCampBundleModal"]');
     if (editBtn) {
-      editBtn.disabled = isClosed;
-      editBtn.style.opacity = isClosed ? '0.5' : '';
-      editBtn.style.cursor = isClosed ? 'not-allowed' : '';
-      editBtn.title = isClosed ? '종료된 캠페인은 수정할 수 없습니다' : '';
+      editBtn.disabled = isLocked;
+      editBtn.style.opacity = isLocked ? '0.5' : '';
+      editBtn.style.cursor = isLocked ? 'not-allowed' : '';
+      editBtn.title = isLocked ? `${lockLabel} 캠페인은 수정할 수 없습니다` : '';
     }
     let lockMsg = card.querySelector('.bundle-lock-msg');
-    if (isClosed) {
+    if (isLocked) {
       if (!lockMsg) {
         lockMsg = document.createElement('div');
         lockMsg.className = 'bundle-lock-msg';
         lockMsg.style.cssText = 'font-size:11px;color:var(--muted);margin-top:6px;display:flex;align-items:center;gap:4px';
-        lockMsg.innerHTML = '<span class="material-icons-round notranslate" translate="no" style="font-size:14px">lock</span>종료된 캠페인은 수정할 수 없습니다';
         card.appendChild(lockMsg);
       }
+      lockMsg.innerHTML = `<span class="material-icons-round notranslate" translate="no" style="font-size:14px">lock</span>${lockLabel} 캠페인은 수정할 수 없습니다`;
     } else if (lockMsg) {
       lockMsg.remove();
     }
@@ -8072,7 +8108,7 @@ async function saveCampaignEdit() {
     //      sanitize 한 번 더 적용 등 미세 차이로 detectSensitiveChange 가 false-positive를
     //      잡아 「날짜만 수정해도 차단」되는 회귀가 있어, 안전하게 caution/participation
     //      필드 4개를 updates에서 제거하고 비교 자체를 skip — db 값 그대로 유지된다.
-    //   2) draft~paused 캠페인: 신청자 ≥1건 + 변경 감지 시 경고 모달로 명시적 확인 요구
+    //   2) draft~closed 캠페인: 신청자 ≥1건 + 변경 감지 시 경고 모달로 명시적 확인 요구
     //   3) Phase 2 — 변경 감지 시 audit 이력 기록 (campaign_caution_history)
     const origStatus = (_editCampOriginal && _editCampOriginal.status) || '';
     let _historyAppCount = 0;
@@ -8513,11 +8549,11 @@ function toggleStatusDropdown(badgeEl) {
   if (!campId) return;
 
   const items = [
-    {val:'draft', label:'준비', cls:'badge-gray'},
+    {val:'draft',     label:'준비',     cls:'badge-gray'},
     {val:'scheduled', label:'모집예정', cls:'badge-blue'},
-    {val:'active', label:'모집중', cls:'badge-green'},
-    {val:'paused', label:'일시정지', cls:'badge-gold'},
-    {val:'closed', label:'종료', cls:'badge-gray'}
+    {val:'active',    label:'모집중',   cls:'badge-green'},
+    {val:'closed',    label:'종료',     cls:'badge-pink'},
+    {val:'expired',   label:'노출마감', cls:'badge-expired'}
   ];
 
   const dd = document.createElement('div');

--- a/admin/index.html
+++ b/admin/index.html
@@ -8068,29 +8068,36 @@ async function saveCampaignEdit() {
     };
 
     // 신청 동의 영향 영역(주의사항/참여방법) 변경 게이트
-    //   1) closed 캠페인은 변경 자체 차단 (DB 트리거가 이중 차단)
-    //   2) 신청자 ≥1건 + 변경 감지 시 경고 모달로 명시적 확인 요구
+    //   1) closed 캠페인: UI 카드가 lock 상태라 사용자가 직접 수정할 수 없음. collect 결과의
+    //      sanitize 한 번 더 적용 등 미세 차이로 detectSensitiveChange 가 false-positive를
+    //      잡아 「날짜만 수정해도 차단」되는 회귀가 있어, 안전하게 caution/participation
+    //      필드 4개를 updates에서 제거하고 비교 자체를 skip — db 값 그대로 유지된다.
+    //   2) draft~paused 캠페인: 신청자 ≥1건 + 변경 감지 시 경고 모달로 명시적 확인 요구
     //   3) Phase 2 — 변경 감지 시 audit 이력 기록 (campaign_caution_history)
-    const change = detectSensitiveChange(updates);
     const origStatus = (_editCampOriginal && _editCampOriginal.status) || '';
-    if (origStatus === 'closed' && change.anyChanged) {
-      toast('종료된 캠페인은 주의사항/참여방법을 수정할 수 없습니다','error');
-      return;
-    }
     let _historyAppCount = 0;
     let _historyBypassAck = false;
-    if (change.anyChanged) {
-      _historyAppCount = await countActiveApplications(campId);
-      if (_historyAppCount >= 1) {
-        const ok = await showSensitiveChangeConfirm({
-          appCount: _historyAppCount,
-          cautionChanged: change.cautionChanged,
-          participationChanged: change.participationChanged,
-          orig: _editCampOriginal,
-          next: updates
-        });
-        if (!ok) return;
-        _historyBypassAck = true;
+    let change = {cautionChanged:false, participationChanged:false, anyChanged:false};
+    if (origStatus === 'closed') {
+      delete updates.caution_set_id;
+      delete updates.caution_items;
+      delete updates.participation_set_id;
+      delete updates.participation_steps;
+    } else {
+      change = detectSensitiveChange(updates);
+      if (change.anyChanged) {
+        _historyAppCount = await countActiveApplications(campId);
+        if (_historyAppCount >= 1) {
+          const ok = await showSensitiveChangeConfirm({
+            appCount: _historyAppCount,
+            cautionChanged: change.cautionChanged,
+            participationChanged: change.participationChanged,
+            orig: _editCampOriginal,
+            next: updates
+          });
+          if (!ok) return;
+          _historyBypassAck = true;
+        }
       }
     }
 

--- a/admin/index.html
+++ b/admin/index.html
@@ -7436,11 +7436,18 @@ function resolveConfirmModal(ok) {
   if (_confirmResolver) { _confirmResolver(!!ok); _confirmResolver = null; }
 }
 
-// 모집 종료일 입력 시 결과물 제출 마감일을 +14일로 자동 제안 (확인 모달)
-async function suggestSubmissionEnd(prefix) {
-  const dl = $(prefix+'Deadline')?.value;
-  if (!dl) return;
-  const target = new Date(dl);
+// 결과물 제출 마감일을 +14일로 자동 제안 (확인 모달)
+//   baseKind: 'purchase'(monitor) | 'visit' | 'recruit'(gifting fallback)
+//   - monitor: 구매 기간 종료일 + 14일
+//   - visit:   방문 기간 종료일 + 14일
+//   - gifting: 구매·방문 기간 없으므로 모집 종료일 + 14일
+async function suggestSubmissionEnd(prefix, baseKind) {
+  const baseSuffix = baseKind === 'purchase' ? 'PurchaseEnd'
+    : baseKind === 'visit' ? 'VisitEnd'
+    : 'Deadline';
+  const baseDate = $(prefix + baseSuffix)?.value;
+  if (!baseDate) return;
+  const target = new Date(baseDate);
   target.setDate(target.getDate() + 14);
   const yyyy = target.getFullYear();
   const mm = String(target.getMonth() + 1).padStart(2, '0');
@@ -7448,7 +7455,8 @@ async function suggestSubmissionEnd(prefix) {
   const suggested = `${yyyy}-${mm}-${dd}`;
   const seEl = $(prefix+'SubmissionEnd');
   if (!seEl || seEl.value === suggested) return;
-  const ok = await showConfirm(`결과물 제출 마감일을 ${yyyy}년 ${mm}월 ${dd}일로 입력하시겠습니까?\n(모집 종료일 + 2주)`);
+  const baseLabel = {purchase: '구매 기간 종료', visit: '방문 기간 종료', recruit: '모집 종료'}[baseKind] || '기준일';
+  const ok = await showConfirm(`결과물 제출 마감일을 ${yyyy}년 ${mm}월 ${dd}일로 입력하시겠습니까?\n(${baseLabel} + 2주)`);
   if (ok) {
     seEl.value = suggested;
     syncCampDateMinMax(prefix);
@@ -7685,7 +7693,14 @@ function _commitFpRangeToHiddenInputs(fp) {
   if (endEl)   endEl.value   = _fpFormatYmd(end);
   if (kind === 'recruit') {
     updateRecruitPastWarn(fp, start);
-    if (end) suggestSubmissionEnd(prefix);
+    // gifting 캠페인은 구매·방문 기간이 없으므로 모집 종료일 기준 +14일 fallback 제안
+    const rtName = prefix === 'editCamp' ? 'editRecruitType' : 'newRecruitType';
+    const currentRt = document.querySelector(`input[name="${rtName}"]:checked`)?.value || 'monitor';
+    if (currentRt === 'gifting' && end) suggestSubmissionEnd(prefix, 'recruit');
+  }
+  // monitor=구매 종료, visit=방문 종료 기준 +14일 제안
+  if ((kind === 'purchase' || kind === 'visit') && end) {
+    suggestSubmissionEnd(prefix, kind);
   }
   syncCampDateMinMax(prefix);
   validateCampDateRangesInline(prefix);

--- a/admin/index.html
+++ b/admin/index.html
@@ -1502,7 +1502,8 @@ textarea.form-input{resize:vertical;min-height:80px}
               </div>
             </div>
 
-            <div class="form-row" style="grid-template-columns:1fr 1fr">
+            <!-- 기간 입력 3열: [모집기간] [구매/방문기간] [결과물 제출 마감일] — 시간 흐름 순 -->
+            <div class="form-row" style="grid-template-columns:1fr 1fr 1fr">
               <div class="form-group">
                 <label class="form-label">모집 기간 <span style="background:var(--pink);color:#fff;font-size:9px;font-weight:700;padding:1px 5px;border-radius:3px;margin-left:4px">필수</span></label>
                 <input type="text" id="editCampRecruitRange" class="form-input fp-range" placeholder="시작일 ~ 종료일 선택" data-range-prefix="editCamp" data-range-kind="recruit" readonly>
@@ -1511,15 +1512,7 @@ textarea.form-input{resize:vertical;min-height:80px}
                 <div class="form-hint">인플루언서를 모집하는 기간을 설정하세요</div>
                 <div id="editCampRecruitWarn" class="form-error" style="display:none;margin-top:4px"></div>
               </div>
-              <div class="form-group">
-                <label class="form-label">결과물 제출 마감일</label>
-                <input type="text" id="editCampSubmissionEnd" class="form-input fp-single" data-single-prefix="editCamp" data-single-target="SubmissionEnd" placeholder="연도. 월. 일." readonly>
-                <div class="form-hint">이 날짜 이후 결과물 제출 불가. 비우면 캠페인 노출 마감일로 폴백</div>
-                <div id="editCampSubmissionWarn" class="form-error" style="display:none;margin-top:4px"></div>
-              </div>
-            </div>
-            <div class="form-row" id="editCampPurchaseRow" style="grid-template-columns:1fr 1fr;display:none">
-              <div class="form-group">
+              <div class="form-group" id="editCampPurchaseRow" style="display:none">
                 <label class="form-label">구매 기간</label>
                 <input type="text" id="editCampPurchaseRange" class="form-input fp-range" placeholder="시작일 ~ 종료일 선택" data-range-prefix="editCamp" data-range-kind="purchase" readonly>
                 <input type="hidden" id="editCampPurchaseStart">
@@ -1527,9 +1520,7 @@ textarea.form-input{resize:vertical;min-height:80px}
                 <div class="form-hint">리뷰어용. 이 기간 내 구매한 영수증만 인정</div>
                 <div id="editCampPurchaseWarn" class="form-error" style="display:none;margin-top:4px"></div>
               </div>
-            </div>
-            <div class="form-row" id="editCampVisitRow" style="grid-template-columns:1fr 1fr;display:none">
-              <div class="form-group">
+              <div class="form-group" id="editCampVisitRow" style="display:none">
                 <label class="form-label">방문 기간</label>
                 <input type="text" id="editCampVisitRange" class="form-input fp-range" placeholder="시작일 ~ 종료일 선택" data-range-prefix="editCamp" data-range-kind="visit" readonly>
                 <input type="hidden" id="editCampVisitStart">
@@ -1537,8 +1528,15 @@ textarea.form-input{resize:vertical;min-height:80px}
                 <div class="form-hint">방문형용. 이 기간 내 매장 방문 가능</div>
                 <div id="editCampVisitWarn" class="form-error" style="display:none;margin-top:4px"></div>
               </div>
+              <div class="form-group">
+                <label class="form-label">결과물 제출 마감일</label>
+                <input type="text" id="editCampSubmissionEnd" class="form-input fp-single" data-single-prefix="editCamp" data-single-target="SubmissionEnd" placeholder="연도. 월. 일." readonly>
+                <div class="form-hint">이 날짜 이후 결과물 제출 불가. 비우면 캠페인 노출 마감일로 폴백</div>
+                <div id="editCampSubmissionWarn" class="form-error" style="display:none;margin-top:4px"></div>
+              </div>
             </div>
-            <div class="form-row" style="grid-template-columns:1fr 1fr">
+            <!-- 기간 입력 2행: [캠페인 노출 마감] | -- | -- (빈 칸 자동) -->
+            <div class="form-row" style="grid-template-columns:1fr 1fr 1fr">
               <div class="form-group">
                 <label class="form-label">캠페인 노출 마감일 <span style="background:var(--pink);color:#fff;font-size:9px;font-weight:700;padding:1px 5px;border-radius:3px;margin-left:4px">필수</span></label>
                 <input type="text" id="editCampPostDeadline" class="form-input fp-single" data-single-prefix="editCamp" data-single-target="PostDeadline" placeholder="연도. 월. 일." readonly>
@@ -1760,8 +1758,8 @@ textarea.form-input{resize:vertical;min-height:80px}
               </div>
             </div>
 
-            <!-- 모집 기간 / 결과물 제출 마감일 -->
-            <div class="form-row" style="grid-template-columns:1fr 1fr">
+            <!-- 기간 입력 3열: [모집기간] [구매/방문기간] [결과물 제출 마감일] — 시간 흐름 순 -->
+            <div class="form-row" style="grid-template-columns:1fr 1fr 1fr">
               <div class="form-group">
                 <label class="form-label">모집 기간 <span style="background:var(--pink);color:#fff;font-size:9px;font-weight:700;padding:1px 5px;border-radius:3px;margin-left:4px">필수</span></label>
                 <input type="text" id="newCampRecruitRange" class="form-input fp-range" placeholder="시작일 ~ 종료일 선택" data-range-prefix="newCamp" data-range-kind="recruit" readonly>
@@ -1770,17 +1768,7 @@ textarea.form-input{resize:vertical;min-height:80px}
                 <div class="form-hint">인플루언서를 모집하는 기간을 설정하세요</div>
                 <div id="newCampRecruitWarn" class="form-error" style="display:none;margin-top:4px"></div>
               </div>
-              <div class="form-group">
-                <label class="form-label">결과물 제출 마감일</label>
-                <input type="text" id="newCampSubmissionEnd" class="form-input fp-single" data-single-prefix="newCamp" data-single-target="SubmissionEnd" placeholder="연도. 월. 일." readonly>
-                <div class="form-hint">이 날짜 이후 결과물(영수증·게시물 URL) 제출 불가. 비우면 캠페인 노출 마감일로 폴백</div>
-                <div id="newCampSubmissionWarn" class="form-error" style="display:none;margin-top:4px"></div>
-              </div>
-            </div>
-
-            <!-- 타입별 기한 — 모든 일자는 모집 시작 ~ 노출 마감 사이로 강제 -->
-            <div class="form-row" id="newCampPurchaseRow" style="grid-template-columns:1fr 1fr;display:none">
-              <div class="form-group">
+              <div class="form-group" id="newCampPurchaseRow" style="display:none">
                 <label class="form-label">구매 기간</label>
                 <input type="text" id="newCampPurchaseRange" class="form-input fp-range" placeholder="시작일 ~ 종료일 선택" data-range-prefix="newCamp" data-range-kind="purchase" readonly>
                 <input type="hidden" id="newCampPurchaseStart">
@@ -1788,9 +1776,7 @@ textarea.form-input{resize:vertical;min-height:80px}
                 <div class="form-hint">리뷰어용. 이 기간 내 구매한 영수증만 인정</div>
                 <div id="newCampPurchaseWarn" class="form-error" style="display:none;margin-top:4px"></div>
               </div>
-            </div>
-            <div class="form-row" id="newCampVisitRow" style="grid-template-columns:1fr 1fr;display:none">
-              <div class="form-group">
+              <div class="form-group" id="newCampVisitRow" style="display:none">
                 <label class="form-label">방문 기간</label>
                 <input type="text" id="newCampVisitRange" class="form-input fp-range" placeholder="시작일 ~ 종료일 선택" data-range-prefix="newCamp" data-range-kind="visit" readonly>
                 <input type="hidden" id="newCampVisitStart">
@@ -1798,8 +1784,15 @@ textarea.form-input{resize:vertical;min-height:80px}
                 <div class="form-hint">방문형용. 이 기간 내 매장 방문 가능</div>
                 <div id="newCampVisitWarn" class="form-error" style="display:none;margin-top:4px"></div>
               </div>
+              <div class="form-group">
+                <label class="form-label">결과물 제출 마감일</label>
+                <input type="text" id="newCampSubmissionEnd" class="form-input fp-single" data-single-prefix="newCamp" data-single-target="SubmissionEnd" placeholder="연도. 월. 일." readonly>
+                <div class="form-hint">이 날짜 이후 결과물(영수증·게시물 URL) 제출 불가. 비우면 캠페인 노출 마감일로 폴백</div>
+                <div id="newCampSubmissionWarn" class="form-error" style="display:none;margin-top:4px"></div>
+              </div>
             </div>
-            <div class="form-row" style="grid-template-columns:1fr 1fr">
+            <!-- 기간 입력 2행: [캠페인 노출 마감] | -- | -- (빈 칸 자동) -->
+            <div class="form-row" style="grid-template-columns:1fr 1fr 1fr">
               <div class="form-group">
                 <label class="form-label">캠페인 노출 마감일 <span style="background:var(--pink);color:#fff;font-size:9px;font-weight:700;padding:1px 5px;border-radius:3px;margin-left:4px">필수</span></label>
                 <input type="text" id="newCampPostDeadline" class="form-input fp-single" data-single-prefix="newCamp" data-single-target="PostDeadline" placeholder="연도. 월. 일." readonly>

--- a/dev/admin/index.html
+++ b/dev/admin/index.html
@@ -392,7 +392,8 @@
               </div>
             </div>
 
-            <div class="form-row" style="grid-template-columns:1fr 1fr">
+            <!-- 기간 입력 3열: [모집기간] [구매/방문기간] [결과물 제출 마감일] — 시간 흐름 순 -->
+            <div class="form-row" style="grid-template-columns:1fr 1fr 1fr">
               <div class="form-group">
                 <label class="form-label">모집 기간 <span style="background:var(--pink);color:#fff;font-size:9px;font-weight:700;padding:1px 5px;border-radius:3px;margin-left:4px">필수</span></label>
                 <input type="text" id="editCampRecruitRange" class="form-input fp-range" placeholder="시작일 ~ 종료일 선택" data-range-prefix="editCamp" data-range-kind="recruit" readonly>
@@ -401,15 +402,7 @@
                 <div class="form-hint">인플루언서를 모집하는 기간을 설정하세요</div>
                 <div id="editCampRecruitWarn" class="form-error" style="display:none;margin-top:4px"></div>
               </div>
-              <div class="form-group">
-                <label class="form-label">결과물 제출 마감일</label>
-                <input type="text" id="editCampSubmissionEnd" class="form-input fp-single" data-single-prefix="editCamp" data-single-target="SubmissionEnd" placeholder="연도. 월. 일." readonly>
-                <div class="form-hint">이 날짜 이후 결과물 제출 불가. 비우면 캠페인 노출 마감일로 폴백</div>
-                <div id="editCampSubmissionWarn" class="form-error" style="display:none;margin-top:4px"></div>
-              </div>
-            </div>
-            <div class="form-row" id="editCampPurchaseRow" style="grid-template-columns:1fr 1fr;display:none">
-              <div class="form-group">
+              <div class="form-group" id="editCampPurchaseRow" style="display:none">
                 <label class="form-label">구매 기간</label>
                 <input type="text" id="editCampPurchaseRange" class="form-input fp-range" placeholder="시작일 ~ 종료일 선택" data-range-prefix="editCamp" data-range-kind="purchase" readonly>
                 <input type="hidden" id="editCampPurchaseStart">
@@ -417,9 +410,7 @@
                 <div class="form-hint">리뷰어용. 이 기간 내 구매한 영수증만 인정</div>
                 <div id="editCampPurchaseWarn" class="form-error" style="display:none;margin-top:4px"></div>
               </div>
-            </div>
-            <div class="form-row" id="editCampVisitRow" style="grid-template-columns:1fr 1fr;display:none">
-              <div class="form-group">
+              <div class="form-group" id="editCampVisitRow" style="display:none">
                 <label class="form-label">방문 기간</label>
                 <input type="text" id="editCampVisitRange" class="form-input fp-range" placeholder="시작일 ~ 종료일 선택" data-range-prefix="editCamp" data-range-kind="visit" readonly>
                 <input type="hidden" id="editCampVisitStart">
@@ -427,8 +418,15 @@
                 <div class="form-hint">방문형용. 이 기간 내 매장 방문 가능</div>
                 <div id="editCampVisitWarn" class="form-error" style="display:none;margin-top:4px"></div>
               </div>
+              <div class="form-group">
+                <label class="form-label">결과물 제출 마감일</label>
+                <input type="text" id="editCampSubmissionEnd" class="form-input fp-single" data-single-prefix="editCamp" data-single-target="SubmissionEnd" placeholder="연도. 월. 일." readonly>
+                <div class="form-hint">이 날짜 이후 결과물 제출 불가. 비우면 캠페인 노출 마감일로 폴백</div>
+                <div id="editCampSubmissionWarn" class="form-error" style="display:none;margin-top:4px"></div>
+              </div>
             </div>
-            <div class="form-row" style="grid-template-columns:1fr 1fr">
+            <!-- 기간 입력 2행: [캠페인 노출 마감] | -- | -- (빈 칸 자동) -->
+            <div class="form-row" style="grid-template-columns:1fr 1fr 1fr">
               <div class="form-group">
                 <label class="form-label">캠페인 노출 마감일 <span style="background:var(--pink);color:#fff;font-size:9px;font-weight:700;padding:1px 5px;border-radius:3px;margin-left:4px">필수</span></label>
                 <input type="text" id="editCampPostDeadline" class="form-input fp-single" data-single-prefix="editCamp" data-single-target="PostDeadline" placeholder="연도. 월. 일." readonly>
@@ -650,8 +648,8 @@
               </div>
             </div>
 
-            <!-- 모집 기간 / 결과물 제출 마감일 -->
-            <div class="form-row" style="grid-template-columns:1fr 1fr">
+            <!-- 기간 입력 3열: [모집기간] [구매/방문기간] [결과물 제출 마감일] — 시간 흐름 순 -->
+            <div class="form-row" style="grid-template-columns:1fr 1fr 1fr">
               <div class="form-group">
                 <label class="form-label">모집 기간 <span style="background:var(--pink);color:#fff;font-size:9px;font-weight:700;padding:1px 5px;border-radius:3px;margin-left:4px">필수</span></label>
                 <input type="text" id="newCampRecruitRange" class="form-input fp-range" placeholder="시작일 ~ 종료일 선택" data-range-prefix="newCamp" data-range-kind="recruit" readonly>
@@ -660,17 +658,7 @@
                 <div class="form-hint">인플루언서를 모집하는 기간을 설정하세요</div>
                 <div id="newCampRecruitWarn" class="form-error" style="display:none;margin-top:4px"></div>
               </div>
-              <div class="form-group">
-                <label class="form-label">결과물 제출 마감일</label>
-                <input type="text" id="newCampSubmissionEnd" class="form-input fp-single" data-single-prefix="newCamp" data-single-target="SubmissionEnd" placeholder="연도. 월. 일." readonly>
-                <div class="form-hint">이 날짜 이후 결과물(영수증·게시물 URL) 제출 불가. 비우면 캠페인 노출 마감일로 폴백</div>
-                <div id="newCampSubmissionWarn" class="form-error" style="display:none;margin-top:4px"></div>
-              </div>
-            </div>
-
-            <!-- 타입별 기한 — 모든 일자는 모집 시작 ~ 노출 마감 사이로 강제 -->
-            <div class="form-row" id="newCampPurchaseRow" style="grid-template-columns:1fr 1fr;display:none">
-              <div class="form-group">
+              <div class="form-group" id="newCampPurchaseRow" style="display:none">
                 <label class="form-label">구매 기간</label>
                 <input type="text" id="newCampPurchaseRange" class="form-input fp-range" placeholder="시작일 ~ 종료일 선택" data-range-prefix="newCamp" data-range-kind="purchase" readonly>
                 <input type="hidden" id="newCampPurchaseStart">
@@ -678,9 +666,7 @@
                 <div class="form-hint">리뷰어용. 이 기간 내 구매한 영수증만 인정</div>
                 <div id="newCampPurchaseWarn" class="form-error" style="display:none;margin-top:4px"></div>
               </div>
-            </div>
-            <div class="form-row" id="newCampVisitRow" style="grid-template-columns:1fr 1fr;display:none">
-              <div class="form-group">
+              <div class="form-group" id="newCampVisitRow" style="display:none">
                 <label class="form-label">방문 기간</label>
                 <input type="text" id="newCampVisitRange" class="form-input fp-range" placeholder="시작일 ~ 종료일 선택" data-range-prefix="newCamp" data-range-kind="visit" readonly>
                 <input type="hidden" id="newCampVisitStart">
@@ -688,8 +674,15 @@
                 <div class="form-hint">방문형용. 이 기간 내 매장 방문 가능</div>
                 <div id="newCampVisitWarn" class="form-error" style="display:none;margin-top:4px"></div>
               </div>
+              <div class="form-group">
+                <label class="form-label">결과물 제출 마감일</label>
+                <input type="text" id="newCampSubmissionEnd" class="form-input fp-single" data-single-prefix="newCamp" data-single-target="SubmissionEnd" placeholder="연도. 월. 일." readonly>
+                <div class="form-hint">이 날짜 이후 결과물(영수증·게시물 URL) 제출 불가. 비우면 캠페인 노출 마감일로 폴백</div>
+                <div id="newCampSubmissionWarn" class="form-error" style="display:none;margin-top:4px"></div>
+              </div>
             </div>
-            <div class="form-row" style="grid-template-columns:1fr 1fr">
+            <!-- 기간 입력 2행: [캠페인 노출 마감] | -- | -- (빈 칸 자동) -->
+            <div class="form-row" style="grid-template-columns:1fr 1fr 1fr">
               <div class="form-group">
                 <label class="form-label">캠페인 노출 마감일 <span style="background:var(--pink);color:#fff;font-size:9px;font-weight:700;padding:1px 5px;border-radius:3px;margin-left:4px">필수</span></label>
                 <input type="text" id="newCampPostDeadline" class="form-input fp-single" data-single-prefix="newCamp" data-single-target="PostDeadline" placeholder="연도. 월. 일." readonly>

--- a/dev/admin/index.html
+++ b/dev/admin/index.html
@@ -307,7 +307,7 @@
               </div>
               <div class="form-group"><label class="form-label">상태</label>
                 <select id="editCampStatus" class="form-input">
-                  <option value="draft">준비</option><option value="scheduled">모집예정</option><option value="active">모집중</option><option value="paused">일시정지</option><option value="closed">종료</option>
+                  <option value="draft">준비</option><option value="scheduled">모집예정</option><option value="active">모집중</option><option value="closed">종료</option><option value="expired">노출마감</option>
                 </select>
               </div>
             </div>
@@ -1797,16 +1797,16 @@
             <td style="padding:8px 10px">「모집중」 / 「募集中」 배지</td>
           </tr>
           <tr>
-            <td style="padding:8px 10px"><span style="background:#F2E6F0;color:#735;font-size:11px;font-weight:700;padding:2px 8px;border-radius:4px">paused</span></td>
-            <td style="padding:8px 10px">일시정지</td>
-            <td style="padding:8px 10px;color:var(--red);font-weight:600">노출 안 됨</td>
-            <td style="padding:8px 10px;color:var(--muted)">—</td>
-          </tr>
-          <tr>
             <td style="padding:8px 10px"><span style="background:#F5F5F5;color:#999;font-size:11px;font-weight:700;padding:2px 8px;border-radius:4px">closed</span></td>
             <td style="padding:8px 10px">모집 종료</td>
             <td style="padding:8px 10px;color:var(--gold);font-weight:600">캠페인 노출 마감일까지 노출</td>
             <td style="padding:8px 10px">「募集締切」 오버레이 + 신청 버튼 비활성</td>
+          </tr>
+          <tr>
+            <td style="padding:8px 10px"><span style="background:#EFEFEF;color:#888;font-size:11px;font-weight:700;padding:2px 8px;border-radius:4px">expired</span></td>
+            <td style="padding:8px 10px">노출 마감 (캠페인 노출 마감일 경과)</td>
+            <td style="padding:8px 10px;color:var(--red);font-weight:600">노출 안 됨</td>
+            <td style="padding:8px 10px;color:var(--muted)">—</td>
           </tr>
         </tbody>
       </table>
@@ -1814,14 +1814,15 @@
         <div style="font-weight:700;color:var(--dark-pink);margin-bottom:6px">자동 전이 규칙</div>
         <ul style="margin:0;padding-left:18px;color:var(--ink)">
           <li><strong>모집 마감일(deadline) 경과</strong>하면 active → closed 로 자동 변경됩니다 (인플루언서 페이지 접속 시 클라이언트 측에서 처리).</li>
+          <li><strong>캠페인 노출 마감일(post_deadline) 경과</strong>하면 closed → expired 로 자동 변경됩니다. expired 상태는 사이트에서 완전히 숨겨집니다.</li>
           <li>모집 마감일이 지난 캠페인은 active / scheduled 상태로 저장·변경할 수 없습니다.</li>
-          <li>closed 라도 <strong>캠페인 노출 마감일(post_deadline)</strong>이 남아 있으면 사이트에서 보입니다 (이미 응모한 인플루언서가 캠페인 정보·결과물 제출 페이지를 열 수 있도록).</li>
+          <li>closed / expired 캠페인의 주의사항·참여방법은 수정할 수 없습니다 (DB에서 이중 차단).</li>
         </ul>
       </div>
       <div style="margin-top:14px;padding:14px;background:var(--surface-dim);border-radius:10px;font-size:12px;line-height:1.6">
-        <div style="font-weight:700;color:var(--ink);margin-bottom:6px">전이 흐름 예시</div>
-        <div style="font-family:monospace;font-size:11px;color:var(--ink)">draft → scheduled → active → closed → (post_deadline 경과 후 비노출)</div>
-        <div style="margin-top:6px;color:var(--muted)">paused 는 임시 중단용 — 작업 끝나면 active 로 복귀</div>
+        <div style="font-weight:700;color:var(--ink);margin-bottom:6px">전이 흐름</div>
+        <div style="font-family:monospace;font-size:11px;color:var(--ink)">draft → scheduled → active → closed → expired</div>
+        <div style="margin-top:6px;color:var(--muted)">closed 는 post_deadline 까지 인플루언서에게 노출(募集締切 표시). expired 는 완전 비노출.</div>
       </div>
     </div>
     <div style="padding:14px 20px;border-top:1px solid var(--line);text-align:right">

--- a/dev/css/components.css
+++ b/dev/css/components.css
@@ -48,6 +48,10 @@
 .badge-gold{background:var(--gold-l);color:var(--gold)}
 .badge-blue{background:var(--blue-l);color:var(--blue)}
 .badge-gray{background:var(--surface-dim);color:var(--muted);border:1px solid var(--outline)}
+/* 캠페인 상태 노출 그룹용 — closed(모집 끝났지만 게시 기간 살아있어 인플루언서 화면에 노출 중) */
+.badge-pink{background:#FFE4EC;color:#B91C5C;border:1px solid #FFB8D0}
+/* 캠페인 상태 비노출 강조 — expired(노출마감, 영구 비노출) */
+.badge-expired{background:#EEEEEE;color:#666666;border:1.5px dashed #999999;opacity:.85}
 .badge-new{background:var(--primary);color:#fff}
 
 /* ── FORMS (Material Text Field - Outlined) ── */

--- a/dev/js/admin.js
+++ b/dev/js/admin.js
@@ -205,7 +205,7 @@ function initMultiFilters() {
     {value:'monitor',label:'리뷰어'},{value:'gifting',label:'기프팅'},{value:'visit',label:'방문형'}
   ], () => filterAdminCampaigns());
   createMultiFilter('campStatusMulti', '전체 상태', [
-    {value:'draft',label:'준비'},{value:'scheduled',label:'모집예정'},{value:'active',label:'모집중'},{value:'paused',label:'일시정지'},{value:'closed',label:'종료'}
+    {value:'draft',label:'준비'},{value:'scheduled',label:'모집예정'},{value:'active',label:'모집중'},{value:'closed',label:'종료'},{value:'expired',label:'노출마감'}
   ], () => filterAdminCampaigns());
   // 신청관리
   createMultiFilter('appTypeMulti', '전체 타입', [
@@ -321,11 +321,11 @@ function renderCampaignBreakdown(camps) {
   if (!statusEl || !chEl) return;
 
   const statusDef = [
-    {key:'draft', label:'준비', color:'#9aa0a6', bg:'#F1F3F4'},
+    {key:'draft',     label:'준비',     color:'#9aa0a6', bg:'#F1F3F4'},
     {key:'scheduled', label:'모집예정', color:'#5B7CFF', bg:'#EEF2FF'},
-    {key:'active', label:'모집중', color:'#0E7E4A', bg:'#E8F7EF'},
-    {key:'paused', label:'일시정지', color:'#B26A00', bg:'#FFF4E5'},
-    {key:'closed', label:'종료', color:'#6B6B6B', bg:'#EEEEEE'},
+    {key:'active',    label:'모집중',   color:'#0E7E4A', bg:'#E8F7EF'},
+    {key:'closed',    label:'종료',     color:'#B91C5C', bg:'#FFE4EC'},
+    {key:'expired',   label:'노출마감', color:'#666666', bg:'#EEEEEE'},
   ];
   const statusCount = {};
   camps.forEach(c => { const s=c.status||'draft'; statusCount[s]=(statusCount[s]||0)+1; });
@@ -736,11 +736,12 @@ async function loadAdminCampaigns(useCache) {
     {value:'draft',     label:'준비',     count: stCounts.draft || 0},
     {value:'scheduled', label:'모집예정', count: stCounts.scheduled || 0},
     {value:'active',    label:'모집중',   count: stCounts.active || 0},
-    {value:'paused',    label:'일시정지', count: stCounts.paused || 0},
     {value:'closed',    label:'종료',     count: stCounts.closed || 0},
+    {value:'expired',   label:'노출마감', count: stCounts.expired || 0},
   ], () => filterAdminCampaigns());
-  const stLabels = {active:'모집중',scheduled:'모집예정',draft:'준비',paused:'일시정지',closed:'종료'};
-  const stColors = {active:'var(--green)',scheduled:'#5B7CFF',draft:'var(--muted)',paused:'var(--gold)',closed:'var(--muted)'};
+  const stLabels = {active:'모집중',scheduled:'모집예정',draft:'준비',closed:'종료',expired:'노출마감'};
+  // 노출 그룹(scheduled/active/closed)은 컬러, 비노출(draft/expired)은 회색·점선으로 시각 구분
+  const stColors = {active:'var(--green)',scheduled:'#5B7CFF',draft:'var(--muted)',closed:'#B91C5C',expired:'#666666'};
   const el = $('adminCampStatusCounts');
   if (el) el.innerHTML = Object.keys(stLabels).filter(k=>stCounts[k]).map(k =>
     `<span style="color:${stColors[k]};font-weight:600">${stLabels[k]} ${stCounts[k]}</span>`
@@ -771,7 +772,7 @@ async function loadAdminCampaigns(useCache) {
     });
   } else if (adminCampSortKey) {
     const dir = adminCampSortDir === 'asc' ? 1 : -1;
-    const statusOrder = {draft:0,scheduled:1,active:2,paused:3,closed:4};
+    const statusOrder = {draft:0,scheduled:1,active:2,closed:3,expired:4};
     const getVal = {
       status: c => statusOrder[c.status]??99,
       created: c => new Date(c.created_at).getTime(),
@@ -789,10 +790,14 @@ async function loadAdminCampaigns(useCache) {
   const isFiltered = searchVal || typeVals.length > 0 || statusVals.length > 0 || !!adminCampSortKey;
 
   const typeLabel = t => getRecruitTypeBadgeKoSm(t);
-  const statusLabel = {draft:'준비',scheduled:'모집예정',active:'모집중',paused:'일시정지',closed:'종료'};
-  const statusBadgeClass = {draft:'badge-gray',scheduled:'badge-blue',active:'badge-green',paused:'badge-gold',closed:'badge-gray'};
+  const statusLabel = {draft:'준비',scheduled:'모집예정',active:'모집중',closed:'종료',expired:'노출마감'};
+  // 노출 그룹(scheduled/active/closed)과 비노출 그룹(draft/expired)을 색·점선으로 구분
+  //   scheduled=파랑, active=초록, closed=핑크(게시 기간 살아있는 동안 노출 중)
+  //   draft=회색+점선, expired=비노출 강조 회색+점선
+  const statusBadgeClass = {draft:'badge-gray',scheduled:'badge-blue',active:'badge-green',closed:'badge-pink',expired:'badge-expired'};
   const statusBadge = s => {
     const cls = statusBadgeClass[s]||'badge-gray';
+    // draft만 점선 인라인 — expired는 .badge-expired 자체에 dashed 정의되어 있어 인라인 불필요
     const dashed = s==='draft' ? 'border:1.5px dashed var(--muted);' : '';
     return `<div style="position:relative;display:inline-block">
       <span class="badge ${cls}" style="cursor:pointer;${dashed}display:inline-flex;align-items:center;gap:3px" onclick="toggleStatusDropdown(this)">${statusLabel[s]||s}<span style="font-size:10px;opacity:.7">▾</span></span>
@@ -1102,28 +1107,29 @@ async function openEditCampaign(campId) {
 
 // 캠페인 편집 폼: 신청 동의 영향 영역 readonly 토글
 //   대상: 주의사항(caution) / 참여방법(participation) 요약 카드의 「편집」 버튼
-//   조건: status === 'closed' 일 때 비활성화 + 잠금 메시지 노출
+//   조건: status === 'closed' 또는 'expired' 일 때 비활성화 + 잠금 메시지 노출
 function applyEditFormSensitiveLocks(status) {
-  const isClosed = status === 'closed';
+  const isLocked = status === 'closed' || status === 'expired';
+  const lockLabel = status === 'expired' ? '노출마감' : '종료';
   ['Pset', 'Cset'].forEach(kind => {
     const card = $('editCamp' + kind + 'Summary');
     if (!card) return;
     const editBtn = card.querySelector('button[onclick*="openCampBundleModal"]');
     if (editBtn) {
-      editBtn.disabled = isClosed;
-      editBtn.style.opacity = isClosed ? '0.5' : '';
-      editBtn.style.cursor = isClosed ? 'not-allowed' : '';
-      editBtn.title = isClosed ? '종료된 캠페인은 수정할 수 없습니다' : '';
+      editBtn.disabled = isLocked;
+      editBtn.style.opacity = isLocked ? '0.5' : '';
+      editBtn.style.cursor = isLocked ? 'not-allowed' : '';
+      editBtn.title = isLocked ? `${lockLabel} 캠페인은 수정할 수 없습니다` : '';
     }
     let lockMsg = card.querySelector('.bundle-lock-msg');
-    if (isClosed) {
+    if (isLocked) {
       if (!lockMsg) {
         lockMsg = document.createElement('div');
         lockMsg.className = 'bundle-lock-msg';
         lockMsg.style.cssText = 'font-size:11px;color:var(--muted);margin-top:6px;display:flex;align-items:center;gap:4px';
-        lockMsg.innerHTML = '<span class="material-icons-round notranslate" translate="no" style="font-size:14px">lock</span>종료된 캠페인은 수정할 수 없습니다';
         card.appendChild(lockMsg);
       }
+      lockMsg.innerHTML = `<span class="material-icons-round notranslate" translate="no" style="font-size:14px">lock</span>${lockLabel} 캠페인은 수정할 수 없습니다`;
     } else if (lockMsg) {
       lockMsg.remove();
     }
@@ -2055,7 +2061,7 @@ async function saveCampaignEdit() {
     //      sanitize 한 번 더 적용 등 미세 차이로 detectSensitiveChange 가 false-positive를
     //      잡아 「날짜만 수정해도 차단」되는 회귀가 있어, 안전하게 caution/participation
     //      필드 4개를 updates에서 제거하고 비교 자체를 skip — db 값 그대로 유지된다.
-    //   2) draft~paused 캠페인: 신청자 ≥1건 + 변경 감지 시 경고 모달로 명시적 확인 요구
+    //   2) draft~closed 캠페인: 신청자 ≥1건 + 변경 감지 시 경고 모달로 명시적 확인 요구
     //   3) Phase 2 — 변경 감지 시 audit 이력 기록 (campaign_caution_history)
     const origStatus = (_editCampOriginal && _editCampOriginal.status) || '';
     let _historyAppCount = 0;
@@ -2496,11 +2502,11 @@ function toggleStatusDropdown(badgeEl) {
   if (!campId) return;
 
   const items = [
-    {val:'draft', label:'준비', cls:'badge-gray'},
+    {val:'draft',     label:'준비',     cls:'badge-gray'},
     {val:'scheduled', label:'모집예정', cls:'badge-blue'},
-    {val:'active', label:'모집중', cls:'badge-green'},
-    {val:'paused', label:'일시정지', cls:'badge-gold'},
-    {val:'closed', label:'종료', cls:'badge-gray'}
+    {val:'active',    label:'모집중',   cls:'badge-green'},
+    {val:'closed',    label:'종료',     cls:'badge-pink'},
+    {val:'expired',   label:'노출마감', cls:'badge-expired'}
   ];
 
   const dd = document.createElement('div');

--- a/dev/js/admin.js
+++ b/dev/js/admin.js
@@ -2051,29 +2051,36 @@ async function saveCampaignEdit() {
     };
 
     // 신청 동의 영향 영역(주의사항/참여방법) 변경 게이트
-    //   1) closed 캠페인은 변경 자체 차단 (DB 트리거가 이중 차단)
-    //   2) 신청자 ≥1건 + 변경 감지 시 경고 모달로 명시적 확인 요구
+    //   1) closed 캠페인: UI 카드가 lock 상태라 사용자가 직접 수정할 수 없음. collect 결과의
+    //      sanitize 한 번 더 적용 등 미세 차이로 detectSensitiveChange 가 false-positive를
+    //      잡아 「날짜만 수정해도 차단」되는 회귀가 있어, 안전하게 caution/participation
+    //      필드 4개를 updates에서 제거하고 비교 자체를 skip — db 값 그대로 유지된다.
+    //   2) draft~paused 캠페인: 신청자 ≥1건 + 변경 감지 시 경고 모달로 명시적 확인 요구
     //   3) Phase 2 — 변경 감지 시 audit 이력 기록 (campaign_caution_history)
-    const change = detectSensitiveChange(updates);
     const origStatus = (_editCampOriginal && _editCampOriginal.status) || '';
-    if (origStatus === 'closed' && change.anyChanged) {
-      toast('종료된 캠페인은 주의사항/참여방법을 수정할 수 없습니다','error');
-      return;
-    }
     let _historyAppCount = 0;
     let _historyBypassAck = false;
-    if (change.anyChanged) {
-      _historyAppCount = await countActiveApplications(campId);
-      if (_historyAppCount >= 1) {
-        const ok = await showSensitiveChangeConfirm({
-          appCount: _historyAppCount,
-          cautionChanged: change.cautionChanged,
-          participationChanged: change.participationChanged,
-          orig: _editCampOriginal,
-          next: updates
-        });
-        if (!ok) return;
-        _historyBypassAck = true;
+    let change = {cautionChanged:false, participationChanged:false, anyChanged:false};
+    if (origStatus === 'closed') {
+      delete updates.caution_set_id;
+      delete updates.caution_items;
+      delete updates.participation_set_id;
+      delete updates.participation_steps;
+    } else {
+      change = detectSensitiveChange(updates);
+      if (change.anyChanged) {
+        _historyAppCount = await countActiveApplications(campId);
+        if (_historyAppCount >= 1) {
+          const ok = await showSensitiveChangeConfirm({
+            appCount: _historyAppCount,
+            cautionChanged: change.cautionChanged,
+            participationChanged: change.participationChanged,
+            orig: _editCampOriginal,
+            next: updates
+          });
+          if (!ok) return;
+          _historyBypassAck = true;
+        }
       }
     }
 

--- a/dev/js/admin.js
+++ b/dev/js/admin.js
@@ -1412,11 +1412,18 @@ function resolveConfirmModal(ok) {
   if (_confirmResolver) { _confirmResolver(!!ok); _confirmResolver = null; }
 }
 
-// 모집 종료일 입력 시 결과물 제출 마감일을 +14일로 자동 제안 (확인 모달)
-async function suggestSubmissionEnd(prefix) {
-  const dl = $(prefix+'Deadline')?.value;
-  if (!dl) return;
-  const target = new Date(dl);
+// 결과물 제출 마감일을 +14일로 자동 제안 (확인 모달)
+//   baseKind: 'purchase'(monitor) | 'visit' | 'recruit'(gifting fallback)
+//   - monitor: 구매 기간 종료일 + 14일
+//   - visit:   방문 기간 종료일 + 14일
+//   - gifting: 구매·방문 기간 없으므로 모집 종료일 + 14일
+async function suggestSubmissionEnd(prefix, baseKind) {
+  const baseSuffix = baseKind === 'purchase' ? 'PurchaseEnd'
+    : baseKind === 'visit' ? 'VisitEnd'
+    : 'Deadline';
+  const baseDate = $(prefix + baseSuffix)?.value;
+  if (!baseDate) return;
+  const target = new Date(baseDate);
   target.setDate(target.getDate() + 14);
   const yyyy = target.getFullYear();
   const mm = String(target.getMonth() + 1).padStart(2, '0');
@@ -1424,7 +1431,8 @@ async function suggestSubmissionEnd(prefix) {
   const suggested = `${yyyy}-${mm}-${dd}`;
   const seEl = $(prefix+'SubmissionEnd');
   if (!seEl || seEl.value === suggested) return;
-  const ok = await showConfirm(`결과물 제출 마감일을 ${yyyy}년 ${mm}월 ${dd}일로 입력하시겠습니까?\n(모집 종료일 + 2주)`);
+  const baseLabel = {purchase: '구매 기간 종료', visit: '방문 기간 종료', recruit: '모집 종료'}[baseKind] || '기준일';
+  const ok = await showConfirm(`결과물 제출 마감일을 ${yyyy}년 ${mm}월 ${dd}일로 입력하시겠습니까?\n(${baseLabel} + 2주)`);
   if (ok) {
     seEl.value = suggested;
     syncCampDateMinMax(prefix);
@@ -1661,7 +1669,14 @@ function _commitFpRangeToHiddenInputs(fp) {
   if (endEl)   endEl.value   = _fpFormatYmd(end);
   if (kind === 'recruit') {
     updateRecruitPastWarn(fp, start);
-    if (end) suggestSubmissionEnd(prefix);
+    // gifting 캠페인은 구매·방문 기간이 없으므로 모집 종료일 기준 +14일 fallback 제안
+    const rtName = prefix === 'editCamp' ? 'editRecruitType' : 'newRecruitType';
+    const currentRt = document.querySelector(`input[name="${rtName}"]:checked`)?.value || 'monitor';
+    if (currentRt === 'gifting' && end) suggestSubmissionEnd(prefix, 'recruit');
+  }
+  // monitor=구매 종료, visit=방문 종료 기준 +14일 제안
+  if ((kind === 'purchase' || kind === 'visit') && end) {
+    suggestSubmissionEnd(prefix, kind);
   }
   syncCampDateMinMax(prefix);
   validateCampDateRangesInline(prefix);

--- a/dev/js/campaign.js
+++ b/dev/js/campaign.js
@@ -24,6 +24,7 @@ async function loadCampaigns() {
 }
 
 // 인플루언서에게 보이는 캠페인: 모집중 + 모집예정 + 모집마감(게시기한 남음)
+// expired(노출마감) 는 post_deadline 경과 후 서버가 자동 전환한 상태 — 완전 비노출
 function visibleCamps(camps) {
   const now = new Date(); now.setHours(0,0,0,0);
   return camps.filter(c => {
@@ -32,6 +33,7 @@ function visibleCamps(camps) {
       const pd = new Date(c.post_deadline); pd.setHours(23,59,59,999);
       return now <= pd;
     }
+    // draft / expired / (closed without post_deadline) → 비노출
     return false;
   });
 }

--- a/dev/lib/i18n/ja.js
+++ b/dev/lib/i18n/ja.js
@@ -73,7 +73,7 @@ window.I18N_JA = {
       scheduled: '近日公開',
       closed: '締切',
       draft: '準備中',
-      paused: '一時停止',
+      expired: '掲載終了',
     },
   },
 

--- a/dev/lib/i18n/ko.js
+++ b/dev/lib/i18n/ko.js
@@ -69,7 +69,7 @@ window.I18N_KO = {
       scheduled: '공개 예정',
       closed: '마감',
       draft: '준비중',
-      paused: '일시정지',
+      expired: '노출마감',
     },
   },
 

--- a/dev/lib/storage.js
+++ b/dev/lib/storage.js
@@ -43,6 +43,7 @@ async function fetchCampaigns() {
     if (data.length > 0) {
       await autoOpenCampaigns(data);   // scheduled → active (recruit_start 도래)
       await autoCloseCampaigns(data);  // active → closed (deadline 경과)
+      await autoExpireCampaigns(data); // closed → expired (post_deadline 경과)
       return data;
     }
     return DEMO_CAMPAIGNS.slice();
@@ -93,6 +94,30 @@ async function autoCloseCampaigns(camps) {
   }));
   results.forEach((r, i) => {
     if (r.status === 'rejected') console.warn('autoCloseCampaigns 실패:', toClose[i]?.id, r.reason);
+  });
+  return camps;
+}
+
+// post_deadline 경과 캠페인 자동 노출마감 전환 (closed → expired)
+//   post_deadline 당일 자정(JST) 이후 접속 시 expired로 전환.
+//   expired 캠페인은 인플루언서 화면에서 완전히 숨겨짐 (closed는 post_deadline까지 표시).
+async function autoExpireCampaigns(camps) {
+  if (!db) return camps;
+  const now = new Date();
+  now.setHours(0, 0, 0, 0);
+  const toExpire = camps.filter(c => {
+    if (c.status !== 'closed' || !c.post_deadline) return false;
+    const pd = new Date(c.post_deadline);
+    pd.setHours(23, 59, 59, 999);
+    return now > pd;
+  });
+  if (!toExpire.length) return camps;
+  const results = await Promise.allSettled(toExpire.map(c => {
+    c.status = 'expired';
+    return db.from('campaigns').update({ status: 'expired' }).eq('id', c.id);
+  }));
+  results.forEach((r, i) => {
+    if (r.status === 'rejected') console.warn('autoExpireCampaigns 실패:', toExpire[i]?.id, r.reason);
   });
   return camps;
 }

--- a/index.html
+++ b/index.html
@@ -133,6 +133,10 @@ img{display:block;max-width:100%}
 .badge-gold{background:var(--gold-l);color:var(--gold)}
 .badge-blue{background:var(--blue-l);color:var(--blue)}
 .badge-gray{background:var(--surface-dim);color:var(--muted);border:1px solid var(--outline)}
+/* 캠페인 상태 노출 그룹용 — closed(모집 끝났지만 게시 기간 살아있어 인플루언서 화면에 노출 중) */
+.badge-pink{background:#FFE4EC;color:#B91C5C;border:1px solid #FFB8D0}
+/* 캠페인 상태 비노출 강조 — expired(노출마감, 영구 비노출) */
+.badge-expired{background:#EEEEEE;color:#666666;border:1.5px dashed #999999;opacity:.85}
 .badge-new{background:var(--primary);color:#fff}
 
 /* ── FORMS (Material Text Field - Outlined) ── */
@@ -1810,7 +1814,7 @@ window.I18N_JA = {
       scheduled: '近日公開',
       closed: '締切',
       draft: '準備中',
-      paused: '一時停止',
+      expired: '掲載終了',
     },
   },
 
@@ -2265,7 +2269,7 @@ window.I18N_KO = {
       scheduled: '공개 예정',
       closed: '마감',
       draft: '준비중',
-      paused: '일시정지',
+      expired: '노출마감',
     },
   },
 
@@ -2776,6 +2780,7 @@ async function fetchCampaigns() {
     if (data.length > 0) {
       await autoOpenCampaigns(data);   // scheduled → active (recruit_start 도래)
       await autoCloseCampaigns(data);  // active → closed (deadline 경과)
+      await autoExpireCampaigns(data); // closed → expired (post_deadline 경과)
       return data;
     }
     return DEMO_CAMPAIGNS.slice();
@@ -2826,6 +2831,30 @@ async function autoCloseCampaigns(camps) {
   }));
   results.forEach((r, i) => {
     if (r.status === 'rejected') console.warn('autoCloseCampaigns 실패:', toClose[i]?.id, r.reason);
+  });
+  return camps;
+}
+
+// post_deadline 경과 캠페인 자동 노출마감 전환 (closed → expired)
+//   post_deadline 당일 자정(JST) 이후 접속 시 expired로 전환.
+//   expired 캠페인은 인플루언서 화면에서 완전히 숨겨짐 (closed는 post_deadline까지 표시).
+async function autoExpireCampaigns(camps) {
+  if (!db) return camps;
+  const now = new Date();
+  now.setHours(0, 0, 0, 0);
+  const toExpire = camps.filter(c => {
+    if (c.status !== 'closed' || !c.post_deadline) return false;
+    const pd = new Date(c.post_deadline);
+    pd.setHours(23, 59, 59, 999);
+    return now > pd;
+  });
+  if (!toExpire.length) return camps;
+  const results = await Promise.allSettled(toExpire.map(c => {
+    c.status = 'expired';
+    return db.from('campaigns').update({ status: 'expired' }).eq('id', c.id);
+  }));
+  results.forEach((r, i) => {
+    if (r.status === 'rejected') console.warn('autoExpireCampaigns 실패:', toExpire[i]?.id, r.reason);
   });
   return camps;
 }
@@ -5271,6 +5300,7 @@ async function loadCampaigns() {
 }
 
 // 인플루언서에게 보이는 캠페인: 모집중 + 모집예정 + 모집마감(게시기한 남음)
+// expired(노출마감) 는 post_deadline 경과 후 서버가 자동 전환한 상태 — 완전 비노출
 function visibleCamps(camps) {
   const now = new Date(); now.setHours(0,0,0,0);
   return camps.filter(c => {
@@ -5279,6 +5309,7 @@ function visibleCamps(camps) {
       const pd = new Date(c.post_deadline); pd.setHours(23,59,59,999);
       return now <= pd;
     }
+    // draft / expired / (closed without post_deadline) → 비노출
     return false;
   });
 }

--- a/supabase/migrations/097_campaigns_status_redesign.sql
+++ b/supabase/migrations/097_campaigns_status_redesign.sql
@@ -1,0 +1,235 @@
+-- ============================================================
+-- 097_campaigns_status_redesign.sql
+-- 2026-05-07
+--
+-- 목적:
+--   1. paused 상태 제거 (사용 빈도 낮음, 기존 데이터는 closed로 일괄 변환)
+--   2. expired 상태 추가 (한국어 라벨: 「노출마감」)
+--      - post_deadline 경과 시 closed → expired 자동 전이 (클라이언트 측 처리)
+--      - 인플루언서 화면에서 완전히 숨겨지는 상태 (closed는 post_deadline까지 노출)
+--   3. 075 트리거 함수 재정의
+--      - 기존: OLD.status = 'closed' AND NEW.status = 'closed' 일 때만 차단
+--      - 변경: closed 또는 expired 중 하나라도 포함 시 차단
+--
+-- 최종 상태 5개:
+--   draft(준비) → scheduled(모집예정) → active(모집중) → closed(종료) → expired(노출마감)
+--
+-- 변경 내용:
+--   [단계 1] paused → closed 일괄 변환 (WHERE status='paused', 멱등)
+--            * 주의: 075 트리거가 closed 캠페인 caution/participation 수정을 차단하므로
+--              트리거 재정의를 단계 1 보다 먼저 실행해야 함.
+--              paused → closed UPDATE는 caution/participation을 건드리지 않으므로
+--              기존 트리거에서도 차단되지 않음. 하지만 안전을 위해
+--              트리거 재정의(단계 3)를 먼저 배치함.
+--   [단계 2] CHECK 제약 갱신
+--            - 기존: ('draft','scheduled','active','paused','closed')
+--            - 변경: ('draft','scheduled','active','closed','expired')
+--   [단계 3] 075 트리거 함수 재정의 (SECURITY DEFINER, SET search_path = '')
+--
+-- 적용 순서:
+--   1. 개발서버(qysmxtipobomefudyixw) SQL Editor 실행 + 기능 검증
+--   2. 운영서버(twofagomeizrtkwlhsuv) SQL Editor 실행
+--      ※ 운영 적용 전 paused 건수 확인 권장:
+--         SELECT status, COUNT(*) FROM campaigns GROUP BY status ORDER BY status;
+--
+-- 검증 쿼리 (적용 후 실행):
+--   -- [1] 상태별 건수 — paused=0 확인
+--   SELECT status, COUNT(*) AS cnt FROM public.campaigns GROUP BY status ORDER BY status;
+--
+--   -- [2] CHECK 제약 정의 확인
+--   SELECT conname, pg_get_constraintdef(oid) AS definition
+--   FROM pg_constraint
+--   WHERE conrelid = 'public.campaigns'::regclass
+--     AND contype = 'c'
+--     AND conname LIKE '%status%';
+--   -- 기대값: ('draft','scheduled','active','closed','expired') 포함, paused 미포함
+--
+--   -- [3] 현재 campaigns 테이블의 모든 CHECK 제약 목록 (사전 확인용)
+--   SELECT conname FROM pg_constraint WHERE conrelid='public.campaigns'::regclass AND contype='c';
+--
+-- rollback:
+--   (하단 주석 참고)
+-- ============================================================
+
+BEGIN;
+
+
+-- ============================================================
+-- 단계 1: 075 트리거 함수 재정의
+--   실행 순서 이유:
+--     paused → closed 변환(단계 2 전) 시 075 트리거가 오작동할 여지 없음
+--     (paused UPDATE는 caution/participation을 변경하지 않음).
+--     그러나 expired 추가 이후 closed ↔ expired 간 전이에서 트리거가
+--     올바르게 작동하도록 먼저 재정의.
+--
+--   변경점:
+--     기존: OLD.status = 'closed' AND NEW.status = 'closed'
+--     변경: OLD.status IN ('closed','expired') AND NEW.status IN ('closed','expired')
+--           → closed/expired 상태 캠페인의 caution/participation 수정을 모두 차단
+--   차단 메시지 갱신:
+--     기존: '종료된 캠페인은 주의사항/참여방법을 수정할 수 없습니다'
+--     변경: '종료/노출마감 캠페인의 주의사항·참여방법은 수정할 수 없습니다.'
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.block_closed_campaign_caution_participation_update()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+BEGIN
+  -- closed 또는 expired 상태에서 caution/participation 4개 컬럼 변경 시 차단
+  -- (상태 전이 자체 — 예: closed→expired — 는 caution/participation을 건드리지 않으면 통과)
+  IF OLD.status IN ('closed', 'expired') AND NEW.status IN ('closed', 'expired') THEN
+    IF OLD.caution_set_id IS DISTINCT FROM NEW.caution_set_id
+       OR OLD.caution_items::text IS DISTINCT FROM NEW.caution_items::text
+       OR OLD.participation_set_id IS DISTINCT FROM NEW.participation_set_id
+       OR COALESCE(OLD.participation_steps::text, '') IS DISTINCT FROM COALESCE(NEW.participation_steps::text, '')
+    THEN
+      RAISE EXCEPTION '종료/노출마감 캠페인의 주의사항·참여방법은 수정할 수 없습니다 (campaign_id=%)', OLD.id
+        USING ERRCODE = 'P0001';
+    END IF;
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+-- 트리거 재등록 (함수 교체 후 트리거는 자동 반영되지만 명시적으로 재생성)
+DROP TRIGGER IF EXISTS trg_block_closed_caution_participation ON public.campaigns;
+CREATE TRIGGER trg_block_closed_caution_participation
+  BEFORE UPDATE ON public.campaigns
+  FOR EACH ROW
+  EXECUTE FUNCTION public.block_closed_campaign_caution_participation_update();
+
+COMMENT ON FUNCTION public.block_closed_campaign_caution_participation_update() IS
+  'closed/expired 캠페인의 caution_items/caution_set_id/participation_steps/participation_set_id 변경 차단 (migration 075 정의 → 097 재정의)';
+
+
+-- ============================================================
+-- 단계 2: 기존 paused 데이터 → closed 일괄 변환
+--   멱등 조건: WHERE status = 'paused' (paused 행이 없으면 0행 UPDATE, 정상)
+--   이 UPDATE는 caution/participation을 건드리지 않으므로
+--   단계 1의 트리거에 의해 차단되지 않음.
+-- ============================================================
+
+UPDATE public.campaigns
+SET status = 'closed'
+WHERE status = 'paused';
+
+-- 변환 건수 확인용 NOTICE (SQL Editor에서 실행 시 Message 탭에 표시됨)
+DO $$
+BEGIN
+  RAISE NOTICE '[097] paused → closed 변환 완료. 현재 paused 건수: %',
+    (SELECT COUNT(*) FROM public.campaigns WHERE status = 'paused');
+END;
+$$;
+
+
+-- ============================================================
+-- 단계 3: CHECK 제약 갱신
+--   기존 제약이 있으면 동적으로 찾아 DROP, 없으면 스킵 (멱등).
+--   새 제약은 명시적 이름 campaigns_status_check 으로 추가
+--   (이미 동일 이름이 존재하면 ADD는 오류 → DO 블록으로 처리).
+--
+--   기존 제약명이 자동 이름(campaigns_status_check1 등)일 수 있으므로
+--   content ILIKE '%status%' + NOT ILIKE '%expired%' 조건으로 탐색.
+-- ============================================================
+
+DO $$
+DECLARE
+  v_conname text;
+BEGIN
+  -- 재실행 안전성: 이미 expired 포함 CHECK 제약이 있으면 ADD까지 모두 스킵.
+  -- 그렇지 않으면 status 관련 구 제약을 찾아 DROP한 뒤 새 제약을 ADD.
+  IF EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conrelid = 'public.campaigns'::regclass
+      AND contype = 'c'
+      AND pg_get_constraintdef(oid) ILIKE '%expired%'
+  ) THEN
+    RAISE NOTICE '[097] CHECK 제약 이미 최신 (expired 포함) — 스킵';
+  ELSE
+    SELECT conname INTO v_conname
+    FROM pg_constraint
+    WHERE conrelid = 'public.campaigns'::regclass
+      AND contype = 'c'
+      AND pg_get_constraintdef(oid) ILIKE '%status%'
+    LIMIT 1;
+
+    IF v_conname IS NOT NULL THEN
+      EXECUTE format('ALTER TABLE public.campaigns DROP CONSTRAINT %I', v_conname);
+      RAISE NOTICE '[097] 기존 status CHECK 제약 삭제: %', v_conname;
+    ELSE
+      RAISE NOTICE '[097] 기존 status CHECK 제약 없음 — 신규 추가만';
+    END IF;
+
+    ALTER TABLE public.campaigns
+      ADD CONSTRAINT campaigns_status_check
+      CHECK (status IN ('draft', 'scheduled', 'active', 'closed', 'expired'));
+    RAISE NOTICE '[097] campaigns_status_check 추가 완료';
+  END IF;
+END;
+$$;
+
+COMMENT ON COLUMN public.campaigns.status IS
+  'draft(준비) / scheduled(모집예정) / active(모집중) / closed(종료, post_deadline까지 노출) / expired(노출마감, 완전 비노출). paused는 migration 097에서 제거됨.';
+
+
+COMMIT;
+
+
+-- ============================================================
+-- 롤백 (적용 취소 시 아래 실행)
+-- 주의:
+--   - paused로 되돌릴 캠페인 목록을 알 수 없으므로 데이터 원복 불가
+--     (운영 적용 전 대상 건수/ID를 반드시 별도 메모)
+--   - expired 행이 이미 존재하면 DELETE 후 롤백 필요
+-- ============================================================
+/*
+
+BEGIN;
+
+-- [1] 트리거 함수 원복 (075 원본)
+CREATE OR REPLACE FUNCTION public.block_closed_campaign_caution_participation_update()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+BEGIN
+  IF OLD.status = 'closed' AND NEW.status = 'closed' THEN
+    IF OLD.caution_set_id IS DISTINCT FROM NEW.caution_set_id
+       OR OLD.caution_items::text IS DISTINCT FROM NEW.caution_items::text
+       OR OLD.participation_set_id IS DISTINCT FROM NEW.participation_set_id
+       OR COALESCE(OLD.participation_steps::text, '') IS DISTINCT FROM COALESCE(NEW.participation_steps::text, '')
+    THEN
+      RAISE EXCEPTION '종료된 캠페인은 주의사항/참여방법을 수정할 수 없습니다 (campaign_id=%)', OLD.id
+        USING ERRCODE = 'P0001';
+    END IF;
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_block_closed_caution_participation ON public.campaigns;
+CREATE TRIGGER trg_block_closed_caution_participation
+  BEFORE UPDATE ON public.campaigns
+  FOR EACH ROW
+  EXECUTE FUNCTION public.block_closed_campaign_caution_participation_update();
+
+-- [2] expired 행 확인 (있으면 처리 후 진행)
+SELECT id, title, status FROM public.campaigns WHERE status = 'expired';
+-- expired 행을 closed로 되돌리거나 삭제 후 아래 실행
+
+-- [3] CHECK 제약 원복 (paused 복원, expired 제거)
+ALTER TABLE public.campaigns DROP CONSTRAINT IF EXISTS campaigns_status_check;
+ALTER TABLE public.campaigns
+  ADD CONSTRAINT campaigns_status_check
+  CHECK (status IN ('draft', 'scheduled', 'active', 'paused', 'closed'));
+
+-- [4] paused 원복은 수동 — 마이그레이션 전 기록한 ID/목록 기준으로 직접 UPDATE
+-- UPDATE public.campaigns SET status = 'paused' WHERE id IN ('<uuid1>', '<uuid2>', ...);
+
+COMMIT;
+
+*/


### PR DESCRIPTION
## Summary

dev 누적 4건 운영 배포. 핵심:

- **migration 097**: paused 상태 제거(기존 데이터 closed로 일괄 변환) + expired (노출마감) 신규 추가. 075 트리거 closed/expired 양쪽 잠금
- 클라이언트 `autoExpireCampaigns()` — post_deadline 경과 시 closed → expired 자동 전이
- 캠페인 상태 컬러 분류 — 노출 그룹(scheduled/active/closed)은 컬러, 비노출(draft/expired)은 회색·점선
- 캠페인 폼 날짜 입력 3열 레이아웃 (모집기간 → 구매/방문기간 → 결과물 제출 마감일, 시간 흐름 순)
- 결과물 제출 마감일 +14일 자동 제안 모달을 모집 picker → 구매/방문 picker로 이동 (gifting fallback 모집 picker)
- closed 캠페인 날짜 수정 시 false-positive 차단 모달 제거

## DB 마이그레이션 — 운영 SQL Editor 적용 완료
- `supabase/migrations/097_campaigns_status_redesign.sql` (paused → closed 일괄 변환 + CHECK 제약 갱신 + 075 트리거 확장) — **운영 적용 완료, CHECK 제약 검증 통과**

## Test plan
- [ ] 운영 — 캠페인 관리 상태 드롭다운 5종(draft/scheduled/active/closed/expired) 표시
- [ ] 운영 — closed 배지 핑크, expired 배지 회색 점선
- [ ] 운영 — post_deadline 경과 캠페인 자동 expired 전환 (다음 fetchCampaigns에서)
- [ ] 운영 — 캠페인 편집 폼 3열 레이아웃 정상
- [ ] 운영 — monitor/visit 캠페인에서 구매·방문 picker 「적용」 시 결과물 제출 마감일 +14일 제안 모달
- [ ] 운영 — closed 캠페인에서 날짜만 수정 시 차단 모달 안 뜸

🤖 Generated with [Claude Code](https://claude.com/claude-code)