### PR TITLE
fix(application): fill viewport with cancel modal while keyboard is up

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -1299,7 +1299,7 @@ textarea.form-input{resize:vertical;min-height:80px}
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-05-11 15:49 · bd330f4</span>
+          <span class="admin-build-text">2026-05-11 16:00 · 8b23f90</span>
         </div>
       </div>
     </aside>

--- a/dev/index.html
+++ b/dev/index.html
@@ -152,7 +152,7 @@ window._supabaseLoaded = false;
 </div>
 
 <!-- 응모 취소 모달 (migration 104 / 사양 §4-2·§4-3) — 단순형/사유 입력형 통합 -->
-<div class="modal-overlay" id="cancelModal" style="z-index:615">
+<div class="modal-overlay" id="cancelModal" style="z-index:615;background:rgba(0,0,0,.65)">
   <div class="modal" style="max-width:440px;border-radius:20px;margin:auto;max-height:90vh;display:flex;flex-direction:column">
     <div class="modal-header" style="padding:18px 20px 12px;border-bottom:1px solid var(--line);display:flex;align-items:center;justify-content:space-between">
       <div id="cancelModalTitle" style="font-size:15px;font-weight:700;color:var(--ink)">応募を取り消しますか？</div>

--- a/dev/js/mypage.js
+++ b/dev/js/mypage.js
@@ -599,20 +599,29 @@ function _attachCancelModalKeyboardSync() {
     const vh = window.visualViewport.height;
     const diff = _cancelModalBaseVvHeight - vh;
     if (diff > 150) {
-      // 키보드 올라옴 → overlay/modal 을 visualViewport 안으로 옮겨
-      // align-items:flex-end 가 모달을 키보드 바로 위에 깔도록 한다.
+      // 키보드 올라옴 → overlay 를 visualViewport 안으로 옮기고 모달이
+      // 그 영역 가득 차도록 height/min-height 를 강제. 콘텐츠가 작아도
+      // 모달이 viewport 위쪽까지 채워서 응모이력 페이지가 모달 위로
+      // 비치지 않게 한다.
       const offsetTop = window.visualViewport.offsetTop;
       overlay.style.height = vh + 'px';
       overlay.style.top = offsetTop + 'px';
       overlay.style.bottom = 'auto';
-      if (modalEl) modalEl.style.maxHeight = Math.max(240, vh - 16) + 'px';
+      if (modalEl) {
+        const targetH = Math.max(240, vh - 16);
+        modalEl.style.maxHeight = targetH + 'px';
+        modalEl.style.height = targetH + 'px';
+      }
     } else {
       // 키보드 내려감 또는 처음(임계 미만) → 기본 CSS 그대로 (inset:0,
       // max-height:90vh) 사용해 backdrop·z-index 가 정상 동작.
       overlay.style.height = '';
       overlay.style.top = '';
       overlay.style.bottom = '';
-      if (modalEl) modalEl.style.maxHeight = '';
+      if (modalEl) {
+        modalEl.style.maxHeight = '';
+        modalEl.style.height = '';
+      }
     }
   };
   window.visualViewport.addEventListener('resize', _cancelModalVvHandler);
@@ -650,7 +659,10 @@ function _detachCancelModalKeyboardSync() {
     overlay.style.bottom = '';
   }
   const modalEl = document.querySelector('#cancelModal .modal');
-  if (modalEl) modalEl.style.maxHeight = '';
+  if (modalEl) {
+    modalEl.style.maxHeight = '';
+    modalEl.style.height = '';
+  }
   _cancelModalBaseVvHeight = 0;
 }
 

--- a/index.html
+++ b/index.html
@@ -652,7 +652,7 @@ textarea.form-input{resize:vertical;min-height:80px}
 </div>
 
 <!-- 응모 취소 모달 (migration 104 / 사양 §4-2·§4-3) — 단순형/사유 입력형 통합 -->
