### PR TITLE
ui(brand-survey): group rows by application + match tab labels to modal

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -479,6 +479,10 @@ textarea.form-input{resize:vertical;min-height:80px}
 .status-tab-btn.on{color:var(--pink);border-bottom-color:var(--pink);font-weight:700}
 .status-tab-btn .tab-count{font-size:11px;color:var(--muted);margin-left:2px;font-weight:400}
 .status-tab-btn.zero-count{color:#aaa}
+
+/* 브랜드 서베이 신청 목록 — 신청 단위 좌측 색 띠 4px (같은 신청 행끼리 동일 색, 짝/홀 교대) */
+#brandAppTableBody tr.app-stripe-even > td:first-child{border-left:4px solid #d4d4d4}
+#brandAppTableBody tr.app-stripe-odd  > td:first-child{border-left:4px solid #8a8a8a}
 .status-tab-btn.zero-count .tab-count{color:#ccc}
 
 /* ─── 캠페인/신청/결과물/브랜드 관리 페인: 가로 스크롤 + 첫 컬럼 sticky-left
@@ -1312,7 +1316,7 @@ textarea.form-input{resize:vertical;min-height:80px}
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-05-12 13:22 · 1ac9971</span>
+          <span class="admin-build-text">2026-05-12 13:39 · 415a2e5</span>
         </div>
       </div>
     </aside>
@@ -6595,19 +6599,19 @@ var _brandAppCurrentId = null; // 상세 모달 열린 신청 ID
 // 상태 탭 현재 활성값 — null = 전체, 문자열 = 특정 상태 코드
 var _brandAppActiveStatusTab = null;
 
-// 상태 탭 순서 및 라벨 정의 (사양서 §2 순서)
+// 상태 탭 순서 및 라벨 정의 (상세 모달 상태 드롭다운 라벨과 통일)
 var BRAND_APP_STATUS_TABS = [
   {code: null,                 label: '전체'},
-  {code: 'new',                label: '신규접수'},
-  {code: 'reviewing',          label: '검수중'},
-  {code: 'quoted',             label: '견적전달'},
+  {code: 'new',                label: '신규'},
+  {code: 'reviewing',          label: '검토중'},
+  {code: 'quoted',             label: '견적 전달'},
   {code: 'paid',               label: '입금완료'},
-  {code: 'kakao_room_created', label: '카톡방생성'},
-  {code: 'orient_sheet_sent',  label: 'OT시트전송'},
-  {code: 'schedule_sent',      label: '일정전송'},
-  {code: 'campaign_registered',label: '캠페인등록'},
+  {code: 'kakao_room_created', label: '카톡방 생성'},
+  {code: 'orient_sheet_sent',  label: '오리엔트 전달'},
+  {code: 'schedule_sent',      label: '일정 전달'},
+  {code: 'campaign_registered',label: '캠페인 등록'},
   {code: 'done',               label: '최종완료'},
-  {code: 'rejected',           label: '거절'},
+  {code: 'rejected',           label: '반려'},
 ];
 
 // URL 해시 쿼리에서 특정 파라미터 추출
@@ -8117,6 +8121,12 @@ function renderBrandApplicationsList() {
 
   // 상태 탭이 켜진 경우 매칭 제품 행만 노출 (행 단위 필터)
   // 「제품 N개」 라벨은 원본 전체 개수, idx는 원본 인덱스 유지(cur.products[idx] 매핑 정확성)
+  // 신청 단위 좌측 색 띠 stripe map — 같은 신청의 모든 행에 동일 색.
+  //   list 정렬·필터 적용 후 인접 신청끼리 색이 교대(짝/홀) 되도록 인덱스 부여.
+  var stripeMap = {};
+  list.forEach(function(a, i) {
+    stripeMap[a.id] = (i % 2 === 0) ? 'app-stripe-even' : 'app-stripe-odd';
+  });
   var renderBrandAppRow = function(a) {
     var allProds = Array.isArray(a.products) ? a.products : [];
     var totalCount = allProds.length;
@@ -8128,11 +8138,12 @@ function renderBrandApplicationsList() {
       });
       if (pairs.length === 0) return ''; // 매칭 제품 없으면 신청 자체 미노출
     }
+    var stripeCls = stripeMap[a.id] || '';
     if (pairs.length === 0) {
-      return renderBrandAppFlatRow(a, {}, 0, 0, true);
+      return renderBrandAppFlatRow(a, {}, 0, 0, true, stripeCls);
     }
     return pairs.map(function(pair, displayIdx) {
-      return renderBrandAppFlatRow(a, pair.p, pair.idx, totalCount, displayIdx === 0);
+      return renderBrandAppFlatRow(a, pair.p, pair.idx, totalCount, displayIdx === 0, stripeCls);
     }).join('');
   };
   if (brandAppLazy) brandAppLazy.destroy();
@@ -8337,8 +8348,10 @@ function _uniformProductValue(prods, key) {
 //   count: 신청 전체 제품 수 (필터 무관 — 「제품 N개」 라벨에 사용)
 //   isFirst: 화면 첫 행 여부 (status 필터로 일부만 노출 시 displayIdx===0 행이 isFirst).
 //            액션 셀(상태/메모/견적서/이력)·폼 배지·제품 N개 라벨·신청 경계 보더는 isFirst에만 표시
-function renderBrandAppFlatRow(a, p, idx, count, isFirst) {
+function renderBrandAppFlatRow(a, p, idx, count, isFirst, stripeClass) {
   if (typeof isFirst === 'undefined') isFirst = (idx === 0);
+  // stripeClass: 신청 단위 좌측 색 띠 (app-stripe-even / app-stripe-odd). 호출처에서 stripeMap 으로 결정
+  var clsAttr = stripeClass ? ' class="' + esc(stripeClass) + '"' : '';
   var qty = Number(p && p.qty) || 0;
   var priceJpy = Number(p && p.price) || 0;
   var priceKrw = priceJpy * BRAND_QUOTE_CONST.FX_JPY_KRW;
@@ -8355,7 +8368,7 @@ function renderBrandAppFlatRow(a, p, idx, count, isFirst) {
     ? '<span style="background:#FFF4E5;color:#B46A1A;font-size:10px;font-weight:600;padding:2px 7px;border-radius:3px;margin-left:4px" title="관리자가 직접 등록한 신청">직접등록</span>'
     : '';
 
-  var html = '<tr data-id="' + esc(a.id) + '" data-product-idx="' + idx + '"' + (isFirst ? ' data-first="1"' : '') + (rowStyle ? ' style="' + rowStyle + '"' : '') + '>';
+  var html = '<tr' + clsAttr + ' data-id="' + esc(a.id) + '" data-product-idx="' + idx + '"' + (isFirst ? ' data-first="1"' : '') + (rowStyle ? ' style="' + rowStyle + '"' : '') + '>';
 
   // 1. 신청번호(-N) + 폼 종류 + 리뷰어 채널 배지(큐텐/엣코스메) — 모든 행에 동일 표시
   // 신청번호 끝에 -1·-2 인덱스 부착(원본 idx+1)으로 행 식별. 「제품 N개」 별도 라벨 불필요

--- a/dev/css/admin.css
+++ b/dev/css/admin.css
@@ -109,6 +109,10 @@
 .status-tab-btn.on{color:var(--pink);border-bottom-color:var(--pink);font-weight:700}
 .status-tab-btn .tab-count{font-size:11px;color:var(--muted);margin-left:2px;font-weight:400}
 .status-tab-btn.zero-count{color:#aaa}
+
+/* 브랜드 서베이 신청 목록 — 신청 단위 좌측 색 띠 4px (같은 신청 행끼리 동일 색, 짝/홀 교대) */
+#brandAppTableBody tr.app-stripe-even > td:first-child{border-left:4px solid #d4d4d4}
+#brandAppTableBody tr.app-stripe-odd  > td:first-child{border-left:4px solid #8a8a8a}
 .status-tab-btn.zero-count .tab-count{color:#ccc}
 
 /* ─── 캠페인/신청/결과물/브랜드 관리 페인: 가로 스크롤 + 첫 컬럼 sticky-left

--- a/dev/js/admin-brand.js
+++ b/dev/js/admin-brand.js
@@ -27,19 +27,19 @@ var _brandAppCurrentId = null; // 상세 모달 열린 신청 ID
 // 상태 탭 현재 활성값 — null = 전체, 문자열 = 특정 상태 코드
 var _brandAppActiveStatusTab = null;
 
-// 상태 탭 순서 및 라벨 정의 (사양서 §2 순서)
+// 상태 탭 순서 및 라벨 정의 (상세 모달 상태 드롭다운 라벨과 통일)
 var BRAND_APP_STATUS_TABS = [
   {code: null,                 label: '전체'},
-  {code: 'new',                label: '신규접수'},
-  {code: 'reviewing',          label: '검수중'},
-  {code: 'quoted',             label: '견적전달'},
+  {code: 'new',                label: '신규'},
+  {code: 'reviewing',          label: '검토중'},
+  {code: 'quoted',             label: '견적 전달'},
   {code: 'paid',               label: '입금완료'},
-  {code: 'kakao_room_created', label: '카톡방생성'},
-  {code: 'orient_sheet_sent',  label: 'OT시트전송'},
-  {code: 'schedule_sent',      label: '일정전송'},
-  {code: 'campaign_registered',label: '캠페인등록'},
+  {code: 'kakao_room_created', label: '카톡방 생성'},
+  {code: 'orient_sheet_sent',  label: '오리엔트 전달'},
+  {code: 'schedule_sent',      label: '일정 전달'},
+  {code: 'campaign_registered',label: '캠페인 등록'},
   {code: 'done',               label: '최종완료'},
-  {code: 'rejected',           label: '거절'},
+  {code: 'rejected',           label: '반려'},
 ];
 
 // URL 해시 쿼리에서 특정 파라미터 추출
@@ -1549,6 +1549,12 @@ function renderBrandApplicationsList() {
 
   // 상태 탭이 켜진 경우 매칭 제품 행만 노출 (행 단위 필터)
   // 「제품 N개」 라벨은 원본 전체 개수, idx는 원본 인덱스 유지(cur.products[idx] 매핑 정확성)
+  // 신청 단위 좌측 색 띠 stripe map — 같은 신청의 모든 행에 동일 색.
+  //   list 정렬·필터 적용 후 인접 신청끼리 색이 교대(짝/홀) 되도록 인덱스 부여.
+  var stripeMap = {};
+  list.forEach(function(a, i) {
+    stripeMap[a.id] = (i % 2 === 0) ? 'app-stripe-even' : 'app-stripe-odd';
+  });
   var renderBrandAppRow = function(a) {
     var allProds = Array.isArray(a.products) ? a.products : [];
     var totalCount = allProds.length;
@@ -1560,11 +1566,12 @@ function renderBrandApplicationsList() {
       });
       if (pairs.length === 0) return ''; // 매칭 제품 없으면 신청 자체 미노출
     }
+    var stripeCls = stripeMap[a.id] || '';
     if (pairs.length === 0) {
-      return renderBrandAppFlatRow(a, {}, 0, 0, true);
+      return renderBrandAppFlatRow(a, {}, 0, 0, true, stripeCls);
     }
     return pairs.map(function(pair, displayIdx) {
-      return renderBrandAppFlatRow(a, pair.p, pair.idx, totalCount, displayIdx === 0);
+      return renderBrandAppFlatRow(a, pair.p, pair.idx, totalCount, displayIdx === 0, stripeCls);
     }).join('');
   };
   if (brandAppLazy) brandAppLazy.destroy();
@@ -1769,8 +1776,10 @@ function _uniformProductValue(prods, key) {
 //   count: 신청 전체 제품 수 (필터 무관 — 「제품 N개」 라벨에 사용)
 //   isFirst: 화면 첫 행 여부 (status 필터로 일부만 노출 시 displayIdx===0 행이 isFirst).
 //            액션 셀(상태/메모/견적서/이력)·폼 배지·제품 N개 라벨·신청 경계 보더는 isFirst에만 표시
-function renderBrandAppFlatRow(a, p, idx, count, isFirst) {
+function renderBrandAppFlatRow(a, p, idx, count, isFirst, stripeClass) {
   if (typeof isFirst === 'undefined') isFirst = (idx === 0);
+  // stripeClass: 신청 단위 좌측 색 띠 (app-stripe-even / app-stripe-odd). 호출처에서 stripeMap 으로 결정
+  var clsAttr = stripeClass ? ' class="' + esc(stripeClass) + '"' : '';
   var qty = Number(p && p.qty) || 0;
   var priceJpy = Number(p && p.price) || 0;
   var priceKrw = priceJpy * BRAND_QUOTE_CONST.FX_JPY_KRW;
@@ -1787,7 +1796,7 @@ function renderBrandAppFlatRow(a, p, idx, count, isFirst) {
     ? '<span style="background:#FFF4E5;color:#B46A1A;font-size:10px;font-weight:600;padding:2px 7px;border-radius:3px;margin-left:4px" title="관리자가 직접 등록한 신청">직접등록</span>'
     : '';
 
-  var html = '<tr data-id="' + esc(a.id) + '" data-product-idx="' + idx + '"' + (isFirst ? ' data-first="1"' : '') + (rowStyle ? ' style="' + rowStyle + '"' : '') + '>';
+  var html = '<tr' + clsAttr + ' data-id="' + esc(a.id) + '" data-product-idx="' + idx + '"' + (isFirst ? ' data-first="1"' : '') + (rowStyle ? ' style="' + rowStyle + '"' : '') + '>';
 
   // 1. 신청번호(-N) + 폼 종류 + 리뷰어 채널 배지(큐텐/엣코스메) — 모든 행에 동일 표시
   // 신청번호 끝에 -1·-2 인덱스 부착(원본 idx+1)으로 행 식별. 「제품 N개」 별도 라벨 불필요


### PR DESCRIPTION
## 사용자 보고 3건 묶음

### 1) 신청 단위 시각 묶음 — 좌측 색 띠 4px
같은 신청의 제품 행끼리 시각적으로 같은 그룹임을 표시. 신청번호만으로 인지가 어렵다는 보고.

| 신청 인덱스 | 좌측 띠 색 |
|---|---|
| 짝수 (0, 2, 4, ...) | `#d4d4d4` (연한 회색) |
| 홀수 (1, 3, 5, ...) | `#8a8a8a` (진한 회색) |

같은 신청의 모든 제품 행은 동일 색 띠. 인접 신청과 색이 교대돼 그룹 경계가 명확.

### 2) 탭 라벨 → 상세 모달 상태 드롭다운과 통일

| 변경 전 | 변경 후 |
|---|---|
| 신규접수 | **신규** |
| 검수중 | **검토중** |
| 견적전달 | **견적 전달** |
| 카톡방생성 | **카톡방 생성** |
| OT시트전송 | **오리엔트 전달** |
| 일정전송 | **일정 전달** |
| 캠페인등록 | **캠페인 등록** |
| 거절 | **반려** |

상태 변경 드롭다운(상세 모달)에서 사용하는 라벨과 통일 — 사용자 혼동 방지.

## 영향 파일
- `dev/css/admin.css` — `.app-stripe-even` / `.app-stripe-odd` 신규
- `dev/js/admin-brand.js` — `BRAND_APP_STATUS_TABS` 라벨 + `stripeMap` 생성 + `renderBrandAppFlatRow` 시그니처에 `stripeClass` 추가

다른 영역(상태 드롭다운·배지 라벨)은 변경 없음 — 탭을 드롭다운에 맞춤.

## qa-tester
**light 권장** — 관리자 브랜드 서베이 페인 단독

🤖 Generated with [Claude Code](https://claude.com/claude-code)