### PR TITLE
chore(claude): multi-session commands + rule de-duplication

### DIFF
--- a/.claude/commands/새세션.md
+++ b/.claude/commands/새세션.md
@@ -1,0 +1,102 @@
+---
+description: 새 작업용 git worktree(별도 작업 폴더)와 feature 브랜치를 자동으로 펼칩니다. 동시에 여러 작업을 하실 때 사용하세요. 사용법 — `/새세션 작업이름` (예: `/새세션 공지개선`).
+---
+
+# 새세션
+
+REVERB JP에서 **여러 작업을 동시에 진행**할 때 충돌을 막기 위한 「새 전시장 펼치기」 단축키.
+
+## 비유
+
+집을 짓는 중에 인부 여러 명이 같은 거실(메인 dev 브랜치)에서 동시에 작업하면 페인트와 벽지가 섞입니다.
+이 명령어는 **본 거실 옆에 임시 전시장을 펼쳐서**, 다른 인부의 작업과 충돌 없이 자기 공간에서 자유롭게 작업하게 해줍니다.
+
+## 입력
+
+`/새세션 <작업이름>`
+
+- 작업이름은 한글·영문·하이픈 모두 가능. 공백은 자동으로 하이픈으로 변환.
+- 예: `/새세션 공지개선`, `/새세션 campaign-fix`, `/새세션 결과물 엑셀 컬럼` (공백 → 하이픈)
+
+## 메인 Claude 가 수행할 절차
+
+### Step 1 — 입력 검증
+- `$ARGUMENTS` 가 비어 있으면 작업 이름 묻기 (`AskUserQuestion` 또는 직접 질문). 종료.
+- 작업이름의 공백을 하이픈으로 치환하여 `SLUG` 변수에 저장.
+  - 예: "결과물 엑셀 컬럼" → "결과물-엑셀-컬럼"
+- `WORKTREE_PATH = ~/Documents/projects/reverb-jp-{SLUG}`
+- `BRANCH_NAME = feature/{SLUG}`
+
+### Step 2 — 충돌 검사
+1. 현재 폴더가 메인 worktree인지 확인:
+   - 메인 worktree 경로 조회: `git worktree list --porcelain | awk '/^worktree/{print $2; exit}'`
+   - 현재 폴더 경로: `pwd` 결과
+   - 두 값이 같지 않으면 (= 이미 다른 worktree 안에 있는 상태) 사용자에게 안내 후 종료:
+     "현재 폴더는 이미 다른 전시장(`{현재경로}`)입니다. 메인 폴더(`{메인경로}`)에서 실행해주세요."
+2. 같은 이름의 worktree가 이미 있는지 확인:
+   - `git worktree list --porcelain | grep "reverb-jp-{SLUG}$"`
+   - 있으면 사용자에게 안내 후 종료:
+     "전시장 「{SLUG}」가 이미 펼쳐져 있습니다. 그 폴더로 가서 작업하시거나, 다른 이름으로 새 전시장을 만드세요."
+3. 같은 이름의 브랜치가 이미 있는지 확인:
+   - `git branch -a | grep "feature/{SLUG}$"`
+   - 있으면 사용자에게 안내 후 종료:
+     "브랜치 `feature/{SLUG}`가 이미 존재합니다. 다른 이름으로 만드시거나, 기존 브랜치로 worktree를 만드시려면 직접 명령해주세요."
+
+### Step 3 — 전시장 펼치기
+1. 메인 폴더에서 최신 dev 가져오기:
+   ```bash
+   git fetch origin dev
+   ```
+2. worktree + feature 브랜치 동시 생성:
+   ```bash
+   git worktree add ../reverb-jp-{SLUG} -b feature/{SLUG} origin/dev
+   ```
+3. 결과 확인:
+   ```bash
+   git worktree list
+   ```
+
+### Step 4 — 사용자 안내 (한국어 + 비유 친화, 이모지 사용 안 함)
+
+```
+[전시장 펼치기 완료] 「{SLUG}」
+
+작업 폴더: ~/Documents/projects/reverb-jp-{SLUG}
+브랜치   : feature/{SLUG} (origin/dev 기반)
+
+다음 단계:
+  1. 터미널을 새로 열어주세요
+  2. cd ~/Documents/projects/reverb-jp-{SLUG}
+  3. 그 폴더에서 Claude Code 세션을 새로 시작하세요
+     (또는 IDE/에디터에서 그 폴더를 여세요)
+  4. 작업이 끝나면 그 세션 안에서 /세션종료 호출
+
+[주의] 본 폴더(reverb-jp/)에서는 같은 작업을 하지 마세요. 충돌 위험.
+```
+
+## 끝낸 뒤
+
+작업이 끝나면 사용자가 그 worktree 안에서 `/세션종료` 호출 → PR 생성. PR 머지 후 메인 폴더에서 아래 안내대로 직접 정리(추후 `/세션정리` 단축키 도입 예정):
+
+```bash
+cd ~/Documents/projects/reverb-jp
+git worktree remove ../reverb-jp-{SLUG}
+git branch -D feature/{SLUG}
+git pull origin dev
+```
+
+## 실패·예외 처리
+
+- `git fetch` 실패 시: 네트워크/원격 권한 확인 안내
+- `git worktree add` 실패 시: 에러 메시지 그대로 전달 + 메인 폴더가 git 저장소인지 확인 안내
+- `gh` 미설치 또는 인증 안 된 경우: `/세션종료` 단계에서 명시. `/새세션` 단계에는 영향 없음
+
+## 사용 시점
+
+- ✅ 동시에 두 개 이상의 작업을 진행하고 싶을 때 (서로 다른 기능)
+- ✅ 한 작업이 길어져서 다른 작업을 끼워넣고 싶을 때
+- ❌ 한 번에 한 작업만 차례차례 할 때 (이때는 메인 폴더에서 그대로 작업해도 충돌 없음)
+
+## 참고
+- `.claude/rules/multi-session.md` — 동시 작업 시 worktree 사용 영구 규칙
+- `.claude/commands/세션종료.md` — 세션 마무리 단축키

