### PR TITLE
ui(brand-survey): widen tab top margin, narrow bottom margin

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -1312,7 +1312,7 @@ textarea.form-input{resize:vertical;min-height:80px}
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-05-12 13:18 · bf1b7b7</span>
+          <span class="admin-build-text">2026-05-12 13:22 · 1ac9971</span>
         </div>
       </div>
     </aside>
@@ -2527,7 +2527,7 @@ textarea.form-input{resize:vertical;min-height:80px}
               </div>
             </div>
             <!-- 상태별 탭 바 (11개 탭 — JS가 동적으로 렌더). 필터 줄 아래·신청목록 카드 바로 위에 위치 -->
-            <div id="brandAppStatusTabBar" class="status-tab-bar" style="margin-top:8px"></div>
+            <div id="brandAppStatusTabBar" class="status-tab-bar" style="margin-top:16px;margin-bottom:2px"></div>
           </div>
           <div class="admin-card">
             <div class="admin-card-header">

--- a/dev/admin/index.html
+++ b/dev/admin/index.html
@@ -1320,7 +1320,7 @@
               </div>
             </div>
             <!-- 상태별 탭 바 (11개 탭 — JS가 동적으로 렌더). 필터 줄 아래·신청목록 카드 바로 위에 위치 -->
-            <div id="brandAppStatusTabBar" class="status-tab-bar" style="margin-top:8px"></div>
+            <div id="brandAppStatusTabBar" class="status-tab-bar" style="margin-top:16px;margin-bottom:2px"></div>
           </div>
           <div class="admin-card">
             <div class="admin-card-header">


### PR DESCRIPTION
## 변경

탭의 상하 여백 미세 조정. 사용자 요청대로 필터와 간격을 벌리고 신청 목록과는 좁힘.

| 위치 | 변경 전 | 변경 후 |
|---|---|---|
| 탭 상단 (필터 ↔ 탭) | `margin-top:8px` | **`margin-top:16px`** |
| 탭 하단 (탭 ↔ 신청 목록) | css `margin-bottom:10px` | **inline `margin-bottom:2px`** |

실제 시각 간격:
- 필터 → 탭: **16px**
- 탭 → 카드: **14px** (`margin-bottom:2px` + sticky-header `padding-bottom:12px`)

`.status-tab-bar` CSS 자체는 그대로 두고 인라인 style로만 override — 다른 페인에 `.status-tab-bar`를 쓰면 기존 여백 유지.

## qa-tester
**skip** — CSS 인라인 값만 변경

🤖 Generated with [Claude Code](https://claude.com/claude-code)