### PR TITLE
ui(admin-accounts): rename mail column + tighten chip + right-align button

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -1301,7 +1301,7 @@ textarea.form-input{resize:vertical;min-height:80px}
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-05-11 18:43 · 7d45b23</span>
+          <span class="admin-build-text">2026-05-12 11:28 · c3f21a9</span>
         </div>
       </div>
     </aside>
@@ -2663,7 +2663,7 @@ textarea.form-input{resize:vertical;min-height:80px}
             </div>
             <div class="admin-table-wrap">
             <table class="data-table">
-              <thead><tr><th>이름</th><th>이메일</th><th>권한</th><th style="width:110px;text-align:center" title="브랜드 서베이 접수 시 알림 메일 수신">설문 메일받기</th><th>등록일</th><th>처리</th></tr></thead>
+              <thead><tr><th>이름</th><th>이메일</th><th>권한</th><th style="width:240px" title="이 관리자가 수신 중인 알림 메일 종류">수신 메일</th><th>등록일</th><th>처리</th></tr></thead>
               <tbody id="adminAccountsBody"><tr><td colspan="6" style="text-align:center;color:var(--muted);padding:24px"><span class="spinner" style="width:20px;height:20px;border-width:2px;border-color:rgba(200,120,163,.2);border-top-color:var(--pink)"></span></td></tr></tbody>
             </table>
             </div>
@@ -14091,13 +14091,16 @@ async function loadAdminAccounts() {
   const renderMailCell = a => {
     const codes = subs[a.id] || [];
     const chips = codes.length
-      ? codes.map(c => `<span class="badge badge-gray" style="font-size:11px;padding:2px 8px;border-radius:10px">${esc(kindLabel(c))}</span>`).join(' ')
+      ? codes.map(c => `<span class="badge badge-gray" style="font-size:10px;padding:1px 6px;border-radius:8px;line-height:1.5;white-space:nowrap">${esc(kindLabel(c))}</span>`).join(' ')
       : '<span style="color:var(--muted);font-size:12px">—</span>';
     const canEdit = isSuper || a.auth_id === currentUser?.id;
     const btn = canEdit
-      ? `<button class="btn btn-ghost btn-xs" data-name="${esc(a.name||'')}" data-email="${esc(a.email)}" onclick="openAdminEmailSubsModal('${a.id}', this.dataset.name, this.dataset.email)" style="margin-left:6px">설정</button>`
+      ? `<button class="btn btn-ghost btn-xs" data-name="${esc(a.name||'')}" data-email="${esc(a.email)}" onclick="openAdminEmailSubsModal('${a.id}', this.dataset.name, this.dataset.email)">설정</button>`
       : '';
-    return `<div style="display:flex;flex-wrap:wrap;align-items:center;gap:4px">${chips}${btn}</div>`;
+    return `<div style="display:flex;align-items:center;gap:8px">
+      <div style="flex:1;min-width:0;display:flex;flex-wrap:wrap;gap:4px">${chips}</div>
+      ${btn}
+    </div>`;
   };
 
   $('adminAccountsBody').innerHTML = admins.length ? admins.map(a => `<tr>

--- a/dev/admin/index.html
+++ b/dev/admin/index.html
@@ -1467,7 +1467,7 @@
             </div>
             <div class="admin-table-wrap">
             <table class="data-table">
-              <thead><tr><th>이름</th><th>이메일</th><th>권한</th><th style="width:110px;text-align:center" title="브랜드 서베이 접수 시 알림 메일 수신">설문 메일받기</th><th>등록일</th><th>처리</th></tr></thead>
+              <thead><tr><th>이름</th><th>이메일</th><th>권한</th><th style="width:240px" title="이 관리자가 수신 중인 알림 메일 종류">수신 메일</th><th>등록일</th><th>처리</th></tr></thead>
               <tbody id="adminAccountsBody"><tr><td colspan="6" style="text-align:center;color:var(--muted);padding:24px"><span class="spinner" style="width:20px;height:20px;border-width:2px;border-color:rgba(200,120,163,.2);border-top-color:var(--pink)"></span></td></tr></tbody>
             </table>
             </div>

--- a/dev/js/admin.js
+++ b/dev/js/admin.js
@@ -4454,13 +4454,16 @@ async function loadAdminAccounts() {
   const renderMailCell = a => {
     const codes = subs[a.id] || [];
     const chips = codes.length
-      ? codes.map(c => `<span class="badge badge-gray" style="font-size:11px;padding:2px 8px;border-radius:10px">${esc(kindLabel(c))}</span>`).join(' ')
+      ? codes.map(c => `<span class="badge badge-gray" style="font-size:10px;padding:1px 6px;border-radius:8px;line-height:1.5;white-space:nowrap">${esc(kindLabel(c))}</span>`).join(' ')
       : '<span style="color:var(--muted);font-size:12px">—</span>';
     const canEdit = isSuper || a.auth_id === currentUser?.id;
     const btn = canEdit
-      ? `<button class="btn btn-ghost btn-xs" data-name="${esc(a.name||'')}" data-email="${esc(a.email)}" onclick="openAdminEmailSubsModal('${a.id}', this.dataset.name, this.dataset.email)" style="margin-left:6px">설정</button>`
+      ? `<button class="btn btn-ghost btn-xs" data-name="${esc(a.name||'')}" data-email="${esc(a.email)}" onclick="openAdminEmailSubsModal('${a.id}', this.dataset.name, this.dataset.email)">설정</button>`
       : '';
-    return `<div style="display:flex;flex-wrap:wrap;align-items:center;gap:4px">${chips}${btn}</div>`;
+    return `<div style="display:flex;align-items:center;gap:8px">
+      <div style="flex:1;min-width:0;display:flex;flex-wrap:wrap;gap:4px">${chips}</div>
+      ${btn}
+    </div>`;
   };
 
   $('adminAccountsBody').innerHTML = admins.length ? admins.map(a => `<tr>


### PR DESCRIPTION
## Summary

운영 배포(#177) 직후 사용자 요청 보강 — 미세 UI 조정:

- 열 제목 「설문 메일받기」 → **「수신 메일」** (브랜드 서베이 외 종류도 다 포함되는 컬럼이라 라벨이 부정확했음)
- 열 너비 110px → **240px** (110에서 칩이 답답하게 줄바꿈)
- 헤더 `text-align:center` 제거 (칩이 왼쪽 정렬일 때 자연스러움)
- 칩 폰트 11→10 / padding·radius·line-height 조정 / `white-space:nowrap` 추가
- 셀 내부 구조를 **좌(칩 wrap) — 우(설정 버튼 고정)** 2단 flex로 변경

스키마·RPC 변경 없음. `renderMailCell`는 `loadAdminAccounts` 내부 closure라 다른 페인 영향 없음.

## Test plan

- [ ] `/admin#admin-accounts` 진입 → 열 제목이 「수신 메일」 로 표시
- [ ] 구독 다건(예: 김영근 — 브랜드 서베이 접수 + 응모 취소 알림) 행: 칩이 한 줄에 정렬 + 「설정」 버튼이 셀 오른쪽 끝
- [ ] 구독 없는 행(예: 이해정 — `—`): `—` 좌측 + 「설정」 우측
- [ ] 권한 없는 행: 칩만 표시, 「설정」 버튼 없음 (기존 가드 유지)
- [ ] 모바일 폭에서도 칩 wrap 깨짐 없음

[via reviewer] OK / qa-tester skip

🤖 Generated with [Claude Code](https://claude.com/claude-code)