### PR TITLE
fix(application): keep cancel-modal textarea above the mobile keyboard

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -1299,7 +1299,7 @@ textarea.form-input{resize:vertical;min-height:80px}
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-05-11 15:35 · 57be27e</span>
+          <span class="admin-build-text">2026-05-11 15:40 · 5e4519f</span>
         </div>
       </div>
     </aside>

--- a/admin/index.html
+++ b/admin/index.html
@@ -1299,7 +1299,7 @@ textarea.form-input{resize:vertical;min-height:80px}
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-05-11 15:29 · 00bcf8c</span>
+          <span class="admin-build-text">2026-05-11 15:35 · 57be27e</span>
         </div>
       </div>
     </aside>

--- a/dev/index.html
+++ b/dev/index.html
@@ -176,7 +176,7 @@ window._supabaseLoaded = false;
       </div>
       <div id="cancelModalNoteWrap" style="display:none;margin-bottom:12px">
         <label style="display:block;font-size:12px;font-weight:600;color:var(--ink);margin-bottom:6px" data-i18n="appHistory.cancel.noteLabel">補足説明 (任意・最大500文字)</label>
-        <textarea id="cancelModalNote" class="form-input" rows="3" maxlength="500" style="font-size:14px;resize:vertical"></textarea>
+        <textarea id="cancelModalNote" class="form-input" rows="3" maxlength="500" style="font-size:16px;resize:vertical;line-height:1.5"></textarea>
       </div>
       <div id="cancelModalAckWrap" style="display:none;margin-bottom:12px">
         <label style="display:flex;align-items:flex-start;gap:8px;font-size:13px;color:var(--ink);cursor:pointer">

