### PR TITLE
feat(campaign-form): suggest submission_end as +19 days (was +14)

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -1299,7 +1299,7 @@ textarea.form-input{resize:vertical;min-height:80px}
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-05-11 10:55 · c2c1f82</span>
+          <span class="admin-build-text">2026-05-11 11:23 · af6eb14</span>
         </div>
       </div>
     </aside>
@@ -11003,6 +11003,34 @@ function _updateFpFooterSummary(fp) {
 }
 
 // ─────────────────────────────────────────────────────────────────
+// flatpickr appendTo:body 모드 viewport 좌우 경계 보정
+//   - flatpickr position:'auto'는 위/아래만 자동 결정. 좌우는 input
+//     의 left 좌표를 그대로 따라가 viewport 밖으로 잘리는 사고 발생.
+//   - 캘린더가 우측 viewport를 넘으면 left를 줄여 안으로 이동.
+//   - 캘린더가 좌측 viewport를 넘으면 left를 늘려 안으로 이동.
+//   - 위치 계산이 끝난 뒤 다음 프레임에 보정 (race 회피).
+// ─────────────────────────────────────────────────────────────────
+function _clampFpToViewport(fpInst) {
+  if (!fpInst || !fpInst.calendarContainer) return;
+  const cal = fpInst.calendarContainer;
+  requestAnimationFrame(() => {
+    const margin = 8;
+    const vw = document.documentElement.clientWidth;
+    let rect = cal.getBoundingClientRect();
+    let currLeft = parseFloat(cal.style.left) || 0;
+    if (rect.right > vw - margin) {
+      currLeft -= (rect.right - (vw - margin));
+      cal.style.left = currLeft + 'px';
+    }
+    rect = cal.getBoundingClientRect();
+    if (rect.left < margin) {
+      currLeft += (margin - rect.left);
+      cal.style.left = currLeft + 'px';
+    }
+  });
+}
+
+// ─────────────────────────────────────────────────────────────────
 // 단일 날짜 picker (결과물 제출 마감일 / 캠페인 노출 마감일)
 //   - input.fp-single[data-single-prefix][data-single-target] 마크업 mount
 //   - input value를 직접 사용 (별도 hidden input 없음)
@@ -11051,6 +11079,7 @@ function setupCampSinglePickers() {
           if (mn) fpInst.jumpToDate(mn);
         }
         _updateFpSingleFooterSummary(fpInst);
