### PR TITLE
ui(brand-survey): clarify count label unit (신청 vs 제품)

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -1312,7 +1312,7 @@ textarea.form-input{resize:vertical;min-height:80px}
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-05-12 12:35 · bca3f21</span>
+          <span class="admin-build-text">2026-05-12 12:41 · 7e35988</span>
         </div>
       </div>
     </aside>
@@ -8104,12 +8104,14 @@ function renderBrandApplicationsList() {
 
   var count = $('brandAppTotalCount');
   if (count) {
+    // 신청 단위(brand_applications 행) 카운트.
+    //   탭 옆 숫자는 제품 단위(_flattenAppsToProducts)라 단위가 다름 — 라벨에 「신청」 명시로 구분.
     var totalAll = (_brandApps || []).length;
     var reviewerN = (_brandApps || []).filter(function(a){ return a.form_type === 'reviewer'; }).length;
     var seedingN  = (_brandApps || []).filter(function(a){ return a.form_type === 'seeding'; }).length;
-    var summary = '전체 ' + totalAll + '건 · 리뷰어 ' + reviewerN + ' · 시딩 ' + seedingN;
+    var summary = '전체 신청 ' + totalAll + '건 · 리뷰어 ' + reviewerN + ' · 시딩 ' + seedingN;
     count.textContent = filterActive
-      ? '(필터 ' + list.length + ' / ' + summary + ')'
+      ? '(필터 결과 ' + list.length + '건 · ' + summary + ')'
       : '(' + summary + ')';
   }
 

--- a/dev/js/admin-brand.js
+++ b/dev/js/admin-brand.js
@@ -1536,12 +1536,14 @@ function renderBrandApplicationsList() {
 
   var count = $('brandAppTotalCount');
   if (count) {
+    // 신청 단위(brand_applications 행) 카운트.
+    //   탭 옆 숫자는 제품 단위(_flattenAppsToProducts)라 단위가 다름 — 라벨에 「신청」 명시로 구분.
     var totalAll = (_brandApps || []).length;
     var reviewerN = (_brandApps || []).filter(function(a){ return a.form_type === 'reviewer'; }).length;
     var seedingN  = (_brandApps || []).filter(function(a){ return a.form_type === 'seeding'; }).length;
-    var summary = '전체 ' + totalAll + '건 · 리뷰어 ' + reviewerN + ' · 시딩 ' + seedingN;
+    var summary = '전체 신청 ' + totalAll + '건 · 리뷰어 ' + reviewerN + ' · 시딩 ' + seedingN;
     count.textContent = filterActive
-      ? '(필터 ' + list.length + ' / ' + summary + ')'
+      ? '(필터 결과 ' + list.length + '건 · ' + summary + ')'
       : '(' + summary + ')';
   }
 


### PR DESCRIPTION
## 보고된 혼란

스크린샷에서 신청 목록 카드 헤더 「필터 5 / 전체 19건 · 리뷰어 15 · 시딩 4」와 상단 상태 탭 「전체(46)」의 숫자가 매칭되지 않음.

## 원인

| 위치 | 단위 | 이유 |
|---|---|---|
| 상태 탭 옆 숫자 | **제품 단위** | `_flattenAppsToProducts`로 펼침. `products[i].status` 우선 (Phase B — 한 신청 안에서 제품별 상태 관리) |
| 카드 헤더 카운트 | **신청 단위** | `brand_applications` 행 수 |

예: 신청 19건의 제품 합계가 46개 → 탭 「전체(46)」, 카드 「전체 19건」.

## 수정 내용

카드 헤더 라벨에 「신청」 단위를 명시:

| 변경 전 | 변경 후 |
|---|---|
| `(필터 5 / 전체 19건 · 리뷰어 15 · 시딩 4)` | `(필터 결과 5건 · 전체 신청 19건 · 리뷰어 15 · 시딩 4)` |

탭은 그대로 제품 단위 유지 (상태별 분포가 정확하게 보이도록).

## 영향
- `dev/js/admin-brand.js` 1537~1547행 라벨 문구만
- JS 로직·CSS·DOM·다른 페인 변경 없음

## qa-tester
**skip** — 라벨 문구 변경 단독

🤖 Generated with [Claude Code](https://claude.com/claude-code)