### PR TITLE
fix(application): respect i18n language in cancel reason labels

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -1299,7 +1299,7 @@ textarea.form-input{resize:vertical;min-height:80px}
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-05-11 14:53 · 0aca534</span>
+          <span class="admin-build-text">2026-05-11 15:29 · 00bcf8c</span>
         </div>
       </div>
     </aside>

--- a/dev/js/mypage.js
+++ b/dev/js/mypage.js
@@ -546,8 +546,11 @@ async function openCancelModalFor(appId) {
     if (!_cancelReasonsCache) _cancelReasonsCache = await fetchCancelReasons();
     const sel = $('cancelModalReasonSelect');
     if (sel) {
+      // 현재 언어 토글에 맞춰 카테고리 라벨 선택 (ko 모드에서 한국어, 그 외 일본어)
+      const lang = (typeof getLang === 'function') ? getLang() : 'ja';
+      const pickLabel = (r) => (lang === 'ko' ? (r.name_ko || r.name_ja) : (r.name_ja || r.name_ko));
       const placeholder = `<option value="">${esc(t('appHistory.cancel.reasonSelect'))}</option>`;
-      const opts = _cancelReasonsCache.map(r => `<option value="${esc(r.code)}">${esc(r.name_ja || r.name_ko)}</option>`).join('');
+      const opts = _cancelReasonsCache.map(r => `<option value="${esc(r.code)}">${esc(pickLabel(r))}</option>`).join('');
       sel.innerHTML = placeholder + opts;
       sel.value = '';
     }
@@ -634,7 +637,10 @@ async function openCancelDetailModal(appId) {
   const reason = _cancelReasonsCache.find(r => r.code === app.cancel_reason_code);
   const setText = (id, text) => { const el = $(id); if (el) el.textContent = text || ''; };
   setText('cancelDetailDatetime', app.cancelled_at ? formatDate(app.cancelled_at) : '—');
-  setText('cancelDetailCategory', reason ? (reason.name_ja || reason.name_ko) : '—');
+  // 현재 언어 토글에 맞춰 카테고리 라벨 표시
+  const lang = (typeof getLang === 'function') ? getLang() : 'ja';
+  const reasonLabel = reason ? (lang === 'ko' ? (reason.name_ko || reason.name_ja) : (reason.name_ja || reason.name_ko)) : '—';
+  setText('cancelDetailCategory', reasonLabel);
   setText('cancelDetailPhase', t(`appHistory.cancelPhase.${app.cancel_phase || 'other'}`));
   // 보충 텍스트는 있을 때만 행 노출.
   // noteRow 는 display:contents 로 grid 가상 행이라 'none'↔'contents' 로 명시 복원.

--- a/index.html
+++ b/index.html
@@ -8318,8 +8318,11 @@ async function openCancelModalFor(appId) {
     if (!_cancelReasonsCache) _cancelReasonsCache = await fetchCancelReasons();
     const sel = $('cancelModalReasonSelect');
     if (sel) {
+      // 현재 언어 토글에 맞춰 카테고리 라벨 선택 (ko 모드에서 한국어, 그 외 일본어)
+      const lang = (typeof getLang === 'function') ? getLang() : 'ja';
+      const pickLabel = (r) => (lang === 'ko' ? (r.name_ko || r.name_ja) : (r.name_ja || r.name_ko));
       const placeholder = `<option value="">${esc(t('appHistory.cancel.reasonSelect'))}</option>`;
-      const opts = _cancelReasonsCache.map(r => `<option value="${esc(r.code)}">${esc(r.name_ja || r.name_ko)}</option>`).join('');
+      const opts = _cancelReasonsCache.map(r => `<option value="${esc(r.code)}">${esc(pickLabel(r))}</option>`).join('');
       sel.innerHTML = placeholder + opts;
       sel.value = '';
     }
@@ -8406,7 +8409,10 @@ async function openCancelDetailModal(appId) {
   const reason = _cancelReasonsCache.find(r => r.code === app.cancel_reason_code);
   const setText = (id, text) => { const el = $(id); if (el) el.textContent = text || ''; };
   setText('cancelDetailDatetime', app.cancelled_at ? formatDate(app.cancelled_at) : '—');
-  setText('cancelDetailCategory', reason ? (reason.name_ja || reason.name_ko) : '—');
+  // 현재 언어 토글에 맞춰 카테고리 라벨 표시
+  const lang = (typeof getLang === 'function') ? getLang() : 'ja';
+  const reasonLabel = reason ? (lang === 'ko' ? (reason.name_ko || reason.name_ja) : (reason.name_ja || reason.name_ko)) : '—';
+  setText('cancelDetailCategory', reasonLabel);
   setText('cancelDetailPhase', t(`appHistory.cancelPhase.${app.cancel_phase || 'other'}`));
   // 보충 텍스트는 있을 때만 행 노출.
   // noteRow 는 display:contents 로 grid 가상 행이라 'none'↔'contents' 로 명시 복원.


### PR DESCRIPTION
## Summary

응모 취소 모달 + 사유 확인 모달의 카테고리 라벨이 언어 토글과 무관하게 일본어 우선이던 문제 수정.

## 변경
- `dev/js/mypage.js`:
  - `openCancelModalFor` 카테고리 select: `getLang()` 결과로 한국어/일본어 분기
  - `openCancelDetailModal` 카테고리 표시: 동일 분기

## Test
- ko 모드(인플루언서 마이페이지 한국어 토글) → 6개 카테고리 한국어 표시
- ja 모드 → 일본어 표시 (기존 동작 유지)

🤖 Generated with [Claude Code](https://claude.com/claude-code)