+        _clampFpToViewport(fpInst);
       },
       onChange: (_selectedDates, _str, fpInst) => {
         // popup 안 시각·푸터 요약만 (input.value는 「적용」 시 commit)
@@ -11202,6 +11231,8 @@ function setupCampRangePickers() {
         }
         // 외부에서 hidden input 직접 변경됐을 수 있으니 푸터 요약 재동기화
         _updateFpFooterSummary(fpInst);
+        // viewport 좌우 보정 (recruit 조기 반환 전에 호출해 모든 range picker 적용)
+        _clampFpToViewport(fpInst);
         if (kind !== 'recruit') return;
         // 캘린더 열릴 때마다 현재 hidden input의 시작일을 기준으로 경고 평가
         updateRecruitPastWarn(fpInst, sv ? new Date(sv) : null);

--- a/admin/index.html
+++ b/admin/index.html
@@ -1299,7 +1299,7 @@ textarea.form-input{resize:vertical;min-height:80px}
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-05-08 19:19 · 0f69792</span>
+          <span class="admin-build-text">2026-05-11 10:55 · c2c1f82</span>
         </div>
       </div>
     </aside>
@@ -10704,11 +10704,11 @@ function resolveConfirmModal(ok) {
   if (_confirmResolver) { _confirmResolver(!!ok); _confirmResolver = null; }
 }
 
-// 결과물 제출 마감일을 +14일로 자동 제안 (확인 모달)
+// 결과물 제출 마감일을 +19일로 자동 제안 (확인 모달)
 //   baseKind: 'purchase'(monitor) | 'visit' | 'recruit'(gifting fallback)
-//   - monitor: 구매 기간 종료일 + 14일
-//   - visit:   방문 기간 종료일 + 14일
-//   - gifting: 구매·방문 기간 없으므로 모집 종료일 + 14일
+//   - monitor: 구매 기간 종료일 + 19일
+//   - visit:   방문 기간 종료일 + 19일
+//   - gifting: 구매·방문 기간 없으므로 모집 종료일 + 19일
 async function suggestSubmissionEnd(prefix, baseKind) {
   const baseSuffix = baseKind === 'purchase' ? 'PurchaseEnd'
     : baseKind === 'visit' ? 'VisitEnd'
@@ -10716,7 +10716,7 @@ async function suggestSubmissionEnd(prefix, baseKind) {
   const baseDate = $(prefix + baseSuffix)?.value;
   if (!baseDate) return;
   const target = new Date(baseDate);
-  target.setDate(target.getDate() + 14);
+  target.setDate(target.getDate() + 19);
   const yyyy = target.getFullYear();
   const mm = String(target.getMonth() + 1).padStart(2, '0');
   const dd = String(target.getDate()).padStart(2, '0');
@@ -10724,7 +10724,7 @@ async function suggestSubmissionEnd(prefix, baseKind) {
   const seEl = $(prefix+'SubmissionEnd');
   if (!seEl || seEl.value === suggested) return;
   const baseLabel = {purchase: '구매 기간 종료', visit: '방문 기간 종료', recruit: '모집 종료'}[baseKind] || '기준일';
-  const ok = await showConfirm(`결과물 제출 마감일을 ${yyyy}년 ${mm}월 ${dd}일로 입력하시겠습니까?\n(${baseLabel} + 2주)`);
+  const ok = await showConfirm(`결과물 제출 마감일을 ${yyyy}년 ${mm}월 ${dd}일로 입력하시겠습니까?\n(${baseLabel} + 19일)`);
   if (ok) {
     seEl.value = suggested;
     syncCampDateMinMax(prefix);
@@ -10961,12 +10961,12 @@ function _commitFpRangeToHiddenInputs(fp) {
   if (endEl)   endEl.value   = _fpFormatYmd(end);
   if (kind === 'recruit') {
     updateRecruitPastWarn(fp, start);
-    // gifting 캠페인은 구매·방문 기간이 없으므로 모집 종료일 기준 +14일 fallback 제안
+    // gifting 캠페인은 구매·방문 기간이 없으므로 모집 종료일 기준 +19일 fallback 제안
     const rtName = prefix === 'editCamp' ? 'editRecruitType' : 'newRecruitType';
     const currentRt = document.querySelector(`input[name="${rtName}"]:checked`)?.value || 'monitor';
     if (currentRt === 'gifting' && end) suggestSubmissionEnd(prefix, 'recruit');
   }
-  // monitor=구매 종료, visit=방문 종료 기준 +14일 제안
+  // monitor=구매 종료, visit=방문 종료 기준 +19일 제안
   if ((kind === 'purchase' || kind === 'visit') && end) {
     suggestSubmissionEnd(prefix, kind);
   }

--- a/dev/js/admin.js
+++ b/dev/js/admin.js
@@ -1726,6 +1726,34 @@ function _updateFpFooterSummary(fp) {
 }
 
 // ─────────────────────────────────────────────────────────────────
+// flatpickr appendTo:body 모드 viewport 좌우 경계 보정
+//   - flatpickr position:'auto'는 위/아래만 자동 결정. 좌우는 input
+//     의 left 좌표를 그대로 따라가 viewport 밖으로 잘리는 사고 발생.
+//   - 캘린더가 우측 viewport를 넘으면 left를 줄여 안으로 이동.
+//   - 캘린더가 좌측 viewport를 넘으면 left를 늘려 안으로 이동.
+//   - 위치 계산이 끝난 뒤 다음 프레임에 보정 (race 회피).
+// ─────────────────────────────────────────────────────────────────
+function _clampFpToViewport(fpInst) {
+  if (!fpInst || !fpInst.calendarContainer) return;
+  const cal = fpInst.calendarContainer;
+  requestAnimationFrame(() => {
+    const margin = 8;
+    const vw = document.documentElement.clientWidth;
+    let rect = cal.getBoundingClientRect();
+    let currLeft = parseFloat(cal.style.left) || 0;
+    if (rect.right > vw - margin) {
+      currLeft -= (rect.right - (vw - margin));
+      cal.style.left = currLeft + 'px';
+    }
+    rect = cal.getBoundingClientRect();
+    if (rect.left < margin) {
+      currLeft += (margin - rect.left);
+      cal.style.left = currLeft + 'px';
+    }
+  });
+}
+
+// ─────────────────────────────────────────────────────────────────
 // 단일 날짜 picker (결과물 제출 마감일 / 캠페인 노출 마감일)
 //   - input.fp-single[data-single-prefix][data-single-target] 마크업 mount
 //   - input value를 직접 사용 (별도 hidden input 없음)
@@ -1774,6 +1802,7 @@ function setupCampSinglePickers() {
           if (mn) fpInst.jumpToDate(mn);
         }
         _updateFpSingleFooterSummary(fpInst);
+        _clampFpToViewport(fpInst);
       },
       onChange: (_selectedDates, _str, fpInst) => {
         // popup 안 시각·푸터 요약만 (input.value는 「적용」 시 commit)
@@ -1925,6 +1954,8 @@ function setupCampRangePickers() {
         }
         // 외부에서 hidden input 직접 변경됐을 수 있으니 푸터 요약 재동기화
         _updateFpFooterSummary(fpInst);
+        // viewport 좌우 보정 (recruit 조기 반환 전에 호출해 모든 range picker 적용)
+        _clampFpToViewport(fpInst);
         if (kind !== 'recruit') return;
         // 캘린더 열릴 때마다 현재 hidden input의 시작일을 기준으로 경고 평가
         updateRecruitPastWarn(fpInst, sv ? new Date(sv) : null);

--- a/dev/js/admin.js
+++ b/dev/js/admin.js
@@ -1427,11 +1427,11 @@ function resolveConfirmModal(ok) {
   if (_confirmResolver) { _confirmResolver(!!ok); _confirmResolver = null; }
 }
 
-// 결과물 제출 마감일을 +14일로 자동 제안 (확인 모달)
+// 결과물 제출 마감일을 +19일로 자동 제안 (확인 모달)
 //   baseKind: 'purchase'(monitor) | 'visit' | 'recruit'(gifting fallback)
-//   - monitor: 구매 기간 종료일 + 14일
-//   - visit:   방문 기간 종료일 + 14일
-//   - gifting: 구매·방문 기간 없으므로 모집 종료일 + 14일
+//   - monitor: 구매 기간 종료일 + 19일
+//   - visit:   방문 기간 종료일 + 19일
+//   - gifting: 구매·방문 기간 없으므로 모집 종료일 + 19일
 async function suggestSubmissionEnd(prefix, baseKind) {
   const baseSuffix = baseKind === 'purchase' ? 'PurchaseEnd'
     : baseKind === 'visit' ? 'VisitEnd'
@@ -1439,7 +1439,7 @@ async function suggestSubmissionEnd(prefix, baseKind) {
   const baseDate = $(prefix + baseSuffix)?.value;
   if (!baseDate) return;
   const target = new Date(baseDate);
-  target.setDate(target.getDate() + 14);
+  target.setDate(target.getDate() + 19);
   const yyyy = target.getFullYear();
   const mm = String(target.getMonth() + 1).padStart(2, '0');
   const dd = String(target.getDate()).padStart(2, '0');
@@ -1447,7 +1447,7 @@ async function suggestSubmissionEnd(prefix, baseKind) {
   const seEl = $(prefix+'SubmissionEnd');
   if (!seEl || seEl.value === suggested) return;
   const baseLabel = {purchase: '구매 기간 종료', visit: '방문 기간 종료', recruit: '모집 종료'}[baseKind] || '기준일';
-  const ok = await showConfirm(`결과물 제출 마감일을 ${yyyy}년 ${mm}월 ${dd}일로 입력하시겠습니까?\n(${baseLabel} + 2주)`);
+  const ok = await showConfirm(`결과물 제출 마감일을 ${yyyy}년 ${mm}월 ${dd}일로 입력하시겠습니까?\n(${baseLabel} + 19일)`);
   if (ok) {
     seEl.value = suggested;
     syncCampDateMinMax(prefix);
@@ -1684,12 +1684,12 @@ function _commitFpRangeToHiddenInputs(fp) {
   if (endEl)   endEl.value   = _fpFormatYmd(end);
   if (kind === 'recruit') {
     updateRecruitPastWarn(fp, start);
-    // gifting 캠페인은 구매·방문 기간이 없으므로 모집 종료일 기준 +14일 fallback 제안
+    // gifting 캠페인은 구매·방문 기간이 없으므로 모집 종료일 기준 +19일 fallback 제안
     const rtName = prefix === 'editCamp' ? 'editRecruitType' : 'newRecruitType';
     const currentRt = document.querySelector(`input[name="${rtName}"]:checked`)?.value || 'monitor';
     if (currentRt === 'gifting' && end) suggestSubmissionEnd(prefix, 'recruit');
   }
-  // monitor=구매 종료, visit=방문 종료 기준 +14일 제안
+  // monitor=구매 종료, visit=방문 종료 기준 +19일 제안
   if ((kind === 'purchase' || kind === 'visit') && end) {
     suggestSubmissionEnd(prefix, kind);
   }


### PR DESCRIPTION
## Summary
- 캠페인 등록/편집 폼에서 구매 기간(monitor) / 방문 기간(visit) / 모집 종료일(gifting fallback) 입력 시 결과물 제출 마감일 자동 제안을 **+14일 → +19일**로 변경
- 사용자에게 노출되는 확인 모달 메시지의 `(${baseLabel} + 2주)` → `(${baseLabel} + 19일)`로 통일
- `suggestSubmissionEnd()` 단일 함수 변경으로 monitor/visit/gifting 세 경로 일관 적용

## 변경 범위
- 단일 파일: `dev/js/admin.js` (8군데 — 주석 6 + 로직 1 + 모달 라벨 1)
- 빌드 산출물: `admin/index.html` 재생성
- DB / RLS / 마이그레이션 변경 없음
- 기존 캠페인 데이터 영향 없음 (입력 보조 UI만 변경)

## Test plan
- [ ] 개발서버(`dev.globalreverb.com`) 관리자 로그인 (`admin@kemo.jp / admin1234`)
- [ ] 캠페인 신규 등록 → 모집 타입 **monitor** → 구매 기간 종료일 선택 → 모달 메시지에 `+ 19일` 표기, 「예」 누르면 결과물 제출 마감일에 구매 종료 + 19일 채워짐
- [ ] 모집 타입 **visit** → 방문 기간 종료일 선택 시 동일 동작
- [ ] 모집 타입 **gifting** → 모집 기간 종료일 선택 시 fallback +19일 모달
- [ ] 캠페인 편집 폼에서도 동일 흐름 확인

[via reviewer] grep check for stale `14`/`2주` passed; OK to commit
qa-tester 권장: skip (단일 파일·UI 보조 흐름, DB 영향 없음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)