### PR TITLE
ui(brand-survey): widen new-app modal from 880px to 1080px

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -1312,7 +1312,7 @@ textarea.form-input{resize:vertical;min-height:80px}
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-05-12 12:32 · 0c31fb0</span>
+          <span class="admin-build-text">2026-05-12 12:35 · bca3f21</span>
         </div>
       </div>
     </aside>
@@ -3317,7 +3317,7 @@ textarea.form-input{resize:vertical;min-height:80px}
 <!-- 관리자 직접 신청 등록 모달 (091 admin_create_brand_application) -->
 <div class="modal-overlay" id="newBrandAppModal" style="z-index:612">
   <style>#newBrandAppModal .form-input,#newBrandAppModal select.form-input,#newBrandAppModal textarea.form-input{font-size:14px}</style>
-  <div class="modal" style="max-width:880px;width:96vw;border-radius:16px;margin:auto;max-height:90vh;display:flex;flex-direction:column">
+  <div class="modal" style="max-width:1080px;width:96vw;border-radius:16px;margin:auto;max-height:90vh;display:flex;flex-direction:column">
     <div class="modal-header" style="padding:16px 20px 12px;border-bottom:1px solid var(--line);display:flex;align-items:center;justify-content:space-between">
       <div>
         <div id="nbaModalTitle" style="font-size:14px;font-weight:700;color:var(--ink)">브랜드 서베이 신청 등록</div>

--- a/dev/admin/index.html
+++ b/dev/admin/index.html
@@ -2112,7 +2112,7 @@
 <!-- 관리자 직접 신청 등록 모달 (091 admin_create_brand_application) -->
 <div class="modal-overlay" id="newBrandAppModal" style="z-index:612">
   <style>#newBrandAppModal .form-input,#newBrandAppModal select.form-input,#newBrandAppModal textarea.form-input{font-size:14px}</style>
-  <div class="modal" style="max-width:880px;width:96vw;border-radius:16px;margin:auto;max-height:90vh;display:flex;flex-direction:column">
+  <div class="modal" style="max-width:1080px;width:96vw;border-radius:16px;margin:auto;max-height:90vh;display:flex;flex-direction:column">
     <div class="modal-header" style="padding:16px 20px 12px;border-bottom:1px solid var(--line);display:flex;align-items:center;justify-content:space-between">
       <div>
         <div id="nbaModalTitle" style="font-size:14px;font-weight:700;color:var(--ink)">브랜드 서베이 신청 등록</div>


### PR DESCRIPTION
## Summary

PR #181 머지 후 사용자 발견: 「브랜드 서베이 신청 수정」 모달 단가(¥) 셀이 4자리 입력 시 잘림. 모집비 칼럼 추가로 그리드가 7+1 → 8+1로 늘어났는데 모달 폭은 그대로라 0.7fr 단가 셀이 ~78px로 좁아짐.

`max-width: 880px → 1080px` 한 줄 변경으로 해소. 단가 셀 ~109px 확보, URL·일본어 셀도 여유. 좁은 화면은 `width: 96vw` 폴백 그대로.

신규 등록(`신청 등록`)·수정(`신청 수정`) 두 모드 같은 `#newBrandAppModal` 마크업이라 동시 해소.

## Test plan

- [ ] 관리자 페인 → 「신청 수정」 → 단가 12340 입력 → 잘림 없이 모두 보임
- [ ] 「신청 등록」 → 동일 확인
- [ ] 가로 1280px 노트북 → 모달 정상 표시
- [ ] 가로 1024px 노트북 → 96vw 폴백 작동, 가로 스크롤 없음

## 운영 배포

PR #178·#179·#180·#181 묶음에 합류.

🤖 Generated with [Claude Code](https://claude.com/claude-code)