--- a/.claude/commands/세션종료.md
+++ b/.claude/commands/세션종료.md
@@ -1,0 +1,140 @@
+---
+description: 현재 worktree(전시장)에서 진행한 작업을 정리하고 dev 브랜치로 PR을 생성합니다. `/새세션`으로 만든 작업 폴더 안에서 사용하세요. 인자는 PR 제목(선택). 예 — `/세션종료 공지 디자인 손보기`
+---
+
+# 세션종료
+
+REVERB JP의 worktree(전시장) 안에서 작업을 마치고 PR을 생성하는 단축키. 메인 dev 브랜치로 작품을 옮기는 「감독 호출」.
+
+## 비유
+
+전시장에서 가구 조립이 끝났습니다. 감독님(PR 리뷰)에게 "본 거실로 옮겨도 될까요?" 묻기 위해 PR을 생성합니다. 머지 자체는 사용자가 직접 GitHub에서 확인 후 진행 (안전 장치).
+
+## 입력
+
+`/세션종료 [PR 제목]`
+
+- PR 제목은 선택. 없으면 현재 브랜치명에서 자동 생성.
+
+## 메인 Claude 가 수행할 절차
+
+### Step 0 — 위치·브랜치 확인 (안전 장치)
+
+```bash
+pwd
+git rev-parse --show-toplevel
+git branch --show-current
+git worktree list
+```
+
+다음 조건 모두 만족해야 진행:
+1. 현재 폴더가 메인 폴더(`~/Documents/projects/reverb-jp`)가 **아님**
+2. 현재 브랜치가 `feature/*` 패턴
+3. 현재 폴더가 `git worktree list` 결과에 포함
+
+조건 미충족 시 안내:
+- 메인 폴더에서 호출됨: "이 명령은 worktree(전시장) 안에서 사용합니다. 메인 폴더에서는 평소처럼 commit·push 후 PR을 직접 만드세요."
+- dev/main 같은 보호 브랜치: "보호 브랜치(`{브랜치명}`)에서는 사용 불가. feature 브랜치로 전환 후 다시 시도하세요."
+- worktree가 아님: "이 폴더는 worktree가 아닙니다. `/새세션`으로 만든 폴더에서만 동작합니다."
+
+### Step 1 — 변경 사항 확인
+
+```bash
+git status --short
+git diff --stat
+```
+
+#### 1a. 변경 없음 + 미푸시 커밋 없음
+"변경 사항이 없습니다. 작업한 것이 없으면 그냥 worktree를 정리해도 됩니다." 안내 후 종료.
+
+#### 1b. 미커밋 변경 있음
+사용자에게 commit 메시지 묻기 (`AskUserQuestion`로 옵션 또는 직접 텍스트):
+- 옵션 1: "이번 변경 한 줄 요약을 적어주세요" 직접 입력
+- 옵션 2: 자동 제안 (변경 파일 패턴으로 추측, 예: `feat(admin): {SLUG} 작업`)
+
+빌드 필요 여부 자동 점검:
+- `dev/` 폴더 안 파일이 변경되었으면 `cd dev && bash build.sh` 자동 실행 (`.claude/rules/build.md` 패턴) → 루트 `index.html`/`admin/index.html` 재빌드
+- 빌드 산출물도 `git status`에 잡히면 함께 add
+
+reverb-reviewer 에이전트 자동 호출 → 검수 후 commit:
+```bash
+git add <변경된 파일들>
+git commit -m "{사용자 입력 메시지}"
+```
+
+#### 1c. 미푸시 커밋만 있음
+바로 push 단계로.
+
+### Step 2 — push
+
+```bash
+git push -u origin {현재 브랜치}
+```
+
+처음 push면 `-u`로 upstream 설정. 이미 설정됐으면 그냥 push.
+
+### Step 3 — PR 생성
+
+PR 제목·본문 자동 작성:
+- 제목: 사용자 인자로 받았으면 그대로, 없으면 브랜치명·최근 커밋에서 추출
+- 본문: 최근 커밋 메시지 + "## Test plan" 체크리스트 (`gh pr create` HEREDOC 패턴)
+- base: `dev` (운영 직접 PR은 보호. dev 머지 후 별도 main PR로)
+- head: 현재 브랜치
+
+```bash
+gh pr create \
+  --base dev \
+  --head feature/{SLUG} \
+  --title "{제목}" \
+  --body "..."
+```
+
+생성 결과 PR URL을 사용자에게 안내.
+
+### Step 4 — 사용자 안내 (한국어 + 다음 단계, 이모지 사용 안 함)
+
+```
+[감독 호출 완료] PR이 만들어졌습니다.
+
+PR 주소: {URL}
+
+다음 단계:
+  1. 위 주소에서 PR 내용 확인
+  2. 문제 없으면 「Merge pull request」 버튼 클릭 (직접)
+  3. 머지가 끝나면 메인 폴더에서 전시장 철거:
+
+     cd ~/Documents/projects/reverb-jp
+     git worktree remove ../reverb-jp-{SLUG}
+     git branch -D feature/{SLUG}
+     git pull origin dev
+
+[주의] 운영서버(main) 배포는 별도 단계입니다.
+       dev에서 검증 끝나면 dev → main PR을 따로 만들어야 합니다.
+```
+
+### Step 5 — 운영 배포 확인 (선택)
+
+dev에 머지된 후 운영 배포 여부는 `AskUserQuestion`으로 묻기:
+- "지금 운영 배포까지 진행 (dev → main PR + 머지)"
+- "개발서버 검증 후 결정 (추천)"
+- "보류"
+
+명시 지시가 있을 때만 자동 진행. 그 외에는 사용자 안내만.
+
+## 실패·예외 처리
+
+- `gh` 미설치/미인증: "GitHub CLI(`gh`)가 필요합니다. 설치 또는 인증 후 재시도하세요." 안내
+- 빌드 실패: 에러 그대로 전달 + 사용자가 코드 수정 후 다시 `/세션종료`
+- reviewer 차단 이슈 발견: 자동 commit 안 함. 사용자에게 정정 요청
+- push 거부 (force needed): 절대 force 안 함. 사용자에게 상황 설명 + 수동 대응 요청
+
+## 사용 시점
+
+- ✅ worktree 안에서 작업이 끝났을 때
+- ✅ 중간 PR을 만들고 추가 검토받고 싶을 때 (작업 계속)
+- ❌ 메인 폴더에서 작업할 때 (이때는 평소처럼 commit·push)
+
+## 참고
+- `.claude/commands/새세션.md` — 작업 시작 단축키
+- `.claude/rules/multi-session.md` — 동시 작업 영구 규칙
+- `.claude/rules/git.md` — 커밋 컨벤션·운영 배포 규칙

