### PR TITLE
feat(admin): show build datetime + git sha at sidebar bottom

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -428,6 +428,10 @@ textarea.form-input{resize:vertical;min-height:80px}
 .admin-layout.collapsed .admin-si-lbl{font-size:0;padding:8px 0;height:0;overflow:hidden}
 .admin-layout.collapsed .admin-si{position:relative}
 .admin-layout.collapsed .admin-si-badge{position:absolute;top:4px;left:50%;margin-left:-2px;min-width:16px;height:16px;padding:0 4px;font-size:9px;font-weight:700;display:flex;align-items:center;justify-content:center;border:2px solid #1A0F18;border-radius:10px;box-sizing:content-box}
+/* 사이드바 최하단 빌드 버전 — 펼친 상태에서만 노출, 접힌 상태에선 숨김 */
+.admin-build-info{padding:10px 20px 14px;font-size:10px;line-height:1.4;color:rgba(255,255,255,.35);font-variant-numeric:tabular-nums;border-top:1px solid rgba(255,255,255,.06);margin-top:6px;flex-shrink:0;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;user-select:text;cursor:default}
+.admin-build-info .admin-build-text{vertical-align:middle}
+.admin-layout.collapsed .admin-build-info{display:none}
 .admin-main{background:var(--surface-container-low);height:100%;overflow:hidden}
 
 .admin-body{padding:24px;height:100%;box-sizing:border-box;display:flex;flex-direction:column}
@@ -1291,6 +1295,11 @@ textarea.form-input{resize:vertical;min-height:80px}
         <div class="admin-si" onclick="adminLogout()">
           <span class="si-icon material-icons-round" style="font-size:18px">logout</span>
           <span class="si-text" style="font-size:12px">로그아웃</span>
+        </div>
+        <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
+        <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
+          <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
+          <span class="admin-build-text">2026-05-08 19:19 · 0f69792</span>
         </div>
       </div>
     </aside>

--- a/dev/admin/index.html
+++ b/dev/admin/index.html
@@ -102,6 +102,11 @@
           <span class="si-icon material-icons-round" style="font-size:18px">logout</span>
           <span class="si-text" style="font-size:12px">로그아웃</span>
         </div>
+        <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
+        <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
+          <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
+          <span class="admin-build-text">__BUILD_DATETIME_KST__ · __GIT_SHA_SHORT__</span>
+        </div>
       </div>
     </aside>
     <main class="admin-main">

--- a/dev/build.sh
+++ b/dev/build.sh
@@ -10,6 +10,10 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 cd "$SCRIPT_DIR"
 
 VERSION="v$(date +%s)"
+# 관리자 사이드바 최하단 버전 표시용 — KST(UTC+9) 사람이 읽기 쉬운 일시 + 7자리 git 커밋 ID
+# git 디렉터리가 없거나(배포 환경) 커밋이 없으면 'local' 폴백
+BUILD_DATETIME_KST="$(TZ='Asia/Seoul' date '+%Y-%m-%d %H:%M')"
+GIT_SHA_SHORT="$(git rev-parse --short=7 HEAD 2>/dev/null || echo 'local')"
 # 큰 CSS/JS 페이로드는 argv 길이 제한(MAX_ARG_STRLEN)에 걸릴 수 있으므로 임시 파일 경유
 BUILD_TMP="$(mktemp -d -t reverb-build-XXXXXX)"
 trap 'rm -rf "$BUILD_TMP"' EXIT
@@ -85,13 +89,15 @@ for f in "${ADMIN_JS_FILES[@]}"; do
   else echo "⚠️  $f 파일을 찾을 수 없습니다"; fi
 done
 
-python3 - "../admin/index.html" "$BUILD_TMP/admin.css" "$BUILD_TMP/admin.js" "$VERSION" "admin/index.html" << 'PYTHON_SCRIPT'
+python3 - "../admin/index.html" "$BUILD_TMP/admin.css" "$BUILD_TMP/admin.js" "$VERSION" "admin/index.html" "$BUILD_DATETIME_KST" "$GIT_SHA_SHORT" << 'PYTHON_SCRIPT'
 import sys, re
 output_path = sys.argv[1]
 css_path = sys.argv[2]
 js_path = sys.argv[3]
 version = sys.argv[4]
 src_html = sys.argv[5]
+build_datetime_kst = sys.argv[6]
+git_sha_short = sys.argv[7]
 
 with open(css_path, "r", encoding="utf-8") as f:
     all_css = f.read()
@@ -105,6 +111,10 @@ with open(src_html, "r", encoding="utf-8") as f:
 html = re.sub(r'<link\s+rel="stylesheet"\s+href="\.\./css/[^"]+"\s*/?>\n?', '', html)
 html = re.sub(r'<script\s+src="(?:\.\./lib|\.\./js|)[^"]*(?:supabase|shared|storage|ui|admin|app)\.js"\s*></script>\n?', '', html)
 
+# 사이드바 최하단 빌드 버전 placeholder 치환
+html = html.replace("__BUILD_DATETIME_KST__", build_datetime_kst)
+html = html.replace("__GIT_SHA_SHORT__", git_sha_short)
+
 version_comment = f"<!-- {version} -->"
 style_block = f"<style>\n{all_css}</style>\n"
 html = html.replace("</head>", f"{style_block}</head>", 1)
@@ -114,7 +124,7 @@ html = html.replace("</body>", f"{script_block}</body>", 1)
 with open(output_path, "w", encoding="utf-8") as f:
     f.write(html)
 
-print(f"  ✅ Admin 빌드 완료 → {output_path}")
+print(f"  ✅ Admin 빌드 완료 → {output_path} (build {build_datetime_kst} · {git_sha_short})")
 PYTHON_SCRIPT
 
 # ══════════════════════════════════════

--- a/dev/css/admin.css
+++ b/dev/css/admin.css
@@ -60,6 +60,10 @@
 .admin-layout.collapsed .admin-si-lbl{font-size:0;padding:8px 0;height:0;overflow:hidden}
 .admin-layout.collapsed .admin-si{position:relative}
 .admin-layout.collapsed .admin-si-badge{position:absolute;top:4px;left:50%;margin-left:-2px;min-width:16px;height:16px;padding:0 4px;font-size:9px;font-weight:700;display:flex;align-items:center;justify-content:center;border:2px solid #1A0F18;border-radius:10px;box-sizing:content-box}
+/* 사이드바 최하단 빌드 버전 — 펼친 상태에서만 노출, 접힌 상태에선 숨김 */
+.admin-build-info{padding:10px 20px 14px;font-size:10px;line-height:1.4;color:rgba(255,255,255,.35);font-variant-numeric:tabular-nums;border-top:1px solid rgba(255,255,255,.06);margin-top:6px;flex-shrink:0;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;user-select:text;cursor:default}
+.admin-build-info .admin-build-text{vertical-align:middle}
+.admin-layout.collapsed .admin-build-info{display:none}
 .admin-main{background:var(--surface-container-low);height:100%;overflow:hidden}
 
 .admin-body{padding:24px;height:100%;box-sizing:border-box;display:flex;flex-direction:column}


### PR DESCRIPTION
## Summary

- 관리자 사이드바 최하단(로그아웃 아래)에 KST 기준 빌드 일시 + 7자리 git 커밋 ID 노출
- 형식 예: `2026-05-08 19:19 · 0f69792`
- 사이드바 접힘 상태에서는 `display:none`으로 숨김

## Why

- 운영팀이 dev.globalreverb.com / globalreverb.com 어디에서 어느 시점 빌드가 배포되었는지 즉시 식별 가능
- 캐시 문제·CDN 지연으로 「내 화면이 최신인지」 묻는 케이스 줄임
- 채팅으로 빌드 ID를 공유할 때 user-select:text로 텍스트 복사 가능

## Changes

| 파일 | 변경 |
|---|---|
| `dev/admin/index.html` | +5 — 로그아웃 항목 아래 `<div class="admin-build-info">` placeholder 마크업 (`__BUILD_DATETIME_KST__ · __GIT_SHA_SHORT__`) |
| `dev/build.sh` | +12 -2 — `BUILD_DATETIME_KST`(KST `date`)·`GIT_SHA_SHORT`(`git rev-parse --short=7 HEAD`, 실패 시 'local' 폴백) 변수 추가. admin Python 스크립트에 인자 전달 후 placeholder 치환 |
| `dev/css/admin.css` | +4 — `.admin-build-info` 스타일 (어두운 회색 텍스트, 작은 글자, 상단 경계선) + 접힘 상태 `display:none` |
| `admin/index.html` | +9 — 빌드 산출물 (자동) |

## How it works

빌드 시점에 `dev/build.sh`가 두 변수를 만들어 admin HTML의 placeholder 두 곳을 일반 문자열 치환:

```sh
BUILD_DATETIME_KST="$(TZ='Asia/Seoul' date '+%Y-%m-%d %H:%M')"
GIT_SHA_SHORT="$(git rev-parse --short=7 HEAD 2>/dev/null || echo 'local')"
```

Python admin 빌드 스텝:
```python
html = html.replace("__BUILD_DATETIME_KST__", build_datetime_kst)
html = html.replace("__GIT_SHA_SHORT__", git_sha_short)
```

빌드 머신에 git이 없거나 detached HEAD 등 엣지 케이스에서는 `local` 폴백으로 안전.

## Test plan

- [x] `bash dev/build.sh` 에러 0
- [x] 산출물 `admin/index.html`에 정확히 1개의 `<span class="admin-build-text">2026-05-08 HH:MM · {SHA7}</span>` 존재
- [x] placeholder `__BUILD_DATETIME_KST__` / `__GIT_SHA_SHORT__` 잔존 0건
- [x] 클라이언트(인플루언서) `index.html`에 `admin-build-info` 미포함
- [ ] dev.globalreverb.com 배포 후 시각 확인:
  - [ ] 사이드바 펼친 상태 → 로그아웃 아래에 `[history 아이콘] 2026-05-08 HH:MM · {SHA7}` 노출
  - [ ] 사이드바 접기 토글 → 텍스트 사라짐
  - [ ] title 속성 hover → 한국어 안내 툴팁
  - [ ] 텍스트 드래그 선택·복사 가능

## Reviewers checked

- [x] reverb-reviewer (GO. Warning 1건 `cursor:default` 추가 fix 적용)
- [ ] qa-tester: skip (시각 요소만 추가)

## Notes

- Vercel 빌드는 GitHub Actions 경유로 `vercel build` + 로컬 commit한 산출물 정적 배포 패턴이라, 빌드 시점 = 로컬 commit 시점. 의미 명확.
- 이 PR과 별개로 메인 폴더(`reverb-jp` dev 브랜치)에 이전 세션의 미커밋 변경(`index.html`, `supabase/seed/test_influencers_staging.sql`, `docs/admin-notices/*` 등)이 남아있음. 본 PR은 origin/dev 0f69792 기준 깨끗한 worktree에서 작업하여 영향 받지 않음.