### PR TITLE
fix(storage): add cacheControl=86400 to image uploads (transform quota mitigation)

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -12,7 +12,7 @@
 // 회귀(2026-05-12 PR #182 머지 직후 발생)를 방지하기 위한 자동 reload 가드.
 // sessionStorage 차단 환경(시크릿 모드 일부, 쿠키 차단)에서는 자연스럽게 skip.
 (function(){
-  var CURRENT_BUILD = 'v1778570576';
+  var CURRENT_BUILD = 'v1778573828';
   if (CURRENT_BUILD.indexOf('__') === 0) return; // 빌드 미적용 (dev/ 직접 열기) 시 skip
   try {
     var prev = sessionStorage.getItem('reverb.adminBuild');
@@ -1339,7 +1339,7 @@ textarea.form-input{resize:vertical;min-height:80px}
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-05-12 16:22 · 436940b</span>
+          <span class="admin-build-text">2026-05-12 17:17 · 411c9bd</span>
         </div>
       </div>
     </aside>
@@ -4209,7 +4209,8 @@ async function uploadFlagEvidence(file, flagId) {
   const ext = file.name ? file.name.split('.').pop().toLowerCase() : 'bin';
   const uuid = crypto.randomUUID ? crypto.randomUUID() : (Date.now().toString(36) + Math.random().toString(36).substring(2));
   const path = `${flagId}/${uuid}.${ext}`;
-  const {error} = await db.storage.from(BUCKET).upload(path, file, {contentType: file.type, upsert: false});
+  // cacheControl: '86400' — 증빙 파일도 동일 캐시 정책. signed URL 만료(1h)와 무관하게 브라우저 캐시 활용
+  const {error} = await db.storage.from(BUCKET).upload(path, file, {contentType: file.type, upsert: false, cacheControl: '86400'});
   if (error) throw error;
   return path;
 }
@@ -4716,7 +4717,9 @@ async function uploadImage(base64Data, fileName, pathPrefix) {
   var prefix = pathPrefix || 'campaigns';
   var ext = mime.split('/')[1] === 'jpeg' ? 'jpg' : mime.split('/')[1];
   var path = prefix + '/' + Date.now() + '_' + Math.random().toString(36).substring(2, 8) + '.' + ext;
-  var {error} = await db.storage.from('campaign-images').upload(path, blob, {contentType: mime, upsert: false});
+  // cacheControl: '86400' — 응답 헤더에 cache-control: max-age=86400 부여 → 브라우저 24h 캐시
+  //   재방문 시 transform/object API 재호출 차단, Storage Image Transformations 월 한도 보호
+  var {error} = await db.storage.from('campaign-images').upload(path, blob, {contentType: mime, upsert: false, cacheControl: '86400'});
   if (error) throw error;
   // 공개 URL 반환
   var {data} = db.storage.from('campaign-images').getPublicUrl(path);

--- a/dev/lib/storage.js
+++ b/dev/lib/storage.js
@@ -275,7 +275,8 @@ async function uploadFlagEvidence(file, flagId) {
   const ext = file.name ? file.name.split('.').pop().toLowerCase() : 'bin';
   const uuid = crypto.randomUUID ? crypto.randomUUID() : (Date.now().toString(36) + Math.random().toString(36).substring(2));
   const path = `${flagId}/${uuid}.${ext}`;
-  const {error} = await db.storage.from(BUCKET).upload(path, file, {contentType: file.type, upsert: false});
+  // cacheControl: '86400' — 증빙 파일도 동일 캐시 정책. signed URL 만료(1h)와 무관하게 브라우저 캐시 활용
+  const {error} = await db.storage.from(BUCKET).upload(path, file, {contentType: file.type, upsert: false, cacheControl: '86400'});
   if (error) throw error;
   return path;
 }
@@ -782,7 +783,9 @@ async function uploadImage(base64Data, fileName, pathPrefix) {
   var prefix = pathPrefix || 'campaigns';
   var ext = mime.split('/')[1] === 'jpeg' ? 'jpg' : mime.split('/')[1];
   var path = prefix + '/' + Date.now() + '_' + Math.random().toString(36).substring(2, 8) + '.' + ext;
-  var {error} = await db.storage.from('campaign-images').upload(path, blob, {contentType: mime, upsert: false});
+  // cacheControl: '86400' — 응답 헤더에 cache-control: max-age=86400 부여 → 브라우저 24h 캐시
+  //   재방문 시 transform/object API 재호출 차단, Storage Image Transformations 월 한도 보호
+  var {error} = await db.storage.from('campaign-images').upload(path, blob, {contentType: mime, upsert: false, cacheControl: '86400'});
   if (error) throw error;
   // 공개 URL 반환
   var {data} = db.storage.from('campaign-images').getPublicUrl(path);

--- a/index.html
+++ b/index.html
@@ -3390,7 +3390,8 @@ async function uploadFlagEvidence(file, flagId) {
   const ext = file.name ? file.name.split('.').pop().toLowerCase() : 'bin';
   const uuid = crypto.randomUUID ? crypto.randomUUID() : (Date.now().toString(36) + Math.random().toString(36).substring(2));
   const path = `${flagId}/${uuid}.${ext}`;
-  const {error} = await db.storage.from(BUCKET).upload(path, file, {contentType: file.type, upsert: false});
+  // cacheControl: '86400' — 증빙 파일도 동일 캐시 정책. signed URL 만료(1h)와 무관하게 브라우저 캐시 활용
+  const {error} = await db.storage.from(BUCKET).upload(path, file, {contentType: file.type, upsert: false, cacheControl: '86400'});
   if (error) throw error;
   return path;
 }
@@ -3897,7 +3898,9 @@ async function uploadImage(base64Data, fileName, pathPrefix) {
   var prefix = pathPrefix || 'campaigns';
   var ext = mime.split('/')[1] === 'jpeg' ? 'jpg' : mime.split('/')[1];
   var path = prefix + '/' + Date.now() + '_' + Math.random().toString(36).substring(2, 8) + '.' + ext;
-  var {error} = await db.storage.from('campaign-images').upload(path, blob, {contentType: mime, upsert: false});
+  // cacheControl: '86400' — 응답 헤더에 cache-control: max-age=86400 부여 → 브라우저 24h 캐시
+  //   재방문 시 transform/object API 재호출 차단, Storage Image Transformations 월 한도 보호
+  var {error} = await db.storage.from('campaign-images').upload(path, blob, {contentType: mime, upsert: false, cacheControl: '86400'});
   if (error) throw error;
   // 공개 URL 반환
   var {data} = db.storage.from('campaign-images').getPublicUrl(path);


### PR DESCRIPTION
## Summary

Supabase Storage Image Transformations 월 한도(Pro 플랜 100건) 초과 대응. 운영 응답 헤더에 `cache-control` 부재로 사용자 재방문마다 transform 재호출되어 한도가 빠르게 소진되던 문제를 신규 업로드부터 점진 개선.

### 변경 내용
- `dev/lib/storage.js` `uploadImage` (campaign-images 버킷): `cacheControl: '86400'` 옵션 추가
- `dev/lib/storage.js` `uploadFlagEvidence` (influencer-flag-evidence 버킷): 일관성 유지 목적 동일 옵션 추가

### 효과
- 신규 업로드 응답 헤더에 `cache-control: max-age=86400` 부여
- 브라우저 24시간 캐시 → 재방문 시 transform/object API 재호출 차단
- 점진적으로 Storage Image Transformations 호출 횟수 감소

## 한계
- **기존 업로드된 이미지에는 미적용** — 옛 이미지 transform 호출은 계속 캐시 없이 발생
- 옛 이미지 일괄 메타데이터 갱신은 별도 작업으로 분리
- `uploadFlagEvidence`는 signed URL 경유라 캐시 효과 미미 (의도된 일관성 유지)

## 본 PR 제외 (후속 작업)
- imgThumb width 표준화 (SM=128/MD=240/LG=320) — 별도 PR. width 변경 시 기존 캐시된 URL 무효화 우려로 한도 여유 확보 후 진행
- 옛 이미지 메타데이터 일괄 갱신 — Storage 콘솔 또는 별도 스크립트

## Test plan
- [ ] dev 환경에서 신규 캠페인 이미지 업로드 1건
- [ ] 업로드 직후 해당 이미지 URL에 `curl -I` → 응답 헤더 `cache-control: max-age=86400` 확인
- [ ] 운영 배포 후 신규 영수증 1건 업로드 → 동일 헤더 확인
- [ ] Storage Image Transformations 월 한도 추이 1주 관찰

[via reviewer] 🟢 GO, qa-tester 권장 skip

🤖 Generated with [Claude Code](https://claude.com/claude-code)