--- a/.claude/rules/git.md
+++ b/.claude/rules/git.md
@@ -29,7 +29,7 @@ globs: "*"
 8. 운영서버 실데이터/환경에서 최종 검증
 
 ## 빌드 필수
-- dev/ 수정 후 반드시 `cd dev && bash build.sh` 실행
+- 빌드 명령·순서·새 파일 추가 절차는 `.claude/rules/build.md` 정의처 참조
 - 루트 `index.html`, `admin/index.html`는 빌드 산출물 (직접 수정 금지)
 - 루트 `js/`, `css/`, `lib/` 폴더는 **존재하지 않음** (2026-04-14 정리 완료)
 

--- a/.claude/rules/multi-session.md
+++ b/.claude/rules/multi-session.md
@@ -1,0 +1,98 @@
+# 멀티 세션 운영 규칙 (영구)
+
+> REVERB JP를 동시에 여러 Claude Code 세션으로 작업할 때 충돌·작업 손실을 막기 위한 규칙.
+> 모든 세션·모든 에이전트에 영구 적용.
+
+## 핵심 원칙
+
+- **한 시점에 한 작업만이면** → 메인 폴더(`~/Documents/projects/reverb-jp`)에서 그대로 작업해도 충돌 없음
+- **동시에 두 개 이상의 작업을 진행하면** → 작업마다 별도 git worktree(전시장)와 feature 브랜치를 사용
+- 같은 기능을 여러 세션이 동시에 수정하는 패턴은 금지 (의미 없고 충돌 유발)
+
+## 비유 (사용자 안내용 — 비개발자 친화)
+
+- 메인 폴더 = 본 거실 (감독이 OK한 작품만 들여놓음)
+- worktree 폴더 = 전시장 (인부 자유 작업장)
+- feature 브랜치 = 그 전시장의 도면
+- PR + 머지 = 전시장 작품을 본 거실로 옮기기
+- 충돌 = 두 인부가 같은 거실에서 같은 벽에 작업해서 망친 상황
+
+## 권장 워크플로
+
+### 1단계 — 세션 시작
+- 메인 폴더(`~/Documents/projects/reverb-jp`)에서 `/새세션 작업이름` 호출
+- Claude가 자동으로 `~/Documents/projects/reverb-jp-{작업이름}` worktree + `feature/{작업이름}` 브랜치 생성
+- 사용자는 새 터미널을 열고 그 폴더에서 Claude Code 세션을 시작
+
+### 2단계 — 세션 안 작업
+- 코드 수정·`bash dev/build.sh`·commit·push 모두 그 worktree 안에서만 수행
+- push 대상은 항상 `feature/{작업이름}` 브랜치 (dev·main 직접 push 금지)
+- 마이그레이션 새로 만들 일이 있으면 §마이그레이션 번호 룰 참조
+
+### 3단계 — 세션 종료
+- worktree 안에서 `/세션종료` 호출
+- Claude가 reviewer 검수·빌드·commit·push·PR 생성을 자동 진행
+- PR URL 안내 받음
+
+### 4단계 — PR 머지 후 정리
+- 사용자가 GitHub에서 PR 직접 검토·머지 (자동 머지는 위험해서 안 함)
+- 머지 완료 후 메인 폴더에서:
+  ```bash
+  cd ~/Documents/projects/reverb-jp
+  git worktree remove ../reverb-jp-{작업이름}
+  git branch -D feature/{작업이름}
+  git pull origin dev
+  ```
+- 또는 추후 `/세션정리` 단축키 도입 시 자동화
+
+## REVERB JP 특화 충돌 포인트
+
+### 마이그레이션 번호 (가장 흔한 충돌)
+- `supabase/migrations/`는 번호 순차 파일로 관리됨. 새 파일을 만들기 전 반드시 `ls supabase/migrations/ | tail -5` 로 마지막 번호를 확인
+- **규칙**: 마이그레이션 새 파일 추가는 **한 세션에서만** 진행. 다른 세션은 그 PR이 dev에 머지된 후 `git pull origin dev` → 자기 worktree에 반영 후 그다음 번호 사용
+- Claude가 마이그레이션 추가 작업 받으면 자동 점검: 다른 worktree에서 같은 번호 작업 중인지 확인이 어려우므로, 사용자에게 「마이그레이션 새로 만들 일이 다른 세션에서도 있나?」 한 번 묻기
+
+### 빌드 산출물 (`index.html`/`admin/index.html`)
+- `dev/build.sh`는 `index.html`/`admin/index.html`을 덮어씀
+- 각 worktree에는 자체 빌드 산출물이 따로 있어 worktree 간 충돌 없음
+- 단 같은 브랜치(feature/X)에서 두 세션이 commit하면 충돌 가능 — feature 브랜치도 한 세션에서만 다루기
+
+### dev 브랜치 직접 push 금지
+- dev 브랜치는 「본 거실」 — 작품을 옮기는 곳이지 작업하는 곳이 아님
+- worktree에서는 항상 feature 브랜치로 push, PR로 dev에 머지
+- 메인 폴더(dev 브랜치)에서 직접 작업하는 시나리오는 **단일 세션 + 시퀀셜 작업**일 때만
+
+### 운영 배포(main)는 별도 단계
+- dev 머지가 끝나도 운영 자동 반영 안 됨
+- 운영 배포는 `dev → main` PR을 별도로 만들어야 함 (`.claude/rules/git.md` 참조)
+- 사용자 명시 지시 없으면 `/세션종료` 단계에서 운영 배포까지 자동 진행 금지
+
+## Claude 가 자동으로 챙겨야 할 동작
+
+세션 시작 시 (특히 Claude Code 세션이 worktree 폴더에서 시작될 때):
+
+1. `git rev-parse --show-toplevel`로 현재 위치 확인
+2. 만약 worktree 안이면 사용자에게 한 줄 안내:
+   ```
+   📁 현재 위치: {WORKTREE}
+   🌿 브랜치: feature/{X}
+   💡 작업 끝나면 /세션종료 호출하세요.
+   ```
+3. 만약 메인 폴더이고 사용자 요청이 「동시에 다른 기능을 추가로 하고 싶다」 류면 `/새세션` 단축키를 안내
+
+## 사용 시점 요약
+
+| 상황 | 권장 |
+|---|---|
+| 한 사람·한 작업 (시퀀셜) | 메인 폴더에서 그대로. worktree 불필요 |
+| 동시에 다른 기능 둘 이상 | 작업마다 `/새세션`로 worktree 분리 |
+| 한 작업이 너무 길어져 다른 작업 끼워넣고 싶음 | 끼워넣을 작업만 `/새세션` |
+| 다른 사람과 같이 작업 | 사람마다 `/새세션` |
+
+## 관련 규칙·단축키
+
+- `.claude/commands/새세션.md` — `/새세션 X` 단축키
+- `.claude/commands/세션종료.md` — `/세션종료` 단축키
+- `.claude/rules/git.md` — 커밋 컨벤션·운영 배포 가드
+- `.claude/rules/build.md` — `bash dev/build.sh` 의무
+- `.claude/rules/interaction.md` — 약어 풀어쓰기·AskUserQuestion 사용