-<div class="modal-overlay" id="cancelModal" style="z-index:615">
+<div class="modal-overlay" id="cancelModal" style="z-index:615;background:rgba(0,0,0,.65)">
   <div class="modal" style="max-width:440px;border-radius:20px;margin:auto;max-height:90vh;display:flex;flex-direction:column">
     <div class="modal-header" style="padding:18px 20px 12px;border-bottom:1px solid var(--line);display:flex;align-items:center;justify-content:space-between">
       <div id="cancelModalTitle" style="font-size:15px;font-weight:700;color:var(--ink)">応募を取り消しますか？</div>
@@ -8371,20 +8371,29 @@ function _attachCancelModalKeyboardSync() {
     const vh = window.visualViewport.height;
     const diff = _cancelModalBaseVvHeight - vh;
     if (diff > 150) {
-      // 키보드 올라옴 → overlay/modal 을 visualViewport 안으로 옮겨
-      // align-items:flex-end 가 모달을 키보드 바로 위에 깔도록 한다.
+      // 키보드 올라옴 → overlay 를 visualViewport 안으로 옮기고 모달이
+      // 그 영역 가득 차도록 height/min-height 를 강제. 콘텐츠가 작아도
+      // 모달이 viewport 위쪽까지 채워서 응모이력 페이지가 모달 위로
+      // 비치지 않게 한다.
       const offsetTop = window.visualViewport.offsetTop;
       overlay.style.height = vh + 'px';
       overlay.style.top = offsetTop + 'px';
       overlay.style.bottom = 'auto';
-      if (modalEl) modalEl.style.maxHeight = Math.max(240, vh - 16) + 'px';
+      if (modalEl) {
+        const targetH = Math.max(240, vh - 16);
+        modalEl.style.maxHeight = targetH + 'px';
+        modalEl.style.height = targetH + 'px';
+      }
     } else {
       // 키보드 내려감 또는 처음(임계 미만) → 기본 CSS 그대로 (inset:0,
       // max-height:90vh) 사용해 backdrop·z-index 가 정상 동작.
       overlay.style.height = '';
       overlay.style.top = '';
       overlay.style.bottom = '';
-      if (modalEl) modalEl.style.maxHeight = '';
+      if (modalEl) {
+        modalEl.style.maxHeight = '';
+        modalEl.style.height = '';
+      }
     }
   };
   window.visualViewport.addEventListener('resize', _cancelModalVvHandler);
@@ -8422,7 +8431,10 @@ function _detachCancelModalKeyboardSync() {
     overlay.style.bottom = '';
   }
   const modalEl = document.querySelector('#cancelModal .modal');
-  if (modalEl) modalEl.style.maxHeight = '';
+  if (modalEl) {
+    modalEl.style.maxHeight = '';
+    modalEl.style.height = '';
+  }
   _cancelModalBaseVvHeight = 0;
 }
 


### PR DESCRIPTION
## Summary

PR #163 머지 후에도 사용자가 "모달이 키보드 위에 작게 떠 있고 위쪽에 응모이력 페이지가 그대로 보임" 보고. 모달이 콘텐츠 크기만큼만이라 visualViewport 영역 일부만 차지하고 위쪽은 backdrop만 → backdrop이 약해 페이지가 잘 보임.

## 변경
1. 키보드 검출 시 `modal.style.height = visualViewport.height - 16`까지 강제 — 모달이 키보드 위 영역 가득 채움. modal-body 가 flex:1 + overflow-y:auto 라 textarea/체크/버튼 모두 내부 스크롤로 접근
2. `#cancelModal` 의 backdrop 을 inline 으로 `rgba(0,0,0,.65)` 로 강화 — 모달 위에 페이지 비침 차단
3. 정리(close/detach) 시 `height` inline 도 함께 클리어 — landscape↔portrait 전환 시 stale sizing 누수 방지

## Test
- 모바일 (iOS Safari / Android Chrome) 인플루언서 응모 이력 → ⋮ → 응모 취소
- 카테고리 선택 → 추가 설명 textarea 탭 → 키보드 올라옴
- 모달이 visualViewport 가득, 위쪽에 응모이력 비치지 않음
- textarea 입력 시 캐럿이 키보드 위로 보임 (scrollIntoView)
- 모달 닫고 다시 열 때 정상 위치 (시트 스타일, 키보드 없을 때 콘텐츠 만큼)

🤖 Generated with [Claude Code](https://claude.com/claude-code)