### PR TITLE
ui(brand-survey): move status tabs below filters, above the list card

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -1312,7 +1312,7 @@ textarea.form-input{resize:vertical;min-height:80px}
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-05-12 12:32 · 0c31fb0</span>
+          <span class="admin-build-text">2026-05-12 12:35 · bca3f21</span>
         </div>
       </div>
     </aside>
@@ -2500,8 +2500,6 @@ textarea.form-input{resize:vertical;min-height:80px}
                 </button>
               </div>
             </div>
-            <!-- 상태별 탭 바 (11개 탭 — JS가 동적으로 렌더) -->
-            <div id="brandAppStatusTabBar" class="status-tab-bar"></div>
             <div style="display:flex;align-items:flex-end;gap:12px;flex-wrap:wrap">
               <div class="admin-filter-group">
                 <label>폼 종류</label>
@@ -2528,6 +2526,8 @@ textarea.form-input{resize:vertical;min-height:80px}
                 </div>
               </div>
             </div>
+            <!-- 상태별 탭 바 (11개 탭 — JS가 동적으로 렌더). 필터 줄 아래·신청목록 카드 바로 위에 위치 -->
+            <div id="brandAppStatusTabBar" class="status-tab-bar" style="margin-top:8px"></div>
           </div>
           <div class="admin-card">
             <div class="admin-card-header">

--- a/dev/admin/index.html
+++ b/dev/admin/index.html
@@ -1293,8 +1293,6 @@
                 </button>
               </div>
             </div>
-            <!-- 상태별 탭 바 (11개 탭 — JS가 동적으로 렌더) -->
-            <div id="brandAppStatusTabBar" class="status-tab-bar"></div>
             <div style="display:flex;align-items:flex-end;gap:12px;flex-wrap:wrap">
               <div class="admin-filter-group">
                 <label>폼 종류</label>
@@ -1321,6 +1319,8 @@
                 </div>
               </div>
             </div>
+            <!-- 상태별 탭 바 (11개 탭 — JS가 동적으로 렌더). 필터 줄 아래·신청목록 카드 바로 위에 위치 -->
+            <div id="brandAppStatusTabBar" class="status-tab-bar" style="margin-top:8px"></div>
           </div>
           <div class="admin-card">
             <div class="admin-card-header">


### PR DESCRIPTION
## 변경 의도

브랜드 서베이 페인(`/admin#brand-applications`)의 상태 탭 위치를 신청 목록 카드 바로 위로 이동.

| 변경 전 | 변경 후 |
|---|---|
| 페인 헤더 → **탭 바** → 폼종류·기간·검색 필터 → 신청 목록 | 페인 헤더 → 폼종류·기간·검색 필터 → **탭 바** → 신청 목록 |

## 효과
- 상위 필터(폼종류·기간·검색)가 먼저 시선에 들어오고
- 탭은 신청 목록과 인접하여 데이터 분류 역할이 시각적으로 강조됨

## 변경 파일
- `dev/admin/index.html` 만 수정 (탭 바 마크업 ↔ 필터 줄 위치 교환)
- JS 로직·CSS·ID·이벤트 핸들러 변경 없음
- sticky-header 영역 안에 그대로 유지 → 페인 스크롤 시 탭도 함께 고정
- 탭과 필터 줄 간격용 `margin-top:8px` 인라인 추가

## qa-tester
**skip** — 단순 마크업 위치 swap, JS/CSS/데이터 변경 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)