### PR TITLE
ui(campaign-form): swap NG and caution bundle cards order

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -1299,7 +1299,7 @@ textarea.form-input{resize:vertical;min-height:80px}
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-05-11 18:14 · 7788c0c</span>
+          <span class="admin-build-text">2026-05-11 18:30 · 425c5d2</span>
         </div>
       </div>
     </aside>
@@ -1664,6 +1664,24 @@ textarea.form-input{resize:vertical;min-height:80px}
               <button type="button" class="btn btn-ghost btn-xs" onclick="addCampPsetStep('edit')" style="margin-top:8px">+ 단계 추가</button>
             </div>
 
+            <!-- NG 사항: 요약 카드 + 편집 모달로 분리 (migration 107)
+                 인플루언서 화면 순서(참여방법 → NG → 주의사항)에 맞춤 -->
+            <div class="bundle-summary-card" id="editCampNsetSummary" data-kind="nset" data-form-mode="edit">
+              <div class="bundle-summary-label">NG 사항 <span style="font-size:11px;font-weight:400;color:var(--muted)">(인플루언서 상세 페이지에 노출 — 신청 모달 미노출)</span></div>
+              <div class="bundle-summary-body">번들 미선택</div>
+              <button type="button" class="btn btn-ghost btn-xs" onclick="openCampBundleModal('nset','edit')">편집</button>
+            </div>
+            <!-- NG 사항 편집 form-group (DOM 이동 대상) -->
+            <div class="form-group" id="editCampNsetGroup" style="display:none">
+              <label class="form-label">NG 사항 <span style="font-size:11px;font-weight:400;color:var(--muted)">(번들 선택 후 필요시 개별 수정 — 저장 시 이 캠페인에 복사됨. 인플루언서 상세 페이지에 노출)</span></label>
+              <div style="display:flex;gap:8px;align-items:center;margin:6px 0 10px">
+                <select id="editCampNsetSelect" class="form-input" style="flex:1" onchange="onNsetSelectChange('edit')"><option value="">— 번들 선택 —</option></select>
+                <button type="button" class="btn btn-ghost btn-xs" onclick="reloadNsetFromBundle('edit')">번들 다시 불러오기</button>
+              </div>
+              <div id="editCampNgItems" style="display:flex;flex-direction:column;gap:10px"></div>
+              <button type="button" class="btn btn-ghost btn-xs" onclick="addCampNsetItem('edit')" style="margin-top:8px">+ 항목 추가</button>
+            </div>
+
             <!-- 주의사항: 요약 카드 + 편집 모달로 분리 -->
             <div class="bundle-summary-card" id="editCampCsetSummary" data-kind="cset" data-form-mode="edit">
               <div class="bundle-summary-label">주의사항 <span style="font-size:11px;font-weight:400;color:var(--muted)">(인플루언서 상세 페이지와 신청 모달에 모두 노출)</span></div>
@@ -1679,23 +1697,6 @@ textarea.form-input{resize:vertical;min-height:80px}
               </div>
               <div id="editCampCautionItems" style="display:flex;flex-direction:column;gap:10px"></div>
               <button type="button" class="btn btn-ghost btn-xs" onclick="addCampCsetItem('edit')" style="margin-top:8px">+ 항목 추가</button>
