### PR TITLE
fix(brand-survey): refresh estimated_krw in place after products edit

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -1301,7 +1301,7 @@ textarea.form-input{resize:vertical;min-height:80px}
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-05-12 11:49 · 0d9e1bf</span>
+          <span class="admin-build-text">2026-05-12 12:06 · 10c1a48</span>
         </div>
       </div>
     </aside>
@@ -5552,11 +5552,14 @@ async function updateBrandApplication(id, patch, expectedVersion) {
   if (!db) return {ok: false, error: 'no_db'};
   try {
     const result = await retryWithRefresh(async () => {
+      // products 변경 시 052/111 트리거가 estimated_krw/total_jpy/total_qty 를
+      // 서버에서 재계산한다. 갱신된 값을 함께 받아 호출처가 메모리 캐시를
+      // 즉시 동기화할 수 있도록 select 에 포함.
       const {data, error} = await db?.from('brand_applications')
         .update(patch)
         .eq('id', id)
         .eq('version', expectedVersion)
-        .select('id, version, status')
+        .select('id, version, status, products, total_jpy, total_qty, estimated_krw')
         .maybeSingle();
       if (error) throw error;
       return data;
@@ -6579,6 +6582,18 @@ var _brandApps = [];          // 캐시된 전체 목록
 var _brandAppSort = {field: 'created', dir: 'desc'};
 var _brandAppCurrentId = null; // 상세 모달 열린 신청 ID
 
+// updateBrandApplication 응답을 메모리 cur 에 동기화.
+// products 변경 시 052/111 트리거가 서버에서 재계산한 estimated_krw /
+// total_jpy / total_qty 까지 즉시 반영해 새로고침 없이 「예상 견적」 등
+// 의존 셀이 갱신되도록 한다.
+function _syncBrandAppCur(cur, result, fallbackVersion) {
+  if (!cur || !result || !result.data) return;
+  cur.version = (result.data.version != null) ? result.data.version : (fallbackVersion + 1);
+  if (result.data.estimated_krw != null) cur.estimated_krw = result.data.estimated_krw;
+  if (result.data.total_jpy != null) cur.total_jpy = result.data.total_jpy;
+  if (result.data.total_qty != null) cur.total_qty = result.data.total_qty;
+}
+
 // 상태 라벨·컬러 (객체 키 순서가 드롭다운 옵션 순서)
 var BRAND_APP_STATUS = {
   'new':                 {label:'신규',             color:'#C33',   bg:'#FEE'},
@@ -6685,7 +6700,7 @@ async function quickChangeBrandAppProductStatus(id, idx, newStatus) {
     return;
   }
   cur.products = nextProducts;
-  cur.version = result.data?.version || (expectedVersion + 1);
+  _syncBrandAppCur(cur, result, expectedVersion);
   _refreshBrandAppHistoryButton(id);
   // 상태 변경은 필터 (NN)건 카운트와 매칭 행 노출에 즉시 영향 — 목록 전체 재렌더
   // 일정 인라인 편집과는 다른 흐름이라 의도적으로 셀-only 재렌더 미사용
@@ -9252,7 +9267,7 @@ async function _saveDateEdit(anyChildEl, primaryVal, endVal) {
     return;
   }
   cur.products = nextProducts;
-  cur.version = result.data?.version || (prevVersion + 1);
+  _syncBrandAppCur(cur, result, prevVersion);
   _refreshBrandAppHistoryButton(id);
   // 해당 셀만 재렌더 — 같은 페이지에서 편집 중인 다른 셀들의 입력 상태가 사라지지 않도록 전체 재렌더 회피
   _restoreDateDisplay(cell, cfg, nextProducts[idx]);
@@ -9347,7 +9362,7 @@ async function confirmTransferFeeEdit(anyChildEl) {
     return;
   }
   cur.products = nextProducts;
-  cur.version = result.data?.version || (prevVersion + 1);
+  _syncBrandAppCur(cur, result, prevVersion);
   _refreshBrandAppHistoryButton(id);
   // 같은 신청의 모든 행 재렌더(이체수수료(원)/최종 견적/VAT포함 컬럼이 동기화됨)
   renderBrandApplicationsList();
@@ -9442,7 +9457,7 @@ async function confirmRecruitFeeEdit(anyChildEl) {
     return;
   }
   cur.products = nextProducts;
-  cur.version = result.data?.version || (prevVersion + 1);
+  _syncBrandAppCur(cur, result, prevVersion);
   _refreshBrandAppHistoryButton(id);
   // 같은 신청의 모든 행 재렌더(모집비/최종 견적/VAT포함 컬럼이 동기화됨)
   renderBrandApplicationsList();
@@ -9539,7 +9554,7 @@ async function confirmQuoteSentEdit(anyChildEl) {
     return;
   }
   cur.quote_sent_at = nextValue;
-  cur.version = result.data?.version || (prevVersion + 1);
+  _syncBrandAppCur(cur, result, prevVersion);
   _restoreQuoteSentDisplay(cell, nextValue, false);
   _refreshBrandAppHistoryButton(id);
   toast(nextValue ? '견적서 전달일이 저장되었습니다.' : '견적서 미전달로 변경했습니다.');
@@ -9628,7 +9643,7 @@ async function confirmMemoEdit(anyChildEl) {
     return;
   }
   cur.admin_memo = nextValue || null;
-  cur.version = result.data?.version || (prevVersion + 1);
+  _syncBrandAppCur(cur, result, prevVersion);
   _restoreMemoDisplay(cell, nextValue, false);
   _refreshBrandAppHistoryButton(id);
   toast('메모가 저장되었습니다.');

--- a/dev/js/admin-brand.js
+++ b/dev/js/admin-brand.js
@@ -24,6 +24,18 @@ var _brandApps = [];          // 캐시된 전체 목록
 var _brandAppSort = {field: 'created', dir: 'desc'};
 var _brandAppCurrentId = null; // 상세 모달 열린 신청 ID
 
+// updateBrandApplication 응답을 메모리 cur 에 동기화.
+// products 변경 시 052/111 트리거가 서버에서 재계산한 estimated_krw /
+// total_jpy / total_qty 까지 즉시 반영해 새로고침 없이 「예상 견적」 등
+// 의존 셀이 갱신되도록 한다.
+function _syncBrandAppCur(cur, result, fallbackVersion) {
+  if (!cur || !result || !result.data) return;
+  cur.version = (result.data.version != null) ? result.data.version : (fallbackVersion + 1);
+  if (result.data.estimated_krw != null) cur.estimated_krw = result.data.estimated_krw;
+  if (result.data.total_jpy != null) cur.total_jpy = result.data.total_jpy;
+  if (result.data.total_qty != null) cur.total_qty = result.data.total_qty;
+}
+
 // 상태 라벨·컬러 (객체 키 순서가 드롭다운 옵션 순서)
 var BRAND_APP_STATUS = {
   'new':                 {label:'신규',             color:'#C33',   bg:'#FEE'},
@@ -130,7 +142,7 @@ async function quickChangeBrandAppProductStatus(id, idx, newStatus) {
     return;
   }
   cur.products = nextProducts;
-  cur.version = result.data?.version || (expectedVersion + 1);
+  _syncBrandAppCur(cur, result, expectedVersion);
   _refreshBrandAppHistoryButton(id);
   // 상태 변경은 필터 (NN)건 카운트와 매칭 행 노출에 즉시 영향 — 목록 전체 재렌더
   // 일정 인라인 편집과는 다른 흐름이라 의도적으로 셀-only 재렌더 미사용
@@ -2697,7 +2709,7 @@ async function _saveDateEdit(anyChildEl, primaryVal, endVal) {
     return;
   }
   cur.products = nextProducts;
-  cur.version = result.data?.version || (prevVersion + 1);
+  _syncBrandAppCur(cur, result, prevVersion);
   _refreshBrandAppHistoryButton(id);
   // 해당 셀만 재렌더 — 같은 페이지에서 편집 중인 다른 셀들의 입력 상태가 사라지지 않도록 전체 재렌더 회피
   _restoreDateDisplay(cell, cfg, nextProducts[idx]);
@@ -2792,7 +2804,7 @@ async function confirmTransferFeeEdit(anyChildEl) {
     return;
   }
   cur.products = nextProducts;
-  cur.version = result.data?.version || (prevVersion + 1);
+  _syncBrandAppCur(cur, result, prevVersion);
   _refreshBrandAppHistoryButton(id);
   // 같은 신청의 모든 행 재렌더(이체수수료(원)/최종 견적/VAT포함 컬럼이 동기화됨)
   renderBrandApplicationsList();
@@ -2887,7 +2899,7 @@ async function confirmRecruitFeeEdit(anyChildEl) {
     return;
   }
   cur.products = nextProducts;
-  cur.version = result.data?.version || (prevVersion + 1);
+  _syncBrandAppCur(cur, result, prevVersion);
   _refreshBrandAppHistoryButton(id);
   // 같은 신청의 모든 행 재렌더(모집비/최종 견적/VAT포함 컬럼이 동기화됨)
   renderBrandApplicationsList();
@@ -2984,7 +2996,7 @@ async function confirmQuoteSentEdit(anyChildEl) {
     return;
   }
   cur.quote_sent_at = nextValue;
-  cur.version = result.data?.version || (prevVersion + 1);
+  _syncBrandAppCur(cur, result, prevVersion);
   _restoreQuoteSentDisplay(cell, nextValue, false);
   _refreshBrandAppHistoryButton(id);
   toast(nextValue ? '견적서 전달일이 저장되었습니다.' : '견적서 미전달로 변경했습니다.');
@@ -3073,7 +3085,7 @@ async function confirmMemoEdit(anyChildEl) {
     return;
   }
   cur.admin_memo = nextValue || null;
-  cur.version = result.data?.version || (prevVersion + 1);
+  _syncBrandAppCur(cur, result, prevVersion);
   _restoreMemoDisplay(cell, nextValue, false);
   _refreshBrandAppHistoryButton(id);
   toast('메모가 저장되었습니다.');

--- a/dev/lib/storage.js
+++ b/dev/lib/storage.js
@@ -1657,11 +1657,14 @@ async function updateBrandApplication(id, patch, expectedVersion) {
   if (!db) return {ok: false, error: 'no_db'};
   try {
     const result = await retryWithRefresh(async () => {
+      // products 변경 시 052/111 트리거가 estimated_krw/total_jpy/total_qty 를
+      // 서버에서 재계산한다. 갱신된 값을 함께 받아 호출처가 메모리 캐시를
+      // 즉시 동기화할 수 있도록 select 에 포함.
       const {data, error} = await db?.from('brand_applications')
         .update(patch)
         .eq('id', id)
         .eq('version', expectedVersion)
-        .select('id, version, status')
+        .select('id, version, status, products, total_jpy, total_qty, estimated_krw')
         .maybeSingle();
       if (error) throw error;
       return data;


### PR DESCRIPTION
## Summary

PR #179 머지 후 사용자 직접 보고: 「모집비 입력 후 새로고침해야 예상 견적이 갱신된다」.

### 원인
- `updateBrandApplication` 응답이 `id, version, status` 만 반환
- 6개 호출처가 `cur.version` 만 갱신하고 `cur.estimated_krw` 등은 메모리에 옛 값 그대로 유지
- 052/111 트리거가 서버에서 정확히 재계산했지만 화면이 메모리 기반이라 옛 값 표시

### 수정
1. `dev/lib/storage.js` `updateBrandApplication` 의 `.select(...)` 에 `products, total_jpy, total_qty, estimated_krw` 추가 — 트리거 재계산 결과를 함께 받음.
2. `dev/js/admin-brand.js` 헬퍼 `_syncBrandAppCur(cur, result, fallbackVersion)` 추가:
   - `cur.version` 갱신 (옛 폴백 로직 동일)
   - `cur.estimated_krw / total_jpy / total_qty` null-safe 갱신
3. 6개 호출처 모두 헬퍼로 교체: 상태 변경 · 일정 셀 · 이체수수료 셀 · 모집비 셀 · 견적서 전달일 · 메모.

### 비대상
- 「상태 변경 (L164)」 · 「전체 편집 모달 저장 (L2184)」 — 이미 `loadBrandApplications()` 전체 재로드 경로라 헬퍼 미적용 의도.

### DB / RPC 변경 없음
sales 폼 · 메일 템플릿 · 신규 등록 모달 작업은 별도(`docs/specs/2026-05-12-brand-app-recruit-fee.md`).

## Test plan

- [ ] 관리자 페인 reviewer 신청에서 모집비 인라인 편집 → 저장 → **새로고침 없이 「예상 견적」 셀 즉시 갱신**
- [ ] 같은 신청의 이체수수료 셀 편집 → 「예상 견적」 즉시 갱신
- [ ] 일정 셀 편집 → 셀 표시 동기화 (estimated_krw 변화 없음, version만 갱신)
- [ ] 메모 / 견적서 전달일 편집 → 영향 없는 컬럼은 그대로 유지 (NaN/undefined 덮어쓰기 없음)
- [ ] 동시 편집 충돌 시나리오: 두 탭에서 같은 신청 편집 → 「다른 관리자가 먼저 저장」 토스트 + loadBrandApplications 재로드

## 운영 배포

PR #178 (수신 메일 UI) + PR #179 (모집비 합산 트리거) 와 묶어 dev → main 통합 PR 로 한 번에 운영 반영.

[via reviewer] OK / qa-tester light

🤖 Generated with [Claude Code](https://claude.com/claude-code)