--- a/.claude/rules/security.md
+++ b/.claude/rules/security.md
@@ -13,10 +13,8 @@ globs: "dev/**/*.js,dev/**/*.html,supabase/**/*.sql"
 - SECURITY DEFINER 함수는 `SET search_path = ''` 필수 (search_path 탈취 방어)
 
 ## 관리자 생성/삭제
-- 관리자 추가는 **초대 방식만** 사용 (`invite_admin` RPC + `resetPasswordForEmail`)
-- super_admin이 비밀번호 직접 지정 금지 (이메일 유효성 미검증 + 비번 누출 위험)
-- 관리자 삭제는 2택 모달로 실수 방지 (권한 해제 vs 완전 삭제)
-- 자기 자신 삭제는 DB 함수에서 차단
+- 초대 방식 (`invite_admin` 원격 호출 함수(RPC) + `resetPasswordForEmail`) + 2택 삭제 모달 + 자기 삭제 차단
+- 상세 RPC·deprecated 함수 목록은 `.claude/rules/supabase.md` 「관리자 추가 (필수)」/「관리자 삭제 (2택)」 섹션 참조
 
 ## Supabase / RLS
 - anon key는 공개 전제 (클라이언트 노출 OK) → **RLS가 유일한 방어선**
@@ -51,6 +49,6 @@ globs: "dev/**/*.js,dev/**/*.html,supabase/**/*.sql"
 - Redirect URLs에는 와일드카드 사용 가능 (`https://globalreverb.com/**`)
 
 ## 마이그레이션 / DB 조작
