### PR TITLE
fix(bundles): drop participation legacy fallback + correct NG preview UI

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -1299,7 +1299,7 @@ textarea.form-input{resize:vertical;min-height:80px}
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-05-11 18:05 · 24d6d21</span>
+          <span class="admin-build-text">2026-05-11 18:14 · 7788c0c</span>
         </div>
       </div>
     </aside>
@@ -12263,13 +12263,8 @@ function renderCampPreview(mode) {
     ? `${camp.product_price>0?`¥${camp.product_price.toLocaleString()} ${rewardLabelJa}`:'商品無償提供'}${camp.reward>0?` + ¥${camp.reward.toLocaleString()} 報酬`:''}`
     : '';
 
-  // 참여방법 (스냅샷 > legacy)
-  const legacySteps = [
-    {title_ja:'応募フォームを提出', desc_ja:'当選された方には当選日にLINEにてご連絡いたします。'},
-    {title_ja:'製品を使用してSNSにレビューを投稿', desc_ja:'① 投稿ガイドを確認 ② SNSにレビューを投稿'},
-    {title_ja:'LINEで投稿リンクを送る', desc_ja:'SNSの投稿リンクをコピーして、LINEで送信してください。'}
-  ];
-  const steps = (Array.isArray(camp.participation_steps) && camp.participation_steps.length) ? camp.participation_steps : legacySteps;
+  // 참여방법 (스냅샷만 사용 — legacy 폴백 제거, migration 110으로 운영 백필 완료)
+  const steps = Array.isArray(camp.participation_steps) ? camp.participation_steps : [];
 
   el.innerHTML = `
     <div class="cp-frame">
@@ -12313,14 +12308,14 @@ function renderCampPreview(mode) {
             return rows.join('');
           })()}
         </div>
-        <div class="cp-participation">
+        ${steps.length ? `<div class="cp-participation">
           <div class="cp-section-heading">参加方法</div>
           ${steps.map((s,i)=>{
             const title = s.title_ja || s.title_ko || '';
             const desc = s.desc_ja || s.desc_ko || '';
             return `<div class="cp-step"><div class="cp-step-num">STEP ${i+1}</div><div><div class="cp-step-title">${esc(title)}</div>${desc?`<div class="cp-step-desc">${esc(desc)}</div>`:''}</div></div>`;
           }).join('')}
-        </div>
+        </div>` : ''}
         ${camp.product_url?`<div class="cp-product-link"><span class="material-icons-round notranslate" translate="no" style="font-size:16px">shopping_bag</span> 商品ページ</div>`:''}
         ${camp.description?`<div class="cp-sec"><div class="cp-section-heading">キャンペーン説明</div><div class="cp-sec-desc-body rich-content">${richFn(camp.description)}</div></div>`:''}
         ${(camp.appeal||camp.hashtags||camp.mentions)?`<div class="cp-sec"><div class="cp-section-heading">投稿ガイドライン</div>
@@ -12335,7 +12330,7 @@ function renderCampPreview(mode) {
           const s = (typeof sanitizeCautionHtml === 'function') ? sanitizeCautionHtml : (h => String(h||''));
           if (ngItems.length) {
             const lis = ngItems.map(it => `<li>${s(it.html_ja || it.html_ko || '')}</li>`).join('');
-            return `<div class="cp-sec"><div class="cp-section-heading">NG事項</div><ul class="cp-sec-body cp-sec-bg-ng" style="margin:0;padding-left:16px;display:flex;flex-direction:column;gap:4px;line-height:1.65">${lis}</ul></div>`;
+            return `<div class="cp-sec"><div class="cp-section-heading">NG事項</div><div class="cp-sec-body cp-sec-bg-ng"><ul style="margin:0;padding-left:18px;line-height:1.7">${lis}</ul></div></div>`;
           }
           if (camp.ng) {
             return `<div class="cp-sec"><div class="cp-section-heading">NG事項</div><div class="cp-sec-body cp-sec-bg-ng rich-content">${richFn(camp.ng)}</div></div>`;
@@ -12345,7 +12340,7 @@ function renderCampPreview(mode) {
         ${(Array.isArray(camp.caution_items) && camp.caution_items.length) ? (() => {
           const s = (typeof sanitizeCautionHtml === 'function') ? sanitizeCautionHtml : (h => String(h||''));
           const lis = camp.caution_items.map(it => `<li>${s(it.html_ja || it.html_ko || '')}</li>`).join('');
-          return `<div class="cp-sec"><div class="cp-section-heading">注意事項</div><ul class="cp-sec-body" style="margin:0;padding-left:16px;display:flex;flex-direction:column;gap:4px;line-height:1.65">${lis}</ul></div>`;
+          return `<div class="cp-sec"><div class="cp-section-heading">注意事項</div><div class="cp-sec-body"><ul style="margin:0;padding-left:18px;line-height:1.7">${lis}</ul></div></div>`;
         })() : ''}
       </div>
       <div class="cp-cta">

--- a/dev/js/admin.js
+++ b/dev/js/admin.js
@@ -2630,13 +2630,8 @@ function renderCampPreview(mode) {
     ? `${camp.product_price>0?`¥${camp.product_price.toLocaleString()} ${rewardLabelJa}`:'商品無償提供'}${camp.reward>0?` + ¥${camp.reward.toLocaleString()} 報酬`:''}`
     : '';
 
-  // 참여방법 (스냅샷 > legacy)
-  const legacySteps = [
-    {title_ja:'応募フォームを提出', desc_ja:'当選された方には当選日にLINEにてご連絡いたします。'},
-    {title_ja:'製品を使用してSNSにレビューを投稿', desc_ja:'① 投稿ガイドを確認 ② SNSにレビューを投稿'},
-    {title_ja:'LINEで投稿リンクを送る', desc_ja:'SNSの投稿リンクをコピーして、LINEで送信してください。'}
-  ];
-  const steps = (Array.isArray(camp.participation_steps) && camp.participation_steps.length) ? camp.participation_steps : legacySteps;
+  // 참여방법 (스냅샷만 사용 — legacy 폴백 제거, migration 110으로 운영 백필 완료)
+  const steps = Array.isArray(camp.participation_steps) ? camp.participation_steps : [];
 
   el.innerHTML = `
     <div class="cp-frame">
@@ -2680,14 +2675,14 @@ function renderCampPreview(mode) {
             return rows.join('');
           })()}
         </div>
-        <div class="cp-participation">
+        ${steps.length ? `<div class="cp-participation">
           <div class="cp-section-heading">参加方法</div>
           ${steps.map((s,i)=>{
             const title = s.title_ja || s.title_ko || '';
             const desc = s.desc_ja || s.desc_ko || '';
             return `<div class="cp-step"><div class="cp-step-num">STEP ${i+1}</div><div><div class="cp-step-title">${esc(title)}</div>${desc?`<div class="cp-step-desc">${esc(desc)}</div>`:''}</div></div>`;
           }).join('')}
-        </div>
+        </div>` : ''}
         ${camp.product_url?`<div class="cp-product-link"><span class="material-icons-round notranslate" translate="no" style="font-size:16px">shopping_bag</span> 商品ページ</div>`:''}
         ${camp.description?`<div class="cp-sec"><div class="cp-section-heading">キャンペーン説明</div><div class="cp-sec-desc-body rich-content">${richFn(camp.description)}</div></div>`:''}
         ${(camp.appeal||camp.hashtags||camp.mentions)?`<div class="cp-sec"><div class="cp-section-heading">投稿ガイドライン</div>
@@ -2702,7 +2697,7 @@ function renderCampPreview(mode) {
           const s = (typeof sanitizeCautionHtml === 'function') ? sanitizeCautionHtml : (h => String(h||''));
           if (ngItems.length) {
             const lis = ngItems.map(it => `<li>${s(it.html_ja || it.html_ko || '')}</li>`).join('');
-            return `<div class="cp-sec"><div class="cp-section-heading">NG事項</div><ul class="cp-sec-body cp-sec-bg-ng" style="margin:0;padding-left:16px;display:flex;flex-direction:column;gap:4px;line-height:1.65">${lis}</ul></div>`;
+            return `<div class="cp-sec"><div class="cp-section-heading">NG事項</div><div class="cp-sec-body cp-sec-bg-ng"><ul style="margin:0;padding-left:18px;line-height:1.7">${lis}</ul></div></div>`;
           }
           if (camp.ng) {
             return `<div class="cp-sec"><div class="cp-section-heading">NG事項</div><div class="cp-sec-body cp-sec-bg-ng rich-content">${richFn(camp.ng)}</div></div>`;
@@ -2712,7 +2707,7 @@ function renderCampPreview(mode) {
         ${(Array.isArray(camp.caution_items) && camp.caution_items.length) ? (() => {
           const s = (typeof sanitizeCautionHtml === 'function') ? sanitizeCautionHtml : (h => String(h||''));
           const lis = camp.caution_items.map(it => `<li>${s(it.html_ja || it.html_ko || '')}</li>`).join('');
-          return `<div class="cp-sec"><div class="cp-section-heading">注意事項</div><ul class="cp-sec-body" style="margin:0;padding-left:16px;display:flex;flex-direction:column;gap:4px;line-height:1.65">${lis}</ul></div>`;
+          return `<div class="cp-sec"><div class="cp-section-heading">注意事項</div><div class="cp-sec-body"><ul style="margin:0;padding-left:18px;line-height:1.7">${lis}</ul></div></div>`;
         })() : ''}
       </div>
       <div class="cp-cta">

--- a/dev/js/application.js
+++ b/dev/js/application.js
@@ -139,15 +139,9 @@ async function openCampaign(id) {
       </div>
 
       ${(() => {
-        // 캠페인별 참여방법 스냅샷 우선, 없으면 legacy 하드코딩 fallback
-        const legacy = [
-          {title_ja:'応募フォームを提出', desc_ja:'当選された方には当選日にLINEにてご連絡いたします。'},
-          {title_ja:'製品を使用してSNSにレビューを投稿', desc_ja:'① 投稿ガイドを確認 ② SNSにレビューを投稿'},
-          {title_ja:'LINEで投稿リンクを送る', desc_ja:'SNSの投稿リンクをコピーして、LINEで送信してください。'}
-        ];
-        const steps = (Array.isArray(camp.participation_steps) && camp.participation_steps.length)
-          ? camp.participation_steps
-          : legacy;
+        // 참여방법: 스냅샷만 사용 — legacy 폴백 제거, migration 110으로 운영 백필 완료
+        const steps = Array.isArray(camp.participation_steps) ? camp.participation_steps : [];
+        if (!steps.length) return '';
         return `
       <div style="background:#fff;padding:16px 0;margin-bottom:10px;border-bottom:1px dashed var(--line)">
         <div style="font-size:14px;font-weight:700;margin-bottom:14px;color:var(--ink)">${t('detail.participationTitle')}</div>

--- a/index.html
+++ b/index.html
@@ -6671,15 +6671,9 @@ async function openCampaign(id) {
       </div>
 
       ${(() => {
-        // 캠페인별 참여방법 스냅샷 우선, 없으면 legacy 하드코딩 fallback
-        const legacy = [
-          {title_ja:'応募フォームを提出', desc_ja:'当選された方には当選日にLINEにてご連絡いたします。'},
-          {title_ja:'製品を使用してSNSにレビューを投稿', desc_ja:'① 投稿ガイドを確認 ② SNSにレビューを投稿'},
-          {title_ja:'LINEで投稿リンクを送る', desc_ja:'SNSの投稿リンクをコピーして、LINEで送信してください。'}
-        ];
-        const steps = (Array.isArray(camp.participation_steps) && camp.participation_steps.length)
-          ? camp.participation_steps
-          : legacy;
+        // 참여방법: 스냅샷만 사용 — legacy 폴백 제거, migration 110으로 운영 백필 완료
+        const steps = Array.isArray(camp.participation_steps) ? camp.participation_steps : [];
+        if (!steps.length) return '';
         return `
       <div style="background:#fff;padding:16px 0;margin-bottom:10px;border-bottom:1px dashed var(--line)">
         <div style="font-size:14px;font-weight:700;margin-bottom:14px;color:var(--ink)">${t('detail.participationTitle')}</div>

--- a/supabase/migrations/110_backfill_participation_steps_legacy.sql
+++ b/supabase/migrations/110_backfill_participation_steps_legacy.sql
@@ -1,0 +1,69 @@
+-- migration 110: 운영 캠페인 참여방법(participation_steps) NULL/빈배열 행 백필
+-- 목적: admin.js / application.js의 legacySteps 하드코딩 폴백을 제거하기 위해
+--       이미 운영 중인 캠페인 중 participation_steps가 없는 행에
+--       기존 3단계 기본값을 일괄 채운다.
+--
+-- 영향 행: campaigns WHERE participation_steps IS NULL OR participation_steps = '[]'::jsonb
+-- 검증 쿼리(적용 후 실행): 아래 롤백 섹션 참조
+--
+-- 롤백 방법 (아래 UPDATE의 jsonb 본문은 본 마이그레이션의 SET 절과 정확히 동일해야 함):
+--   UPDATE public.campaigns
+--   SET participation_steps = '[]'::jsonb
+--   WHERE participation_steps = '[
+--     {
+--       "title_ja": "応募フォームを提出",
+--       "title_ko": "신청 폼 제출",
+--       "desc_ja": "当選された方には当選日にLINEにてご連絡いたします。",
+--       "desc_ko": "선정된 분께는 선정일에 LINE으로 안내드립니다."
+--     },
+--     {
+--       "title_ja": "製品を使用してSNSにレビューを投稿",
+--       "title_ko": "제품을 사용해 SNS에 리뷰 게시",
+--       "desc_ja": "① 投稿ガイドを確認 ② SNSにレビューを投稿",
+--       "desc_ko": "① 게시 가이드 확인 ② SNS에 리뷰 게시"
+--     },
+--     {
+--       "title_ja": "LINEで投稿リンクを送る",
+--       "title_ko": "LINE으로 게시 링크 전송",
+--       "desc_ja": "SNSの投稿リンクをコピーして、LINEで送信してください。",
+--       "desc_ko": "SNS 게시 링크를 복사해 LINE으로 보내주세요."
+--     }
+--   ]'::jsonb
+--     AND participation_set_id IS NULL;
+--
+--   주의: 백필 후 운영자가 폼에서 본 값을 직접 수정한 행은 jsonb 본문이 달라 위 WHERE에 안 걸림.
+--         그 경우 안전한 롤백은 적용 전 pg_dump 백업에서 복원.
+
+BEGIN;
+
+UPDATE public.campaigns
+SET participation_steps = '[
+  {
+    "title_ja": "応募フォームを提出",
+    "title_ko": "신청 폼 제출",
+    "desc_ja": "当選された方には当選日にLINEにてご連絡いたします。",
+    "desc_ko": "선정된 분께는 선정일에 LINE으로 안내드립니다."
+  },
+  {
+    "title_ja": "製品を使用してSNSにレビューを投稿",
+    "title_ko": "제품을 사용해 SNS에 리뷰 게시",
+    "desc_ja": "① 投稿ガイドを確認 ② SNSにレビューを投稿",
+    "desc_ko": "① 게시 가이드 확인 ② SNS에 리뷰 게시"
+  },
+  {
+    "title_ja": "LINEで投稿リンクを送る",
+    "title_ko": "LINE으로 게시 링크 전송",
+    "desc_ja": "SNSの投稿リンクをコピーして、LINEで送信してください。",
+    "desc_ko": "SNS 게시 링크를 복사해 LINE으로 보내주세요."
+  }
+]'::jsonb
+WHERE (participation_steps IS NULL OR participation_steps = '[]'::jsonb);
+
+-- 영향 행 확인용 (적용 직후 실행)
+-- SELECT id, title, participation_steps
+-- FROM public.campaigns
+-- WHERE jsonb_array_length(participation_steps) = 3
+--   AND participation_set_id IS NULL
+-- ORDER BY created_at DESC;
+
+COMMIT;


### PR DESCRIPTION
## 사용자 보고 2건 동시 fix

### 보고 1 — 참여방법 번들 미선택인데 미리보기에 STEP 1/2/3 출력
- 원인: `buildPreviewCamp` (admin.js)·`application.js` 양쪽에 `legacySteps` 하드코딩 폴백
- 해결: **migration 110** 으로 운영 캠페인 백필 → 양쪽 폴백 제거 → steps 비어있으면 섹션 자체 숨김

### 보고 2 — NG 사항 미리보기 UI 틀어짐
- 원인: `<ul class="cp-sec-bg-ng" style="display:flex">` — ul 에 직접 배경+flex → bullet marker padding 충돌
- 해결: 박스(배경+보더+padding) `<div>`, 리스트 `<ul>` 분리. caution 미리보기도 동일 패턴 적용 (일관성)

## 변경 내역

| 파일 | 변경 |
|---|---|
| `supabase/migrations/110_backfill_participation_steps_legacy.sql` (신규) | `participation_steps` NULL/`[]` 행에 기본 3단계 백필. `participation_set_id`는 NULL 유지 (PR-C 안전망 가상 옵션 활용) |
| `dev/js/admin.js` | NG/주의사항 미리보기 박스 div/ul 분리, `legacySteps` 폴백 제거 |
| `dev/js/application.js` | 인플루언서 캠페인 상세 참가방법 `legacy` 폴백 제거 + 섹션 숨김 |
| 빌드 산출물 2개 | 자동 재생성 |

## ⚠️ 운영 배포 시 적용 순서 (반드시 준수)

코드 배포 전 마이그레이션을 먼저 적용해야 합니다. 순서가 바뀌면 운영 캠페인 중 `participation_steps`가 빈 행이 있을 때 인플루언서가 참가방법 섹션을 못 보는 짧은 공백이 발생합니다.

1. **(먼저)** 운영 Supabase SQL Editor에서 `110_backfill_participation_steps_legacy.sql` 적용
2. **(그다음)** 본 PR을 `dev → main` 으로 머지

## ⚠️ 적용 전 운영 데이터 사전 검토 권장

마이그레이션 110은 `participation_steps`가 비어있는 모든 캠페인에 동일한 기본 3단계를 채웁니다. 모집 타입(monitor/gifting/visit)별로 다른 단계를 의도했던 캠페인이 있을 수 있으니 적용 전 다음 SQL로 점검:

```sql
SELECT id, title, recruit_type, participation_set_id, participation_steps
FROM public.campaigns
WHERE participation_steps IS NULL OR participation_steps = '[]'::jsonb
ORDER BY status, created_at DESC;
```

특별히 다른 단계를 가져야 하는 캠페인이 있다면 마이그레이션 적용 후 수동 편집 또는 마이그레이션 적용 전 `WHERE` 조건 보완.

## 검수 결과 (reverb-reviewer)
- **Critical/Major 없음**
- Warning 3건:
  - W-1 (롤백 주석 `[...]` 플레이스홀더) — **본 PR에서 처리 완료** (완전한 jsonb 본문으로 갱신)
  - W-2 (운영 적용 순서) — 본 PR 본문 ⚠️ 섹션
  - W-3 (백필 일률 3단계) — 본 PR 본문 ⚠️ 섹션 점검 SQL

## qa-tester
**light 권장** — 관리자 캠페인 미리보기(NG/주의사항 박스 렌더) + 인플루언서 캠페인 상세(참가방법 노출/숨김) 2개 시나리오. 인증/신청 플로우 변경 없음.

## 영향 없음
- 인플루언서 신청 모달, 회원가입, 마이페이지, 알림
- 약관·개인정보처리방침
- NG 사항·주의사항 번들 자체 (PR-A·B·C에서 이미 도입)

🤖 Generated with [Claude Code](https://claude.com/claude-code)