-            </div>
-
-            <!-- NG 사항: 요약 카드 + 편집 모달로 분리 (migration 107) -->
-            <div class="bundle-summary-card" id="editCampNsetSummary" data-kind="nset" data-form-mode="edit">
-              <div class="bundle-summary-label">NG 사항 <span style="font-size:11px;font-weight:400;color:var(--muted)">(인플루언서 상세 페이지에 노출 — 신청 모달 미노출)</span></div>
-              <div class="bundle-summary-body">번들 미선택</div>
-              <button type="button" class="btn btn-ghost btn-xs" onclick="openCampBundleModal('nset','edit')">편집</button>
-            </div>
-            <!-- NG 사항 편집 form-group (DOM 이동 대상) -->
-            <div class="form-group" id="editCampNsetGroup" style="display:none">
-              <label class="form-label">NG 사항 <span style="font-size:11px;font-weight:400;color:var(--muted)">(번들 선택 후 필요시 개별 수정 — 저장 시 이 캠페인에 복사됨. 인플루언서 상세 페이지에 노출)</span></label>
-              <div style="display:flex;gap:8px;align-items:center;margin:6px 0 10px">
-                <select id="editCampNsetSelect" class="form-input" style="flex:1" onchange="onNsetSelectChange('edit')"><option value="">— 번들 선택 —</option></select>
-                <button type="button" class="btn btn-ghost btn-xs" onclick="reloadNsetFromBundle('edit')">번들 다시 불러오기</button>
-              </div>
-              <div id="editCampNgItems" style="display:flex;flex-direction:column;gap:10px"></div>
-              <button type="button" class="btn btn-ghost btn-xs" onclick="addCampNsetItem('edit')" style="margin-top:8px">+ 항목 추가</button>
             </div>
 
 
@@ -1939,6 +1940,23 @@ textarea.form-input{resize:vertical;min-height:80px}
               <button type="button" class="btn btn-ghost btn-xs" onclick="addCampPsetStep('new')" style="margin-top:8px">+ 단계 추가</button>
             </div>
 
+            <!-- NG 사항: 요약 카드 + 편집 모달로 분리 (migration 107)
+                 인플루언서 화면 순서(참여방법 → NG → 주의사항)에 맞춤 -->
+            <div class="bundle-summary-card" id="newCampNsetSummary" data-kind="nset" data-form-mode="new">
+              <div class="bundle-summary-label">NG 사항 <span style="font-size:11px;font-weight:400;color:var(--muted)">(인플루언서 상세 페이지에 노출 — 신청 모달 미노출)</span></div>
+              <div class="bundle-summary-body">번들 미선택</div>
+              <button type="button" class="btn btn-ghost btn-xs" onclick="openCampBundleModal('nset','new')">편집</button>
+            </div>
+            <div class="form-group" id="newCampNsetGroup" style="display:none">
+              <label class="form-label">NG 사항 <span style="font-size:11px;font-weight:400;color:var(--muted)">(번들 선택 후 필요시 개별 수정 — 저장 시 이 캠페인에 복사됨. 인플루언서 상세 페이지에 노출)</span></label>
+              <div style="display:flex;gap:8px;align-items:center;margin:6px 0 10px">
+                <select id="newCampNsetSelect" class="form-input" style="flex:1" onchange="onNsetSelectChange('new')"><option value="">— 번들 선택 —</option></select>
+                <button type="button" class="btn btn-ghost btn-xs" onclick="reloadNsetFromBundle('new')">번들 다시 불러오기</button>
+              </div>
+              <div id="newCampNgItems" style="display:flex;flex-direction:column;gap:10px"></div>
+              <button type="button" class="btn btn-ghost btn-xs" onclick="addCampNsetItem('new')" style="margin-top:8px">+ 항목 추가</button>
+            </div>
+
             <!-- 주의사항: 요약 카드 + 편집 모달로 분리 -->
             <div class="bundle-summary-card" id="newCampCsetSummary" data-kind="cset" data-form-mode="new">
               <div class="bundle-summary-label">주의사항 <span style="font-size:11px;font-weight:400;color:var(--muted)">(인플루언서 상세 페이지와 신청 모달에 모두 노출)</span></div>
@@ -1953,22 +1971,6 @@ textarea.form-input{resize:vertical;min-height:80px}
               </div>
               <div id="newCampCautionItems" style="display:flex;flex-direction:column;gap:10px"></div>
               <button type="button" class="btn btn-ghost btn-xs" onclick="addCampCsetItem('new')" style="margin-top:8px">+ 항목 추가</button>
