### PR TITLE
feat(brand-survey): include recruit_fee_krw in estimated_krw trigger

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -1301,7 +1301,7 @@ textarea.form-input{resize:vertical;min-height:80px}
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-05-12 11:28 · c3f21a9</span>
+          <span class="admin-build-text">2026-05-12 11:49 · 0d9e1bf</span>
         </div>
       </div>
     </aside>
@@ -2553,7 +2553,7 @@ textarea.form-input{resize:vertical;min-height:80px}
                 <th style="width:100px">상품 가격(원) <span class="col-help" data-tooltip="상품 가격(엔) × 10  (환율 ¥1 = ₩10)"><span class="material-icons-round notranslate" translate="no">help_outline</span></span></th>
                 <th style="width:130px">모집비 <span class="col-help" data-tooltip="제품별 단가 직접 입력"><span class="material-icons-round notranslate" translate="no">help_outline</span></span></th>
                 <th style="width:120px">이체수수료(건)</th>
-                <th style="width:120px">예상 견적 <span class="col-help" data-tooltip="DB 트리거 자동 계산 (신청 INSERT 시 고정)&#10;reviewer: (∑ 엔가격×수량×10 + ∑ 수량×₩2,500) × 1.1&#10;seeding: 0 (수동 협의)&#10;※ 모집비는 미포함&#10;※ 같은 신청의 모든 제품 행에 동일 값 표시"><span class="material-icons-round notranslate" translate="no">help_outline</span></span> <span class="sort-arrows" data-sort="estimated" onclick="toggleBrandAppSort('estimated')">▲▼</span></th>
+                <th style="width:120px">예상 견적 <span class="col-help" data-tooltip="DB 트리거 자동 계산 (신청 INSERT/UPDATE 시 재계산)&#10;reviewer: ( ∑(엔가격×수량)×환율₩10 + ∑(수량×모집비) + ∑(수량×이체수수료) ) × VAT 1.1&#10;seeding: 0 (수동 협의)&#10;※ 모집비·이체수수료 미입력 시 0 (이체수수료는 ₩2,500 자동 채움)&#10;※ 같은 신청의 모든 제품 행에 동일 값 표시"><span class="material-icons-round notranslate" translate="no">help_outline</span></span> <span class="sort-arrows" data-sort="estimated" onclick="toggleBrandAppSort('estimated')">▲▼</span></th>
                 <th style="width:130px">견적서 전달 <span class="sort-arrows" data-sort="quoteSent" onclick="toggleBrandAppSort('quoteSent')">▲▼</span></th>
                 <th style="width:80px">관리</th>
               </tr></thead>

--- a/dev/admin/index.html
+++ b/dev/admin/index.html
@@ -1357,7 +1357,7 @@
                 <th style="width:100px">상품 가격(원) <span class="col-help" data-tooltip="상품 가격(엔) × 10  (환율 ¥1 = ₩10)"><span class="material-icons-round notranslate" translate="no">help_outline</span></span></th>
                 <th style="width:130px">모집비 <span class="col-help" data-tooltip="제품별 단가 직접 입력"><span class="material-icons-round notranslate" translate="no">help_outline</span></span></th>
                 <th style="width:120px">이체수수료(건)</th>
-                <th style="width:120px">예상 견적 <span class="col-help" data-tooltip="DB 트리거 자동 계산 (신청 INSERT 시 고정)&#10;reviewer: (∑ 엔가격×수량×10 + ∑ 수량×₩2,500) × 1.1&#10;seeding: 0 (수동 협의)&#10;※ 모집비는 미포함&#10;※ 같은 신청의 모든 제품 행에 동일 값 표시"><span class="material-icons-round notranslate" translate="no">help_outline</span></span> <span class="sort-arrows" data-sort="estimated" onclick="toggleBrandAppSort('estimated')">▲▼</span></th>
+                <th style="width:120px">예상 견적 <span class="col-help" data-tooltip="DB 트리거 자동 계산 (신청 INSERT/UPDATE 시 재계산)&#10;reviewer: ( ∑(엔가격×수량)×환율₩10 + ∑(수량×모집비) + ∑(수량×이체수수료) ) × VAT 1.1&#10;seeding: 0 (수동 협의)&#10;※ 모집비·이체수수료 미입력 시 0 (이체수수료는 ₩2,500 자동 채움)&#10;※ 같은 신청의 모든 제품 행에 동일 값 표시"><span class="material-icons-round notranslate" translate="no">help_outline</span></span> <span class="sort-arrows" data-sort="estimated" onclick="toggleBrandAppSort('estimated')">▲▼</span></th>
                 <th style="width:130px">견적서 전달 <span class="sort-arrows" data-sort="quoteSent" onclick="toggleBrandAppSort('quoteSent')">▲▼</span></th>
                 <th style="width:80px">관리</th>
               </tr></thead>