-- 운영 DB 수정은 항상 개발서버 먼저 → 검증 → 운영 적용
+- 배포 워크플로(개발서버 먼저 → 검증 → 운영 적용)는 `.claude/rules/git.md` 「배포 워크플로 (필수)」 정의처 참조
 - 직접 `auth.users` UPDATE는 최후 수단 (메타데이터 누락 주의)
-- 관리자 삭제는 반드시 RPC 통해서 (고아 데이터 방지)
+- 관리자 삭제는 반드시 원격 호출 함수(RPC) 통해서 (고아 데이터 방지)

--- a/.claude/rules/supabase.md
+++ b/.claude/rules/supabase.md
@@ -10,7 +10,7 @@ globs: "dev/lib/*.js,dev/js/*.js,supabase/**/*.sql"
 - **개발서버**: `qysmxtipobomefudyixw.supabase.co` (🇯🇵 Tokyo `ap-northeast-1`, Pro / MICRO compute) — Org 레벨 PRO라 양 프로젝트 모두 Pro 혜택
 - URL/Key 관리는 `dev/lib/supabase.js`의 `SUPABASE_ENVS`에서만 (하드코딩 금지)
 - 도메인 분기: `globalreverb.com` / `www.globalreverb.com` → 운영, 나머지 → 개발
