### PR TITLE
fix(lookup): extend lookup_values_kind_check for migrations 103 + 104

### DIFF
--- a/supabase/migrations/106_lookup_values_kind_check_extend.sql
+++ b/supabase/migrations/106_lookup_values_kind_check_extend.sql
@@ -1,0 +1,44 @@
+-- ════════════════════════════════════════════════════════════════════
+-- migration 106: lookup_values.kind CHECK 제약 확장
+-- ════════════════════════════════════════════════════════════════════
+--
+-- 배경:
+--   - migration 067 에서 lookup_values_kind_check 를 8개 kind 로 한정
+--     (channel/category/content_type/ng_item/reject_reason/
+--     blacklist_reason/violation_reason/caution)
+--   - migration 103 (admin_email_subscriptions) 가 'admin_email_kind'
+--     시드를 INSERT 하는데 CHECK 제약을 확장하지 않아 23514 에러
+--   - migration 104 (application_cancellation) 도 'cancel_reason' 시드
+--     를 INSERT 하므로 동일 문제
+--
+-- 본 마이그레이션은 CHECK 제약을 두 신규 kind 까지 확장한다.
+-- 103/104 의 INSERT 가 ON CONFLICT DO NOTHING 으로 멱등이므로
+-- 본 마이그레이션 실행 후 103/104 를 재실행하면 시드가 정상 INSERT 된다.
+--
+-- 적용 순서 (이미 23514 가 발생한 환경):
+--   1) 본 마이그레이션 106 을 SQL Editor 에서 실행
+--   2) migration 103 을 다시 실행 (이미 적용된 부분은 IF NOT EXISTS /
+--      ON CONFLICT 로 건너뜀; INSERT 만 새로 추가됨)
+--   3) migration 104 실행
+--   4) migration 105 실행
+-- ════════════════════════════════════════════════════════════════════
+
+ALTER TABLE public.lookup_values DROP CONSTRAINT IF EXISTS lookup_values_kind_check;
+
+ALTER TABLE public.lookup_values
+  ADD CONSTRAINT lookup_values_kind_check
+  CHECK (kind IN (
+    'channel',
+    'category',
+    'content_type',
+    'ng_item',
+    'reject_reason',
+    'blacklist_reason',
+    'violation_reason',
+    'caution',
+    'admin_email_kind',
+    'cancel_reason'
+  ));
+
+COMMENT ON COLUMN public.lookup_values.kind IS
+  'channel | category | content_type | ng_item | reject_reason | blacklist_reason | violation_reason | caution | admin_email_kind | cancel_reason';


### PR DESCRIPTION
## Summary

dev 마이그레이션 적용 중 발견된 누락 보강. migration 067의 `lookup_values_kind_check` CHECK 제약이 8개 kind 로 한정되어 있어, **migration 103** (admin_email_kind) 과 **migration 104** (cancel_reason) 의 시드 INSERT 가 23514 에러로 실패.

본 PR이 신규 마이그레이션 **106**으로 CHECK 제약을 10개 kind 로 확장합니다.

## 적용 순서 (dev/운영 SQL Editor)
1. `106_lookup_values_kind_check_extend.sql` — CHECK 확장
2. `103_admin_email_subscriptions.sql` — 재실행 (멱등)
3. `104_application_cancellation.sql`
4. `105_notifications_kind_application_cancelled.sql`

## 검증
```sql
SELECT code, name_ko FROM lookup_values WHERE kind='cancel_reason' ORDER BY sort_order;
-- 6건이면 정상
SELECT code, name_ko FROM lookup_values WHERE kind='admin_email_kind' ORDER BY sort_order;
-- 2건이면 정상
```

## 후속
- 운영 배포 시 release PR에 본 마이그레이션 106 포함. 운영 SQL Editor에서도 동일 순서로 실행
- 향후 lookup_values에 신규 kind 추가하는 마이그레이션은 CHECK 확장도 함께 포함하도록 reviewer 체크 항목 추가 권장

🤖 Generated with [Claude Code](https://claude.com/claude-code)