-            </div>
-
-            <!-- NG 사항: 요약 카드 + 편집 모달로 분리 (migration 107) -->
-            <div class="bundle-summary-card" id="newCampNsetSummary" data-kind="nset" data-form-mode="new">
-              <div class="bundle-summary-label">NG 사항 <span style="font-size:11px;font-weight:400;color:var(--muted)">(인플루언서 상세 페이지에 노출 — 신청 모달 미노출)</span></div>
-              <div class="bundle-summary-body">번들 미선택</div>
-              <button type="button" class="btn btn-ghost btn-xs" onclick="openCampBundleModal('nset','new')">편집</button>
-            </div>
-            <div class="form-group" id="newCampNsetGroup" style="display:none">
-              <label class="form-label">NG 사항 <span style="font-size:11px;font-weight:400;color:var(--muted)">(번들 선택 후 필요시 개별 수정 — 저장 시 이 캠페인에 복사됨. 인플루언서 상세 페이지에 노출)</span></label>
-              <div style="display:flex;gap:8px;align-items:center;margin:6px 0 10px">
-                <select id="newCampNsetSelect" class="form-input" style="flex:1" onchange="onNsetSelectChange('new')"><option value="">— 번들 선택 —</option></select>
-                <button type="button" class="btn btn-ghost btn-xs" onclick="reloadNsetFromBundle('new')">번들 다시 불러오기</button>
-              </div>
-              <div id="newCampNgItems" style="display:flex;flex-direction:column;gap:10px"></div>
-              <button type="button" class="btn btn-ghost btn-xs" onclick="addCampNsetItem('new')" style="margin-top:8px">+ 항목 추가</button>
             </div>
 
             <div style="display:flex;gap:10px;margin-top:16px;justify-content:flex-end">

--- a/dev/admin/index.html
+++ b/dev/admin/index.html
@@ -470,6 +470,24 @@
               <button type="button" class="btn btn-ghost btn-xs" onclick="addCampPsetStep('edit')" style="margin-top:8px">+ 단계 추가</button>
             </div>
 
+            <!-- NG 사항: 요약 카드 + 편집 모달로 분리 (migration 107)
+                 인플루언서 화면 순서(참여방법 → NG → 주의사항)에 맞춤 -->
+            <div class="bundle-summary-card" id="editCampNsetSummary" data-kind="nset" data-form-mode="edit">
+              <div class="bundle-summary-label">NG 사항 <span style="font-size:11px;font-weight:400;color:var(--muted)">(인플루언서 상세 페이지에 노출 — 신청 모달 미노출)</span></div>
+              <div class="bundle-summary-body">번들 미선택</div>
+              <button type="button" class="btn btn-ghost btn-xs" onclick="openCampBundleModal('nset','edit')">편집</button>
+            </div>
+            <!-- NG 사항 편집 form-group (DOM 이동 대상) -->
+            <div class="form-group" id="editCampNsetGroup" style="display:none">
+              <label class="form-label">NG 사항 <span style="font-size:11px;font-weight:400;color:var(--muted)">(번들 선택 후 필요시 개별 수정 — 저장 시 이 캠페인에 복사됨. 인플루언서 상세 페이지에 노출)</span></label>
+              <div style="display:flex;gap:8px;align-items:center;margin:6px 0 10px">
+                <select id="editCampNsetSelect" class="form-input" style="flex:1" onchange="onNsetSelectChange('edit')"><option value="">— 번들 선택 —</option></select>
+                <button type="button" class="btn btn-ghost btn-xs" onclick="reloadNsetFromBundle('edit')">번들 다시 불러오기</button>
+              </div>
+              <div id="editCampNgItems" style="display:flex;flex-direction:column;gap:10px"></div>
+              <button type="button" class="btn btn-ghost btn-xs" onclick="addCampNsetItem('edit')" style="margin-top:8px">+ 항목 추가</button>
+            </div>
+
             <!-- 주의사항: 요약 카드 + 편집 모달로 분리 -->
             <div class="bundle-summary-card" id="editCampCsetSummary" data-kind="cset" data-form-mode="edit">
               <div class="bundle-summary-label">주의사항 <span style="font-size:11px;font-weight:400;color:var(--muted)">(인플루언서 상세 페이지와 신청 모달에 모두 노출)</span></div>