--- a/docs/specs/2026-05-12-brand-recruit-fee-in-quote.md
+++ b/docs/specs/2026-05-12-brand-recruit-fee-in-quote.md
@@ -1,0 +1,214 @@
+# 브랜드 서베이 — 예상 견적에 모집비 합산 추가
+
+> **작성일**: 2026-05-12
+> **작성 세션**: 메인 폴더 (개발1, 사용자 인계 진행)
+> **선행**: PR #177 운영 배포 완료, PR #178 dev 머지
+
+---
+
+## 1. 결정 요약
+
+| 항목 | 결정 |
+|---|---|
+| 트리거 신규 수식 (reviewer) | `supply = Σ(price×qty×10) + Σ(qty×recruit_fee_krw) + Σ(qty×transfer_fee_krw)` / `vat = floor(supply×0.1)` / `estimated_krw = supply + vat` |
+| 모집비 키 | `products[i].recruit_fee_krw`(이미 존재, 클라이언트 인라인 편집 가능) — 미입력 시 NULL/0 |
+| 이체수수료 키 | `products[i].transfer_fee_krw`(092 트리거가 reviewer 신청에 기본값 2500 자동 채움) |
+| seeding 영향 | 없음 (`estimated_krw = 0` 그대로) |
+| 기존 데이터 백필 | 자동 호환 (`recruit_fee_krw` 미입력 시 새 공식이 옛 공식과 결과 동일). 별도 UPDATE 백필 불필요 |
+| `final_quote_krw`(확정 견적) 영향 | 없음 (별도 컬럼, 영업이 수동 입력) |
+| 후속 상태(quoted 이후) 보호 | 적용 (아래 §3 결정) |
+| 클라이언트 표시 | 트리거가 DB 컬럼 갱신 → 화면 자동 동기화. 별도 보정 코드 추가 불필요 |
+| 툴팁 텍스트 | 새 공식 + 환율 명시 + 모집비 항 추가 (아래 §4) |
+| 마이그레이션 번호 | **111** (현재 dev/main 모두 110까지 점유) |
+| 파일명 | `supabase/migrations/111_recalc_with_recruit_fee.sql` |
+| PR 분할 | 단일 PR (트리거 마이그레이션 + 툴팁 텍스트 동시) |
+
+---
+
+## 2. 데이터베이스 변경
+
+### 2-1. `recalc_brand_application_totals()` 재정의
+
+`CREATE OR REPLACE FUNCTION` 으로 052의 함수를 같은 시그니처로 교체. 트리거 자체(`trg_brand_app_recalc`)는 재정의 불필요.
+
+```sql
+CREATE OR REPLACE FUNCTION public.recalc_brand_application_totals()
+  RETURNS trigger
+  LANGUAGE plpgsql
+  SECURITY DEFINER
+  SET search_path = ''
+AS $$
+DECLARE
+  v_total_jpy       numeric := 0;
+  v_total_qty       integer := 0;
+  v_recruit_total   numeric := 0;
+  v_transfer_total  numeric := 0;
+  v_supply          numeric := 0;
+  v_vat             numeric := 0;
+  v_item            jsonb;
+BEGIN
+  BEGIN
+    FOR v_item IN SELECT jsonb_array_elements(NEW.products)
+    LOOP
+      v_total_jpy      := v_total_jpy
+                         + COALESCE((v_item->>'price')::numeric, 0)
+                         * COALESCE((v_item->>'qty')::numeric, 0);
+      v_total_qty      := v_total_qty
+                         + COALESCE((v_item->>'qty')::integer, 0);
+      v_recruit_total  := v_recruit_total
+                         + COALESCE((v_item->>'qty')::numeric, 0)
+                         * COALESCE((v_item->>'recruit_fee_krw')::numeric, 0);
+      v_transfer_total := v_transfer_total
+                         + COALESCE((v_item->>'qty')::numeric, 0)
+                         * COALESCE((v_item->>'transfer_fee_krw')::numeric, 0);
+    END LOOP;
+
+    NEW.total_jpy := v_total_jpy;
+    NEW.total_qty := v_total_qty;
+
+    IF NEW.form_type = 'reviewer' THEN
+      v_supply := (v_total_jpy * 10) + v_recruit_total + v_transfer_total;
+      v_vat    := floor(v_supply * 0.1);
+      NEW.estimated_krw := v_supply + v_vat;
+    ELSE
+      NEW.estimated_krw := 0;
+    END IF;
+
+  EXCEPTION WHEN OTHERS THEN
+    RAISE WARNING '[111] recalc_brand_application_totals: 재계산 실패, 클라이언트 값 유지. error=%', SQLERRM;
+  END;
+
+  RETURN NEW;
+END;
+$$;
+
+COMMENT ON FUNCTION public.recalc_brand_application_totals IS
+  '[111] brand_applications BEFORE INSERT/UPDATE 트리거. products 배열 합계 재계산. 052의 고정 2500 공식을 products[i].recruit_fee_krw + transfer_fee_krw 합산 방식으로 교체.';
+```
+
+### 2-2. 기존 데이터 호환 검증
+
+- 기존 reviewer 행: `recruit_fee_krw` 미입력 = NULL → COALESCE(0) → `v_recruit_total = 0`. `transfer_fee_krw` = 2500 (092 트리거가 채움) → `v_transfer_total = total_qty × 2500`. 결과: `supply = total_jpy×10 + 0 + total_qty×2500` = **옛 공식과 동일**. 자동 호환.
+- seeding 행: 분기 진입 안 함. 영향 없음.
+
+### 2-3. 검증 SQL (운영 적용 후 SQL Editor 실행)
+
+```sql
+-- [V1] 함수 갱신 확인
+SELECT prosrc ILIKE '%recruit_fee_krw%' AS has_recruit, prosrc ILIKE '%transfer_fee_krw%' AS has_transfer
+FROM pg_proc WHERE proname='recalc_brand_application_totals';
+-- 두 컬럼 모두 true
+
+-- [V2] 기존 reviewer 행 1건의 estimated_krw 비교 (UPDATE 전후)
+-- WHERE 절에 안전한 테스트용 application_no 또는 id 적용
+SELECT id, products, total_jpy, total_qty, estimated_krw
+FROM brand_applications WHERE id='<TEST_ID>';
+-- 같은 행을 같은 데이터로 UPDATE 트리거 시 estimated_krw 변화 없는지 확인
+
+-- [V3] 모집비 추가 시 합산 확인
+-- 테스트용 행에 products[0].recruit_fee_krw = 1000 추가 → UPDATE → estimated_krw 증가 확인
+```
+
+---
+
+## 3. 후속 상태(quoted 이후) 보호 정책
+
+**결정**: 보호 분기 없음. 모든 UPDATE 에서 새 공식 자동 재계산.
+
+배경: 사용자 확인 결과 `final_quote_krw` 컬럼이 관리자 페인 컬럼에 노출되지 않아 영업이 활용하지 않음. 따라서 `final_quote_krw` 채워짐 여부로 보호하는 분기(원래 §3 안 C)는 의미 없음. 단순 안 A 채택.
+
+---
+
+## 4. 툴팁 텍스트 갱신
+
+### 위치
+- 소스: `dev/admin/index.html` L1360 `data-tooltip` 속성
+- 빌드 산출물: `admin/index.html` (자동 갱신)
+
+### Before
+```
+DB 트리거 자동 계산 (신청 INSERT 시 고정)
+reviewer: (∑ 엔가격×수량×10 + ∑ 수량×₩2,500) × 1.1
+seeding: 0 (수동 협의)
+※ 모집비는 미포함
+※ 같은 신청의 모든 제품 행에 동일 값 표시
+```
+
+### After
+```
+DB 트리거 자동 계산 (신청 INSERT/UPDATE 시 재계산)
+reviewer: ( ∑(엔가격×수량)×환율₩10 + ∑(수량×모집비) + ∑(수량×이체수수료) ) × VAT 1.1
+seeding: 0 (수동 협의)
+※ 모집비·이체수수료 미입력 시 0
+※ 같은 신청의 모든 제품 행에 동일 값 표시
+```
+
+(후속 보호 안 C 채택 시 추가 한 줄: `※ 확정 견적 입력 후엔 자동 갱신 중단`)
+
+### 「신청 INSERT 시 고정」 → 「INSERT/UPDATE 시 재계산」 표현
+- 052 트리거는 사실 BEFORE INSERT + UPDATE 양쪽이라 옛 표현이 부정확. 갱신 시 정정.
+
+---
+
+## 5. 결정 분기점 (사용자 확인 필요)
+
+Q1. 새 수식 채택안 — **안 A** (recruit_fee + transfer_fee 모두 sum) 권장. 확인만.
+
+Q2. 후속 상태 보호 정책
+- 안 A) 보호 없음 (UPDATE 시 자동 재계산) — 단순
+- 안 C) `final_quote_krw` 가 채워지면 estimated_krw 갱신 스킵 — 영업 혼란 방지 (권장)
+
+Q3. 운영 적용 시점
+- 즉시 (dev 검증 후 사용자 OK 신호 시 main 머지)
+- PR #178(수신 메일 UI)과 묶어서 한 번에 운영
+
+---
+
+## 6. QA 시나리오 (개발서버 → reverb-qa-tester)
+
+1. 신규 reviewer 신청 INSERT (sales 폼) → products 에 recruit_fee_krw 0 → estimated_krw 옛 공식과 동일
+2. 신규 reviewer 신청 INSERT → products 에 recruit_fee_krw 1000, qty 5 → estimated_krw 에 +5000 + VAT 반영
+3. 기존 행 모집비 인라인 편집 (관리자 페인) → UPDATE → estimated_krw 즉시 갱신
+4. seeding 신청 → recruit_fee_krw 입력해도 estimated_krw=0 유지
+5. (안 C 채택 시) final_quote_krw 채워진 행에 모집비 변경 → estimated_krw 갱신 안 됨, OLD 유지
+6. 「예상 견적」 컬럼 툴팁 새 텍스트로 표시
+7. 클라이언트 카드/엑셀/대시보드 합계의 estimated_krw 합 → 트리거 결과 그대로 동기화
+
+---
+
+## 7. 영향 분석
+
+| 영역 | 영향 |
+|---|---|
+| 운영 DB | 마이그레이션 111 SQL Editor 적용 필요 |
+| 클라이언트 코드 | `dev/admin/index.html` 툴팁 1줄 외 변경 없음 |
+| 코드 빌드 | `bash dev/build.sh` 필요 (admin/index.html 갱신) |
+| 데이터 정합성 | 기존 행 옛 공식과 결과 동일 (자동 호환) |
+| 영업 운영 | 안 C 채택 시 quoted 이후 영업 견적 보호 |
+| 사양 외 영향 | 없음 |
+
+---
+
+## 8. PR 분할
+
+| PR | 범위 | 의존 |
+|---|---|---|
+| **단일 PR (예: feature/brand-recruit-fee-in-quote)** | 마이그레이션 111 + 툴팁 텍스트 + 빌드 산출물 | 없음 (dev 직접) |
+
+---
+
+## 9. 시작 절차
+
+```
+1. 사용자 §5 Q1·Q2·Q3 확인 → 결정 반영
+2. 마이그레이션 111 작성 (§2 본문 + 안 C 추가 여부)
+3. dev/admin/index.html 툴팁 텍스트 갱신
+4. cd dev && bash build.sh
+5. reverb-reviewer 호출
+6. dev 푸시 + PR 생성 (base=dev)
+7. dev SQL Editor에 111 적용
+8. 개발서버 검증 (qa-tester light)
+9. 사용자 OK 신호 시 dev → main 통합 (PR #178 묶음 또는 단독 결정)
+10. 운영 SQL Editor에 111 적용
+11. 운영 검증
+```