--- a/dev/js/mypage.js
+++ b/dev/js/mypage.js
@@ -566,11 +566,66 @@ async function openCancelModalFor(appId) {
   const errEl = $('cancelModalError');
   if (errEl) { errEl.textContent = ''; errEl.style.display = 'none'; }
   openModal('cancelModal');
+  // 모바일 키보드 대응: visualViewport 가 줄어들면 modal max-height 도
+  // 그만큼 줄여 textarea 가 키보드 위로 보이도록.
+  _attachCancelModalKeyboardSync();
 }
 
 function closeCancelModal() {
+  _detachCancelModalKeyboardSync();
   closeModal('cancelModal');
   _cancelTargetAppId = null;
+}
+
+// ── 모바일 키보드 대응 ─────────────────────────────────────────
+//   modal-overlay 가 position:fixed;inset:0 라 키보드가 올라와도 자동 보정
+//   안 됨. visualViewport.height 로 modal max-height 동적 갱신 + textarea
+//   focus 시 textarea 를 modal-body 안에서 중앙으로 스크롤.
+let _cancelModalVvHandler = null;
+let _cancelModalTextareaFocusHandler = null;
+
+function _attachCancelModalKeyboardSync() {
+  if (!window.visualViewport) return;
+  if (_cancelModalVvHandler) return;
+  const modalEl = document.querySelector('#cancelModal .modal');
+  _cancelModalVvHandler = () => {
+    const overlay = document.getElementById('cancelModal');
+    if (!overlay || !overlay.classList.contains('open')) return;
+    if (!modalEl) return;
+    const vh = window.visualViewport.height;
+    // 상하 16px 여백
+    modalEl.style.maxHeight = Math.max(240, vh - 16) + 'px';
+  };
+  window.visualViewport.addEventListener('resize', _cancelModalVvHandler);
+  window.visualViewport.addEventListener('scroll', _cancelModalVvHandler);
+  _cancelModalVvHandler();
+
+  // textarea focus 시 0.3s 후 modal-body 안에서 중앙으로 스크롤
+  const ta = document.getElementById('cancelModalNote');
+  if (ta) {
+    _cancelModalTextareaFocusHandler = () => {
+      setTimeout(() => {
+        try { ta.scrollIntoView({block: 'center', behavior: 'smooth'}); } catch(_e) {}
+      }, 300);
+    };
+    ta.addEventListener('focus', _cancelModalTextareaFocusHandler);
+  }
+}
+
+function _detachCancelModalKeyboardSync() {
+  if (window.visualViewport && _cancelModalVvHandler) {
+    window.visualViewport.removeEventListener('resize', _cancelModalVvHandler);
+    window.visualViewport.removeEventListener('scroll', _cancelModalVvHandler);
+    _cancelModalVvHandler = null;
+  }
+  const ta = document.getElementById('cancelModalNote');
+  if (ta && _cancelModalTextareaFocusHandler) {
+    ta.removeEventListener('focus', _cancelModalTextareaFocusHandler);
+    _cancelModalTextareaFocusHandler = null;
+  }
+  // modal max-height 원복
+  const modalEl = document.querySelector('#cancelModal .modal');
+  if (modalEl) modalEl.style.maxHeight = '';
 }
 
 async function submitCancelApplication() {

--- a/dev/js/mypage.js
+++ b/dev/js/mypage.js
@@ -587,14 +587,20 @@ let _cancelModalTextareaFocusHandler = null;
 function _attachCancelModalKeyboardSync() {
   if (!window.visualViewport) return;
   if (_cancelModalVvHandler) return;
-  const modalEl = document.querySelector('#cancelModal .modal');
+  const overlay = document.getElementById('cancelModal');
+  const modalEl = overlay?.querySelector('.modal');
   _cancelModalVvHandler = () => {
-    const overlay = document.getElementById('cancelModal');
     if (!overlay || !overlay.classList.contains('open')) return;
-    if (!modalEl) return;
     const vh = window.visualViewport.height;
-    // 상하 16px 여백
-    modalEl.style.maxHeight = Math.max(240, vh - 16) + 'px';
+    const offsetTop = window.visualViewport.offsetTop;
+    // overlay 가 position:fixed;inset:0 라 키보드와 무관하게 window 전체를
+    // 차지. app.js 의 appShell 보정 패턴을 그대로 적용해 overlay 를
+    // visualViewport 안으로 옮긴다 → 모달이 키보드 위에 떠 있게 됨.
+    overlay.style.height = vh + 'px';
+    overlay.style.top = offsetTop + 'px';
+    overlay.style.bottom = 'auto';
+    // 모달 자체도 visualViewport 안에 fit. 32px 여백 (상하 16px 씩).
+    if (modalEl) modalEl.style.maxHeight = Math.max(240, vh - 32) + 'px';
   };
   window.visualViewport.addEventListener('resize', _cancelModalVvHandler);
   window.visualViewport.addEventListener('scroll', _cancelModalVvHandler);
@@ -623,7 +629,13 @@ function _detachCancelModalKeyboardSync() {
     ta.removeEventListener('focus', _cancelModalTextareaFocusHandler);
     _cancelModalTextareaFocusHandler = null;
   }
-  // modal max-height 원복
+  // overlay 위치 + 모달 max-height 원복
+  const overlay = document.getElementById('cancelModal');
+  if (overlay) {
+    overlay.style.height = '';
+    overlay.style.top = '';
+    overlay.style.bottom = '';
+  }
   const modalEl = document.querySelector('#cancelModal .modal');
   if (modalEl) modalEl.style.maxHeight = '';
 }

--- a/index.html
+++ b/index.html
@@ -8359,14 +8359,20 @@ let _cancelModalTextareaFocusHandler = null;
 function _attachCancelModalKeyboardSync() {
   if (!window.visualViewport) return;
   if (_cancelModalVvHandler) return;
-  const modalEl = document.querySelector('#cancelModal .modal');
+  const overlay = document.getElementById('cancelModal');
+  const modalEl = overlay?.querySelector('.modal');
   _cancelModalVvHandler = () => {
-    const overlay = document.getElementById('cancelModal');
     if (!overlay || !overlay.classList.contains('open')) return;
-    if (!modalEl) return;
     const vh = window.visualViewport.height;
-    // 상하 16px 여백
-    modalEl.style.maxHeight = Math.max(240, vh - 16) + 'px';
+    const offsetTop = window.visualViewport.offsetTop;
+    // overlay 가 position:fixed;inset:0 라 키보드와 무관하게 window 전체를
+    // 차지. app.js 의 appShell 보정 패턴을 그대로 적용해 overlay 를
+    // visualViewport 안으로 옮긴다 → 모달이 키보드 위에 떠 있게 됨.
+    overlay.style.height = vh + 'px';
+    overlay.style.top = offsetTop + 'px';
+    overlay.style.bottom = 'auto';
+    // 모달 자체도 visualViewport 안에 fit. 32px 여백 (상하 16px 씩).
+    if (modalEl) modalEl.style.maxHeight = Math.max(240, vh - 32) + 'px';
   };
   window.visualViewport.addEventListener('resize', _cancelModalVvHandler);
   window.visualViewport.addEventListener('scroll', _cancelModalVvHandler);
@@ -8395,7 +8401,13 @@ function _detachCancelModalKeyboardSync() {
     ta.removeEventListener('focus', _cancelModalTextareaFocusHandler);
     _cancelModalTextareaFocusHandler = null;
   }
-  // modal max-height 원복
+  // overlay 위치 + 모달 max-height 원복
+  const overlay = document.getElementById('cancelModal');
+  if (overlay) {
+    overlay.style.height = '';
+    overlay.style.top = '';
+    overlay.style.bottom = '';
+  }
   const modalEl = document.querySelector('#cancelModal .modal');
   if (modalEl) modalEl.style.maxHeight = '';
 }

--- a/index.html
+++ b/index.html
@@ -676,7 +676,7 @@ textarea.form-input{resize:vertical;min-height:80px}
       </div>
       <div id="cancelModalNoteWrap" style="display:none;margin-bottom:12px">
         <label style="display:block;font-size:12px;font-weight:600;color:var(--ink);margin-bottom:6px" data-i18n="appHistory.cancel.noteLabel">補足説明 (任意・最大500文字)</label>
-        <textarea id="cancelModalNote" class="form-input" rows="3" maxlength="500" style="font-size:14px;resize:vertical"></textarea>
+        <textarea id="cancelModalNote" class="form-input" rows="3" maxlength="500" style="font-size:16px;resize:vertical;line-height:1.5"></textarea>
       </div>
       <div id="cancelModalAckWrap" style="display:none;margin-bottom:12px">
         <label style="display:flex;align-items:flex-start;gap:8px;font-size:13px;color:var(--ink);cursor:pointer">
@@ -8338,11 +8338,66 @@ async function openCancelModalFor(appId) {
   const errEl = $('cancelModalError');
   if (errEl) { errEl.textContent = ''; errEl.style.display = 'none'; }
   openModal('cancelModal');
+  // 모바일 키보드 대응: visualViewport 가 줄어들면 modal max-height 도
+  // 그만큼 줄여 textarea 가 키보드 위로 보이도록.
+  _attachCancelModalKeyboardSync();
 }
 
 function closeCancelModal() {
+  _detachCancelModalKeyboardSync();
   closeModal('cancelModal');
   _cancelTargetAppId = null;
+}
+
+// ── 모바일 키보드 대응 ─────────────────────────────────────────
+//   modal-overlay 가 position:fixed;inset:0 라 키보드가 올라와도 자동 보정
+//   안 됨. visualViewport.height 로 modal max-height 동적 갱신 + textarea
+//   focus 시 textarea 를 modal-body 안에서 중앙으로 스크롤.
+let _cancelModalVvHandler = null;
+let _cancelModalTextareaFocusHandler = null;
+
+function _attachCancelModalKeyboardSync() {
+  if (!window.visualViewport) return;
+  if (_cancelModalVvHandler) return;
+  const modalEl = document.querySelector('#cancelModal .modal');
+  _cancelModalVvHandler = () => {
+    const overlay = document.getElementById('cancelModal');
+    if (!overlay || !overlay.classList.contains('open')) return;
+    if (!modalEl) return;
+    const vh = window.visualViewport.height;
+    // 상하 16px 여백
+    modalEl.style.maxHeight = Math.max(240, vh - 16) + 'px';
+  };
+  window.visualViewport.addEventListener('resize', _cancelModalVvHandler);
+  window.visualViewport.addEventListener('scroll', _cancelModalVvHandler);
+  _cancelModalVvHandler();
+
+  // textarea focus 시 0.3s 후 modal-body 안에서 중앙으로 스크롤
+  const ta = document.getElementById('cancelModalNote');
+  if (ta) {
+    _cancelModalTextareaFocusHandler = () => {
+      setTimeout(() => {
+        try { ta.scrollIntoView({block: 'center', behavior: 'smooth'}); } catch(_e) {}
+      }, 300);
+    };
+    ta.addEventListener('focus', _cancelModalTextareaFocusHandler);
+  }
+}
+
+function _detachCancelModalKeyboardSync() {
+  if (window.visualViewport && _cancelModalVvHandler) {
+    window.visualViewport.removeEventListener('resize', _cancelModalVvHandler);
+    window.visualViewport.removeEventListener('scroll', _cancelModalVvHandler);
+    _cancelModalVvHandler = null;
+  }
+  const ta = document.getElementById('cancelModalNote');
+  if (ta && _cancelModalTextareaFocusHandler) {
+    ta.removeEventListener('focus', _cancelModalTextareaFocusHandler);
+    _cancelModalTextareaFocusHandler = null;
+  }
+  // modal max-height 원복
+  const modalEl = document.querySelector('#cancelModal .modal');
+  if (modalEl) modalEl.style.maxHeight = '';
 }
 
 async function submitCancelApplication() {


### PR DESCRIPTION
## Summary

모바일에서 응모 취소 모달의 추가 설명 textarea에 글을 칠 때 2번째 줄부터 키보드 뒤로 가려져 안 보이는 문제 픽스.

## 변경
1. **textarea font-size 14px → 16px** — iOS는 16px 미만 입력 요소를 focus 시 자동 zoom in 함 (`.claude/rules` Mobile Layout Rule 명시). zoom 멈춤만으로도 textarea가 viewport 안에 머무름
2. **visualViewport 패턴 적용** — `app.js` 의 appShell 보정 패턴을 cancel 모달에 미러
   - 모달 open 시 `visualViewport.resize/scroll` listener 부착
   - `modal.style.maxHeight = visualViewport.height - 16` 로 모달 자체를 키보드 위로 fit
   - textarea focus 300ms 뒤 `scrollIntoView({block:'center'})` — 모달 안에서 캐럿이 보이도록
   - closeCancelModal 시 listener 정리 + maxHeight 원복

활동관리 페이지 헤더 「응모 취소」 버튼도 동일 모달 재사용이라 자동 커버.

## Test plan
- iOS Safari / Android Chrome dev.globalreverb.com
- 응모 취소 모달 → 카테고리 선택 → 추가 설명 textarea → 키보드 올라옴
- 2번째·3번째 줄 입력해도 캐럿이 키보드 위로 보임
- 모달 닫고 다시 열 때 max-height 원복 (다른 콘텐츠 정상 표시)

🤖 Generated with [Claude Code](https://claude.com/claude-code)