### PR TITLE
ui(brand-survey): unify counts to 신청 단위 (card + tabs)

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -1312,7 +1312,7 @@ textarea.form-input{resize:vertical;min-height:80px}
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-05-12 12:41 · 7e35988</span>
+          <span class="admin-build-text">2026-05-12 13:18 · bf1b7b7</span>
         </div>
       </div>
     </aside>
@@ -8087,10 +8087,12 @@ function renderBrandApplicationsList() {
            (a.application_no || '').toLowerCase().includes(qForTab) ||
            (a.request_note || '').toLowerCase().includes(qForTab);
   });
-  // 상태별 건수는 제품 단위로 카운트
+  // 상태별 건수는 신청 단위로 카운트 (a.status 기준).
+  //   한 신청에 제품별 status 가 여러 개여도 신청 1건 = 카운트 1.
+  //   카드 헤더의 「신청 결과 N건」과 단위 일관 — 사용자 혼동 방지.
   var tabStatusCounts = {};
-  _flattenAppsToProducts(tabBase).forEach(function(f) {
-    if (f.status) tabStatusCounts[f.status] = (tabStatusCounts[f.status] || 0) + 1;
+  tabBase.forEach(function(a) {
+    if (a.status) tabStatusCounts[a.status] = (tabStatusCounts[a.status] || 0) + 1;
   });
   renderBrandAppStatusTabs(tabStatusCounts);
 
@@ -8104,15 +8106,13 @@ function renderBrandApplicationsList() {
 
   var count = $('brandAppTotalCount');
   if (count) {
-    // 신청 단위(brand_applications 행) 카운트.
+    // 신청 단위(brand_applications 행) 카운트 — 현재 필터 결과 기준 폼타입 분포.
     //   탭 옆 숫자는 제품 단위(_flattenAppsToProducts)라 단위가 다름 — 라벨에 「신청」 명시로 구분.
-    var totalAll = (_brandApps || []).length;
-    var reviewerN = (_brandApps || []).filter(function(a){ return a.form_type === 'reviewer'; }).length;
-    var seedingN  = (_brandApps || []).filter(function(a){ return a.form_type === 'seeding'; }).length;
-    var summary = '전체 신청 ' + totalAll + '건 · 리뷰어 ' + reviewerN + ' · 시딩 ' + seedingN;
-    count.textContent = filterActive
-      ? '(필터 결과 ' + list.length + '건 · ' + summary + ')'
-      : '(' + summary + ')';
+    //   필터 비활성 시 list = _brandApps 전체와 동일하므로 같은 list 기준 분포 그대로 사용.
+    var resultReviewer = list.filter(function(a){ return a.form_type === 'reviewer'; }).length;
+    var resultSeeding  = list.filter(function(a){ return a.form_type === 'seeding'; }).length;
+    var leadLabel = filterActive ? '신청 결과 ' : '전체 신청 ';
+    count.textContent = '(' + leadLabel + list.length + '건 · 리뷰어 ' + resultReviewer + ' · 시딩 ' + resultSeeding + ')';
   }
 
   // 상태 탭이 켜진 경우 매칭 제품 행만 노출 (행 단위 필터)

--- a/dev/js/admin-brand.js
+++ b/dev/js/admin-brand.js
@@ -1519,10 +1519,12 @@ function renderBrandApplicationsList() {
            (a.application_no || '').toLowerCase().includes(qForTab) ||
            (a.request_note || '').toLowerCase().includes(qForTab);
   });
-  // 상태별 건수는 제품 단위로 카운트
+  // 상태별 건수는 신청 단위로 카운트 (a.status 기준).
+  //   한 신청에 제품별 status 가 여러 개여도 신청 1건 = 카운트 1.
+  //   카드 헤더의 「신청 결과 N건」과 단위 일관 — 사용자 혼동 방지.
   var tabStatusCounts = {};
-  _flattenAppsToProducts(tabBase).forEach(function(f) {
-    if (f.status) tabStatusCounts[f.status] = (tabStatusCounts[f.status] || 0) + 1;
+  tabBase.forEach(function(a) {
+    if (a.status) tabStatusCounts[a.status] = (tabStatusCounts[a.status] || 0) + 1;
   });
   renderBrandAppStatusTabs(tabStatusCounts);
 
@@ -1536,15 +1538,13 @@ function renderBrandApplicationsList() {
 
   var count = $('brandAppTotalCount');
   if (count) {
-    // 신청 단위(brand_applications 행) 카운트.
+    // 신청 단위(brand_applications 행) 카운트 — 현재 필터 결과 기준 폼타입 분포.
     //   탭 옆 숫자는 제품 단위(_flattenAppsToProducts)라 단위가 다름 — 라벨에 「신청」 명시로 구분.
-    var totalAll = (_brandApps || []).length;
-    var reviewerN = (_brandApps || []).filter(function(a){ return a.form_type === 'reviewer'; }).length;
-    var seedingN  = (_brandApps || []).filter(function(a){ return a.form_type === 'seeding'; }).length;
-    var summary = '전체 신청 ' + totalAll + '건 · 리뷰어 ' + reviewerN + ' · 시딩 ' + seedingN;
-    count.textContent = filterActive
-      ? '(필터 결과 ' + list.length + '건 · ' + summary + ')'
-      : '(' + summary + ')';
+    //   필터 비활성 시 list = _brandApps 전체와 동일하므로 같은 list 기준 분포 그대로 사용.
+    var resultReviewer = list.filter(function(a){ return a.form_type === 'reviewer'; }).length;
+    var resultSeeding  = list.filter(function(a){ return a.form_type === 'seeding'; }).length;
+    var leadLabel = filterActive ? '신청 결과 ' : '전체 신청 ';
+    count.textContent = '(' + leadLabel + list.length + '건 · 리뷰어 ' + resultReviewer + ' · 시딩 ' + resultSeeding + ')';
   }
 
   // 상태 탭이 켜진 경우 매칭 제품 행만 노출 (행 단위 필터)


### PR DESCRIPTION
## 사용자 보고 2건

### 1) 카드 헤더 라벨 — 필터 결과 기준 폼타입 분포로
사용자 요청: 「(신청 결과 5건 · 리뷰어 5 · 시딩 0)」 — 현재 필터 결과 안의 폼타입 분포

| 시점 | 변경 전 | 변경 후 |
|---|---|---|
| 필터 활성 | (필터 결과 5건 · 전체 신청 19건 · 리뷰어 15 · 시딩 4) | **(신청 결과 5건 · 리뷰어 5 · 시딩 0)** |
| 필터 비활성 | (전체 신청 19건 · 리뷰어 15 · 시딩 4) | **(전체 신청 19건 · 리뷰어 15 · 시딩 4)** |

reviewer/seeding 카운트가 `_brandApps` 전체 → 현재 `list`(필터 적용 결과)로 변경.

### 2) 탭 옆 카운트 — 신청 단위로 통일
사용자 요청: 「탭옆에 숫자도 신청건수로 표시」

| 시점 | 변경 전 | 변경 후 |
|---|---|---|
| 단위 | 제품 단위(`_flattenAppsToProducts`) | **신청 단위(`a.status`)** |
| 예시 | 전체(46) — 신청 19건의 제품 합계 | **전체(19)** — 신청 행 수와 일치 |

한 신청에 제품 status가 여러 개여도 카운트는 1. 카드 헤더의 「신청 결과 N건」과 단위 일관.

## 영향
- `dev/js/admin-brand.js` 카운트 함수 2곳 변경
- 탭 클릭 시 필터링 로직(`((p&&p.status)||a.status) === tabStatus`)은 변경 없음 → 한 신청에 매칭 제품 있으면 노출되는 기존 동작 유지

## 회귀 위험
- 한 신청에 status 다른 제품이 섞인 케이스에서 탭 카운트(1)와 화면 행 수(N)가 차이날 수 있음. 일반 운영 시나리오에서는 신청 단위 status 가 기본이라 체감 미미. 후속 이슈 보고 시 필터링 단위도 통일 검토.

## qa-tester
**light 권장** — 관리자 브랜드 서베이 페인 단독, 카운트 표시만 변경.

🤖 Generated with [Claude Code](https://claude.com/claude-code)