--- a/supabase/migrations/111_recalc_with_recruit_fee.sql
+++ b/supabase/migrations/111_recalc_with_recruit_fee.sql
@@ -1,0 +1,238 @@
+-- ============================================================
+-- 111_recalc_with_recruit_fee.sql
+-- brand_applications 견적 트리거에 모집비(recruit_fee_krw) 합산 추가
+-- 작성일: 2026-05-12
+-- ============================================================
+-- 배경:
+--   052의 recalc_brand_application_totals() 트리거는 reviewer 공식에서
+--     supply = total_jpy × 10 + total_qty × 2500
+--   처럼 1인당 이체수수료 2500을 고정값으로 사용하고
+--   products[i].recruit_fee_krw 는 무시하여
+--   관리자가 모집비를 입력해도 estimated_krw 에 반영되지 않았다.
+--   (관리자 페인 「예상 견적」 컬럼 툴팁에 "모집비는 미포함"으로 명시되어 있었음.)
+--
+--   클라이언트(admin-brand.js)는 이미 모집비를 카드 모달 등에서 합산하지만
+--   DB 컬럼이 동기화되지 않아 페인 표·합계는 모집비 없는 옛 값.
+--
+-- 해결:
+--   recalc_brand_application_totals() 함수를 CREATE OR REPLACE 로 재정의.
+--   reviewer 공식을
+--     supply = Σ(price × qty × 10)
+--            + Σ(qty × recruit_fee_krw)
+--            + Σ(qty × transfer_fee_krw)
+--   로 변경. transfer_fee_krw 도 1인당 2500 고정에서 sum 으로 전환 (092
+--   트리거가 reviewer 신청 INSERT 시 기본값 2500 을 채우므로 기존 데이터는
+--   결과 동일).
+--
+-- 기존 데이터 호환:
+--   - reviewer 행: recruit_fee_krw 미입력 → COALESCE(0). transfer_fee_krw
+--     = 2500 (092 기본값). 결과적으로 옛 공식과 동일한 supply 값.
+--   - seeding 행: 분기 진입 없음. 영향 없음.
+--   - 백필 UPDATE 불필요.
+--
+-- 영향 분석:
+--   - 트리거 자체(trg_brand_app_recalc) 재정의 불필요. CREATE OR REPLACE
+--     FUNCTION 만으로 효과.
+--   - final_quote_krw (확정 견적) 컬럼은 별개. 관리자 수동 입력.
+--   - 클라이언트 표시 코드(admin-brand.js)는 a.estimated_krw 그대로
+--     렌더 → 트리거 갱신만으로 자동 동기화.
+--   - 092 트리거(fill_reviewer_transfer_fee)는 그대로 유효.
+--
+-- 사양: docs/specs/2026-05-12-brand-recruit-fee-in-quote.md
+--
+-- supabase-expert 검토 후 추가 사항:
+--   - 기존 trg_brand_app_recalc 는 BEFORE INSERT 전용 → UPDATE 시 미동작.
+--     UPDATE OF products, form_type 으로 확장. status·admin_memo 변경
+--     같은 무관 컬럼 UPDATE 에서는 발동 안 함 (성능·복잡도 최소화).
+--   - 함수 교체 + 트리거 재정의를 BEGIN/COMMIT 으로 감싸 부분 실패 시
+--     원자성 보장.
+-- ============================================================
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.recalc_brand_application_totals()
+  RETURNS trigger
+  LANGUAGE plpgsql
+  SECURITY DEFINER
+  SET search_path = ''
+AS $$
+DECLARE
+  v_total_jpy       numeric := 0;
+  v_total_qty       integer := 0;
+  v_recruit_total   numeric := 0;
+  v_transfer_total  numeric := 0;
+  v_supply          numeric := 0;
+  v_vat             numeric := 0;
+  v_item            jsonb;
+BEGIN
+  BEGIN
+    FOR v_item IN SELECT jsonb_array_elements(NEW.products)
+    LOOP
+      v_total_jpy      := v_total_jpy
+                         + COALESCE((v_item->>'price')::numeric, 0)
+                         * COALESCE((v_item->>'qty')::numeric, 0);
+      v_total_qty      := v_total_qty
+                         + COALESCE((v_item->>'qty')::integer, 0);
+      v_recruit_total  := v_recruit_total
+                         + COALESCE((v_item->>'qty')::numeric, 0)
+                         * COALESCE((v_item->>'recruit_fee_krw')::numeric, 0);
+      -- transfer_fee_krw 폴백:
+      --   092 트리거(fill_reviewer_transfer_fee)가 reviewer 신청 INSERT 시 2500 을
+      --   채우지만, PostgreSQL BEFORE 트리거는 이름 사전순으로 실행되므로
+      --   trg_brand_app_recalc(b)가 trg_fill_reviewer_transfer_fee(f) 보다 먼저
+      --   실행된다. 즉 INSERT 시점에 본 함수가 products 를 읽을 때는 092 가
+      --   아직 키를 채우기 전이라 (v_item->>'transfer_fee_krw') = NULL.
+      --   reviewer 일 때 폴백 2500 으로 사전 합산해 092 가 채우는 값과
+      --   일치하도록 한다. UPDATE 시점에는 키가 이미 있어 폴백 미사용.
+      --   seeding 은 분기 진입 안 하므로 폴백 0 이어도 무관.
+      v_transfer_total := v_transfer_total
+                         + COALESCE((v_item->>'qty')::numeric, 0)
+                         * COALESCE(
+                             (v_item->>'transfer_fee_krw')::numeric,
+                             CASE WHEN NEW.form_type = 'reviewer' THEN 2500 ELSE 0 END
+                           );
+    END LOOP;
+
+    NEW.total_jpy := v_total_jpy;
+    NEW.total_qty := v_total_qty;
+
+    IF NEW.form_type = 'reviewer' THEN
+      -- 새 공식 (안 A):
+      --   supply = 상품 합계(원) + 모집비 합계(원) + 이체수수료 합계(원)
+      --   vat = floor(supply × 0.1)
+      --   estimated_krw = supply + vat
+      v_supply := (v_total_jpy * 10) + v_recruit_total + v_transfer_total;
+      v_vat    := floor(v_supply * 0.1);
+      NEW.estimated_krw := v_supply + v_vat;
+    ELSE
+      -- seeding 은 별도 견적 필요 (수동 협의)
+      NEW.estimated_krw := 0;
+    END IF;
+
+  EXCEPTION WHEN OTHERS THEN
+    -- 데이터 형식 오류 등 예외 시 클라이언트 값 유지
+    RAISE WARNING '[111] recalc_brand_application_totals: 재계산 실패, 클라이언트 값 유지. error=%', SQLERRM;
+  END;
+
+  RETURN NEW;
+END;
+$$;
+
+COMMENT ON FUNCTION public.recalc_brand_application_totals IS
+  '[111] brand_applications BEFORE INSERT/UPDATE 트리거. reviewer 공식에 products[i].recruit_fee_krw 와 transfer_fee_krw 를 sum 으로 합산. 052의 고정 2500 공식을 교체. seeding 영향 없음.';
+
+
+-- ============================================================
+-- 트리거 재정의: BEFORE INSERT → BEFORE INSERT OR UPDATE OF products,form_type
+-- 052 는 INSERT 전용으로 등록되어 있어 UPDATE 시점에 estimated_krw 가
+-- 갱신되지 않는 버그가 있었다. 모집비 인라인 편집 후 저장 시 자동 동기화
+-- 되도록 UPDATE 이벤트를 추가한다. status / admin_memo 등 무관 컬럼
+-- UPDATE 는 발동하지 않도록 컬럼 한정.
+-- ============================================================
+DROP TRIGGER IF EXISTS trg_brand_app_recalc ON public.brand_applications;
+CREATE TRIGGER trg_brand_app_recalc
+  BEFORE INSERT OR UPDATE OF products, form_type
+  ON public.brand_applications
+  FOR EACH ROW
+  EXECUTE FUNCTION public.recalc_brand_application_totals();
+
+
+COMMIT;
+
+
+-- ============================================================
+-- 검증 SQL (적용 후 SQL Editor에서 실행)
+-- ============================================================
+/*
+-- [V1] 함수 본문 갱신 확인
+SELECT prosrc ILIKE '%recruit_fee_krw%' AS has_recruit,
+       prosrc ILIKE '%transfer_fee_krw%' AS has_transfer
+FROM pg_proc WHERE proname='recalc_brand_application_totals';
+-- 두 컬럼 모두 true
+
+-- [V2] 기존 reviewer 행 호환 검증 (UPDATE 전후 비교)
+-- ※ 운영 데이터 영향을 피하려면 read-only 비교 권장
+SELECT id, total_jpy, total_qty, estimated_krw
+FROM brand_applications
+WHERE form_type='reviewer' AND status='new'
+ORDER BY created_at DESC
+LIMIT 3;
+-- 같은 행을 같은 products 값으로 UPDATE → estimated_krw 변화 없는지 확인 가능
+
+-- [V3] 모집비 추가 시 합산 검증 (ROLLBACK 권장)
+BEGIN;
+UPDATE brand_applications
+SET products = jsonb_set(
+  products,
+  '{0,recruit_fee_krw}',
+  '5000'::jsonb
+)
+WHERE id = '<TEST_ID>' AND form_type='reviewer';
+SELECT estimated_krw FROM brand_applications WHERE id = '<TEST_ID>';
+-- 옛 estimated_krw + qty × 5000 × 1.1 (VAT) 증가 확인
+ROLLBACK;
+
+-- [V4] seeding 영향 없음 확인
+SELECT estimated_krw FROM brand_applications
+WHERE form_type='seeding' LIMIT 5;
+-- 모두 0
+*/
+
+
+-- [V5] 트리거 이벤트 확장 확인
+SELECT tgname, pg_get_triggerdef(oid) AS def
+FROM pg_trigger
+WHERE tgrelid='public.brand_applications'::regclass
+  AND tgname='trg_brand_app_recalc';
+-- def 본문에 'INSERT OR UPDATE OF products, form_type' 포함되어야 함
+
+
+-- ============================================================
+-- 롤백 SQL
+-- ============================================================
+/*
+BEGIN;
+-- 052 의 원본 본문으로 되돌림
+CREATE OR REPLACE FUNCTION public.recalc_brand_application_totals()
+  RETURNS trigger
+  LANGUAGE plpgsql
+  SECURITY DEFINER
+  SET search_path = ''
+AS $$
+DECLARE
+  v_total_jpy  numeric := 0;
+  v_total_qty  integer := 0;
+  v_supply     numeric := 0;
+  v_vat        numeric := 0;
+  v_item       jsonb;
+BEGIN
+  BEGIN
+    FOR v_item IN SELECT jsonb_array_elements(NEW.products)
+    LOOP
+      v_total_jpy := v_total_jpy + COALESCE((v_item->>'price')::numeric, 0)
+                                  * COALESCE((v_item->>'qty')::numeric, 0);
+      v_total_qty := v_total_qty + COALESCE((v_item->>'qty')::integer, 0);
+    END LOOP;
+    NEW.total_jpy := v_total_jpy;
+    NEW.total_qty := v_total_qty;
+    IF NEW.form_type = 'reviewer' THEN
+      v_supply          := v_total_jpy * 10 + v_total_qty * 2500;
+      v_vat             := floor(v_supply * 0.1);
+      NEW.estimated_krw := v_supply + v_vat;
+    ELSE
+      NEW.estimated_krw := 0;
+    END IF;
+  EXCEPTION WHEN OTHERS THEN
+    RAISE WARNING '[052-rollback] recalc_brand_application_totals: 재계산 실패. error=%', SQLERRM;
+  END;
+  RETURN NEW;
+END;
+$$;
+-- 트리거를 052 원본 INSERT 전용으로 되돌림
+DROP TRIGGER IF EXISTS trg_brand_app_recalc ON public.brand_applications;
+CREATE TRIGGER trg_brand_app_recalc
+  BEFORE INSERT ON public.brand_applications
+  FOR EACH ROW
+  EXECUTE FUNCTION public.recalc_brand_application_totals();
+COMMIT;
+*/


