### PR TITLE
ui(brand-survey): widen 단가/모집비/이체수수료 cols in product input

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -1320,7 +1320,7 @@ textarea.form-input{resize:vertical;min-height:80px}
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-05-12 14:48 · 72668cd</span>
+          <span class="admin-build-text">2026-05-12 14:52 · eecbb9b</span>
         </div>
       </div>
     </aside>
@@ -3428,7 +3428,7 @@ textarea.form-input{resize:vertical;min-height:80px}
           <span class="material-icons-round notranslate" translate="no" style="font-size:14px">add</span>제품 추가
         </button>
       </div>
-      <div id="nbaProductHead" style="display:grid;grid-template-columns:1.4fr 1.4fr 80px 90px 90px 90px 1fr 32px;gap:8px;padding:0 10px;margin-bottom:6px;font-size:11px;color:var(--muted);font-weight:600">
+      <div id="nbaProductHead" style="display:grid;grid-template-columns:1.4fr 1.4fr 100px 90px 120px 120px 1fr 32px;gap:8px;padding:0 10px;margin-bottom:6px;font-size:11px;color:var(--muted);font-weight:600">
         <div>제품명</div>
         <div>제품명 일본어 <span style="font-size:9px;color:var(--muted)">(선택)</span></div>
         <div>단가 (¥)</div>
@@ -8773,7 +8773,7 @@ function addNbaProductRow() {
   var row = document.createElement('div');
   row.className = 'nba-product-row';
   row.dataset.idx = rowIdx;
-  row.style.cssText = 'display:grid;grid-template-columns:1.4fr 1.4fr 80px 90px 90px 90px 1fr 32px;gap:8px;align-items:stretch;padding:8px 10px;background:var(--bg);border-radius:8px';
+  row.style.cssText = 'display:grid;grid-template-columns:1.4fr 1.4fr 100px 90px 120px 120px 1fr 32px;gap:8px;align-items:stretch;padding:8px 10px;background:var(--bg);border-radius:8px';
   row.innerHTML =
     '<input type="text" class="form-input nba-prod-name" placeholder="제품 이름" style="font-size:14px">' +
     '<input type="text" class="form-input nba-prod-name-ja" placeholder="상품명 (일본어)" style="font-size:14px">' +

--- a/dev/admin/index.html
+++ b/dev/admin/index.html
@@ -2215,7 +2215,7 @@
           <span class="material-icons-round notranslate" translate="no" style="font-size:14px">add</span>제품 추가
         </button>
       </div>
-      <div id="nbaProductHead" style="display:grid;grid-template-columns:1.4fr 1.4fr 80px 90px 90px 90px 1fr 32px;gap:8px;padding:0 10px;margin-bottom:6px;font-size:11px;color:var(--muted);font-weight:600">
+      <div id="nbaProductHead" style="display:grid;grid-template-columns:1.4fr 1.4fr 100px 90px 120px 120px 1fr 32px;gap:8px;padding:0 10px;margin-bottom:6px;font-size:11px;color:var(--muted);font-weight:600">
         <div>제품명</div>
         <div>제품명 일본어 <span style="font-size:9px;color:var(--muted)">(선택)</span></div>
         <div>단가 (¥)</div>

--- a/dev/js/admin-brand.js
+++ b/dev/js/admin-brand.js
@@ -2194,7 +2194,7 @@ function addNbaProductRow() {
   var row = document.createElement('div');
   row.className = 'nba-product-row';
   row.dataset.idx = rowIdx;
-  row.style.cssText = 'display:grid;grid-template-columns:1.4fr 1.4fr 80px 90px 90px 90px 1fr 32px;gap:8px;align-items:stretch;padding:8px 10px;background:var(--bg);border-radius:8px';
+  row.style.cssText = 'display:grid;grid-template-columns:1.4fr 1.4fr 100px 90px 120px 120px 1fr 32px;gap:8px;align-items:stretch;padding:8px 10px;background:var(--bg);border-radius:8px';
   row.innerHTML =
     '<input type="text" class="form-input nba-prod-name" placeholder="제품 이름" style="font-size:14px">' +
     '<input type="text" class="form-input nba-prod-name-ja" placeholder="상품명 (일본어)" style="font-size:14px">' +


### PR DESCRIPTION
| 컬럼 | 변경 전 | 변경 후 |
|---|---|---|
| 단가 (¥) | 80px | **100px** |
| 모집비 | 90px | **120px** |
| 이체수수료 | 90px | **120px** |

수량은 PR #194에서 90px로 확대한 그대로 유지.

🤖 Generated with [Claude Code](https://claude.com/claude-code)