### PR TITLE
fix(activity): unblock receipt resubmission for stale pending accumulation

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -12,7 +12,7 @@
 // 회귀(2026-05-12 PR #182 머지 직후 발생)를 방지하기 위한 자동 reload 가드.
 // sessionStorage 차단 환경(시크릿 모드 일부, 쿠키 차단)에서는 자연스럽게 skip.
 (function(){
-  var CURRENT_BUILD = 'v1778573828';
+  var CURRENT_BUILD = 'v1778575052';
   if (CURRENT_BUILD.indexOf('__') === 0) return; // 빌드 미적용 (dev/ 직접 열기) 시 skip
   try {
     var prev = sessionStorage.getItem('reverb.adminBuild');
@@ -1339,7 +1339,7 @@ textarea.form-input{resize:vertical;min-height:80px}
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-05-12 17:17 · 411c9bd</span>
+          <span class="admin-build-text">2026-05-12 17:37 · 7a70d1f</span>
         </div>
       </div>
     </aside>

--- a/dev/js/application.js
+++ b/dev/js/application.js
@@ -822,9 +822,17 @@ function renderActivityReceiptList(delivs) {
   const addBtn = $('addReceiptBtn');
   const maxNote = $('receiptMaxNote');
   // monitor 캠페인은 영수증 1장만 제출 가능 (visit는 현장 사진 여러 장 가능 — 그대로 둠)
-  // active = draft|pending|approved (rejected는 제외, 재제출 가능)
+  // active 판정: kind별 가장 최신 1건이 rejected가 아니면 active로 본다.
+  //   같은 application에 옛 pending 행이 누적되어도(관리자 미검수 방치 등) 가장 최신이
+  //   rejected면 재제출 form 노출. 2026-05-12 a4y2u9.i@gmail.com 케이스 — pending 3건
+  //   누적 + 최신 rejected였는데 단순 `status !== 'rejected'` 카운트로 인해 재제출 차단됨.
   const isMonitor = (_activityCamp?.recruit_type === 'monitor');
-  const activeCount = (delivs || []).filter(d => d.status !== 'rejected').length;
+  const latestPerKind = {};
+  (delivs || []).forEach(function(d) {
+    var prev = latestPerKind[d.kind];
+    if (!prev || new Date(d.created_at) > new Date(prev.created_at)) latestPerKind[d.kind] = d;
+  });
+  const activeCount = Object.values(latestPerKind).filter(function(d) { return d.status !== 'rejected'; }).length;
   const reachedMax = isMonitor && activeCount >= 1;
   if (formBox) formBox.style.display = reachedMax ? 'none' : '';
   if (addBtn) addBtn.style.display = reachedMax ? 'none' : '';
@@ -877,8 +885,14 @@ function renderActivityReviewImageList(delivs) {
   const maxNote = $('reviewImageMaxNote');
   const formBox = $('reviewImageForm');
   // 1장 제약: 어떤 상태든(draft/pending/approved) 1건이라도 있으면 추가 불가
-  // — 단, rejected 1건뿐이면 재제출 가능 (active=draft|pending|approved 정의)
-  const activeCount = (delivs || []).filter(d => d.status !== 'rejected').length;
+  //   active 판정은 kind별 가장 최신 1건 기준 — 같은 application에 옛 pending 누적되어도
+  //   가장 최신이 rejected면 재제출 form 노출 (renderActivityList 와 동일 패턴)
+  const latestPerKind = {};
+  (delivs || []).forEach(function(d) {
+    var prev = latestPerKind[d.kind];
+    if (!prev || new Date(d.created_at) > new Date(prev.created_at)) latestPerKind[d.kind] = d;
+  });
+  const activeCount = Object.values(latestPerKind).filter(function(d) { return d.status !== 'rejected'; }).length;
   const reachedMax = activeCount >= 1;
   if (formBox) formBox.style.display = reachedMax ? 'none' : '';
   if (addBtn) addBtn.style.display = reachedMax ? 'none' : '';

--- a/index.html
+++ b/index.html
@@ -7363,9 +7363,17 @@ function renderActivityReceiptList(delivs) {
   const addBtn = $('addReceiptBtn');
   const maxNote = $('receiptMaxNote');
   // monitor 캠페인은 영수증 1장만 제출 가능 (visit는 현장 사진 여러 장 가능 — 그대로 둠)
-  // active = draft|pending|approved (rejected는 제외, 재제출 가능)
+  // active 판정: kind별 가장 최신 1건이 rejected가 아니면 active로 본다.
+  //   같은 application에 옛 pending 행이 누적되어도(관리자 미검수 방치 등) 가장 최신이
+  //   rejected면 재제출 form 노출. 2026-05-12 a4y2u9.i@gmail.com 케이스 — pending 3건
+  //   누적 + 최신 rejected였는데 단순 `status !== 'rejected'` 카운트로 인해 재제출 차단됨.
   const isMonitor = (_activityCamp?.recruit_type === 'monitor');
-  const activeCount = (delivs || []).filter(d => d.status !== 'rejected').length;
+  const latestPerKind = {};
+  (delivs || []).forEach(function(d) {
+    var prev = latestPerKind[d.kind];
+    if (!prev || new Date(d.created_at) > new Date(prev.created_at)) latestPerKind[d.kind] = d;
+  });
+  const activeCount = Object.values(latestPerKind).filter(function(d) { return d.status !== 'rejected'; }).length;
   const reachedMax = isMonitor && activeCount >= 1;
   if (formBox) formBox.style.display = reachedMax ? 'none' : '';
   if (addBtn) addBtn.style.display = reachedMax ? 'none' : '';
@@ -7418,8 +7426,14 @@ function renderActivityReviewImageList(delivs) {
   const maxNote = $('reviewImageMaxNote');
   const formBox = $('reviewImageForm');
   // 1장 제약: 어떤 상태든(draft/pending/approved) 1건이라도 있으면 추가 불가
-  // — 단, rejected 1건뿐이면 재제출 가능 (active=draft|pending|approved 정의)
-  const activeCount = (delivs || []).filter(d => d.status !== 'rejected').length;
+  //   active 판정은 kind별 가장 최신 1건 기준 — 같은 application에 옛 pending 누적되어도
+  //   가장 최신이 rejected면 재제출 form 노출 (renderActivityList 와 동일 패턴)
+  const latestPerKind = {};
+  (delivs || []).forEach(function(d) {
+    var prev = latestPerKind[d.kind];
+    if (!prev || new Date(d.created_at) > new Date(prev.created_at)) latestPerKind[d.kind] = d;
+  });
+  const activeCount = Object.values(latestPerKind).filter(function(d) { return d.status !== 'rejected'; }).length;
   const reachedMax = activeCount >= 1;
   if (formBox) formBox.style.display = reachedMax ? 'none' : '';
   if (addBtn) addBtn.style.display = reachedMax ? 'none' : '';


### PR DESCRIPTION
## Summary

🚨 긴급 운영 hotfix — 인플루언서 영수증 재제출 차단 회귀.

### 증상
인플루언서가 영수증 반려 후 재제출 시도해도 화면에 form/버튼 자체가 안 나옴.

### 원인
`application.js`의 `activeCount` 계산이 같은 application의 옛 pending 행을 모두 카운트 → monitor 캠페인에서 `reachedMax=true` → 재제출 form hide.

- 예: `a4y2u9.i@gmail.com` 신청 `5b3cc87c`에 receipt 4건(pending 3 + rejected 1) 누적
- 관리자가 옛 pending 3건 미검수 + 가장 최신 1건만 반려 → activeCount=3 → 재제출 차단

### 해결
`renderActivityList`(영수증) + `renderActivityReviewImageList`(리뷰 캡처) 두 곳에서 activeCount 계산을 **kind별 가장 최신 1건 기준**으로 변경. 옛 pending 누적되어도 가장 최신이 rejected면 form 노출.

### 영향
- a4y2u9.i 케이스 즉시 회복 (가장 최신 rejected → activeCount=0 → form 노출)
- nanarin52 같은 정상 케이스(가장 최신 pending) 차단 동작 그대로 보존

### 한계
- 같은 application에 multiple deliverable 행 누적 패턴 자체는 변경 없음 (DB unique constraint 없음)
- 옛 pending 행 정리는 관리자 SQL로 별도 처리 권장

## Test plan
- [ ] 머지 후 운영 globalreverb.com에 a4y2u9.i@gmail.com 인플루언서 화면 진입 확인 (영수증 form/추가 버튼 노출)
- [ ] 영수증 재첨부 + 「再提出」 흐름 1건 정상 처리
- [ ] deliverable_events에 resubmit 액션 정상 기록 확인
- [ ] 정상 케이스(가장 최신 pending) 추가 제출 차단 보존 확인

[via reviewer] 🟢 GO, qa-tester 권장 light

🤖 Generated with [Claude Code](https://claude.com/claude-code)