### PR DESCRIPTION
## Summary

브랜드 서베이 「예상 견적」 컬럼이 모집비(`products[i].recruit_fee_krw`)를 합산하도록 052 트리거를 갱신. 사용자가 직접 발견한 \"※ 모집비는 미포함\" 문구 그대로의 회귀를 해소.

## 변경 내용

### 마이그레이션 111
- `recalc_brand_application_totals()` 함수 CREATE OR REPLACE
- 새 reviewer 공식: `supply = Σ(price×qty×10) + Σ(qty×recruit_fee_krw) + Σ(qty×transfer_fee_krw)`
- 기존 데이터 자동 호환: `recruit_fee_krw` 미입력 → COALESCE(0), `transfer_fee_krw` 미입력 → 폴백 2500 (092 트리거가 INSERT 시 채우는 값과 일치). 옛 공식 결과와 동일.
- seeding 영향 없음 (estimated_krw=0 유지)
- 백필 UPDATE 불필요

### supabase-expert 검토 반영
- **트리거 이벤트 확장**: `BEFORE INSERT` → `BEFORE INSERT OR UPDATE OF products, form_type`. 052의 INSERT-only 한계로 관리자가 모집비 인라인 편집 후 저장해도 estimated_krw 갱신 안 되던 버그도 함께 수정.
- **BEGIN/COMMIT 원자성**: 함수 교체 + 트리거 재정의 + COMMENT를 하나의 트랜잭션으로 묶음.

