### PR TITLE
Deploy 2026-05-07 #3: 캠페인 상세 정비 + 홈 top10/필터/검색 + 신청 이름 가드 + 페이지 전환 새로고침

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -581,8 +581,10 @@ textarea.form-input{resize:vertical;min-height:80px}
 .cp-sec-desc-body{font-size:13px;color:var(--ink);line-height:1.7;word-break:break-word}
 .cp-sec-body{font-size:12px;color:var(--ink);line-height:1.7;word-break:break-word}
 .cp-sec-body .rich-content *{font-size:inherit!important}
-.cp-sec-bg-pink{background:var(--bg);padding:10px 12px;border-radius:8px}
-.cp-sec-bg-guide{background:var(--bg);padding:12px;border-radius:8px}
+/* 캠페인 미리보기·상세 — 브랜드 어필 / 촬영 가이드 / NG 사항 박스
+   var(--bg) 흐린 회색이 가독성 떨어진다는 사용자 보고 → 옅은 핑크/라일락 + 보더로 구분 강조 */
+.cp-sec-bg-pink{background:#fff5ff;padding:10px 12px;border-radius:8px;border:1px solid #f0d8e8}
+.cp-sec-bg-guide{background:#fdf5fd;padding:12px;border-radius:8px;border:1px solid #e8d4e8}
 .cp-sec-bg-ng{background:#fff8f8;padding:12px;border-radius:8px;border:1px solid #fdd}
 .cp-sec-subtitle{font-size:11px;font-weight:700;color:var(--pink);text-transform:uppercase;letter-spacing:.05em;margin-bottom:5px}
 /* 하단 고정 CTA 모방 */
@@ -8383,8 +8385,11 @@ function renderCampPreview(mode) {
   const contentTypeNames = contentTypeCodes.map(c => (typeof getLookupLabel === 'function' ? getLookupLabel('content_type', c) : c));
   const richFn = (typeof richHtml === 'function') ? richHtml : (s => esc(s).replace(/\n/g,'<br>'));
   const fmt = v => v ? (typeof formatDate === 'function' ? formatDate(v) : v) : '—';
+  // monitor(리뷰어) 캠페인은 「ペイバック」 워딩, 그 외는 기존 「相当の製品を無償提供」
+  const isMonitorPreview = camp.recruit_type === 'monitor';
+  const rewardLabelJa = isMonitorPreview ? '円ペイバック' : '円相当の製品を無償提供';
   const rewardText = (camp.product_price>0 || camp.reward>0)
-    ? `${camp.product_price>0?`¥${camp.product_price.toLocaleString()} 円相当の製品を無償提供`:'商品無償提供'}${camp.reward>0?` + ¥${camp.reward.toLocaleString()} 報酬`:''}`
+    ? `${camp.product_price>0?`¥${camp.product_price.toLocaleString()} ${rewardLabelJa}`:'商品無償提供'}${camp.reward>0?` + ¥${camp.reward.toLocaleString()} 報酬`:''}`
     : '';
 
   // 참여방법 (스냅샷 > legacy)
@@ -8411,22 +8416,31 @@ function renderCampPreview(mode) {
           ${camp.brand?`<div class="cp-brand">${esc(camp.brand)}</div>`:''}
           ${rtLabel?`<div class="cp-rt">${esc(rtLabel)}</div>`:''}
           <div class="cp-title">${esc(camp.title||'(캠페인명)')}</div>
-          ${camp.product_price>0?`<div class="cp-price-box"><span class="cp-price-amount">¥${camp.product_price.toLocaleString()}</span><span class="cp-price-label">円相当の製品を無償提供</span></div>`:''}
+          ${camp.product_price>0?`<div class="cp-price-box"><span class="cp-price-amount">¥${camp.product_price.toLocaleString()}</span><span class="cp-price-label">${rewardLabelJa}</span></div>`:''}
           ${camp.reward>0?`<div class="cp-reward-cash">+ ¥${camp.reward.toLocaleString()} 報酬</div>`:''}
         </div>
         <div class="cp-info">
-          <div class="cp-info-row"><div class="cp-info-key">製品名</div><div class="cp-info-val">${esc(camp.product||'—')}</div></div>
-          <div class="cp-info-row"><div class="cp-info-key">募集タイプ</div><div class="cp-info-val">${rtBadge?`<span class="cp-rt-badge" style="background:${rtBadge.bg};color:${rtBadge.color}">${rtBadge.label}</span>`:'—'}</div></div>
-          ${channelNames.length?`<div class="cp-info-row"><div class="cp-info-key">チャンネル</div><div class="cp-info-val"><div class="cp-chips">${channelNames.map((n,i)=>(i>0?`<span class="cp-chip-sep">${chSep}</span>`:'')+`<span class="cp-chip">${esc(n)}</span>`).join('')}</div></div></div>`:''}
-          ${contentTypeNames.length?`<div class="cp-info-row"><div class="cp-info-key">コンテンツ種類</div><div class="cp-info-val"><div class="cp-chips">${contentTypeNames.map(n=>`<span class="cp-chip cp-chip-sm">${esc(n)}</span>`).join('')}</div></div></div>`:''}
-          <div class="cp-info-row"><div class="cp-info-key">募集期間</div><div class="cp-info-val">${fmt(camp.recruit_start || new Date())} 〜 ${fmt(camp.deadline)}</div></div>
-          ${camp.slots?`<div class="cp-info-row"><div class="cp-info-key">募集人数</div><div class="cp-info-val">${camp.slots}名</div></div>`:''}
-          ${camp.min_followers?`<div class="cp-info-row"><div class="cp-info-key">最小フォロワー</div><div class="cp-info-val">${camp.min_followers.toLocaleString()}</div></div>`:''}
-          <div class="cp-info-row"><div class="cp-info-key">当選発表</div><div class="cp-info-val">${esc(camp.winner_announce||'選考後、LINEにてご連絡')}</div></div>
-          ${(camp.recruit_type==='monitor'&&(camp.purchase_start||camp.purchase_end))?`<div class="cp-info-row"><div class="cp-info-key">購入期間</div><div class="cp-info-val">${fmt(camp.purchase_start)} 〜 ${fmt(camp.purchase_end)}</div></div>`:''}
-          ${(camp.recruit_type==='visit'&&(camp.visit_start||camp.visit_end))?`<div class="cp-info-row"><div class="cp-info-key">訪問期間</div><div class="cp-info-val">${fmt(camp.visit_start)} 〜 ${fmt(camp.visit_end)}</div></div>`:''}
-          ${camp.submission_end?`<div class="cp-info-row"><div class="cp-info-key">提出締切</div><div class="cp-info-val" style="font-weight:600">${fmt(camp.submission_end)}</div></div>`:''}
-          ${(rewardText||camp.reward_note)?`<div class="cp-info-row"><div class="cp-info-key">報酬</div><div class="cp-info-val cp-info-val-pink">${rewardText?esc(rewardText):''}${camp.reward_note?`<div style="margin-top:${rewardText?'6px':'0'};font-size:11px;color:var(--muted);font-weight:400;line-height:1.6;white-space:pre-wrap">${esc(camp.reward_note)}</div>`:''}</div></div>`:''}
+          ${(()=>{
+            // 시간 흐름 순: 製品名 → 募集タイプ → チャンネル → コンテンツ → 募集期間 → 購入/訪問 → 提出締切 → 募集人数
+            //              → (monitor 외) 当選発表 → (monitor 외) 報酬
+            const rows = [];
+            rows.push(`<div class="cp-info-row"><div class="cp-info-key">製品名</div><div class="cp-info-val">${esc(camp.product||'—')}</div></div>`);
+            rows.push(`<div class="cp-info-row"><div class="cp-info-key">募集タイプ</div><div class="cp-info-val">${rtBadge?`<span class="cp-rt-badge" style="background:${rtBadge.bg};color:${rtBadge.color}">${rtBadge.label}</span>`:'—'}</div></div>`);
+            if (channelNames.length) rows.push(`<div class="cp-info-row"><div class="cp-info-key">チャンネル</div><div class="cp-info-val"><div class="cp-chips">${channelNames.map((n,i)=>(i>0?`<span class="cp-chip-sep">${chSep}</span>`:'')+`<span class="cp-chip">${esc(n)}</span>`).join('')}</div></div></div>`);
+            if (contentTypeNames.length) rows.push(`<div class="cp-info-row"><div class="cp-info-key">コンテンツ種類</div><div class="cp-info-val"><div class="cp-chips">${contentTypeNames.map(n=>`<span class="cp-chip cp-chip-sm">${esc(n)}</span>`).join('')}</div></div></div>`);
+            rows.push(`<div class="cp-info-row"><div class="cp-info-key">募集期間</div><div class="cp-info-val">${fmt(camp.recruit_start || new Date())} 〜 ${fmt(camp.deadline)}</div></div>`);
+            if (isMonitorPreview && (camp.purchase_start || camp.purchase_end)) rows.push(`<div class="cp-info-row"><div class="cp-info-key">購入期間</div><div class="cp-info-val">${fmt(camp.purchase_start)} 〜 ${fmt(camp.purchase_end)}</div></div>`);
+            if (camp.recruit_type === 'visit' && (camp.visit_start || camp.visit_end)) rows.push(`<div class="cp-info-row"><div class="cp-info-key">訪問期間</div><div class="cp-info-val">${fmt(camp.visit_start)} 〜 ${fmt(camp.visit_end)}</div></div>`);
+            if (camp.submission_end) rows.push(`<div class="cp-info-row"><div class="cp-info-key">提出締切</div><div class="cp-info-val" style="font-weight:600">${fmt(camp.submission_end)}</div></div>`);
+            if (camp.slots) rows.push(`<div class="cp-info-row"><div class="cp-info-key">募集人数</div><div class="cp-info-val">${camp.slots}名</div></div>`);
+            if (camp.min_followers) rows.push(`<div class="cp-info-row"><div class="cp-info-key">最小フォロワー</div><div class="cp-info-val">${camp.min_followers.toLocaleString()}</div></div>`);
+            // 리뷰어(monitor) 캠페인은 当選発表·報酬 행 제외
+            if (!isMonitorPreview) {
+              rows.push(`<div class="cp-info-row"><div class="cp-info-key">当選発表</div><div class="cp-info-val">${esc(camp.winner_announce||'選考後、LINEにてご連絡')}</div></div>`);
+              if (rewardText || camp.reward_note) rows.push(`<div class="cp-info-row"><div class="cp-info-key">報酬</div><div class="cp-info-val cp-info-val-pink">${rewardText?esc(rewardText):''}${camp.reward_note?`<div style="margin-top:${rewardText?'6px':'0'};font-size:11px;color:var(--muted);font-weight:400;line-height:1.6;white-space:pre-wrap">${esc(camp.reward_note)}</div>`:''}</div></div>`);
+            }
+            return rows.join('');
+          })()}
         </div>
         <div class="cp-participation">
           <div class="cp-section-heading">参加方法</div>
@@ -8452,7 +8466,7 @@ function renderCampPreview(mode) {
         })() : ''}
       </div>
       <div class="cp-cta">
-        <div class="cp-cta-name">${esc(camp.title||'—')}<small>${camp.product_price>0?`¥${camp.product_price.toLocaleString()} 円相当の製品を無償提供`:''}</small></div>
+        <div class="cp-cta-name">${esc(camp.title||'—')}<small>${camp.product_price>0?`¥${camp.product_price.toLocaleString()} ${rewardLabelJa}`:''}</small></div>
         <div class="cp-cta-btn">応募</div>
       </div>
     </div>`;

--- a/dev/css/admin.css
+++ b/dev/css/admin.css
@@ -238,8 +238,10 @@
 .cp-sec-desc-body{font-size:13px;color:var(--ink);line-height:1.7;word-break:break-word}
 .cp-sec-body{font-size:12px;color:var(--ink);line-height:1.7;word-break:break-word}
 .cp-sec-body .rich-content *{font-size:inherit!important}
-.cp-sec-bg-pink{background:var(--bg);padding:10px 12px;border-radius:8px}
-.cp-sec-bg-guide{background:var(--bg);padding:12px;border-radius:8px}
+/* 캠페인 미리보기·상세 — 브랜드 어필 / 촬영 가이드 / NG 사항 박스
+   var(--bg) 흐린 회색이 가독성 떨어진다는 사용자 보고 → 옅은 핑크/라일락 + 보더로 구분 강조 */
+.cp-sec-bg-pink{background:#fff5ff;padding:10px 12px;border-radius:8px;border:1px solid #f0d8e8}
+.cp-sec-bg-guide{background:#fdf5fd;padding:12px;border-radius:8px;border:1px solid #e8d4e8}
 .cp-sec-bg-ng{background:#fff8f8;padding:12px;border-radius:8px;border:1px solid #fdd}
 .cp-sec-subtitle{font-size:11px;font-weight:700;color:var(--pink);text-transform:uppercase;letter-spacing:.05em;margin-bottom:5px}
 /* 하단 고정 CTA 모방 */

--- a/dev/index.html
+++ b/dev/index.html
@@ -235,6 +235,10 @@ window._supabaseLoaded = false;
       <!-- 채널 필터 -->
       <div class="filter-row" id="filterRow" style="margin-bottom:14px"></div>
       <div class="camp-grid" id="campGrid"></div>
+      <!-- 더보기 — 홈 화면은 최대 10건, 초과분은 캠페인 페이지로 이동 -->
+      <div id="campMoreBtnWrap" style="display:none;text-align:center;margin-top:16px">
+        <button onclick="navigate('campaigns')" class="btn btn-ghost btn-block" style="font-size:13px;font-weight:600" data-i18n="campaign.moreBtn">もっと見る</button>
+      </div>
     </div>
   </section>
 
@@ -309,6 +313,17 @@ window._supabaseLoaded = false;
         <button id="campPageType-monitor" onclick="setCampPageType('monitor',this)" style="flex:1;padding:10px 0;font-size:13px;font-weight:600;color:var(--muted);border:none;background:none;cursor:pointer;border-bottom:2px solid transparent" data-i18n="campaigns.typeMonitor">レビュアー</button>
         <button id="campPageType-gifting" onclick="setCampPageType('gifting',this)" style="flex:1;padding:10px 0;font-size:13px;font-weight:600;color:var(--muted);border:none;background:none;cursor:pointer;border-bottom:2px solid transparent" data-i18n="campaigns.typeGifting">ギフティング</button>
         <button id="campPageType-visit" onclick="setCampPageType('visit',this)" style="flex:1;padding:10px 0;font-size:13px;font-weight:600;color:var(--muted);border:none;background:none;cursor:pointer;border-bottom:2px solid transparent" data-i18n="campaigns.typeVisit">訪問</button>
+      </div>
+      <!-- 캠페인 상태 칩 -->
+      <div class="filter-row" style="padding:10px 0 4px;display:flex;gap:6px;flex-wrap:wrap">
+        <button id="campPageStatus-all" class="chip on" onclick="setCampPageStatus('all',this)" data-i18n="campaigns.statusAll">すべて</button>
+        <button id="campPageStatus-active" class="chip" onclick="setCampPageStatus('active',this)" data-i18n="campaigns.statusActive">募集中</button>
+        <button id="campPageStatus-scheduled" class="chip" onclick="setCampPageStatus('scheduled',this)" data-i18n="campaigns.statusScheduled">近日公開</button>
+        <button id="campPageStatus-closed" class="chip" onclick="setCampPageStatus('closed',this)" data-i18n="campaigns.statusClosed">募集締切</button>
+      </div>
+      <!-- 검색 -->
+      <div style="padding:6px 0 12px">
+        <input type="search" id="campPageSearch" oninput="onCampPageSearchInput(this.value)" placeholder="キャンペーン名・ブランド検索" data-i18n-attr="placeholder:campaigns.searchPlaceholder" autocomplete="off" style="width:100%;padding:8px 12px;border:1px solid var(--line);border-radius:8px;font-size:16px;color:var(--ink);background:#fff">
       </div>
     </div>
   </div>

--- a/dev/js/admin.js
+++ b/dev/js/admin.js
@@ -2336,8 +2336,11 @@ function renderCampPreview(mode) {
   const contentTypeNames = contentTypeCodes.map(c => (typeof getLookupLabel === 'function' ? getLookupLabel('content_type', c) : c));
   const richFn = (typeof richHtml === 'function') ? richHtml : (s => esc(s).replace(/\n/g,'<br>'));
   const fmt = v => v ? (typeof formatDate === 'function' ? formatDate(v) : v) : '—';
+  // monitor(리뷰어) 캠페인은 「ペイバック」 워딩, 그 외는 기존 「相当の製品を無償提供」
+  const isMonitorPreview = camp.recruit_type === 'monitor';
+  const rewardLabelJa = isMonitorPreview ? '円ペイバック' : '円相当の製品を無償提供';
   const rewardText = (camp.product_price>0 || camp.reward>0)
-    ? `${camp.product_price>0?`¥${camp.product_price.toLocaleString()} 円相当の製品を無償提供`:'商品無償提供'}${camp.reward>0?` + ¥${camp.reward.toLocaleString()} 報酬`:''}`
+    ? `${camp.product_price>0?`¥${camp.product_price.toLocaleString()} ${rewardLabelJa}`:'商品無償提供'}${camp.reward>0?` + ¥${camp.reward.toLocaleString()} 報酬`:''}`
     : '';
 
   // 참여방법 (스냅샷 > legacy)
@@ -2364,22 +2367,31 @@ function renderCampPreview(mode) {
           ${camp.brand?`<div class="cp-brand">${esc(camp.brand)}</div>`:''}
           ${rtLabel?`<div class="cp-rt">${esc(rtLabel)}</div>`:''}
           <div class="cp-title">${esc(camp.title||'(캠페인명)')}</div>
-          ${camp.product_price>0?`<div class="cp-price-box"><span class="cp-price-amount">¥${camp.product_price.toLocaleString()}</span><span class="cp-price-label">円相当の製品を無償提供</span></div>`:''}
+          ${camp.product_price>0?`<div class="cp-price-box"><span class="cp-price-amount">¥${camp.product_price.toLocaleString()}</span><span class="cp-price-label">${rewardLabelJa}</span></div>`:''}
           ${camp.reward>0?`<div class="cp-reward-cash">+ ¥${camp.reward.toLocaleString()} 報酬</div>`:''}
         </div>
         <div class="cp-info">
-          <div class="cp-info-row"><div class="cp-info-key">製品名</div><div class="cp-info-val">${esc(camp.product||'—')}</div></div>
-          <div class="cp-info-row"><div class="cp-info-key">募集タイプ</div><div class="cp-info-val">${rtBadge?`<span class="cp-rt-badge" style="background:${rtBadge.bg};color:${rtBadge.color}">${rtBadge.label}</span>`:'—'}</div></div>
-          ${channelNames.length?`<div class="cp-info-row"><div class="cp-info-key">チャンネル</div><div class="cp-info-val"><div class="cp-chips">${channelNames.map((n,i)=>(i>0?`<span class="cp-chip-sep">${chSep}</span>`:'')+`<span class="cp-chip">${esc(n)}</span>`).join('')}</div></div></div>`:''}
-          ${contentTypeNames.length?`<div class="cp-info-row"><div class="cp-info-key">コンテンツ種類</div><div class="cp-info-val"><div class="cp-chips">${contentTypeNames.map(n=>`<span class="cp-chip cp-chip-sm">${esc(n)}</span>`).join('')}</div></div></div>`:''}
-          <div class="cp-info-row"><div class="cp-info-key">募集期間</div><div class="cp-info-val">${fmt(camp.recruit_start || new Date())} 〜 ${fmt(camp.deadline)}</div></div>
-          ${camp.slots?`<div class="cp-info-row"><div class="cp-info-key">募集人数</div><div class="cp-info-val">${camp.slots}名</div></div>`:''}
-          ${camp.min_followers?`<div class="cp-info-row"><div class="cp-info-key">最小フォロワー</div><div class="cp-info-val">${camp.min_followers.toLocaleString()}</div></div>`:''}
-          <div class="cp-info-row"><div class="cp-info-key">当選発表</div><div class="cp-info-val">${esc(camp.winner_announce||'選考後、LINEにてご連絡')}</div></div>
-          ${(camp.recruit_type==='monitor'&&(camp.purchase_start||camp.purchase_end))?`<div class="cp-info-row"><div class="cp-info-key">購入期間</div><div class="cp-info-val">${fmt(camp.purchase_start)} 〜 ${fmt(camp.purchase_end)}</div></div>`:''}
-          ${(camp.recruit_type==='visit'&&(camp.visit_start||camp.visit_end))?`<div class="cp-info-row"><div class="cp-info-key">訪問期間</div><div class="cp-info-val">${fmt(camp.visit_start)} 〜 ${fmt(camp.visit_end)}</div></div>`:''}
-          ${camp.submission_end?`<div class="cp-info-row"><div class="cp-info-key">提出締切</div><div class="cp-info-val" style="font-weight:600">${fmt(camp.submission_end)}</div></div>`:''}
-          ${(rewardText||camp.reward_note)?`<div class="cp-info-row"><div class="cp-info-key">報酬</div><div class="cp-info-val cp-info-val-pink">${rewardText?esc(rewardText):''}${camp.reward_note?`<div style="margin-top:${rewardText?'6px':'0'};font-size:11px;color:var(--muted);font-weight:400;line-height:1.6;white-space:pre-wrap">${esc(camp.reward_note)}</div>`:''}</div></div>`:''}
+          ${(()=>{
+            // 시간 흐름 순: 製品名 → 募集タイプ → チャンネル → コンテンツ → 募集期間 → 購入/訪問 → 提出締切 → 募集人数
+            //              → (monitor 외) 当選発表 → (monitor 외) 報酬
+            const rows = [];
+            rows.push(`<div class="cp-info-row"><div class="cp-info-key">製品名</div><div class="cp-info-val">${esc(camp.product||'—')}</div></div>`);
+            rows.push(`<div class="cp-info-row"><div class="cp-info-key">募集タイプ</div><div class="cp-info-val">${rtBadge?`<span class="cp-rt-badge" style="background:${rtBadge.bg};color:${rtBadge.color}">${rtBadge.label}</span>`:'—'}</div></div>`);
+            if (channelNames.length) rows.push(`<div class="cp-info-row"><div class="cp-info-key">チャンネル</div><div class="cp-info-val"><div class="cp-chips">${channelNames.map((n,i)=>(i>0?`<span class="cp-chip-sep">${chSep}</span>`:'')+`<span class="cp-chip">${esc(n)}</span>`).join('')}</div></div></div>`);
+            if (contentTypeNames.length) rows.push(`<div class="cp-info-row"><div class="cp-info-key">コンテンツ種類</div><div class="cp-info-val"><div class="cp-chips">${contentTypeNames.map(n=>`<span class="cp-chip cp-chip-sm">${esc(n)}</span>`).join('')}</div></div></div>`);
+            rows.push(`<div class="cp-info-row"><div class="cp-info-key">募集期間</div><div class="cp-info-val">${fmt(camp.recruit_start || new Date())} 〜 ${fmt(camp.deadline)}</div></div>`);
+            if (isMonitorPreview && (camp.purchase_start || camp.purchase_end)) rows.push(`<div class="cp-info-row"><div class="cp-info-key">購入期間</div><div class="cp-info-val">${fmt(camp.purchase_start)} 〜 ${fmt(camp.purchase_end)}</div></div>`);
+            if (camp.recruit_type === 'visit' && (camp.visit_start || camp.visit_end)) rows.push(`<div class="cp-info-row"><div class="cp-info-key">訪問期間</div><div class="cp-info-val">${fmt(camp.visit_start)} 〜 ${fmt(camp.visit_end)}</div></div>`);
+            if (camp.submission_end) rows.push(`<div class="cp-info-row"><div class="cp-info-key">提出締切</div><div class="cp-info-val" style="font-weight:600">${fmt(camp.submission_end)}</div></div>`);
+            if (camp.slots) rows.push(`<div class="cp-info-row"><div class="cp-info-key">募集人数</div><div class="cp-info-val">${camp.slots}名</div></div>`);
+            if (camp.min_followers) rows.push(`<div class="cp-info-row"><div class="cp-info-key">最小フォロワー</div><div class="cp-info-val">${camp.min_followers.toLocaleString()}</div></div>`);
+            // 리뷰어(monitor) 캠페인은 当選発表·報酬 행 제외
+            if (!isMonitorPreview) {
+              rows.push(`<div class="cp-info-row"><div class="cp-info-key">当選発表</div><div class="cp-info-val">${esc(camp.winner_announce||'選考後、LINEにてご連絡')}</div></div>`);
+              if (rewardText || camp.reward_note) rows.push(`<div class="cp-info-row"><div class="cp-info-key">報酬</div><div class="cp-info-val cp-info-val-pink">${rewardText?esc(rewardText):''}${camp.reward_note?`<div style="margin-top:${rewardText?'6px':'0'};font-size:11px;color:var(--muted);font-weight:400;line-height:1.6;white-space:pre-wrap">${esc(camp.reward_note)}</div>`:''}</div></div>`);
+            }
+            return rows.join('');
+          })()}
         </div>
         <div class="cp-participation">
           <div class="cp-section-heading">参加方法</div>
@@ -2405,7 +2417,7 @@ function renderCampPreview(mode) {
         })() : ''}
       </div>
       <div class="cp-cta">
-        <div class="cp-cta-name">${esc(camp.title||'—')}<small>${camp.product_price>0?`¥${camp.product_price.toLocaleString()} 円相当の製品を無償提供`:''}</small></div>
+        <div class="cp-cta-name">${esc(camp.title||'—')}<small>${camp.product_price>0?`¥${camp.product_price.toLocaleString()} ${rewardLabelJa}`:''}</small></div>
         <div class="cp-cta-btn">応募</div>
       </div>
     </div>`;

--- a/dev/js/application.js
+++ b/dev/js/application.js
@@ -323,10 +323,11 @@ function renderApplyCaution(camp) {
 
 async function submitApplication() {
   if (!currentUser) { toast(t('apply.needLogin'),'error'); return; }
-  // 배송지 이름 누락 차단 — 한자명/일반 이름 둘 다 비어 있으면 신청 자체 불가
+  // 배송지 이름 누락 차단 — 한자명·가나명 둘 다 필수.
   // 관리자 화면에서 신청자 이름이 「-」로 표시되던 케이스 방지 (마이페이지에서 등록 후 재시도)
-  const profileName = ((currentUserProfile?.name_kanji || currentUserProfile?.name) || '').trim();
-  if (!profileName || profileName === '-') {
+  const nameKanji = (currentUserProfile?.name_kanji || currentUserProfile?.name || '').trim();
+  const nameKana = (currentUserProfile?.name_kana || '').trim();
+  if (!nameKanji || nameKanji === '-' || !nameKana || nameKana === '-') {
     toast(t('apply.needName'),'error');
     return;
   }

--- a/dev/js/application.js
+++ b/dev/js/application.js
@@ -76,69 +76,49 @@ async function openCampaign(id) {
           <div style="font-size:11px;color:var(--pink);font-weight:700;letter-spacing:.06em;margin-bottom:5px">${esc(camp.brand)}</div>
           ${camp.recruit_type ? `<div style="font-size:10px;font-weight:700;color:var(--pink);margin-bottom:4px">${esc(getRecruitTypeLabelJa(camp.recruit_type))}</div>` : ''}
           <div style="font-size:18px;font-weight:800;color:var(--ink);line-height:1.3;margin-bottom:10px">${esc(camp.title)}</div>
-          ${camp.product_price>0?`<div style="display:inline-flex;align-items:center;gap:6px;background:var(--light-pink);border-radius:8px;padding:6px 12px;margin-bottom:4px"><span style="font-size:17px;font-weight:900;color:var(--pink)">¥${camp.product_price.toLocaleString()}</span><span style="font-size:12px;color:var(--dark-pink);font-weight:600">${t('detail.rewardProduct')}</span></div>`:''}
+          ${camp.product_price>0?`<div style="display:inline-flex;align-items:center;gap:6px;background:var(--light-pink);border-radius:8px;padding:6px 12px;margin-bottom:4px"><span style="font-size:17px;font-weight:900;color:var(--pink)">¥${camp.product_price.toLocaleString()}</span><span style="font-size:12px;color:var(--dark-pink);font-weight:600">${camp.recruit_type === 'monitor' ? t('detail.rewardPayback') : t('detail.rewardProduct')}</span></div>`:''}
           ${camp.reward>0?`<div style="font-size:12px;color:var(--green);font-weight:600;margin-top:4px">${t('detail.rewardCash').replace('{amount}',camp.reward.toLocaleString())}</div>`:''}
         </div>
-        <div style="font-size:13px">
-          <div style="display:flex;border-top:1px solid #faf5f9">
-            <div style="width:90px;padding:10px 14px;color:var(--dark-pink);font-weight:600;font-size:11px;background:#fdf5fb;flex-shrink:0">${t('detail.productName')}</div>
-            <div style="padding:10px 13px;flex:1;font-size:12px">${esc(camp.product)||'—'}</div>
-          </div>
-          <div style="display:flex;border-top:1px solid #faf5f9">
-            <div style="width:90px;padding:10px 14px;color:var(--dark-pink);font-weight:600;font-size:11px;background:#fdf5fb;flex-shrink:0">${t('detail.recruitType')}</div>
-            <div style="padding:10px 13px;flex:1;font-size:12px">
-              ${(()=>{const t=camp.recruit_type;const map={monitor:['var(--blue-l)','var(--blue)','レビュアー'],gifting:['var(--gold-l)','var(--gold)','ギフティング'],visit:['#E8F7EF','#0E7E4A','訪問']};const m=map[t];return m?`<span style="background:${m[0]};color:${m[1]};font-size:11px;font-weight:700;padding:2px 8px;border-radius:20px">${m[2]}</span>`:'—'})()}
-            </div>
-          </div>
-          <div style="display:flex;border-top:1px solid #faf5f9">
-            <div style="width:90px;padding:10px 14px;color:var(--dark-pink);font-weight:600;font-size:11px;background:#fdf5fb;flex-shrink:0">${t('detail.channel')}</div>
-            <div style="padding:10px 13px;flex:1;font-size:12px;display:flex;gap:6px;flex-wrap:wrap;align-items:center">
-              ${(()=>{const sep = camp.channel_match === 'and' ? '&' : 'or'; return (camp.channel||'').split(',').map(s=>s.trim()).filter(Boolean).map(code=>`<span style="background:var(--light-pink);color:var(--dark-pink);font-size:11px;font-weight:600;padding:2px 10px;border-radius:20px">${esc(getChannelLabel(code))}</span>`).join(`<span style="color:var(--muted);font-size:11px;font-weight:600">${sep}</span>`);})()}
-            </div>
-          </div>
-          ${camp.content_types?`
-          <div style="display:flex;border-top:1px solid #faf5f9">
-            <div style="width:90px;padding:10px 14px;color:var(--dark-pink);font-weight:600;font-size:11px;background:#fdf5fb;flex-shrink:0">${t('detail.contentType')}</div>
-            <div style="padding:10px 13px;flex:1;font-size:12px;display:flex;gap:4px;flex-wrap:wrap">
-              ${camp.content_types.split(',').map(t=>`<span style="background:var(--light-pink);color:var(--dark-pink);font-size:10px;font-weight:600;padding:2px 8px;border-radius:20px">${esc(getLookupLabel('content_type', t.trim()))}</span>`).join('')}
-            </div>
-          </div>`:''}
-          <div style="display:flex;border-top:1px solid #faf5f9">
-            <div style="width:90px;padding:10px 14px;color:var(--dark-pink);font-weight:600;font-size:11px;background:#fdf5fb;flex-shrink:0">${t('detail.recruitPeriod')}</div>
-            <div style="padding:10px 13px;flex:1;font-size:12px">${formatDate(camp.recruit_start || new Date())} 〜 ${formatDate(camp.deadline)}</div>
-          </div>
-          <div style="display:flex;border-top:1px solid #faf5f9">
-            <div style="width:90px;padding:10px 14px;color:var(--dark-pink);font-weight:600;font-size:11px;background:#fdf5fb;flex-shrink:0">${t('detail.recruitSlots')}</div>
-            <div style="padding:10px 13px;flex:1;font-size:12px">${camp.slots}${t('detail.peopleUnit')}</div>
-          </div>
-          <div style="display:flex;border-top:1px solid #faf5f9">
-            <div style="width:90px;padding:10px 14px;color:var(--dark-pink);font-weight:600;font-size:11px;background:#fdf5fb;flex-shrink:0">${t('detail.winnerAnnounce')}</div>
-            <div style="padding:10px 13px;flex:1;font-size:12px">${esc(camp.winner_announce || t('detail.winnerAnnounceValue'))}</div>
-          </div>
-          ${(camp.recruit_type==='monitor' && (camp.purchase_start||camp.purchase_end))?`
-          <div style="display:flex;border-top:1px solid #faf5f9">
-            <div style="width:90px;padding:10px 14px;color:var(--dark-pink);font-weight:600;font-size:11px;background:#fdf5fb;flex-shrink:0">${t('detail.purchasePeriod')}</div>
-            <div style="padding:10px 13px;flex:1;font-size:12px">${camp.purchase_start?formatDate(camp.purchase_start):'—'} 〜 ${camp.purchase_end?formatDate(camp.purchase_end):'—'}</div>
-          </div>`:''}
-          ${(camp.recruit_type==='visit' && (camp.visit_start||camp.visit_end))?`
-          <div style="display:flex;border-top:1px solid #faf5f9">
-            <div style="width:90px;padding:10px 14px;color:var(--dark-pink);font-weight:600;font-size:11px;background:#fdf5fb;flex-shrink:0">${t('detail.visitPeriod')}</div>
-            <div style="padding:10px 13px;flex:1;font-size:12px">${camp.visit_start?formatDate(camp.visit_start):'—'} 〜 ${camp.visit_end?formatDate(camp.visit_end):'—'}</div>
-          </div>`:''}
-          ${camp.submission_end?`
-          <div style="display:flex;border-top:1px solid #faf5f9">
-            <div style="width:90px;padding:10px 14px;color:var(--dark-pink);font-weight:600;font-size:11px;background:#fdf5fb;flex-shrink:0">${t('detail.submissionEnd')}</div>
-            <div style="padding:10px 13px;flex:1;font-size:12px;font-weight:600;color:var(--ink)">${formatDate(camp.submission_end)}</div>
-          </div>`:''}
-          ${(camp.product_price>0||camp.reward>0||camp.reward_note)?`
-          <div style="display:flex;border-top:1px solid #faf5f9">
-            <div style="width:90px;padding:10px 14px;color:var(--dark-pink);font-weight:600;font-size:11px;background:#fdf5fb;flex-shrink:0">${t('detail.reward')}</div>
-            <div style="padding:10px 13px;flex:1;font-size:12px;color:var(--pink);font-weight:600">
-              ${(camp.product_price>0||camp.reward>0)?`${camp.product_price>0?t('detail.rewardProductAmount').replace('{price}',camp.product_price.toLocaleString()):t('detail.rewardProductFree')}${camp.reward>0?` + ${t('detail.rewardCashAmount').replace('{amount}',camp.reward.toLocaleString())}`:''}`:''}
-              ${camp.reward_note?`<div style="margin-top:${(camp.product_price>0||camp.reward>0)?'6px':'0'};font-size:11px;color:var(--muted);font-weight:400;line-height:1.6;white-space:pre-wrap">${esc(camp.reward_note)}</div>`:''}
-            </div>
-          </div>`:''}
-        </div>
+        ${(()=>{
+          // 캠페인 상세 표 — 시간 흐름 순으로 행 배치
+          // 순서: 상품명 → 모집타입 → 채널 → 콘텐츠 → 모집기간 → 구매/방문기간 → 결과물 제출 마감 → 모집인원
+          //       → (monitor 외) 당선 발표 → (monitor 외) 리워드
+          const isMonitor = camp.recruit_type === 'monitor';
+          const KEY = 'width:90px;padding:10px 14px;color:var(--dark-pink);font-weight:600;font-size:11px;background:#fdf5fb;flex-shrink:0';
+          const VAL = 'padding:10px 13px;flex:1;font-size:12px';
+          const ROW = 'display:flex;border-top:1px solid #faf5f9';
+          const rows = [];
+          rows.push(`<div style="${ROW}"><div style="${KEY}">${t('detail.productName')}</div><div style="${VAL}">${esc(camp.product)||'—'}</div></div>`);
+          rows.push(`<div style="${ROW}"><div style="${KEY}">${t('detail.recruitType')}</div><div style="${VAL}">${(()=>{const t=camp.recruit_type;const map={monitor:['var(--blue-l)','var(--blue)','レビュアー'],gifting:['var(--gold-l)','var(--gold)','ギフティング'],visit:['#E8F7EF','#0E7E4A','訪問']};const m=map[t];return m?`<span style="background:${m[0]};color:${m[1]};font-size:11px;font-weight:700;padding:2px 8px;border-radius:20px">${m[2]}</span>`:'—'})()}</div></div>`);
+          rows.push(`<div style="${ROW}"><div style="${KEY}">${t('detail.channel')}</div><div style="${VAL};display:flex;gap:6px;flex-wrap:wrap;align-items:center">${(()=>{const sep = camp.channel_match === 'and' ? '&' : 'or'; return (camp.channel||'').split(',').map(s=>s.trim()).filter(Boolean).map(code=>`<span style="background:var(--light-pink);color:var(--dark-pink);font-size:11px;font-weight:600;padding:2px 10px;border-radius:20px">${esc(getChannelLabel(code))}</span>`).join(`<span style="color:var(--muted);font-size:11px;font-weight:600">${sep}</span>`);})()}</div></div>`);
+          if (camp.content_types) {
+            const ctList = camp.content_types.split(',').map(c => c.trim()).filter(Boolean);
+            if (ctList.length) {
+              rows.push(`<div style="${ROW}"><div style="${KEY}">${t('detail.contentType')}</div><div style="${VAL};display:flex;gap:4px;flex-wrap:wrap">${ctList.map(c=>`<span style="background:var(--light-pink);color:var(--dark-pink);font-size:10px;font-weight:600;padding:2px 8px;border-radius:20px">${esc(getLookupLabel('content_type', c))}</span>`).join('')}</div></div>`);
+            }
+          }
+          rows.push(`<div style="${ROW}"><div style="${KEY}">${t('detail.recruitPeriod')}</div><div style="${VAL}">${formatDate(camp.recruit_start || new Date())} 〜 ${formatDate(camp.deadline)}</div></div>`);
+          if (isMonitor && (camp.purchase_start || camp.purchase_end)) {
+            rows.push(`<div style="${ROW}"><div style="${KEY}">${t('detail.purchasePeriod')}</div><div style="${VAL}">${camp.purchase_start?formatDate(camp.purchase_start):'—'} 〜 ${camp.purchase_end?formatDate(camp.purchase_end):'—'}</div></div>`);
+          }
+          if (camp.recruit_type === 'visit' && (camp.visit_start || camp.visit_end)) {
+            rows.push(`<div style="${ROW}"><div style="${KEY}">${t('detail.visitPeriod')}</div><div style="${VAL}">${camp.visit_start?formatDate(camp.visit_start):'—'} 〜 ${camp.visit_end?formatDate(camp.visit_end):'—'}</div></div>`);
+          }
+          if (camp.submission_end) {
+            rows.push(`<div style="${ROW}"><div style="${KEY}">${t('detail.submissionEnd')}</div><div style="${VAL};font-weight:600;color:var(--ink)">${formatDate(camp.submission_end)}</div></div>`);
+          }
+          rows.push(`<div style="${ROW}"><div style="${KEY}">${t('detail.recruitSlots')}</div><div style="${VAL}">${camp.slots}${t('detail.peopleUnit')}</div></div>`);
+          // 리뷰어(monitor) 캠페인은 당선 발표·리워드 행 제외
+          if (!isMonitor) {
+            rows.push(`<div style="${ROW}"><div style="${KEY}">${t('detail.winnerAnnounce')}</div><div style="${VAL}">${esc(camp.winner_announce || t('detail.winnerAnnounceValue'))}</div></div>`);
+            if (camp.product_price>0 || camp.reward>0 || camp.reward_note) {
+              const rewardLine = (camp.product_price>0 || camp.reward>0) ? `${camp.product_price>0?t('detail.rewardProductAmount').replace('{price}',camp.product_price.toLocaleString()):t('detail.rewardProductFree')}${camp.reward>0?` + ${t('detail.rewardCashAmount').replace('{amount}',camp.reward.toLocaleString())}`:''}` : '';
+              const noteLine = camp.reward_note ? `<div style="margin-top:${rewardLine?'6px':'0'};font-size:11px;color:var(--muted);font-weight:400;line-height:1.6;white-space:pre-wrap">${esc(camp.reward_note)}</div>` : '';
+              rows.push(`<div style="${ROW}"><div style="${KEY}">${t('detail.reward')}</div><div style="${VAL};color:var(--pink);font-weight:600">${rewardLine}${noteLine}</div></div>`);
+            }
+          }
+          return `<div style="font-size:13px">${rows.join('')}</div>`;
+        })()}
       </div>
 
       ${(() => {
@@ -181,7 +161,7 @@ async function openCampaign(id) {
       ${(camp.hashtags||camp.mentions||camp.appeal) ? `
       <div style="background:#fff;padding:16px;margin-bottom:10px;border-bottom:8px solid var(--bg)">
         <div style="font-size:14px;font-weight:700;margin-bottom:12px;color:var(--ink)">${t('detail.postGuideline')}</div>
-        ${camp.appeal ? `<div style="margin-bottom:12px"><div style="font-size:11px;font-weight:700;color:var(--pink);margin-bottom:5px;text-transform:uppercase;letter-spacing:.05em">${t('detail.brandAppeal')}</div><div class="rich-content" style="font-size:12px;color:var(--ink);line-height:1.7;background:var(--bg);padding:10px 12px;border-radius:8px">${richHtml(camp.appeal)}</div></div>` : ''}
+        ${camp.appeal ? `<div style="margin-bottom:12px"><div style="font-size:11px;font-weight:700;color:var(--pink);margin-bottom:5px;text-transform:uppercase;letter-spacing:.05em">${t('detail.brandAppeal')}</div><div class="rich-content" style="font-size:12px;color:var(--ink);line-height:1.7;background:#fff5ff;padding:10px 12px;border-radius:8px;border:1px solid #f0d8e8">${richHtml(camp.appeal)}</div></div>` : ''}
         ${camp.hashtags ? `<div style="margin-bottom:10px"><div style="font-size:11px;font-weight:700;color:var(--pink);margin-bottom:5px;text-transform:uppercase;letter-spacing:.05em">${t('detail.requiredHashtag')}</div><div style="display:flex;flex-wrap:wrap;gap:5px">${camp.hashtags.split(',').map(t=>`<span style="background:var(--light-pink);color:var(--dark-pink);font-size:12px;font-weight:600;padding:3px 10px;border-radius:20px">${esc(t.trim())}</span>`).join('')}</div></div>` : ''}
         ${camp.mentions ? `<div><div style="font-size:11px;font-weight:700;color:var(--pink);margin-bottom:5px;text-transform:uppercase;letter-spacing:.05em">${t('detail.requiredMention')}</div><div style="display:flex;flex-wrap:wrap;gap:5px">${camp.mentions.split(',').map(t=>`<span style="background:#f0f0ff;color:#4040cc;font-size:12px;font-weight:600;padding:3px 10px;border-radius:20px">${esc(t.trim())}</span>`).join('')}</div></div>` : ''}
       </div>` : ''}
@@ -189,7 +169,7 @@ async function openCampaign(id) {
       ${camp.guide ? `
       <div style="background:#fff;padding:16px;margin-bottom:10px;border-bottom:8px solid var(--bg)">
         <div style="font-size:14px;font-weight:700;margin-bottom:10px;color:var(--ink)">${t('detail.shootingGuide')}</div>
-        <div class="rich-content" style="font-size:12px;color:var(--ink);line-height:1.7;background:var(--bg);padding:12px;border-radius:8px">${richHtml(camp.guide)}</div>
+        <div class="rich-content" style="font-size:12px;color:var(--ink);line-height:1.7;background:#fdf5fd;padding:12px;border-radius:8px;border:1px solid #e8d4e8">${richHtml(camp.guide)}</div>
       </div>` : ''}
 
       ${camp.ng ? `

--- a/dev/js/application.js
+++ b/dev/js/application.js
@@ -323,6 +323,13 @@ function renderApplyCaution(camp) {
 
 async function submitApplication() {
   if (!currentUser) { toast(t('apply.needLogin'),'error'); return; }
+  // 배송지 이름 누락 차단 — 한자명/일반 이름 둘 다 비어 있으면 신청 자체 불가
+  // 관리자 화면에서 신청자 이름이 「-」로 표시되던 케이스 방지 (마이페이지에서 등록 후 재시도)
+  const profileName = ((currentUserProfile?.name_kanji || currentUserProfile?.name) || '').trim();
+  if (!profileName || profileName === '-') {
+    toast(t('apply.needName'),'error');
+    return;
+  }
   const msg = $('applyMessage').value.trim();
   const addr = $('applyAddress').value.trim();
   const prCheck = $('applyPrCheck').checked;

--- a/dev/js/campaign.js
+++ b/dev/js/campaign.js
@@ -80,7 +80,9 @@ let campPageStatusFilter = 'all';   // all | active | scheduled | closed
 let campPageSearch = '';
 
 async function loadCampaignsPage() {
-  if (!allCampaigns || allCampaigns.length === 0) await loadCampaigns();
+  // 진입할 때마다 캠페인 데이터 새로고침 — 캐시(allCampaigns)에 의존하지 않음.
+  // 사용자가 로고 클릭/화면 전환 시 새 데이터를 보고 싶다고 해서 도입.
+  await loadCampaigns();
   campPageTypeFilter = 'all';
   campPageStatusFilter = 'all';
   campPageSearch = '';

--- a/dev/js/campaign.js
+++ b/dev/js/campaign.js
@@ -38,6 +38,25 @@ function visibleCamps(camps) {
   });
 }
 
+// 인플루언서 노출 캠페인의 정렬: 모집중(active) > 모집예정(scheduled) > 모집완료(closed)
+// 같은 상태 안에서는 모집기간 시작~종료일 최신순.
+//   1차: recruit_start (모집 시작일) 최신순 — "가장 최근에 시작한 캠페인"이 위로
+//   2차: deadline (모집 종료일) 최신순 — recruit_start가 없을 때 fallback
+//   3차: created_at 최신순 — 둘 다 없을 때 fallback
+function sortByStatusAndDeadline(camps) {
+  const order = {active: 0, scheduled: 1, closed: 2};
+  const ts = (c) => new Date(c.recruit_start || c.deadline || c.created_at || 0).getTime();
+  return camps.slice().sort((a, b) => {
+    const sa = order[a.status] ?? 99;
+    const sb = order[b.status] ?? 99;
+    if (sa !== sb) return sa - sb;
+    return ts(b) - ts(a);  // 최신순(내림차순)
+  });
+}
+
+// 홈 화면에 노출할 카드 수 — 초과분은 「더보기」 버튼으로 캠페인 페이지로 이동
+const HOME_CAMP_LIMIT = 10;
+
 function updateStats(camps) {
   const visible = visibleCamps(camps);
   $('statCampaigns').textContent = visible.length;
@@ -56,9 +75,16 @@ function buildChannelFilters(camps) {
     channels.map(ch => `<button class="chip" onclick="filterCamps('${ch}',this)">${esc(getChannelLabel(ch))}</button>`).join('');
 }
 
+// 캠페인 페이지 — 모집 유형 + 상태 + 검색 필터
+let campPageStatusFilter = 'all';   // all | active | scheduled | closed
+let campPageSearch = '';
+
 async function loadCampaignsPage() {
   if (!allCampaigns || allCampaigns.length === 0) await loadCampaigns();
   campPageTypeFilter = 'all';
+  campPageStatusFilter = 'all';
+  campPageSearch = '';
+  const searchEl = $('campPageSearch'); if (searchEl) searchEl.value = '';
   ['all','monitor','gifting','visit'].forEach(t => {
     const btn = $('campPageType-'+t);
     if (!btn) return;
@@ -66,6 +92,9 @@ async function loadCampaignsPage() {
     btn.style.borderBottomColor = t==='all'?'var(--pink)':'transparent';
     btn.style.fontWeight = t==='all'?'700':'600';
   });
+  // 상태 필터 칩 초기화
+  document.querySelectorAll('[id^="campPageStatus-"]').forEach(c => c.classList.remove('on'));
+  const allChip = $('campPageStatus-all'); if (allChip) allChip.classList.add('on');
   renderCampaignGrid();
 }
 
@@ -78,15 +107,33 @@ function setCampPageType(type, el) {
   renderCampaignGrid();
 }
 
+// 상태 칩 (전체 / 모집중 / 모집예정 / 모집완료)
+function setCampPageStatus(status, el) {
+  campPageStatusFilter = status;
+  document.querySelectorAll('[id^="campPageStatus-"]').forEach(c => c.classList.remove('on'));
+  if (el) el.classList.add('on');
+  renderCampaignGrid();
+}
+
+// 검색 입력
+function onCampPageSearchInput(value) {
+  campPageSearch = (value || '').trim().toLowerCase();
+  renderCampaignGrid();
+}
+
 function renderCampaignGrid() {
   const grid = $('campListGrid');
   if (!grid) return;
   let camps = visibleCamps(allCampaigns);
   if (campPageTypeFilter !== 'all') camps = camps.filter(c => c.recruit_type === campPageTypeFilter);
-  camps = camps.sort((a,b) => {
-    if (a.order_index != null && b.order_index != null) return a.order_index - b.order_index;
-    return new Date(b.created_at) - new Date(a.created_at);
-  });
+  if (campPageStatusFilter !== 'all') camps = camps.filter(c => c.status === campPageStatusFilter);
+  if (campPageSearch) {
+    camps = camps.filter(c => {
+      const haystack = ((c.title||'') + ' ' + (c.brand||'') + ' ' + (c.brand_ko||'') + ' ' + (c.product||'') + ' ' + (c.product_ko||'') + ' ' + (c.campaign_no||'')).toLowerCase();
+      return haystack.includes(campPageSearch);
+    });
+  }
+  camps = sortByStatusAndDeadline(camps);
   if (!camps.length) {
     grid.innerHTML = `<div class="empty-state" style="grid-column:1/-1"><div class="empty-icon"><span class="material-icons-round notranslate" translate="no" style="font-size:48px;color:var(--muted)">assignment</span></div><div class="empty-text">${t('campaign.emptyState')}</div><div class="empty-sub">${t('campaign.emptyStateSub')}</div></div>`;
     return;
@@ -109,15 +156,13 @@ function filterCamps(filter, el) {
 
 function applyHomeFilter() {
   let camps = visibleCamps(allCampaigns);
-  camps = camps.sort((a,b) => {
-    if (a.order_index != null && b.order_index != null) return a.order_index - b.order_index;
-    return new Date(b.created_at) - new Date(a.created_at);
-  });
   if (currentTypeFilter !== 'all') camps = camps.filter(c=>c.recruit_type===currentTypeFilter);
   if (currentFilter !== 'all') camps = camps.filter(c=>{
     const chs = (c.channel||'').split(',').map(s=>s.trim());
     return chs.includes(currentFilter) || c.category===currentFilter;
   });
+  // 정렬: 모집중 > 모집예정 > 모집완료, 같은 상태 안에서는 모집기간 종료일 최신순
+  camps = sortByStatusAndDeadline(camps);
   renderCampaigns(camps);
 }
 
@@ -184,13 +229,17 @@ function buildCampCards(camps) {
 function renderCampaigns(camps) {
   const grid = $('campGrid');
   if (!grid) return;
-  const visible = visibleCamps(camps).sort((a,b)=>{
-    if (a.order_index!=null&&b.order_index!=null) return a.order_index-b.order_index;
-    return new Date(b.created_at)-new Date(a.created_at);
-  });
+  // 호출처에서 이미 visibleCamps + sortByStatusAndDeadline 한 결과를 넘기지만,
+  // applyHomeFilter 외 경로(예: 초기 home 진입)에서도 안전하도록 한 번 더 정렬한다
+  const visible = sortByStatusAndDeadline(visibleCamps(camps));
+  const moreBtnWrap = $('campMoreBtnWrap');
   if (!visible.length) {
     grid.innerHTML = `<div class="empty-state" style="grid-column:1/-1"><div class="empty-icon"><span class="material-icons-round notranslate" translate="no" style="font-size:48px;color:var(--muted)">assignment</span></div><div class="empty-text">${t('campaign.emptyState')}</div><div class="empty-sub">${t('campaign.emptyStateSub')}</div></div>`;
+    if (moreBtnWrap) moreBtnWrap.style.display = 'none';
     return;
   }
-  grid.innerHTML = buildCampCards(visible);
+  // 홈 화면은 최대 HOME_CAMP_LIMIT(10건)만 노출 — 초과분은 「더보기」 버튼으로 캠페인 페이지 이동
+  const sliced = visible.slice(0, HOME_CAMP_LIMIT);
+  grid.innerHTML = buildCampCards(sliced);
+  if (moreBtnWrap) moreBtnWrap.style.display = visible.length > HOME_CAMP_LIMIT ? '' : 'none';
 }

--- a/dev/js/mypage.js
+++ b/dev/js/mypage.js
@@ -88,7 +88,8 @@ async function loadMyApplications() {
     const {data} = await db.from('applications').select('*').eq('user_id', currentUser.id).order('created_at', {ascending:false});
     _myApps = data || [];
   }
-  if (!allCampaigns || !allCampaigns.length) allCampaigns = await fetchCampaigns();
+  // 캠페인 데이터도 진입 시마다 새로고침 — 응모이력 행에 노출되는 캠페인 상태/제목 stale 방지
+  allCampaigns = await fetchCampaigns();
   renderMyApplyTabs();
   renderMyApplyList();
 }

--- a/dev/lib/i18n/ja.js
+++ b/dev/lib/i18n/ja.js
@@ -309,7 +309,7 @@ window.I18N_JA = {
     prAgreeFull: '投稿時に<strong>#PR</strong>または<strong>#広告</strong>タグを必ず表記します（ステルスマーケティング規制準拠）',
     submitNow: '今すぐ応募する →',
     needLogin: 'ログインが必要です',
-    needName: '配送のため、お名前(漢字)の登録が必要です。マイページで基本情報を入力してから再度ご応募ください。',
+    needName: '配送のため、お名前(漢字とカナ)の登録が必要です。マイページで基本情報を入力してから再度ご応募ください。',
     needReason: '応募理由を入力してください',
     needAddress: '配送先住所を入力してください',
     needPrAgree: '#PRタグの表記に同意が必要です',

--- a/dev/lib/i18n/ja.js
+++ b/dev/lib/i18n/ja.js
@@ -64,6 +64,11 @@ window.I18N_JA = {
     typeMonitor: 'レビュアー',
     typeGifting: 'ギフティング',
     typeVisit: '訪問',
+    statusAll: 'すべて',
+    statusActive: '募集中',
+    statusScheduled: '近日公開',
+    statusClosed: '募集締切',
+    searchPlaceholder: 'キャンペーン名・ブランド検索',
   },
 
   // 캠페인 상태
@@ -304,6 +309,7 @@ window.I18N_JA = {
     prAgreeFull: '投稿時に<strong>#PR</strong>または<strong>#広告</strong>タグを必ず表記します（ステルスマーケティング規制準拠）',
     submitNow: '今すぐ応募する →',
     needLogin: 'ログインが必要です',
+    needName: '配送のため、お名前(漢字)の登録が必要です。マイページで基本情報を入力してから再度ご応募ください。',
     needReason: '応募理由を入力してください',
     needAddress: '配送先住所を入力してください',
     needPrAgree: '#PRタグの表記に同意が必要です',
@@ -400,6 +406,7 @@ window.I18N_JA = {
     rewardFreeStrong: '<strong>製品無償提供</strong>',
     rewardFreeSimple: '<strong>無償提供</strong>',
     channelAll: 'すべて',
+    moreBtn: 'もっと見る',
   },
 
   // 프로필 라벨

--- a/dev/lib/i18n/ja.js
+++ b/dev/lib/i18n/ja.js
@@ -241,6 +241,7 @@ window.I18N_JA = {
     appliedBtn: '応募済み',
     manageBtn: '活動管理',
     rewardProduct: '円相当の製品を無償提供',
+    rewardPayback: '円ペイバック',
     rewardCash: '+ 現金報酬 ¥{amount}',
     rewardFree: '製品全額無償提供',
     rewardProductAmount: '製品 ¥{price}円相当',

--- a/dev/lib/i18n/ko.js
+++ b/dev/lib/i18n/ko.js
@@ -228,6 +228,7 @@ window.I18N_KO = {
     appliedBtn: '응모 완료',
     manageBtn: '활동 관리',
     rewardProduct: '원 상당 제품 무상 제공',
+    rewardPayback: '원 페이백',
     rewardCash: '+ 현금 리워드 ¥{amount}',
     rewardFree: '제품 전액 무상 제공',
     rewardProductAmount: '제품 ¥{price}원 상당',

--- a/dev/lib/i18n/ko.js
+++ b/dev/lib/i18n/ko.js
@@ -295,7 +295,7 @@ window.I18N_KO = {
     prAgreeFull: '게시 시 <strong>#PR</strong> 또는 <strong>#広告</strong> 태그를 반드시 표기합니다 (스텔스 마케팅 규제 준수)',
     submitNow: '지금 응모하기 →',
     needLogin: '로그인이 필요합니다',
-    needName: '배송을 위해 이름(한자) 등록이 필요합니다. 마이페이지 기본 정보를 먼저 입력한 뒤 다시 응모해주세요.',
+    needName: '배송을 위해 이름(한자·가나) 등록이 필요합니다. 마이페이지 기본 정보를 먼저 입력한 뒤 다시 응모해주세요.',
     needReason: '응모 사유를 입력해주세요',
     needAddress: '배송지 주소를 입력해주세요',
     needPrAgree: '#PR 태그 표기에 동의가 필요합니다',

--- a/dev/lib/i18n/ko.js
+++ b/dev/lib/i18n/ko.js
@@ -61,6 +61,11 @@ window.I18N_KO = {
     typeMonitor: 'Reviewer',
     typeGifting: '기프팅',
     typeVisit: '방문형',
+    statusAll: '전체',
+    statusActive: '모집중',
+    statusScheduled: '모집예정',
+    statusClosed: '모집완료',
+    searchPlaceholder: '캠페인명·브랜드 검색',
   },
 
   status: {
@@ -290,6 +295,7 @@ window.I18N_KO = {
     prAgreeFull: '게시 시 <strong>#PR</strong> 또는 <strong>#広告</strong> 태그를 반드시 표기합니다 (스텔스 마케팅 규제 준수)',
     submitNow: '지금 응모하기 →',
     needLogin: '로그인이 필요합니다',
+    needName: '배송을 위해 이름(한자) 등록이 필요합니다. 마이페이지 기본 정보를 먼저 입력한 뒤 다시 응모해주세요.',
     needReason: '응모 사유를 입력해주세요',
     needAddress: '배송지 주소를 입력해주세요',
     needPrAgree: '#PR 태그 표기에 동의가 필요합니다',
@@ -383,6 +389,7 @@ window.I18N_KO = {
     rewardFreeStrong: '<strong>제품 무상 제공</strong>',
     rewardFreeSimple: '<strong>무상 제공</strong>',
     channelAll: '전체',
+    moreBtn: '더 보기',
   },
 
   profile: {

--- a/index.html
+++ b/index.html
@@ -2065,7 +2065,7 @@ window.I18N_JA = {
     prAgreeFull: '投稿時に<strong>#PR</strong>または<strong>#広告</strong>タグを必ず表記します（ステルスマーケティング規制準拠）',
     submitNow: '今すぐ応募する →',
     needLogin: 'ログインが必要です',
-    needName: '配送のため、お名前(漢字)の登録が必要です。マイページで基本情報を入力してから再度ご応募ください。',
+    needName: '配送のため、お名前(漢字とカナ)の登録が必要です。マイページで基本情報を入力してから再度ご応募ください。',
     needReason: '応募理由を入力してください',
     needAddress: '配送先住所を入力してください',
     needPrAgree: '#PRタグの表記に同意が必要です',
@@ -2518,7 +2518,7 @@ window.I18N_KO = {
     prAgreeFull: '게시 시 <strong>#PR</strong> 또는 <strong>#広告</strong> 태그를 반드시 표기합니다 (스텔스 마케팅 규제 준수)',
     submitNow: '지금 응모하기 →',
     needLogin: '로그인이 필요합니다',
-    needName: '배송을 위해 이름(한자) 등록이 필요합니다. 마이페이지 기본 정보를 먼저 입력한 뒤 다시 응모해주세요.',
+    needName: '배송을 위해 이름(한자·가나) 등록이 필요합니다. 마이페이지 기본 정보를 먼저 입력한 뒤 다시 응모해주세요.',
     needReason: '응모 사유를 입력해주세요',
     needAddress: '배송지 주소를 입력해주세요',
     needPrAgree: '#PR 태그 표기에 동의가 필요합니다',
@@ -6141,10 +6141,11 @@ function renderApplyCaution(camp) {
 
 async function submitApplication() {
   if (!currentUser) { toast(t('apply.needLogin'),'error'); return; }
-  // 배송지 이름 누락 차단 — 한자명/일반 이름 둘 다 비어 있으면 신청 자체 불가
+  // 배송지 이름 누락 차단 — 한자명·가나명 둘 다 필수.
   // 관리자 화면에서 신청자 이름이 「-」로 표시되던 케이스 방지 (마이페이지에서 등록 후 재시도)
-  const profileName = ((currentUserProfile?.name_kanji || currentUserProfile?.name) || '').trim();
-  if (!profileName || profileName === '-') {
+  const nameKanji = (currentUserProfile?.name_kanji || currentUserProfile?.name || '').trim();
+  const nameKana = (currentUserProfile?.name_kana || '').trim();
+  if (!nameKanji || nameKanji === '-' || !nameKana || nameKana === '-') {
     toast(t('apply.needName'),'error');
     return;
   }

--- a/index.html
+++ b/index.html
@@ -710,6 +710,10 @@ textarea.form-input{resize:vertical;min-height:80px}
       <!-- 채널 필터 -->
       <div class="filter-row" id="filterRow" style="margin-bottom:14px"></div>
       <div class="camp-grid" id="campGrid"></div>
+      <!-- 더보기 — 홈 화면은 최대 10건, 초과분은 캠페인 페이지로 이동 -->
+      <div id="campMoreBtnWrap" style="display:none;text-align:center;margin-top:16px">
+        <button onclick="navigate('campaigns')" class="btn btn-ghost btn-block" style="font-size:13px;font-weight:600" data-i18n="campaign.moreBtn">もっと見る</button>
+      </div>
     </div>
   </section>
 
@@ -784,6 +788,17 @@ textarea.form-input{resize:vertical;min-height:80px}
         <button id="campPageType-monitor" onclick="setCampPageType('monitor',this)" style="flex:1;padding:10px 0;font-size:13px;font-weight:600;color:var(--muted);border:none;background:none;cursor:pointer;border-bottom:2px solid transparent" data-i18n="campaigns.typeMonitor">レビュアー</button>
         <button id="campPageType-gifting" onclick="setCampPageType('gifting',this)" style="flex:1;padding:10px 0;font-size:13px;font-weight:600;color:var(--muted);border:none;background:none;cursor:pointer;border-bottom:2px solid transparent" data-i18n="campaigns.typeGifting">ギフティング</button>
         <button id="campPageType-visit" onclick="setCampPageType('visit',this)" style="flex:1;padding:10px 0;font-size:13px;font-weight:600;color:var(--muted);border:none;background:none;cursor:pointer;border-bottom:2px solid transparent" data-i18n="campaigns.typeVisit">訪問</button>
+      </div>
+      <!-- 캠페인 상태 칩 -->
+      <div class="filter-row" style="padding:10px 0 4px;display:flex;gap:6px;flex-wrap:wrap">
+        <button id="campPageStatus-all" class="chip on" onclick="setCampPageStatus('all',this)" data-i18n="campaigns.statusAll">すべて</button>
+        <button id="campPageStatus-active" class="chip" onclick="setCampPageStatus('active',this)" data-i18n="campaigns.statusActive">募集中</button>
+        <button id="campPageStatus-scheduled" class="chip" onclick="setCampPageStatus('scheduled',this)" data-i18n="campaigns.statusScheduled">近日公開</button>
+        <button id="campPageStatus-closed" class="chip" onclick="setCampPageStatus('closed',this)" data-i18n="campaigns.statusClosed">募集締切</button>
+      </div>
+      <!-- 검색 -->
+      <div style="padding:6px 0 12px">
+        <input type="search" id="campPageSearch" oninput="onCampPageSearchInput(this.value)" placeholder="キャンペーン名・ブランド検索" data-i18n-attr="placeholder:campaigns.searchPlaceholder" autocomplete="off" style="width:100%;padding:8px 12px;border:1px solid var(--line);border-radius:8px;font-size:16px;color:var(--ink);background:#fff">
       </div>
     </div>
   </div>
@@ -1805,6 +1820,11 @@ window.I18N_JA = {
     typeMonitor: 'レビュアー',
     typeGifting: 'ギフティング',
     typeVisit: '訪問',
+    statusAll: 'すべて',
+    statusActive: '募集中',
+    statusScheduled: '近日公開',
+    statusClosed: '募集締切',
+    searchPlaceholder: 'キャンペーン名・ブランド検索',
   },
 
   // 캠페인 상태
@@ -2045,6 +2065,7 @@ window.I18N_JA = {
     prAgreeFull: '投稿時に<strong>#PR</strong>または<strong>#広告</strong>タグを必ず表記します（ステルスマーケティング規制準拠）',
     submitNow: '今すぐ応募する →',
     needLogin: 'ログインが必要です',
+    needName: '配送のため、お名前(漢字)の登録が必要です。マイページで基本情報を入力してから再度ご応募ください。',
     needReason: '応募理由を入力してください',
     needAddress: '配送先住所を入力してください',
     needPrAgree: '#PRタグの表記に同意が必要です',
@@ -2141,6 +2162,7 @@ window.I18N_JA = {
     rewardFreeStrong: '<strong>製品無償提供</strong>',
     rewardFreeSimple: '<strong>無償提供</strong>',
     channelAll: 'すべて',
+    moreBtn: 'もっと見る',
   },
 
   // 프로필 라벨
@@ -2262,6 +2284,11 @@ window.I18N_KO = {
     typeMonitor: 'Reviewer',
     typeGifting: '기프팅',
     typeVisit: '방문형',
+    statusAll: '전체',
+    statusActive: '모집중',
+    statusScheduled: '모집예정',
+    statusClosed: '모집완료',
+    searchPlaceholder: '캠페인명·브랜드 검색',
   },
 
   status: {
@@ -2491,6 +2518,7 @@ window.I18N_KO = {
     prAgreeFull: '게시 시 <strong>#PR</strong> 또는 <strong>#広告</strong> 태그를 반드시 표기합니다 (스텔스 마케팅 규제 준수)',
     submitNow: '지금 응모하기 →',
     needLogin: '로그인이 필요합니다',
+    needName: '배송을 위해 이름(한자) 등록이 필요합니다. 마이페이지 기본 정보를 먼저 입력한 뒤 다시 응모해주세요.',
     needReason: '응모 사유를 입력해주세요',
     needAddress: '배송지 주소를 입력해주세요',
     needPrAgree: '#PR 태그 표기에 동의가 필요합니다',
@@ -2584,6 +2612,7 @@ window.I18N_KO = {
     rewardFreeStrong: '<strong>제품 무상 제공</strong>',
     rewardFreeSimple: '<strong>무상 제공</strong>',
     channelAll: '전체',
+    moreBtn: '더 보기',
   },
 
   profile: {
@@ -5316,6 +5345,25 @@ function visibleCamps(camps) {
   });
 }
 
+// 인플루언서 노출 캠페인의 정렬: 모집중(active) > 모집예정(scheduled) > 모집완료(closed)
+// 같은 상태 안에서는 모집기간 시작~종료일 최신순.
+//   1차: recruit_start (모집 시작일) 최신순 — "가장 최근에 시작한 캠페인"이 위로
+//   2차: deadline (모집 종료일) 최신순 — recruit_start가 없을 때 fallback
+//   3차: created_at 최신순 — 둘 다 없을 때 fallback
+function sortByStatusAndDeadline(camps) {
+  const order = {active: 0, scheduled: 1, closed: 2};
+  const ts = (c) => new Date(c.recruit_start || c.deadline || c.created_at || 0).getTime();
+  return camps.slice().sort((a, b) => {
+    const sa = order[a.status] ?? 99;
+    const sb = order[b.status] ?? 99;
+    if (sa !== sb) return sa - sb;
+    return ts(b) - ts(a);  // 최신순(내림차순)
+  });
+}
+
+// 홈 화면에 노출할 카드 수 — 초과분은 「더보기」 버튼으로 캠페인 페이지로 이동
+const HOME_CAMP_LIMIT = 10;
+
 function updateStats(camps) {
   const visible = visibleCamps(camps);
   $('statCampaigns').textContent = visible.length;
@@ -5334,9 +5382,16 @@ function buildChannelFilters(camps) {
     channels.map(ch => `<button class="chip" onclick="filterCamps('${ch}',this)">${esc(getChannelLabel(ch))}</button>`).join('');
 }
 
+// 캠페인 페이지 — 모집 유형 + 상태 + 검색 필터
+let campPageStatusFilter = 'all';   // all | active | scheduled | closed
+let campPageSearch = '';
+
 async function loadCampaignsPage() {
   if (!allCampaigns || allCampaigns.length === 0) await loadCampaigns();
   campPageTypeFilter = 'all';
+  campPageStatusFilter = 'all';
+  campPageSearch = '';
+  const searchEl = $('campPageSearch'); if (searchEl) searchEl.value = '';
   ['all','monitor','gifting','visit'].forEach(t => {
     const btn = $('campPageType-'+t);
     if (!btn) return;
@@ -5344,6 +5399,9 @@ async function loadCampaignsPage() {
     btn.style.borderBottomColor = t==='all'?'var(--pink)':'transparent';
     btn.style.fontWeight = t==='all'?'700':'600';
   });
+  // 상태 필터 칩 초기화
+  document.querySelectorAll('[id^="campPageStatus-"]').forEach(c => c.classList.remove('on'));
+  const allChip = $('campPageStatus-all'); if (allChip) allChip.classList.add('on');
   renderCampaignGrid();
 }
 
@@ -5356,15 +5414,33 @@ function setCampPageType(type, el) {
   renderCampaignGrid();
 }
 
+// 상태 칩 (전체 / 모집중 / 모집예정 / 모집완료)
+function setCampPageStatus(status, el) {
+  campPageStatusFilter = status;
+  document.querySelectorAll('[id^="campPageStatus-"]').forEach(c => c.classList.remove('on'));
+  if (el) el.classList.add('on');
+  renderCampaignGrid();
+}
+
+// 검색 입력
+function onCampPageSearchInput(value) {
+  campPageSearch = (value || '').trim().toLowerCase();
+  renderCampaignGrid();
+}
+
 function renderCampaignGrid() {
   const grid = $('campListGrid');
   if (!grid) return;
   let camps = visibleCamps(allCampaigns);
   if (campPageTypeFilter !== 'all') camps = camps.filter(c => c.recruit_type === campPageTypeFilter);
-  camps = camps.sort((a,b) => {
-    if (a.order_index != null && b.order_index != null) return a.order_index - b.order_index;
-    return new Date(b.created_at) - new Date(a.created_at);
-  });
+  if (campPageStatusFilter !== 'all') camps = camps.filter(c => c.status === campPageStatusFilter);
+  if (campPageSearch) {
+    camps = camps.filter(c => {
+      const haystack = ((c.title||'') + ' ' + (c.brand||'') + ' ' + (c.brand_ko||'') + ' ' + (c.product||'') + ' ' + (c.product_ko||'') + ' ' + (c.campaign_no||'')).toLowerCase();
+      return haystack.includes(campPageSearch);
+    });
+  }
+  camps = sortByStatusAndDeadline(camps);
   if (!camps.length) {
     grid.innerHTML = `<div class="empty-state" style="grid-column:1/-1"><div class="empty-icon"><span class="material-icons-round notranslate" translate="no" style="font-size:48px;color:var(--muted)">assignment</span></div><div class="empty-text">${t('campaign.emptyState')}</div><div class="empty-sub">${t('campaign.emptyStateSub')}</div></div>`;
     return;
@@ -5387,15 +5463,13 @@ function filterCamps(filter, el) {
 
 function applyHomeFilter() {
   let camps = visibleCamps(allCampaigns);
-  camps = camps.sort((a,b) => {
-    if (a.order_index != null && b.order_index != null) return a.order_index - b.order_index;
-    return new Date(b.created_at) - new Date(a.created_at);
-  });
   if (currentTypeFilter !== 'all') camps = camps.filter(c=>c.recruit_type===currentTypeFilter);
   if (currentFilter !== 'all') camps = camps.filter(c=>{
     const chs = (c.channel||'').split(',').map(s=>s.trim());
     return chs.includes(currentFilter) || c.category===currentFilter;
   });
+  // 정렬: 모집중 > 모집예정 > 모집완료, 같은 상태 안에서는 모집기간 종료일 최신순
+  camps = sortByStatusAndDeadline(camps);
   renderCampaigns(camps);
 }
 
@@ -5462,15 +5536,19 @@ function buildCampCards(camps) {
 function renderCampaigns(camps) {
   const grid = $('campGrid');
   if (!grid) return;
-  const visible = visibleCamps(camps).sort((a,b)=>{
-    if (a.order_index!=null&&b.order_index!=null) return a.order_index-b.order_index;
-    return new Date(b.created_at)-new Date(a.created_at);
-  });
+  // 호출처에서 이미 visibleCamps + sortByStatusAndDeadline 한 결과를 넘기지만,
+  // applyHomeFilter 외 경로(예: 초기 home 진입)에서도 안전하도록 한 번 더 정렬한다
+  const visible = sortByStatusAndDeadline(visibleCamps(camps));
+  const moreBtnWrap = $('campMoreBtnWrap');
   if (!visible.length) {
     grid.innerHTML = `<div class="empty-state" style="grid-column:1/-1"><div class="empty-icon"><span class="material-icons-round notranslate" translate="no" style="font-size:48px;color:var(--muted)">assignment</span></div><div class="empty-text">${t('campaign.emptyState')}</div><div class="empty-sub">${t('campaign.emptyStateSub')}</div></div>`;
+    if (moreBtnWrap) moreBtnWrap.style.display = 'none';
     return;
   }
-  grid.innerHTML = buildCampCards(visible);
+  // 홈 화면은 최대 HOME_CAMP_LIMIT(10건)만 노출 — 초과분은 「더보기」 버튼으로 캠페인 페이지 이동
+  const sliced = visible.slice(0, HOME_CAMP_LIMIT);
+  grid.innerHTML = buildCampCards(sliced);
+  if (moreBtnWrap) moreBtnWrap.style.display = visible.length > HOME_CAMP_LIMIT ? '' : 'none';
 }
 
 // ══════════════════════════════════════
@@ -6063,6 +6141,13 @@ function renderApplyCaution(camp) {
 
 async function submitApplication() {
   if (!currentUser) { toast(t('apply.needLogin'),'error'); return; }
+  // 배송지 이름 누락 차단 — 한자명/일반 이름 둘 다 비어 있으면 신청 자체 불가
+  // 관리자 화면에서 신청자 이름이 「-」로 표시되던 케이스 방지 (마이페이지에서 등록 후 재시도)
+  const profileName = ((currentUserProfile?.name_kanji || currentUserProfile?.name) || '').trim();
+  if (!profileName || profileName === '-') {
+    toast(t('apply.needName'),'error');
+    return;
+  }
   const msg = $('applyMessage').value.trim();
   const addr = $('applyAddress').value.trim();
   const prCheck = $('applyPrCheck').checked;

--- a/index.html
+++ b/index.html
@@ -1982,6 +1982,7 @@ window.I18N_JA = {
     appliedBtn: '応募済み',
     manageBtn: '活動管理',
     rewardProduct: '円相当の製品を無償提供',
+    rewardPayback: '円ペイバック',
     rewardCash: '+ 現金報酬 ¥{amount}',
     rewardFree: '製品全額無償提供',
     rewardProductAmount: '製品 ¥{price}円相当',
@@ -2428,6 +2429,7 @@ window.I18N_KO = {
     appliedBtn: '응모 완료',
     manageBtn: '활동 관리',
     rewardProduct: '원 상당 제품 무상 제공',
+    rewardPayback: '원 페이백',
     rewardCash: '+ 현금 리워드 ¥{amount}',
     rewardFree: '제품 전액 무상 제공',
     rewardProductAmount: '제품 ¥{price}원 상당',
@@ -5814,69 +5816,49 @@ async function openCampaign(id) {
           <div style="font-size:11px;color:var(--pink);font-weight:700;letter-spacing:.06em;margin-bottom:5px">${esc(camp.brand)}</div>
           ${camp.recruit_type ? `<div style="font-size:10px;font-weight:700;color:var(--pink);margin-bottom:4px">${esc(getRecruitTypeLabelJa(camp.recruit_type))}</div>` : ''}
           <div style="font-size:18px;font-weight:800;color:var(--ink);line-height:1.3;margin-bottom:10px">${esc(camp.title)}</div>
-          ${camp.product_price>0?`<div style="display:inline-flex;align-items:center;gap:6px;background:var(--light-pink);border-radius:8px;padding:6px 12px;margin-bottom:4px"><span style="font-size:17px;font-weight:900;color:var(--pink)">¥${camp.product_price.toLocaleString()}</span><span style="font-size:12px;color:var(--dark-pink);font-weight:600">${t('detail.rewardProduct')}</span></div>`:''}
+          ${camp.product_price>0?`<div style="display:inline-flex;align-items:center;gap:6px;background:var(--light-pink);border-radius:8px;padding:6px 12px;margin-bottom:4px"><span style="font-size:17px;font-weight:900;color:var(--pink)">¥${camp.product_price.toLocaleString()}</span><span style="font-size:12px;color:var(--dark-pink);font-weight:600">${camp.recruit_type === 'monitor' ? t('detail.rewardPayback') : t('detail.rewardProduct')}</span></div>`:''}
           ${camp.reward>0?`<div style="font-size:12px;color:var(--green);font-weight:600;margin-top:4px">${t('detail.rewardCash').replace('{amount}',camp.reward.toLocaleString())}</div>`:''}
         </div>
-        <div style="font-size:13px">
-          <div style="display:flex;border-top:1px solid #faf5f9">
-            <div style="width:90px;padding:10px 14px;color:var(--dark-pink);font-weight:600;font-size:11px;background:#fdf5fb;flex-shrink:0">${t('detail.productName')}</div>
-            <div style="padding:10px 13px;flex:1;font-size:12px">${esc(camp.product)||'—'}</div>
-          </div>
-          <div style="display:flex;border-top:1px solid #faf5f9">
-            <div style="width:90px;padding:10px 14px;color:var(--dark-pink);font-weight:600;font-size:11px;background:#fdf5fb;flex-shrink:0">${t('detail.recruitType')}</div>
-            <div style="padding:10px 13px;flex:1;font-size:12px">
-              ${(()=>{const t=camp.recruit_type;const map={monitor:['var(--blue-l)','var(--blue)','レビュアー'],gifting:['var(--gold-l)','var(--gold)','ギフティング'],visit:['#E8F7EF','#0E7E4A','訪問']};const m=map[t];return m?`<span style="background:${m[0]};color:${m[1]};font-size:11px;font-weight:700;padding:2px 8px;border-radius:20px">${m[2]}</span>`:'—'})()}
-            </div>
-          </div>
-          <div style="display:flex;border-top:1px solid #faf5f9">
-            <div style="width:90px;padding:10px 14px;color:var(--dark-pink);font-weight:600;font-size:11px;background:#fdf5fb;flex-shrink:0">${t('detail.channel')}</div>
-            <div style="padding:10px 13px;flex:1;font-size:12px;display:flex;gap:6px;flex-wrap:wrap;align-items:center">
-              ${(()=>{const sep = camp.channel_match === 'and' ? '&' : 'or'; return (camp.channel||'').split(',').map(s=>s.trim()).filter(Boolean).map(code=>`<span style="background:var(--light-pink);color:var(--dark-pink);font-size:11px;font-weight:600;padding:2px 10px;border-radius:20px">${esc(getChannelLabel(code))}</span>`).join(`<span style="color:var(--muted);font-size:11px;font-weight:600">${sep}</span>`);})()}
-            </div>
-          </div>
-          ${camp.content_types?`
-          <div style="display:flex;border-top:1px solid #faf5f9">
-            <div style="width:90px;padding:10px 14px;color:var(--dark-pink);font-weight:600;font-size:11px;background:#fdf5fb;flex-shrink:0">${t('detail.contentType')}</div>
-            <div style="padding:10px 13px;flex:1;font-size:12px;display:flex;gap:4px;flex-wrap:wrap">
-              ${camp.content_types.split(',').map(t=>`<span style="background:var(--light-pink);color:var(--dark-pink);font-size:10px;font-weight:600;padding:2px 8px;border-radius:20px">${esc(getLookupLabel('content_type', t.trim()))}</span>`).join('')}
-            </div>
-          </div>`:''}
-          <div style="display:flex;border-top:1px solid #faf5f9">
-            <div style="width:90px;padding:10px 14px;color:var(--dark-pink);font-weight:600;font-size:11px;background:#fdf5fb;flex-shrink:0">${t('detail.recruitPeriod')}</div>
-            <div style="padding:10px 13px;flex:1;font-size:12px">${formatDate(camp.recruit_start || new Date())} 〜 ${formatDate(camp.deadline)}</div>
-          </div>
-          <div style="display:flex;border-top:1px solid #faf5f9">
-            <div style="width:90px;padding:10px 14px;color:var(--dark-pink);font-weight:600;font-size:11px;background:#fdf5fb;flex-shrink:0">${t('detail.recruitSlots')}</div>
-            <div style="padding:10px 13px;flex:1;font-size:12px">${camp.slots}${t('detail.peopleUnit')}</div>
-          </div>
-          <div style="display:flex;border-top:1px solid #faf5f9">
-            <div style="width:90px;padding:10px 14px;color:var(--dark-pink);font-weight:600;font-size:11px;background:#fdf5fb;flex-shrink:0">${t('detail.winnerAnnounce')}</div>
-            <div style="padding:10px 13px;flex:1;font-size:12px">${esc(camp.winner_announce || t('detail.winnerAnnounceValue'))}</div>
-          </div>
-          ${(camp.recruit_type==='monitor' && (camp.purchase_start||camp.purchase_end))?`
-          <div style="display:flex;border-top:1px solid #faf5f9">
-            <div style="width:90px;padding:10px 14px;color:var(--dark-pink);font-weight:600;font-size:11px;background:#fdf5fb;flex-shrink:0">${t('detail.purchasePeriod')}</div>
-            <div style="padding:10px 13px;flex:1;font-size:12px">${camp.purchase_start?formatDate(camp.purchase_start):'—'} 〜 ${camp.purchase_end?formatDate(camp.purchase_end):'—'}</div>
-          </div>`:''}
-          ${(camp.recruit_type==='visit' && (camp.visit_start||camp.visit_end))?`
-          <div style="display:flex;border-top:1px solid #faf5f9">
-            <div style="width:90px;padding:10px 14px;color:var(--dark-pink);font-weight:600;font-size:11px;background:#fdf5fb;flex-shrink:0">${t('detail.visitPeriod')}</div>
-            <div style="padding:10px 13px;flex:1;font-size:12px">${camp.visit_start?formatDate(camp.visit_start):'—'} 〜 ${camp.visit_end?formatDate(camp.visit_end):'—'}</div>
-          </div>`:''}
-          ${camp.submission_end?`
-          <div style="display:flex;border-top:1px solid #faf5f9">
-            <div style="width:90px;padding:10px 14px;color:var(--dark-pink);font-weight:600;font-size:11px;background:#fdf5fb;flex-shrink:0">${t('detail.submissionEnd')}</div>
-            <div style="padding:10px 13px;flex:1;font-size:12px;font-weight:600;color:var(--ink)">${formatDate(camp.submission_end)}</div>
-          </div>`:''}
-          ${(camp.product_price>0||camp.reward>0||camp.reward_note)?`
-          <div style="display:flex;border-top:1px solid #faf5f9">
-            <div style="width:90px;padding:10px 14px;color:var(--dark-pink);font-weight:600;font-size:11px;background:#fdf5fb;flex-shrink:0">${t('detail.reward')}</div>
-            <div style="padding:10px 13px;flex:1;font-size:12px;color:var(--pink);font-weight:600">
-              ${(camp.product_price>0||camp.reward>0)?`${camp.product_price>0?t('detail.rewardProductAmount').replace('{price}',camp.product_price.toLocaleString()):t('detail.rewardProductFree')}${camp.reward>0?` + ${t('detail.rewardCashAmount').replace('{amount}',camp.reward.toLocaleString())}`:''}`:''}
-              ${camp.reward_note?`<div style="margin-top:${(camp.product_price>0||camp.reward>0)?'6px':'0'};font-size:11px;color:var(--muted);font-weight:400;line-height:1.6;white-space:pre-wrap">${esc(camp.reward_note)}</div>`:''}
-            </div>
-          </div>`:''}
-        </div>
+        ${(()=>{
+          // 캠페인 상세 표 — 시간 흐름 순으로 행 배치
+          // 순서: 상품명 → 모집타입 → 채널 → 콘텐츠 → 모집기간 → 구매/방문기간 → 결과물 제출 마감 → 모집인원
+          //       → (monitor 외) 당선 발표 → (monitor 외) 리워드
+          const isMonitor = camp.recruit_type === 'monitor';
+          const KEY = 'width:90px;padding:10px 14px;color:var(--dark-pink);font-weight:600;font-size:11px;background:#fdf5fb;flex-shrink:0';
+          const VAL = 'padding:10px 13px;flex:1;font-size:12px';
+          const ROW = 'display:flex;border-top:1px solid #faf5f9';
+          const rows = [];
+          rows.push(`<div style="${ROW}"><div style="${KEY}">${t('detail.productName')}</div><div style="${VAL}">${esc(camp.product)||'—'}</div></div>`);
+          rows.push(`<div style="${ROW}"><div style="${KEY}">${t('detail.recruitType')}</div><div style="${VAL}">${(()=>{const t=camp.recruit_type;const map={monitor:['var(--blue-l)','var(--blue)','レビュアー'],gifting:['var(--gold-l)','var(--gold)','ギフティング'],visit:['#E8F7EF','#0E7E4A','訪問']};const m=map[t];return m?`<span style="background:${m[0]};color:${m[1]};font-size:11px;font-weight:700;padding:2px 8px;border-radius:20px">${m[2]}</span>`:'—'})()}</div></div>`);
+          rows.push(`<div style="${ROW}"><div style="${KEY}">${t('detail.channel')}</div><div style="${VAL};display:flex;gap:6px;flex-wrap:wrap;align-items:center">${(()=>{const sep = camp.channel_match === 'and' ? '&' : 'or'; return (camp.channel||'').split(',').map(s=>s.trim()).filter(Boolean).map(code=>`<span style="background:var(--light-pink);color:var(--dark-pink);font-size:11px;font-weight:600;padding:2px 10px;border-radius:20px">${esc(getChannelLabel(code))}</span>`).join(`<span style="color:var(--muted);font-size:11px;font-weight:600">${sep}</span>`);})()}</div></div>`);
+          if (camp.content_types) {
+            const ctList = camp.content_types.split(',').map(c => c.trim()).filter(Boolean);
+            if (ctList.length) {
+              rows.push(`<div style="${ROW}"><div style="${KEY}">${t('detail.contentType')}</div><div style="${VAL};display:flex;gap:4px;flex-wrap:wrap">${ctList.map(c=>`<span style="background:var(--light-pink);color:var(--dark-pink);font-size:10px;font-weight:600;padding:2px 8px;border-radius:20px">${esc(getLookupLabel('content_type', c))}</span>`).join('')}</div></div>`);
+            }
+          }
+          rows.push(`<div style="${ROW}"><div style="${KEY}">${t('detail.recruitPeriod')}</div><div style="${VAL}">${formatDate(camp.recruit_start || new Date())} 〜 ${formatDate(camp.deadline)}</div></div>`);
+          if (isMonitor && (camp.purchase_start || camp.purchase_end)) {
+            rows.push(`<div style="${ROW}"><div style="${KEY}">${t('detail.purchasePeriod')}</div><div style="${VAL}">${camp.purchase_start?formatDate(camp.purchase_start):'—'} 〜 ${camp.purchase_end?formatDate(camp.purchase_end):'—'}</div></div>`);
+          }
+          if (camp.recruit_type === 'visit' && (camp.visit_start || camp.visit_end)) {
+            rows.push(`<div style="${ROW}"><div style="${KEY}">${t('detail.visitPeriod')}</div><div style="${VAL}">${camp.visit_start?formatDate(camp.visit_start):'—'} 〜 ${camp.visit_end?formatDate(camp.visit_end):'—'}</div></div>`);
+          }
+          if (camp.submission_end) {
+            rows.push(`<div style="${ROW}"><div style="${KEY}">${t('detail.submissionEnd')}</div><div style="${VAL};font-weight:600;color:var(--ink)">${formatDate(camp.submission_end)}</div></div>`);
+          }
+          rows.push(`<div style="${ROW}"><div style="${KEY}">${t('detail.recruitSlots')}</div><div style="${VAL}">${camp.slots}${t('detail.peopleUnit')}</div></div>`);
+          // 리뷰어(monitor) 캠페인은 당선 발표·리워드 행 제외
+          if (!isMonitor) {
+            rows.push(`<div style="${ROW}"><div style="${KEY}">${t('detail.winnerAnnounce')}</div><div style="${VAL}">${esc(camp.winner_announce || t('detail.winnerAnnounceValue'))}</div></div>`);
+            if (camp.product_price>0 || camp.reward>0 || camp.reward_note) {
+              const rewardLine = (camp.product_price>0 || camp.reward>0) ? `${camp.product_price>0?t('detail.rewardProductAmount').replace('{price}',camp.product_price.toLocaleString()):t('detail.rewardProductFree')}${camp.reward>0?` + ${t('detail.rewardCashAmount').replace('{amount}',camp.reward.toLocaleString())}`:''}` : '';
+              const noteLine = camp.reward_note ? `<div style="margin-top:${rewardLine?'6px':'0'};font-size:11px;color:var(--muted);font-weight:400;line-height:1.6;white-space:pre-wrap">${esc(camp.reward_note)}</div>` : '';
+              rows.push(`<div style="${ROW}"><div style="${KEY}">${t('detail.reward')}</div><div style="${VAL};color:var(--pink);font-weight:600">${rewardLine}${noteLine}</div></div>`);
+            }
+          }
+          return `<div style="font-size:13px">${rows.join('')}</div>`;
+        })()}
       </div>
 
       ${(() => {
@@ -5919,7 +5901,7 @@ async function openCampaign(id) {
       ${(camp.hashtags||camp.mentions||camp.appeal) ? `
       <div style="background:#fff;padding:16px;margin-bottom:10px;border-bottom:8px solid var(--bg)">
         <div style="font-size:14px;font-weight:700;margin-bottom:12px;color:var(--ink)">${t('detail.postGuideline')}</div>
-        ${camp.appeal ? `<div style="margin-bottom:12px"><div style="font-size:11px;font-weight:700;color:var(--pink);margin-bottom:5px;text-transform:uppercase;letter-spacing:.05em">${t('detail.brandAppeal')}</div><div class="rich-content" style="font-size:12px;color:var(--ink);line-height:1.7;background:var(--bg);padding:10px 12px;border-radius:8px">${richHtml(camp.appeal)}</div></div>` : ''}
+        ${camp.appeal ? `<div style="margin-bottom:12px"><div style="font-size:11px;font-weight:700;color:var(--pink);margin-bottom:5px;text-transform:uppercase;letter-spacing:.05em">${t('detail.brandAppeal')}</div><div class="rich-content" style="font-size:12px;color:var(--ink);line-height:1.7;background:#fff5ff;padding:10px 12px;border-radius:8px;border:1px solid #f0d8e8">${richHtml(camp.appeal)}</div></div>` : ''}
         ${camp.hashtags ? `<div style="margin-bottom:10px"><div style="font-size:11px;font-weight:700;color:var(--pink);margin-bottom:5px;text-transform:uppercase;letter-spacing:.05em">${t('detail.requiredHashtag')}</div><div style="display:flex;flex-wrap:wrap;gap:5px">${camp.hashtags.split(',').map(t=>`<span style="background:var(--light-pink);color:var(--dark-pink);font-size:12px;font-weight:600;padding:3px 10px;border-radius:20px">${esc(t.trim())}</span>`).join('')}</div></div>` : ''}
         ${camp.mentions ? `<div><div style="font-size:11px;font-weight:700;color:var(--pink);margin-bottom:5px;text-transform:uppercase;letter-spacing:.05em">${t('detail.requiredMention')}</div><div style="display:flex;flex-wrap:wrap;gap:5px">${camp.mentions.split(',').map(t=>`<span style="background:#f0f0ff;color:#4040cc;font-size:12px;font-weight:600;padding:3px 10px;border-radius:20px">${esc(t.trim())}</span>`).join('')}</div></div>` : ''}
       </div>` : ''}
@@ -5927,7 +5909,7 @@ async function openCampaign(id) {
       ${camp.guide ? `
       <div style="background:#fff;padding:16px;margin-bottom:10px;border-bottom:8px solid var(--bg)">
         <div style="font-size:14px;font-weight:700;margin-bottom:10px;color:var(--ink)">${t('detail.shootingGuide')}</div>
-        <div class="rich-content" style="font-size:12px;color:var(--ink);line-height:1.7;background:var(--bg);padding:12px;border-radius:8px">${richHtml(camp.guide)}</div>
+        <div class="rich-content" style="font-size:12px;color:var(--ink);line-height:1.7;background:#fdf5fd;padding:12px;border-radius:8px;border:1px solid #e8d4e8">${richHtml(camp.guide)}</div>
       </div>` : ''}
 
       ${camp.ng ? `

--- a/index.html
+++ b/index.html
@@ -5387,7 +5387,9 @@ let campPageStatusFilter = 'all';   // all | active | scheduled | closed
 let campPageSearch = '';
 
 async function loadCampaignsPage() {
-  if (!allCampaigns || allCampaigns.length === 0) await loadCampaigns();
+  // 진입할 때마다 캠페인 데이터 새로고침 — 캐시(allCampaigns)에 의존하지 않음.
+  // 사용자가 로고 클릭/화면 전환 시 새 데이터를 보고 싶다고 해서 도입.
+  await loadCampaigns();
   campPageTypeFilter = 'all';
   campPageStatusFilter = 'all';
   campPageSearch = '';
@@ -7163,7 +7165,8 @@ async function loadMyApplications() {
     const {data} = await db.from('applications').select('*').eq('user_id', currentUser.id).order('created_at', {ascending:false});
     _myApps = data || [];
   }
-  if (!allCampaigns || !allCampaigns.length) allCampaigns = await fetchCampaigns();
+  // 캠페인 데이터도 진입 시마다 새로고침 — 응모이력 행에 노출되는 캠페인 상태/제목 stale 방지
+  allCampaigns = await fetchCampaigns();
   renderMyApplyTabs();
   renderMyApplyList();
 }


### PR DESCRIPTION
## Summary

dev 누적 4건 운영 배포. **DB 변경 없음** (마이그레이션 097은 직전 PR에서 운영 적용 완료).

### 인플루언서 페이지
- 캠페인 상세 표 시간 흐름 순 재배치 (상품명 → 모집타입 → 채널 → 콘텐츠 → 모집기간 → 구매/방문 → 결과물 제출 마감 → 모집 인원 → (monitor 외) 당선 발표/리워드)
- 리뷰어(monitor) 캠페인은 「당선 발표」/「리워드」 행 제외
- 리뷰어 캠페인 상단 가격 박스 「ペイバック / 페이백」 워딩
- 브랜드 어필 / 촬영 가이드 박스 색상·테두리 강화 (#fff5ff / #fdf5fd)
- 홈 화면 top-10 + 「もっと見る / 더 보기」 버튼
- 정렬: 모집중 → 모집예정 → 모집완료, 같은 상태 안에서 모집기간 시작~종료일 최신순
- 캠페인 페이지 — 상태 칩(전체/모집중/모집예정/모집완료) + 검색(캠페인명·브랜드·상품·캠페인번호)
- 신청 시 한자명·가나명 둘 다 필수 (배송지 이름 누락 차단)
- **로고 클릭/페이지 전환 시 캠페인 데이터 항상 fetch** (캐시 가드 제거 — stale 화면 방지)

### 관리자 페이지
- 캠페인 미리보기 모달 동일 변경 (표 재배치 + 페이백 워딩 + 색상)

## DB 마이그레이션
이번 PR에서 추가 마이그레이션 없음.

## Test plan
- [ ] 운영 — 인플루언서 캠페인 상세 표 순서/페이백/색상 정상
- [ ] 운영 — 홈 화면에 10건만 노출, 더보기 클릭 시 캠페인 페이지 이동
- [ ] 운영 — 정렬 순서 (모집중 우선, 같은 상태 내 시작일 최신순)
- [ ] 운영 — 캠페인 페이지 상태 필터 + 검색 동작
- [ ] 운영 — 한자명·가나명 둘 다 비어있는 인플루언서가 신청 시도 → 토스트 차단
- [ ] 운영 — 로고 클릭 시 캠페인 데이터 새로고침 (관리자가 변경한 내용 즉시 반영)

🤖 Generated with [Claude Code](https://claude.com/claude-code)