### PR TITLE
feat(ng-sets): NG-PR-D extend history modal with NG diff

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -139,6 +139,8 @@ img{display:block;max-width:100%}
 .badge-pink{background:#FFE4EC;color:#B91C5C;border:1px solid #FFB8D0}
 /* 캠페인 상태 비노출 강조 — expired(노출마감, 영구 비노출) */
 .badge-expired{background:#EEEEEE;color:#666666;border:1.5px dashed #999999;opacity:.85}
+/* NG 사항 배지 — 진한 빨강 계열 (badge-pink 분홍과 명확히 구분, cp-sec-bg-ng 톤과 일관) */
+.badge-ng{background:#FFEBEE;color:#B71C1C;border:1px solid #EF9A9A}
 .badge-new{background:var(--primary);color:#fff}
 
 /* ── FORMS (Material Text Field - Outlined) ── */
@@ -1299,7 +1301,7 @@ textarea.form-input{resize:vertical;min-height:80px}
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-05-11 18:30 · 425c5d2</span>
+          <span class="admin-build-text">2026-05-11 18:43 · 7d45b23</span>
         </div>
       </div>
     </aside>
@@ -11075,13 +11077,18 @@ function renderCautionHistoryModal() {
     ? `<div style="font-size:12px;color:var(--muted);margin-bottom:14px">캠페인 · <b style="color:var(--ink)">${esc(camp.title || '')}</b>${camp.campaign_no ? ` <span style="color:var(--muted)">[${esc(camp.campaign_no)}]</span>` : ''}</div>`
     : '';
   if (!list.length) {
-    body.innerHTML = `${headerLine}<div style="text-align:center;padding:40px;color:var(--muted);font-size:13px">아직 변경 이력이 없습니다.<br><span style="font-size:11px">주의사항/참여방법 변경이 발생하면 자동 기록됩니다.</span></div>`;
+    body.innerHTML = `${headerLine}<div style="text-align:center;padding:40px;color:var(--muted);font-size:13px">아직 변경 이력이 없습니다.<br><span style="font-size:11px">주의사항/참여방법/NG 사항 변경이 발생하면 자동 기록됩니다.</span></div>`;
     return;
   }
   const safeRich = (typeof sanitizeCautionHtml === 'function') ? sanitizeCautionHtml : (h => esc(String(h||'')));
   const renderCautionItems = (arr) => {
     if (!Array.isArray(arr) || !arr.length) return '<li style="color:var(--muted)">(없음)</li>';
     return arr.map(it => `<li>${safeRich(it.html_ja || it.html_ko || '')}</li>`).join('');
+  };
+  // NG 항목: 관리자 페이지 한국어 원칙 — html_ko 우선, 없으면 html_ja 폴백
+  const renderNgItems = (arr) => {
+    if (!Array.isArray(arr) || !arr.length) return '<li style="color:var(--muted)">(없음)</li>';
+    return arr.map(it => `<li>${safeRich(it.html_ko || it.html_ja || '')}</li>`).join('');
   };
   const renderPsetSteps = (arr) => {
     if (!Array.isArray(arr) || !arr.length) return '<li style="color:var(--muted)">(없음)</li>';
@@ -11098,9 +11105,14 @@ function renderCautionHistoryModal() {
     const participationChanged =
       (row.prev_participation_set_id || null) !== (row.next_participation_set_id || null)
       || JSON.stringify(row.prev_participation_steps ?? null) !== JSON.stringify(row.next_participation_steps ?? null);
+    // NG 사항 변경 감지 — migration 109에서 추가된 컬럼 (없으면 null 취급)
+    const ngChanged =
+      (row.ng_set_id_prev || null) !== (row.ng_set_id_next || null)
+      || JSON.stringify(row.ng_items_prev ?? null) !== JSON.stringify(row.ng_items_next ?? null);
     const tags = [];
     if (cautionChanged) tags.push('<span class="badge badge-pink" style="font-size:10px">주의사항</span>');
     if (participationChanged) tags.push('<span class="badge badge-blue" style="font-size:10px">참여방법</span>');
+    if (ngChanged) tags.push('<span class="badge badge-ng" style="font-size:10px">NG 사항</span>');
     const ackBadge = row.bypass_warning_ack
       ? '<span class="badge badge-gold" style="font-size:10px" title="신청자 ≥1건 + 경고 모달 통과">경고 확인</span>'
       : '<span class="badge badge-gray" style="font-size:10px" title="신청자 0건 — 모달 미표시">자동</span>';
@@ -11122,7 +11134,7 @@ function renderCautionHistoryModal() {
             </div>
           </div>` : ''}
         ${participationChanged ? `
-          <div>
+          <div${cautionChanged || ngChanged ? ' style="margin-bottom:14px"' : ''}>
             <div style="font-size:12px;font-weight:700;color:var(--ink);margin-bottom:6px">참여방법</div>
             <div style="display:grid;grid-template-columns:1fr 1fr;gap:10px;font-size:12px">
               <div style="border:1px solid var(--line);border-radius:8px;padding:10px;background:#fff">
@@ -11135,6 +11147,22 @@ function renderCautionHistoryModal() {
               </div>
             </div>
           </div>` : ''}
+        ${ngChanged ? `
+          <div>
+            <div style="font-size:12px;font-weight:700;color:var(--ink);margin-bottom:6px">NG 사항</div>
+            <div style="display:grid;grid-template-columns:1fr 1fr;gap:10px;font-size:12px">
+              <div style="border:1px solid var(--line);border-radius:8px;padding:10px;background:#fff">
+                <div style="font-size:11px;color:var(--muted);margin-bottom:4px">변경 전</div>
+                <ul style="margin:0;padding-left:18px;line-height:1.6">${renderNgItems(row.ng_items_prev)}</ul>
+              </div>
+              <div style="border:1px solid #f5b1b1;border-radius:8px;padding:10px;background:#fff5f5">
+                <div style="font-size:11px;color:#B3261E;margin-bottom:4px;font-weight:700">변경 후</div>
+                <ul style="margin:0;padding-left:18px;line-height:1.6">${renderNgItems(row.ng_items_next)}</ul>
+              </div>
+            </div>
+          </div>` : ''}
+        ${!cautionChanged && !participationChanged && !ngChanged ? `
+          <div style="font-size:12px;color:var(--muted);padding:8px 0">변경 내용이 기록되지 않았습니다.</div>` : ''}
       </div>
     `;
     return `

--- a/dev/css/components.css
+++ b/dev/css/components.css
@@ -52,6 +52,8 @@
 .badge-pink{background:#FFE4EC;color:#B91C5C;border:1px solid #FFB8D0}
 /* 캠페인 상태 비노출 강조 — expired(노출마감, 영구 비노출) */
 .badge-expired{background:#EEEEEE;color:#666666;border:1.5px dashed #999999;opacity:.85}
+/* NG 사항 배지 — 진한 빨강 계열 (badge-pink 분홍과 명확히 구분, cp-sec-bg-ng 톤과 일관) */
+.badge-ng{background:#FFEBEE;color:#B71C1C;border:1px solid #EF9A9A}
 .badge-new{background:var(--primary);color:#fff}
 
 /* ── FORMS (Material Text Field - Outlined) ── */

--- a/dev/js/admin.js
+++ b/dev/js/admin.js
@@ -1440,13 +1440,18 @@ function renderCautionHistoryModal() {
     ? `<div style="font-size:12px;color:var(--muted);margin-bottom:14px">캠페인 · <b style="color:var(--ink)">${esc(camp.title || '')}</b>${camp.campaign_no ? ` <span style="color:var(--muted)">[${esc(camp.campaign_no)}]</span>` : ''}</div>`
     : '';
   if (!list.length) {
-    body.innerHTML = `${headerLine}<div style="text-align:center;padding:40px;color:var(--muted);font-size:13px">아직 변경 이력이 없습니다.<br><span style="font-size:11px">주의사항/참여방법 변경이 발생하면 자동 기록됩니다.</span></div>`;
+    body.innerHTML = `${headerLine}<div style="text-align:center;padding:40px;color:var(--muted);font-size:13px">아직 변경 이력이 없습니다.<br><span style="font-size:11px">주의사항/참여방법/NG 사항 변경이 발생하면 자동 기록됩니다.</span></div>`;
     return;
   }
   const safeRich = (typeof sanitizeCautionHtml === 'function') ? sanitizeCautionHtml : (h => esc(String(h||'')));
   const renderCautionItems = (arr) => {
     if (!Array.isArray(arr) || !arr.length) return '<li style="color:var(--muted)">(없음)</li>';
     return arr.map(it => `<li>${safeRich(it.html_ja || it.html_ko || '')}</li>`).join('');
+  };
+  // NG 항목: 관리자 페이지 한국어 원칙 — html_ko 우선, 없으면 html_ja 폴백
+  const renderNgItems = (arr) => {
+    if (!Array.isArray(arr) || !arr.length) return '<li style="color:var(--muted)">(없음)</li>';
+    return arr.map(it => `<li>${safeRich(it.html_ko || it.html_ja || '')}</li>`).join('');
   };
   const renderPsetSteps = (arr) => {
     if (!Array.isArray(arr) || !arr.length) return '<li style="color:var(--muted)">(없음)</li>';
@@ -1463,9 +1468,14 @@ function renderCautionHistoryModal() {
     const participationChanged =
       (row.prev_participation_set_id || null) !== (row.next_participation_set_id || null)
       || JSON.stringify(row.prev_participation_steps ?? null) !== JSON.stringify(row.next_participation_steps ?? null);
+    // NG 사항 변경 감지 — migration 109에서 추가된 컬럼 (없으면 null 취급)
+    const ngChanged =
+      (row.ng_set_id_prev || null) !== (row.ng_set_id_next || null)
+      || JSON.stringify(row.ng_items_prev ?? null) !== JSON.stringify(row.ng_items_next ?? null);
     const tags = [];
     if (cautionChanged) tags.push('<span class="badge badge-pink" style="font-size:10px">주의사항</span>');
     if (participationChanged) tags.push('<span class="badge badge-blue" style="font-size:10px">참여방법</span>');
+    if (ngChanged) tags.push('<span class="badge badge-ng" style="font-size:10px">NG 사항</span>');
     const ackBadge = row.bypass_warning_ack
       ? '<span class="badge badge-gold" style="font-size:10px" title="신청자 ≥1건 + 경고 모달 통과">경고 확인</span>'
       : '<span class="badge badge-gray" style="font-size:10px" title="신청자 0건 — 모달 미표시">자동</span>';
@@ -1487,7 +1497,7 @@ function renderCautionHistoryModal() {
             </div>
           </div>` : ''}
         ${participationChanged ? `
-          <div>
+          <div${cautionChanged || ngChanged ? ' style="margin-bottom:14px"' : ''}>
             <div style="font-size:12px;font-weight:700;color:var(--ink);margin-bottom:6px">참여방법</div>
             <div style="display:grid;grid-template-columns:1fr 1fr;gap:10px;font-size:12px">
               <div style="border:1px solid var(--line);border-radius:8px;padding:10px;background:#fff">
@@ -1500,6 +1510,22 @@ function renderCautionHistoryModal() {
               </div>
             </div>
           </div>` : ''}
+        ${ngChanged ? `
+          <div>
+            <div style="font-size:12px;font-weight:700;color:var(--ink);margin-bottom:6px">NG 사항</div>
+            <div style="display:grid;grid-template-columns:1fr 1fr;gap:10px;font-size:12px">
+              <div style="border:1px solid var(--line);border-radius:8px;padding:10px;background:#fff">
+                <div style="font-size:11px;color:var(--muted);margin-bottom:4px">변경 전</div>
+                <ul style="margin:0;padding-left:18px;line-height:1.6">${renderNgItems(row.ng_items_prev)}</ul>
+              </div>
+              <div style="border:1px solid #f5b1b1;border-radius:8px;padding:10px;background:#fff5f5">
+                <div style="font-size:11px;color:#B3261E;margin-bottom:4px;font-weight:700">변경 후</div>
+                <ul style="margin:0;padding-left:18px;line-height:1.6">${renderNgItems(row.ng_items_next)}</ul>
+              </div>
+            </div>
+          </div>` : ''}
+        ${!cautionChanged && !participationChanged && !ngChanged ? `
+          <div style="font-size:12px;color:var(--muted);padding:8px 0">변경 내용이 기록되지 않았습니다.</div>` : ''}
       </div>
     `;
     return `

--- a/index.html
+++ b/index.html
@@ -137,6 +137,8 @@ img{display:block;max-width:100%}
 .badge-pink{background:#FFE4EC;color:#B91C5C;border:1px solid #FFB8D0}
 /* 캠페인 상태 비노출 강조 — expired(노출마감, 영구 비노출) */
 .badge-expired{background:#EEEEEE;color:#666666;border:1.5px dashed #999999;opacity:.85}
+/* NG 사항 배지 — 진한 빨강 계열 (badge-pink 분홍과 명확히 구분, cp-sec-bg-ng 톤과 일관) */
+.badge-ng{background:#FFEBEE;color:#B71C1C;border:1px solid #EF9A9A}
 .badge-new{background:var(--primary);color:#fff}
 
 /* ── FORMS (Material Text Field - Outlined) ── */


### PR DESCRIPTION
## 변경 의도 (사양서 §5-5)

캠페인 변경 이력 모달(super_admin 한정)에 NG 사항 변경 비교 확장. PR-A migration 109 가 이미 추가한 NG audit 컬럼(`ng_set_id_prev/next`·`ng_items_prev/next`)을 UI에서 렌더.

## 변경 내용
- `dev/js/admin.js` `renderCautionHistoryModal` 함수
  - `renderNgItems(arr)` 로컬 헬퍼 (XSS sanitize, 빈 배열 「(없음)」 폴백)
  - `ngChanged` 감지 (set_id 비교 OR items JSON 비교)
  - tags 배열에 「NG 사항」 `badge-ng` 추가
  - NG 비교 섹션 (변경 전/후, `ngChanged` true 시만)
  - 세 항목 모두 변경 없는 행에 안내 문구
- `dev/css/components.css` `badge-ng` 클래스 신규 (진한 빨강 — `#FFEBEE`/`#B71C1C`/`#EF9A9A`)

## 영향 없음
- DB 마이그레이션 추가 없음 (109 컬럼 활용만)
- `storage.js` / `recordCautionHistory` 호출 (이미 NG 파라미터 포함)
- 인플루언서 `mypage.js` 비교 토글 (NG는 동의 항목 아니라 범위 외)

## 검수 결과 (reverb-reviewer)
- Critical/Major 없음
- Warning 1건(badge 색 구분) **본 PR 에서 처리 완료**

## qa-tester
**light 권장** — 관리자 변경 이력 모달(super_admin 전용)

🤖 Generated with [Claude Code](https://claude.com/claude-code)