### PR TITLE
fix(application): cancel page — re-render on lang switch + focus scroll

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -1299,7 +1299,7 @@ textarea.form-input{resize:vertical;min-height:80px}
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-05-11 16:09 · 69b6904</span>
+          <span class="admin-build-text">2026-05-11 16:35 · 1462109</span>
         </div>
       </div>
     </aside>

--- a/dev/index.html
+++ b/dev/index.html
@@ -462,7 +462,9 @@ window._supabaseLoaded = false;
 재사용한다.
 ══════════════════════════════════ -->
 <div id="page-app-cancel" class="page">
-  <div class="container" style="padding:16px 16px 32px">
+  <!-- padding-bottom 을 크게 잡아 모바일 키보드가 올라와도 input/textarea
+       가 .page.active 자연 스크롤로 키보드 위로 올라올 여유 확보 -->
+  <div class="container" style="padding:16px 16px 50vh">
     <div class="detail-back" onclick="navigateBackFromCancelApp()" style="font-size:13px;margin-bottom:12px;display:inline-flex;align-items:center;gap:4px;cursor:pointer"><span class="material-icons-round notranslate" translate="no" style="font-size:18px;vertical-align:-3px">arrow_back</span> <span data-i18n="appHistory.cancel.cancelBtn">戻る</span></div>
     <div style="font-size:18px;font-weight:800;color:var(--ink);margin-bottom:6px" data-i18n="appHistory.cancel.title">応募を取り消しますか？</div>
     <div style="font-size:13px;color:var(--muted);margin-bottom:18px">

--- a/dev/js/app.js
+++ b/dev/js/app.js
@@ -97,6 +97,15 @@ window.addEventListener('langchange', function() {
   if (page === 'home') { if (typeof loadCampaigns === 'function') loadCampaigns(); }
   else if (page === 'campaigns') { if (typeof loadCampaignsPage === 'function') loadCampaignsPage(); }
   else if (page.startsWith('detail-')) { if (typeof openCampaign === 'function') openCampaign(page.replace('detail-','')); }
+  else if (page === 'app-cancel') {
+    // 응모 취소 페이지: data-i18n 정적 텍스트는 applyI18n 가 처리하지만
+    // JS 로 동적 채운 영역(경고 메시지, 카테고리 select)은 stale.
+    // 현재 대상 신청 ID 가 있으면 페이지 데이터 재렌더.
+    if (typeof _cancelTargetAppId !== 'undefined' && _cancelTargetAppId
+        && typeof openCancelModalFor === 'function') {
+      openCancelModalFor(_cancelTargetAppId);
+    }
+  }
   // 햄버거 메뉴 재렌더 (언어에 따라 라벨 갱신)
   if (typeof renderNavMenu === 'function') renderNavMenu();
 });

--- a/dev/js/mypage.js
+++ b/dev/js/mypage.js
@@ -580,6 +580,28 @@ async function openCancelModalFor(appId) {
   // 페이지 전환
   if (typeof navigate === 'function') navigate('app-cancel');
   if (typeof applyI18n === 'function') applyI18n();
+  // 모바일 키보드 대응: input/select/textarea focus 시 명시적 scrollIntoView.
+  // #appShell 이 position:fixed + overflow:hidden 이라 iOS Safari 의 자동
+  // 스크롤이 .page.active 내부 컨테이너에서 작동하지 않으므로 직접 처리.
+  _attachCancelPageFocusScroll();
+}
+
+// 이미 등록됐는지 플래그 — 페이지 재진입 시 listener 중복 부착 방지
+let _cancelPageFocusScrollBound = false;
+function _attachCancelPageFocusScroll() {
+  if (_cancelPageFocusScrollBound) return;
+  const page = document.getElementById('page-app-cancel');
+  if (!page) return;
+  const targets = page.querySelectorAll('select, textarea, input[type="text"], input[type="number"]');
+  targets.forEach(el => {
+    el.addEventListener('focus', () => {
+      // 0.3s 후 — 키보드/picker 슬라이드-업이 끝나 visualViewport 가 안정된 뒤
+      setTimeout(() => {
+        try { el.scrollIntoView({block: 'center', behavior: 'smooth'}); } catch(_e) {}
+      }, 300);
+    });
+  });
+  _cancelPageFocusScrollBound = true;
 }
 
 // 페이지 진입 출처 — 뒤로가기 동선 결정.

--- a/index.html
+++ b/index.html
@@ -962,7 +962,9 @@ textarea.form-input{resize:vertical;min-height:80px}
 재사용한다.
 ══════════════════════════════════ -->
 <div id="page-app-cancel" class="page">
