### PR TITLE
fix(application): only override cancel-modal overlay when keyboard is up

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -1299,7 +1299,7 @@ textarea.form-input{resize:vertical;min-height:80px}
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-05-11 15:40 · 5e4519f</span>
+          <span class="admin-build-text">2026-05-11 15:49 · bd330f4</span>
         </div>
       </div>
     </aside>

--- a/dev/js/mypage.js
+++ b/dev/js/mypage.js
@@ -584,27 +584,40 @@ function closeCancelModal() {
 let _cancelModalVvHandler = null;
 let _cancelModalTextareaFocusHandler = null;
 
+// 모달이 열린 시점의 visualViewport.height — 키보드 검출 임계값 기준.
+// 키보드가 올라오면 visualViewport.height 가 150px 이상 줄어든다.
+let _cancelModalBaseVvHeight = 0;
+
 function _attachCancelModalKeyboardSync() {
   if (!window.visualViewport) return;
   if (_cancelModalVvHandler) return;
   const overlay = document.getElementById('cancelModal');
   const modalEl = overlay?.querySelector('.modal');
+  _cancelModalBaseVvHeight = window.visualViewport.height;
   _cancelModalVvHandler = () => {
     if (!overlay || !overlay.classList.contains('open')) return;
     const vh = window.visualViewport.height;
-    const offsetTop = window.visualViewport.offsetTop;
-    // overlay 가 position:fixed;inset:0 라 키보드와 무관하게 window 전체를
-    // 차지. app.js 의 appShell 보정 패턴을 그대로 적용해 overlay 를
-    // visualViewport 안으로 옮긴다 → 모달이 키보드 위에 떠 있게 됨.
-    overlay.style.height = vh + 'px';
-    overlay.style.top = offsetTop + 'px';
-    overlay.style.bottom = 'auto';
-    // 모달 자체도 visualViewport 안에 fit. 32px 여백 (상하 16px 씩).
-    if (modalEl) modalEl.style.maxHeight = Math.max(240, vh - 32) + 'px';
+    const diff = _cancelModalBaseVvHeight - vh;
+    if (diff > 150) {
+      // 키보드 올라옴 → overlay/modal 을 visualViewport 안으로 옮겨
+      // align-items:flex-end 가 모달을 키보드 바로 위에 깔도록 한다.
+      const offsetTop = window.visualViewport.offsetTop;
+      overlay.style.height = vh + 'px';
+      overlay.style.top = offsetTop + 'px';
+      overlay.style.bottom = 'auto';
+      if (modalEl) modalEl.style.maxHeight = Math.max(240, vh - 16) + 'px';
+    } else {
+      // 키보드 내려감 또는 처음(임계 미만) → 기본 CSS 그대로 (inset:0,
+      // max-height:90vh) 사용해 backdrop·z-index 가 정상 동작.
+      overlay.style.height = '';
+      overlay.style.top = '';
+      overlay.style.bottom = '';
+      if (modalEl) modalEl.style.maxHeight = '';
+    }
   };
   window.visualViewport.addEventListener('resize', _cancelModalVvHandler);
   window.visualViewport.addEventListener('scroll', _cancelModalVvHandler);
-  _cancelModalVvHandler();
+  // 초기 1회 호출 안 함 — 키보드 안 올라온 상태에서 inline style 박지 않음
 
   // textarea focus 시 0.3s 후 modal-body 안에서 중앙으로 스크롤
   const ta = document.getElementById('cancelModalNote');
@@ -638,6 +651,7 @@ function _detachCancelModalKeyboardSync() {
   }
   const modalEl = document.querySelector('#cancelModal .modal');
   if (modalEl) modalEl.style.maxHeight = '';
+  _cancelModalBaseVvHeight = 0;
 }
 
 async function submitCancelApplication() {

--- a/index.html
+++ b/index.html
@@ -8356,27 +8356,40 @@ function closeCancelModal() {
 let _cancelModalVvHandler = null;
 let _cancelModalTextareaFocusHandler = null;
 
+// 모달이 열린 시점의 visualViewport.height — 키보드 검출 임계값 기준.
+// 키보드가 올라오면 visualViewport.height 가 150px 이상 줄어든다.
+let _cancelModalBaseVvHeight = 0;
+
 function _attachCancelModalKeyboardSync() {
   if (!window.visualViewport) return;
   if (_cancelModalVvHandler) return;
   const overlay = document.getElementById('cancelModal');
   const modalEl = overlay?.querySelector('.modal');
+  _cancelModalBaseVvHeight = window.visualViewport.height;
   _cancelModalVvHandler = () => {
     if (!overlay || !overlay.classList.contains('open')) return;
     const vh = window.visualViewport.height;
-    const offsetTop = window.visualViewport.offsetTop;
-    // overlay 가 position:fixed;inset:0 라 키보드와 무관하게 window 전체를
-    // 차지. app.js 의 appShell 보정 패턴을 그대로 적용해 overlay 를
-    // visualViewport 안으로 옮긴다 → 모달이 키보드 위에 떠 있게 됨.
-    overlay.style.height = vh + 'px';
-    overlay.style.top = offsetTop + 'px';
-    overlay.style.bottom = 'auto';
-    // 모달 자체도 visualViewport 안에 fit. 32px 여백 (상하 16px 씩).
-    if (modalEl) modalEl.style.maxHeight = Math.max(240, vh - 32) + 'px';
+    const diff = _cancelModalBaseVvHeight - vh;
+    if (diff > 150) {
+      // 키보드 올라옴 → overlay/modal 을 visualViewport 안으로 옮겨
+      // align-items:flex-end 가 모달을 키보드 바로 위에 깔도록 한다.
+      const offsetTop = window.visualViewport.offsetTop;
+      overlay.style.height = vh + 'px';
+      overlay.style.top = offsetTop + 'px';
+      overlay.style.bottom = 'auto';
+      if (modalEl) modalEl.style.maxHeight = Math.max(240, vh - 16) + 'px';
+    } else {
+      // 키보드 내려감 또는 처음(임계 미만) → 기본 CSS 그대로 (inset:0,
+      // max-height:90vh) 사용해 backdrop·z-index 가 정상 동작.
+      overlay.style.height = '';
+      overlay.style.top = '';
+      overlay.style.bottom = '';
+      if (modalEl) modalEl.style.maxHeight = '';
+    }
   };
   window.visualViewport.addEventListener('resize', _cancelModalVvHandler);
   window.visualViewport.addEventListener('scroll', _cancelModalVvHandler);
-  _cancelModalVvHandler();
+  // 초기 1회 호출 안 함 — 키보드 안 올라온 상태에서 inline style 박지 않음
 
   // textarea focus 시 0.3s 후 modal-body 안에서 중앙으로 스크롤
   const ta = document.getElementById('cancelModalNote');
@@ -8410,6 +8423,7 @@ function _detachCancelModalKeyboardSync() {
   }
   const modalEl = document.querySelector('#cancelModal .modal');
   if (modalEl) modalEl.style.maxHeight = '';
+  _cancelModalBaseVvHeight = 0;
 }
 
 async function submitCancelApplication() {


### PR DESCRIPTION
## Summary

사용자 보고(이미지): 응모 취소 모달 열림 시 GNB·페이지 헤더·탭·필터가 모달 위에 보이고 backdrop이 안 깔리는 현상. 원인은 직전 PR #162에서 `_attachCancelModalKeyboardSync` 가 열림 시점에 즉시 1회 호출되어 키보드 안 올라온 상태에서도 overlay 에 inline `top/bottom/height` 를 박는 것.

## 변경
- `_cancelModalVvHandler` 는 **키보드 검출 임계값 150px 초과** 일 때만 inline 보정 발동. 미만이면 모든 inline 스타일 클리어 → 기본 CSS(`inset:0`, `max-height:90vh`, `align-items:flex-end`) 그대로 동작
- 모달 open 시점 1회 호출 제거 — 키보드 안 올라온 상태에선 아무 변경 없음
- close 시 listener 정리 + 모든 inline 스타일 원복

textarea focus 시 scrollIntoView 는 그대로 유지 — 키보드 슬라이드-업이 끝난 뒤 캐럿이 모달 중앙으로 옴.

## Test plan
- 모달 열기만 (textarea 미접근) → backdrop 정상, GNB/탭 가려짐, 모달 90vh 중앙
- textarea focus → 키보드 올라옴 → visualViewport.height 150px+ 감소 → overlay/모달이 visualViewport 안으로 fit → textarea 키보드 위로 보임
- textarea blur → visualViewport 원복 → 모달 90vh 복원
- 모달 close → inline 스타일 모두 클리어

🤖 Generated with [Claude Code](https://claude.com/claude-code)