### reviewer pass 2 검토 반영
- INSERT 시점 트리거 실행 순서 이슈 발견: 092 트리거(f...)가 111 트리거(b...)보다 사전순으로 뒤. 즉 INSERT 시 transfer_fee_krw=NULL 상태에서 합산. → **함수 내부 폴백** 추가: `form_type='reviewer'` 일 때 transfer_fee_krw NULL이면 2500 사용 (092가 직후 채우는 값과 일치).

### 툴팁 텍스트 갱신 (`dev/admin/index.html` L1360)
```
Before: DB 트리거 자동 계산 (신청 INSERT 시 고정)
        reviewer: (∑ 엔가격×수량×10 + ∑ 수량×₩2,500) × 1.1
        ※ 모집비는 미포함

After:  DB 트리거 자동 계산 (신청 INSERT/UPDATE 시 재계산)
        reviewer: ( ∑(엔가격×수량)×환율₩10 + ∑(수량×모집비) + ∑(수량×이체수수료) ) × VAT 1.1
        ※ 모집비·이체수수료 미입력 시 0 (이체수수료는 ₩2,500 자동 채움)
```

## 사양서

`docs/specs/2026-05-12-brand-recruit-fee-in-quote.md` (포함됨)

## Test plan

### 운영 SQL 적용 후 (개발서버 먼저)
- [ ] 마이그레이션 111 SQL Editor 적용 (BEGIN/COMMIT 자동 트랜잭션)
- [ ] V1 검증: 함수 본문에 recruit_fee_krw / transfer_fee_krw 포함
- [ ] V5 검증: 트리거 정의에 `INSERT OR UPDATE OF products, form_type` 포함

### 동작 검증
- [ ] 신규 reviewer 신청 INSERT, recruit_fee=0 → estimated_krw 옛 공식과 동일
- [ ] 신규 reviewer 신청 INSERT, recruit_fee=1000, qty=5 → estimated_krw 에 +5,500 (1000×5 + VAT 10%)
- [ ] 기존 reviewer 신청 관리자 페인에서 모집비 인라인 편집 → UPDATE 시 estimated_krw 즉시 갱신
- [ ] seeding 신청 → estimated_krw=0 유지
- [ ] 「예상 견적」 컬럼 툴팁 새 텍스트 표시

## 운영 배포 시점

PR #178 (관리자 계정 수신 메일 UI 보강) 과 묶어 한 번에 dev → main 통합 PR 로 운영 반영. (사용자 결정)

[via planner-equivalent: spec authored / via supabase-expert: trigger fix / via reviewer pass 1 + 2: BEGIN/COMMIT + ordering fallback]

## qa-tester 권장: skip (트리거 본문 변경 단일 테이블 한정)

🤖 Generated with [Claude Code](https://claude.com/claude-code)