-  <div class="container" style="padding:16px 16px 32px">
+  <!-- padding-bottom 을 크게 잡아 모바일 키보드가 올라와도 input/textarea
+       가 .page.active 자연 스크롤로 키보드 위로 올라올 여유 확보 -->
+  <div class="container" style="padding:16px 16px 50vh">
     <div class="detail-back" onclick="navigateBackFromCancelApp()" style="font-size:13px;margin-bottom:12px;display:inline-flex;align-items:center;gap:4px;cursor:pointer"><span class="material-icons-round notranslate" translate="no" style="font-size:18px;vertical-align:-3px">arrow_back</span> <span data-i18n="appHistory.cancel.cancelBtn">戻る</span></div>
     <div style="font-size:18px;font-weight:800;color:var(--ink);margin-bottom:6px" data-i18n="appHistory.cancel.title">応募を取り消しますか？</div>
     <div style="font-size:13px;color:var(--muted);margin-bottom:18px">
@@ -8360,6 +8362,28 @@ async function openCancelModalFor(appId) {
   // 페이지 전환
   if (typeof navigate === 'function') navigate('app-cancel');
   if (typeof applyI18n === 'function') applyI18n();
+  // 모바일 키보드 대응: input/select/textarea focus 시 명시적 scrollIntoView.
+  // #appShell 이 position:fixed + overflow:hidden 이라 iOS Safari 의 자동
+  // 스크롤이 .page.active 내부 컨테이너에서 작동하지 않으므로 직접 처리.
+  _attachCancelPageFocusScroll();
+}
+
+// 이미 등록됐는지 플래그 — 페이지 재진입 시 listener 중복 부착 방지
+let _cancelPageFocusScrollBound = false;
+function _attachCancelPageFocusScroll() {
+  if (_cancelPageFocusScrollBound) return;
+  const page = document.getElementById('page-app-cancel');
+  if (!page) return;
+  const targets = page.querySelectorAll('select, textarea, input[type="text"], input[type="number"]');
+  targets.forEach(el => {
+    el.addEventListener('focus', () => {
+      // 0.3s 후 — 키보드/picker 슬라이드-업이 끝나 visualViewport 가 안정된 뒤
+      setTimeout(() => {
+        try { el.scrollIntoView({block: 'center', behavior: 'smooth'}); } catch(_e) {}
+      }, 300);
+    });
+  });
+  _cancelPageFocusScrollBound = true;
 }
 
 // 페이지 진입 출처 — 뒤로가기 동선 결정.
@@ -8573,6 +8597,15 @@ window.addEventListener('langchange', function() {
   if (page === 'home') { if (typeof loadCampaigns === 'function') loadCampaigns(); }
   else if (page === 'campaigns') { if (typeof loadCampaignsPage === 'function') loadCampaignsPage(); }
   else if (page.startsWith('detail-')) { if (typeof openCampaign === 'function') openCampaign(page.replace('detail-','')); }
+  else if (page === 'app-cancel') {
+    // 응모 취소 페이지: data-i18n 정적 텍스트는 applyI18n 가 처리하지만
+    // JS 로 동적 채운 영역(경고 메시지, 카테고리 select)은 stale.
+    // 현재 대상 신청 ID 가 있으면 페이지 데이터 재렌더.
+    if (typeof _cancelTargetAppId !== 'undefined' && _cancelTargetAppId
+        && typeof openCancelModalFor === 'function') {
+      openCancelModalFor(_cancelTargetAppId);
+    }
+  }
   // 햄버거 메뉴 재렌더 (언어에 따라 라벨 갱신)
   if (typeof renderNavMenu === 'function') renderNavMenu();
 });


### PR DESCRIPTION
## Summary

PR #166(모달→페이지) 후 보고된 두 가지 추가 이슈 정리.

1. **모바일 키보드가 textarea/select를 가림** — #appShell이 position:fixed + overflow:hidden이라 iOS Safari 자동 scrollIntoView 미작동
2. **일본어/한국어 토글 시 페이지 안 일부 텍스트가 한국어 잔존** — data-i18n은 applyI18n 자동 재렌더 하지만 JS textContent로 채운 영역(경고 문장, 카테고리 select)은 stale

## 변경
- `dev/index.html` — `#page-app-cancel` 의 padding-bottom 을 `50vh` 로 확장 (키보드 위로 input 들이 올라올 스크롤 여유)
- `dev/js/mypage.js` — `_attachCancelPageFocusScroll()` 신규: select/textarea/input 에 focus 시 0.3s 뒤 `scrollIntoView({block:'center'})` 호출. 1회만 등록
- `dev/js/app.js` — `langchange` 이벤트 핸들러에 `app-cancel` 분기 추가: `_cancelTargetAppId` 가 있으면 `openCancelModalFor` 재호출 → JS 채운 영역(경고/카테고리)이 새 언어로 갱신

## Test
- 응모 취소 페이지 진입 → 카테고리 select 탭 → picker 열리지만 textarea/체크/버튼 영역 스크롤로 접근
- textarea 탭 → 키보드 올라옴 → textarea 가 키보드 위로 자동 스크롤
- 페이지 안에서 일본어 ↔ 한국어 토글 → 경고 문장 + 카테고리 옵션 모두 새 언어로 즉시 변경

🤖 Generated with [Claude Code](https://claude.com/claude-code)