-- **DB 변경은 항상 개발서버 먼저 적용 → 검증 → 운영 적용**
+- DB 변경 흐름(개발서버 먼저 → 검증 → 운영 적용)은 `.claude/rules/git.md` 「배포 워크플로 (필수)」 정의처 참조
 
 ## DB 접근 패턴
 - DB 참조 시 항상 `db?.from()` 사용 (null-safe, DEMO_MODE 대응)
@@ -89,9 +89,8 @@ globs: "dev/lib/*.js,dev/js/*.js,supabase/**/*.sql"
 - `supabase/seed/*.sql` — 초기 데이터 투입용 (lookup_values, test_influencers 등)
 - Supabase 대시보드 SQL Editor의 저장된 스니펫은 삭제 무관 (repo 파일이 source of truth)
 
-## 계정 열거 방지 (보안)
-- 비밀번호 찾기 성공 메시지는 조건부 표현 (`"등록된 계정이면 메일 발송"`)
-- 회원가입/로그인 에러도 이메일 존재 여부 직접 노출 금지
+## 계정 열거 방지
+- 정의·구현 패턴(비밀번호 찾기 조건부 메시지 등)은 `.claude/rules/security.md` 「계정 열거 방지 (Account Enumeration)」 정의처 참조
 
 ## localStorage 폴백 (DEMO_MODE)
 - Supabase 미연결 시 자동으로 localStorage 동작


### PR DESCRIPTION
## Summary
Cherry-pick 2 .claude/-only commits from dev to main. No code/DB/UI impact.

## Commits
- `8f767cf` (was `ade9aa5` on dev) — multi-session worktree commands (`/새세션`, `/세션종료`) + `multi-session.md` rule
- `8385539` (was `bb8c73c` on dev) — consolidate 4 duplicated rule blocks (build / admin add-delete / account enumeration / DB change flow)

## Why cherry-pick instead of full dev → main
Other dev commits include in-progress features (brand survey 4-column inline edit, deliverable mail i18n previews) that are still being verified in dev. Only the .claude/ tooling changes are ready for production.

## Test plan
- [x] reverb-reviewer 검수 — 정의처-참조 정합성 확인, 정보 손실 없음
- [x] Korean typo grep 0건
- [x] dev 배포 확인 — https://dev.globalreverb.com (no behavioral change since .claude/ only)
- [ ] main 머지 후 main 브랜치를 clone한 다른 터미널에서 `/새세션` 호출 가능 여부 확인 (선택)

🤖 Generated with [Claude Code](https://claude.com/claude-code)