@@ -485,23 +503,6 @@
               </div>
               <div id="editCampCautionItems" style="display:flex;flex-direction:column;gap:10px"></div>
               <button type="button" class="btn btn-ghost btn-xs" onclick="addCampCsetItem('edit')" style="margin-top:8px">+ 항목 추가</button>
-            </div>
-
-            <!-- NG 사항: 요약 카드 + 편집 모달로 분리 (migration 107) -->
-            <div class="bundle-summary-card" id="editCampNsetSummary" data-kind="nset" data-form-mode="edit">
-              <div class="bundle-summary-label">NG 사항 <span style="font-size:11px;font-weight:400;color:var(--muted)">(인플루언서 상세 페이지에 노출 — 신청 모달 미노출)</span></div>
-              <div class="bundle-summary-body">번들 미선택</div>
-              <button type="button" class="btn btn-ghost btn-xs" onclick="openCampBundleModal('nset','edit')">편집</button>
-            </div>
-            <!-- NG 사항 편집 form-group (DOM 이동 대상) -->
-            <div class="form-group" id="editCampNsetGroup" style="display:none">
-              <label class="form-label">NG 사항 <span style="font-size:11px;font-weight:400;color:var(--muted)">(번들 선택 후 필요시 개별 수정 — 저장 시 이 캠페인에 복사됨. 인플루언서 상세 페이지에 노출)</span></label>
-              <div style="display:flex;gap:8px;align-items:center;margin:6px 0 10px">
-                <select id="editCampNsetSelect" class="form-input" style="flex:1" onchange="onNsetSelectChange('edit')"><option value="">— 번들 선택 —</option></select>
-                <button type="button" class="btn btn-ghost btn-xs" onclick="reloadNsetFromBundle('edit')">번들 다시 불러오기</button>
-              </div>
-              <div id="editCampNgItems" style="display:flex;flex-direction:column;gap:10px"></div>
-              <button type="button" class="btn btn-ghost btn-xs" onclick="addCampNsetItem('edit')" style="margin-top:8px">+ 항목 추가</button>
             </div>
 
 
@@ -745,6 +746,23 @@
               <button type="button" class="btn btn-ghost btn-xs" onclick="addCampPsetStep('new')" style="margin-top:8px">+ 단계 추가</button>
             </div>
 
+            <!-- NG 사항: 요약 카드 + 편집 모달로 분리 (migration 107)
+                 인플루언서 화면 순서(참여방법 → NG → 주의사항)에 맞춤 -->
+            <div class="bundle-summary-card" id="newCampNsetSummary" data-kind="nset" data-form-mode="new">
+              <div class="bundle-summary-label">NG 사항 <span style="font-size:11px;font-weight:400;color:var(--muted)">(인플루언서 상세 페이지에 노출 — 신청 모달 미노출)</span></div>
+              <div class="bundle-summary-body">번들 미선택</div>
+              <button type="button" class="btn btn-ghost btn-xs" onclick="openCampBundleModal('nset','new')">편집</button>
+            </div>
+            <div class="form-group" id="newCampNsetGroup" style="display:none">
+              <label class="form-label">NG 사항 <span style="font-size:11px;font-weight:400;color:var(--muted)">(번들 선택 후 필요시 개별 수정 — 저장 시 이 캠페인에 복사됨. 인플루언서 상세 페이지에 노출)</span></label>
+              <div style="display:flex;gap:8px;align-items:center;margin:6px 0 10px">
+                <select id="newCampNsetSelect" class="form-input" style="flex:1" onchange="onNsetSelectChange('new')"><option value="">— 번들 선택 —</option></select>
+                <button type="button" class="btn btn-ghost btn-xs" onclick="reloadNsetFromBundle('new')">번들 다시 불러오기</button>
+              </div>
+              <div id="newCampNgItems" style="display:flex;flex-direction:column;gap:10px"></div>
+              <button type="button" class="btn btn-ghost btn-xs" onclick="addCampNsetItem('new')" style="margin-top:8px">+ 항목 추가</button>
+            </div>
+
             <!-- 주의사항: 요약 카드 + 편집 모달로 분리 -->
             <div class="bundle-summary-card" id="newCampCsetSummary" data-kind="cset" data-form-mode="new">
               <div class="bundle-summary-label">주의사항 <span style="font-size:11px;font-weight:400;color:var(--muted)">(인플루언서 상세 페이지와 신청 모달에 모두 노출)</span></div>
@@ -759,22 +777,6 @@
               </div>
               <div id="newCampCautionItems" style="display:flex;flex-direction:column;gap:10px"></div>
               <button type="button" class="btn btn-ghost btn-xs" onclick="addCampCsetItem('new')" style="margin-top:8px">+ 항목 추가</button>
-            </div>
-
-            <!-- NG 사항: 요약 카드 + 편집 모달로 분리 (migration 107) -->
-            <div class="bundle-summary-card" id="newCampNsetSummary" data-kind="nset" data-form-mode="new">
-              <div class="bundle-summary-label">NG 사항 <span style="font-size:11px;font-weight:400;color:var(--muted)">(인플루언서 상세 페이지에 노출 — 신청 모달 미노출)</span></div>
-              <div class="bundle-summary-body">번들 미선택</div>
-              <button type="button" class="btn btn-ghost btn-xs" onclick="openCampBundleModal('nset','new')">편집</button>
-            </div>
-            <div class="form-group" id="newCampNsetGroup" style="display:none">
-              <label class="form-label">NG 사항 <span style="font-size:11px;font-weight:400;color:var(--muted)">(번들 선택 후 필요시 개별 수정 — 저장 시 이 캠페인에 복사됨. 인플루언서 상세 페이지에 노출)</span></label>
-              <div style="display:flex;gap:8px;align-items:center;margin:6px 0 10px">
-                <select id="newCampNsetSelect" class="form-input" style="flex:1" onchange="onNsetSelectChange('new')"><option value="">— 번들 선택 —</option></select>
-                <button type="button" class="btn btn-ghost btn-xs" onclick="reloadNsetFromBundle('new')">번들 다시 불러오기</button>
-              </div>
-              <div id="newCampNgItems" style="display:flex;flex-direction:column;gap:10px"></div>
-              <button type="button" class="btn btn-ghost btn-xs" onclick="addCampNsetItem('new')" style="margin-top:8px">+ 항목 추가</button>
             </div>
 
             <div style="display:flex;gap:10px;margin-top:16px;justify-content:flex-end">


### PR DESCRIPTION
## 변경 의도

캠페인 등록/편집 폼의 번들 카드 순서를 인플루언서 화면 순서와 통일.

| 화면 | 변경 전 | 변경 후 |
|---|---|---|
| 인플루언서 캠페인 상세 | 참여방법 → NG → 주의사항 | (변경 없음) |
| 미리보기 모달 | 참여방법 → NG → 주의사항 | (변경 없음) |
| **관리자 캠페인 폼** | 참여방법 → 주의사항 → NG ❌ | **참여방법 → NG → 주의사항** ✓ |

## 변경 내용
- `dev/admin/index.html` 편집 폼 + 신규 폼 2곳
- NG 카드(`*NsetSummary` + 숨김 `*NsetGroup`)와 주의사항 카드(`*CsetSummary` + 숨김 `*CsetGroup`) **짝 단위로 통째 swap**
- 카드 마크업 자체 변경 없음 (onclick/id/data-* 속성 모두 보존)

## 검수 결과 (reverb-reviewer)
- **Critical/Major/Minor 없음**
- JS 코드의 DOM 인덱스 의존 없음 (모두 `getElementById` 기반) → 위치 변경에 안전
- 빌드 산출물 일관성 확인

## qa-tester
**skip** — 마크업 위치 swap 단독, JS 로직·데이터 변경 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)