### PR TITLE
feat(admin): multi-select campaign export + UX polish

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -12,7 +12,7 @@
 // 회귀(2026-05-12 PR #182 머지 직후 발생)를 방지하기 위한 자동 reload 가드.
 // sessionStorage 차단 환경(시크릿 모드 일부, 쿠키 차단)에서는 자연스럽게 skip.
 (function(){
-  var CURRENT_BUILD = 'v1778815038';
+  var CURRENT_BUILD = 'v1778815488';
   if (CURRENT_BUILD.indexOf('__') === 0) return; // 빌드 미적용 (dev/ 직접 열기) 시 skip
   try {
     var prev = sessionStorage.getItem('reverb.adminBuild');
@@ -1443,7 +1443,7 @@ textarea.form-input{resize:vertical;min-height:80px}
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-05-15 12:17 · 473d24c</span>
+          <span class="admin-build-text">2026-05-15 12:24 · 145d367</span>
         </div>
       </div>
     </aside>
@@ -11306,6 +11306,7 @@ function updateCampTableHead() {
     head.innerHTML = `<tr><th>순서</th><th>캠페인</th><th>브랜드</th><th>제품</th><th>상태 ${statusHelpIcon}</th><th>조회</th><th>신청</th><th>등록일</th><th>수정일</th></tr>`;
   } else {
     head.innerHTML = `<tr>
+      <th style="width:36px;text-align:center"><input type="checkbox" id="campSelectAll" onchange="toggleCampSelectAll(this.checked)" title="필터 결과 전체 선택"></th>
       <th>캠페인</th>
       <th>브랜드</th>
       <th>제품</th>
@@ -18290,7 +18291,8 @@ function updateCampSelectionUI() {
 }
 
 // 시트1 헬퍼: 선택한 캠페인 N개 요약 행
-function _buildCampaignSummarySheet(wb, campaigns) {
+//   appsByCampId: {campaignId: appsArray} — 시트2 export 시 이미 fetch한 결과 재사용 (round-trip 절약)
+function _buildCampaignSummarySheet(wb, campaigns, appsByCampId) {
   var ws = wb.addWorksheet('캠페인 정보');
   ws.columns = [
     { header: '캠페인 번호', key: 'no',      width: 18 },
@@ -18314,7 +18316,7 @@ function _buildCampaignSummarySheet(wb, campaigns) {
   var rtypeLabel = function(t) { return t === 'monitor' ? '리뷰어' : t === 'gifting' ? '기프팅' : t === 'visit' ? '방문형' : (t || ''); };
   var statusKo = function(s) { return s === 'draft' ? '준비' : s === 'scheduled' ? '모집예정' : s === 'active' ? '모집중' : s === 'closed' ? '종료' : s === 'expired' ? '노출마감' : (s || ''); };
   campaigns.forEach(function(c) {
-    var campApps = (Array.isArray(allApps) ? allApps : []).filter(function(a){ return a.campaign_id === c.id; });
+    var campApps = (appsByCampId && appsByCampId[c.id]) || [];
     var approvedCnt = campApps.filter(function(a){ return a.status === 'approved'; }).length;
     ws.addRow({
       no:       c.campaign_no || '',
@@ -18361,18 +18363,20 @@ async function exportSelectedCampaignsApplicants() {
     var users = await fetchInfluencers();
     var userByEmail = {};
     (users || []).forEach(function(u){ if (u.email) userByEmail[u.email] = u; });
-    // 신청자: 캠페인별로 fetch (서버 round-trip)
+    // 신청자: 캠페인별로 fetch (서버 round-trip) — appsByCampId 캐시도 동시 빌드
     var allCampApps = [];
+    var appsByCampId = {};
     for (var i = 0; i < camps.length; i++) {
       var c = camps[i];
       var apps = await fetchApplications({ campaign_id: c.id });
+      appsByCampId[c.id] = apps || [];
       (apps || []).forEach(function(a){ a._campMeta = c; allCampApps.push(a); });
     }
 
     var wb = new ExcelJS.Workbook();
     wb.creator = 'REVERB JP Admin';
     wb.created = new Date();
-    _buildCampaignSummarySheet(wb, camps);
+    _buildCampaignSummarySheet(wb, camps, appsByCampId);
 
     var ws = wb.addWorksheet('신청자');
     ws.columns = [
@@ -18490,6 +18494,13 @@ async function exportSelectedCampaignsDeliverables() {
     var users = await fetchInfluencers();
     var userByEmail = {};
     (users || []).forEach(function(u){ if (u.email) userByEmail[u.email] = u; });
+    // 시트1 캠페인 요약 「신청 수」 컬럼을 채우기 위해 신청 전체 fetch 1회 + groupBy
+    var allAppsForSummary = await fetchApplications();
+    var appsByCampId = {};
+    (allAppsForSummary || []).forEach(function(a){
+      if (!appsByCampId[a.campaign_id]) appsByCampId[a.campaign_id] = [];
+      appsByCampId[a.campaign_id].push(a);
+    });
     var allDelivs = [];
     for (var i = 0; i < camps.length; i++) {
       var c = camps[i];
@@ -18500,7 +18511,7 @@ async function exportSelectedCampaignsDeliverables() {
     var wb = new ExcelJS.Workbook();
     wb.creator = 'REVERB JP Admin';
     wb.created = new Date();
-    _buildCampaignSummarySheet(wb, camps);
+    _buildCampaignSummarySheet(wb, camps, appsByCampId);
 
     var ws = wb.addWorksheet('결과물');
     ws.columns = [

--- a/admin/index.html
+++ b/admin/index.html
@@ -12,7 +12,7 @@
 // 회귀(2026-05-12 PR #182 머지 직후 발생)를 방지하기 위한 자동 reload 가드.
 // sessionStorage 차단 환경(시크릿 모드 일부, 쿠키 차단)에서는 자연스럽게 skip.
 (function(){
-  var CURRENT_BUILD = 'v1778815488';
+  var CURRENT_BUILD = 'v1778815709';
   if (CURRENT_BUILD.indexOf('__') === 0) return; // 빌드 미적용 (dev/ 직접 열기) 시 skip
   try {
     var prev = sessionStorage.getItem('reverb.adminBuild');
@@ -1443,7 +1443,7 @@ textarea.form-input{resize:vertical;min-height:80px}
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-05-15 12:24 · 145d367</span>
+          <span class="admin-build-text">2026-05-15 12:28 · cfd044b</span>
         </div>
       </div>
     </aside>
@@ -1578,7 +1578,7 @@ textarea.form-input{resize:vertical;min-height:80px}
             <div class="admin-table-wrap">
             <table class="data-table">
               <thead id="adminCampTableHead"><tr>
-  <th style="width:36px;text-align:center"><input type="checkbox" id="campSelectAll" onchange="toggleCampSelectAll(this.checked)" title="필터 결과 전체 선택"></th>
+  <th style="width:44px;min-width:44px;max-width:44px;text-align:center;padding:8px 4px"><input type="checkbox" id="campSelectAll" onchange="toggleCampSelectAll(this.checked)" title="필터 결과 전체 선택"></th>
   <th>캠페인</th>
   <th>브랜드</th>
   <th>제품</th>
@@ -11306,7 +11306,7 @@ function updateCampTableHead() {
     head.innerHTML = `<tr><th>순서</th><th>캠페인</th><th>브랜드</th><th>제품</th><th>상태 ${statusHelpIcon}</th><th>조회</th><th>신청</th><th>등록일</th><th>수정일</th></tr>`;
   } else {
     head.innerHTML = `<tr>
-      <th style="width:36px;text-align:center"><input type="checkbox" id="campSelectAll" onchange="toggleCampSelectAll(this.checked)" title="필터 결과 전체 선택"></th>
+      <th style="width:44px;min-width:44px;max-width:44px;text-align:center;padding:8px 4px"><input type="checkbox" id="campSelectAll" onchange="toggleCampSelectAll(this.checked)" title="필터 결과 전체 선택"></th>
       <th>캠페인</th>
       <th>브랜드</th>
       <th>제품</th>
@@ -11471,7 +11471,7 @@ async function loadAdminCampaigns(useCache) {
           <button class="btn btn-ghost btn-xs" ${i===0?'disabled':''} onclick="moveCampOrder('${c.id}',-1)" style="padding:2px 6px;font-size:13px">↑</button>
           <button class="btn btn-ghost btn-xs" ${i===totalLen-1?'disabled':''} onclick="moveCampOrder('${c.id}',1)" style="padding:2px 6px;font-size:13px">↓</button>
         </div>
-      </td>` : `<td style="text-align:center;width:36px"><input type="checkbox" class="camp-select-cb" data-camp-id="${esc(c.id)}" ${isSelected?'checked':''} onchange="toggleCampSelect('${c.id}', this.checked)"></td>`}
+      </td>` : `<td style="text-align:center;width:44px;min-width:44px;max-width:44px;padding:8px 4px"><input type="checkbox" class="camp-select-cb" data-camp-id="${esc(c.id)}" ${isSelected?'checked':''} onchange="toggleCampSelect('${c.id}', this.checked)"></td>`}
       <td style="max-width:280px">
         <div style="display:flex;align-items:center;gap:10px">
           <div style="position:relative;width:44px;height:44px;flex-shrink:0;border-radius:8px;overflow:hidden;background:var(--surface-dim)">

--- a/admin/index.html
+++ b/admin/index.html
@@ -12,7 +12,7 @@
 // 회귀(2026-05-12 PR #182 머지 직후 발생)를 방지하기 위한 자동 reload 가드.
 // sessionStorage 차단 환경(시크릿 모드 일부, 쿠키 차단)에서는 자연스럽게 skip.
 (function(){
-  var CURRENT_BUILD = 'v1778813801';
+  var CURRENT_BUILD = 'v1778815038';
   if (CURRENT_BUILD.indexOf('__') === 0) return; // 빌드 미적용 (dev/ 직접 열기) 시 skip
   try {
     var prev = sessionStorage.getItem('reverb.adminBuild');
@@ -1443,7 +1443,7 @@ textarea.form-input{resize:vertical;min-height:80px}
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-05-15 11:56 · 4bf9563</span>
+          <span class="admin-build-text">2026-05-15 12:17 · 473d24c</span>
         </div>
       </div>
     </aside>
@@ -1566,8 +1566,11 @@ textarea.form-input{resize:vertical;min-height:80px}
           </div>
           <div class="admin-card">
             <div class="admin-card-header">
-              <div style="display:flex;align-items:center;gap:8px"><span class="admin-card-title">캠페인 목록</span><span id="adminCampStatusCounts" style="font-size:12px;color:var(--muted)"></span></div>
+              <div style="display:flex;align-items:center;gap:8px"><span class="admin-card-title">캠페인 목록</span><span id="adminCampStatusCounts" style="font-size:12px;color:var(--muted)"></span><span id="adminCampSelectedCount" style="font-size:12px;color:var(--pink);font-weight:600;display:none"></span></div>
               <div style="display:flex;align-items:center;gap:6px">
+                <button class="btn btn-ghost btn-xs" id="btnCampSelectClear" onclick="clearCampSelection()" style="display:none">선택 초기화</button>
+                <button class="btn btn-ghost btn-xs" id="btnCampSelectApplicants" onclick="exportSelectedCampaignsApplicants()" disabled title="캠페인을 1개 이상 선택하세요"><span class="material-icons-round notranslate" translate="no" style="font-size:14px;vertical-align:middle">download</span> 신청자 엑셀</button>
+                <button class="btn btn-ghost btn-xs" id="btnCampSelectDeliverables" onclick="exportSelectedCampaignsDeliverables()" disabled title="캠페인을 1개 이상 선택하세요"><span class="material-icons-round notranslate" translate="no" style="font-size:14px;vertical-align:middle">download</span> 결과물 엑셀</button>
                 <button class="btn btn-ghost btn-xs" id="btnCampSortReset" onclick="resetCampSort()" style="display:none">정렬 초기화</button>
                 <button class="btn btn-ghost btn-xs" id="btnReorderMode" onclick="enterReorderMode()">순서 변경</button>
               </div>
@@ -1575,6 +1578,7 @@ textarea.form-input{resize:vertical;min-height:80px}
             <div class="admin-table-wrap">
             <table class="data-table">
               <thead id="adminCampTableHead"><tr>
+  <th style="width:36px;text-align:center"><input type="checkbox" id="campSelectAll" onchange="toggleCampSelectAll(this.checked)" title="필터 결과 전체 선택"></th>
   <th>캠페인</th>
   <th>브랜드</th>
   <th>제품</th>
@@ -1585,7 +1589,7 @@ textarea.form-input{resize:vertical;min-height:80px}
   <th>수정일 <span class="sort-arrows" data-sort="updated" onclick="toggleCampSort('updated')">▲▼</span></th>
   <th></th>
 </tr></thead>
-              <tbody id="adminCampsBody"><tr><td colspan="9" style="text-align:center;color:var(--muted);padding:24px"><span class="spinner" style="width:20px;height:20px;border-width:2px;border-color:rgba(200,120,163,.2);border-top-color:var(--pink)"></span></td></tr></tbody>
+              <tbody id="adminCampsBody"><tr><td colspan="10" style="text-align:center;color:var(--muted);padding:24px"><span class="spinner" style="width:20px;height:20px;border-width:2px;border-color:rgba(200,120,163,.2);border-top-color:var(--pink)"></span></td></tr></tbody>
             </table>
             </div>
           </div>
@@ -11351,6 +11355,11 @@ function applyImageCropsToList(imgList, cropsMap) {
 var campsLazy = null;
 const CAMPS_PAGE_SIZE = 50;
 
+// 캠페인 다중 선택 — 현재 필터/정렬 적용된 캠페인 리스트 캐시
+// loadAdminCampaigns 가 매 호출마다 갱신. toggleCampSelectAll·updateCampSelectionUI 에서 참조
+var _currentFilteredCamps = [];
+function getCurrentFilteredCamps() { return _currentFilteredCamps; }
+
 async function loadAdminCampaigns(useCache) {
   updateCampTableHead();
   let camps = useCache ? allCampaigns.slice() : await fetchCampaigns();
@@ -11440,6 +11449,9 @@ async function loadAdminCampaigns(useCache) {
       <span class="badge ${cls}" style="cursor:pointer;${dashed}display:inline-flex;align-items:center;gap:3px" onclick="toggleStatusDropdown(this)">${statusLabel[s]||s}<span style="font-size:10px;opacity:.7">▾</span></span>
     </div>`;
   };
+  // 캠페인 다중 선택 — 현재 필터 결과를 전역 캐시 (전체 선택 헤더가 참조)
+  _currentFilteredCamps = camps.slice();
+
   const campsBody = $('adminCampsBody');
   if (!campsBody) return;
   const buildCampRow = (c, i, totalLen) => {
@@ -11451,13 +11463,14 @@ async function loadAdminCampaigns(useCache) {
     const imgs = [c.img1,c.img2,c.img3,c.img4,c.img5,c.img6,c.img7,c.img8,c.image_url].filter(Boolean).filter((v,idx,a)=>a.indexOf(v)===idx);
     const thumbUrl = imgs[0] || '';
     const imgCount = imgs.length;
+    const isSelected = (_selectedCampIds && _selectedCampIds.has(c.id));
     return `<tr data-camp-id="${c.id}" data-id="${esc(c.id)}">
       ${adminReorderMode ? `<td style="white-space:nowrap">
         <div style="display:flex;gap:3px">
           <button class="btn btn-ghost btn-xs" ${i===0?'disabled':''} onclick="moveCampOrder('${c.id}',-1)" style="padding:2px 6px;font-size:13px">↑</button>
           <button class="btn btn-ghost btn-xs" ${i===totalLen-1?'disabled':''} onclick="moveCampOrder('${c.id}',1)" style="padding:2px 6px;font-size:13px">↓</button>
         </div>
-      </td>` : ''}
+      </td>` : `<td style="text-align:center;width:36px"><input type="checkbox" class="camp-select-cb" data-camp-id="${esc(c.id)}" ${isSelected?'checked':''} onchange="toggleCampSelect('${c.id}', this.checked)"></td>`}
       <td style="max-width:280px">
         <div style="display:flex;align-items:center;gap:10px">
           <div style="position:relative;width:44px;height:44px;flex-shrink:0;border-radius:8px;overflow:hidden;background:var(--surface-dim)">
@@ -11509,7 +11522,7 @@ async function loadAdminCampaigns(useCache) {
       </td>`}
     </tr>`;
   };
-  const emptyHtml = `<tr><td colspan="9" style="text-align:center;color:var(--muted);padding:24px">캠페인 없음</td></tr>`;
+  const emptyHtml = `<tr><td colspan="10" style="text-align:center;color:var(--muted);padding:24px">캠페인 없음</td></tr>`;
   if (adminReorderMode) {
     // 순서변경 모드: 전체 DOM 필요 (↑↓ 위치 인덱스 기반). lazy 비활성.
     if (campsLazy) { campsLazy.destroy(); campsLazy = null; }
@@ -11524,6 +11537,10 @@ async function loadAdminCampaigns(useCache) {
       pageSize: CAMPS_PAGE_SIZE,
       emptyHtml,
     });
+  }
+  // 행 렌더 후 선택 UI (버튼/배지/select-all indeterminate) 동기화
+  if (typeof updateCampSelectionUI === 'function') {
+    setTimeout(updateCampSelectionUI, 0);
   }
 }
 
@@ -18182,8 +18199,377 @@ function imgToJpegArrayBuffer(url, maxW, maxH) {
   });
 }
 
+// ─── 캠페인 다중 선택 + 통합 엑셀 ────────────────────────────────────
+// _selectedCampIds: 사용자가 체크한 캠페인 id 집합. 페인 이동/새로고침 시 초기화.
+// 필터·정렬·lazy-load remount 와 무관하게 Set 기반 절대 선택 유지.
+var _selectedCampIds = new Set();
+
+// 다운로드 쿨다운 가드 — 단시간 다중 클릭 방지
+var _exportInProgress = false;
+var _lastExportAt = 0;
+var EXPORT_COOLDOWN_MS = 5000;
+
+function _checkExportAllowed() {
+  if (_exportInProgress) {
+    toast('다운로드가 진행 중입니다. 잠시 기다려주세요.', 'warn');
+    return false;
+  }
+  var now = Date.now();
+  var elapsed = now - _lastExportAt;
+  if (elapsed < EXPORT_COOLDOWN_MS) {
+    var wait = Math.ceil((EXPORT_COOLDOWN_MS - elapsed) / 1000);
+    toast(wait + '초 후 다시 시도해주세요', 'warn');
+    return false;
+  }
+  return true;
+}
+
+function _markExportStart() { _exportInProgress = true; }
+function _markExportEnd() { _exportInProgress = false; _lastExportAt = Date.now(); }
+
+function toggleCampSelect(campId, checked) {
+  if (checked) _selectedCampIds.add(campId);
+  else _selectedCampIds.delete(campId);
+  updateCampSelectionUI();
+}
+
+function toggleCampSelectAll(checked) {
+  // 필터 결과 전체 — getCurrentFilteredCamps() 반환을 우선, 없으면 캠페인 전체 캐시
+  var filtered = (typeof getCurrentFilteredCamps === 'function') ? getCurrentFilteredCamps() : null;
+  if (!filtered) filtered = (Array.isArray(allCampaigns) ? allCampaigns : []);
+  if (checked) {
+    filtered.forEach(function(c) { _selectedCampIds.add(c.id); });
+  } else {
+    filtered.forEach(function(c) { _selectedCampIds.delete(c.id); });
+  }
+  // DOM 행의 체크박스도 동기 (현재 렌더된 행만)
+  document.querySelectorAll('.camp-select-cb').forEach(function(cb) {
+    var id = cb.dataset.campId;
+    cb.checked = _selectedCampIds.has(id);
+  });
+  updateCampSelectionUI();
+}
+
+function clearCampSelection() {
+  _selectedCampIds.clear();
+  document.querySelectorAll('.camp-select-cb').forEach(function(cb) { cb.checked = false; });
+  var sa = document.getElementById('campSelectAll');
+  if (sa) { sa.checked = false; sa.indeterminate = false; }
+  updateCampSelectionUI();
+}
+
+function updateCampSelectionUI() {
+  var n = _selectedCampIds.size;
+  var btnApp = document.getElementById('btnCampSelectApplicants');
+  var btnDel = document.getElementById('btnCampSelectDeliverables');
+  var btnClr = document.getElementById('btnCampSelectClear');
+  var cntEl = document.getElementById('adminCampSelectedCount');
+  if (btnApp) {
+    btnApp.disabled = (n === 0);
+    btnApp.innerHTML = '<span class="material-icons-round notranslate" translate="no" style="font-size:14px;vertical-align:middle">download</span> ' + (n > 0 ? '선택 ' + n + '개 ' : '') + '신청자 엑셀';
+  }
+  if (btnDel) {
+    btnDel.disabled = (n === 0);
+    btnDel.innerHTML = '<span class="material-icons-round notranslate" translate="no" style="font-size:14px;vertical-align:middle">download</span> ' + (n > 0 ? '선택 ' + n + '개 ' : '') + '결과물 엑셀';
+  }
+  if (btnClr) btnClr.style.display = n > 0 ? '' : 'none';
+  if (cntEl) {
+    if (n > 0) { cntEl.textContent = '· ' + n + '개 선택'; cntEl.style.display = ''; }
+    else { cntEl.textContent = ''; cntEl.style.display = 'none'; }
+  }
+  // 전체 선택 체크박스 indeterminate
+  var sa = document.getElementById('campSelectAll');
+  if (sa) {
+    var filtered = (typeof getCurrentFilteredCamps === 'function') ? getCurrentFilteredCamps() : null;
+    if (!filtered) filtered = (Array.isArray(allCampaigns) ? allCampaigns : []);
+    var total = filtered.length;
+    var selectedInFiltered = filtered.filter(function(c) { return _selectedCampIds.has(c.id); }).length;
+    sa.checked = (total > 0 && selectedInFiltered === total);
+    sa.indeterminate = (selectedInFiltered > 0 && selectedInFiltered < total);
+  }
+}
+
+// 시트1 헬퍼: 선택한 캠페인 N개 요약 행
+function _buildCampaignSummarySheet(wb, campaigns) {
+  var ws = wb.addWorksheet('캠페인 정보');
+  ws.columns = [
+    { header: '캠페인 번호', key: 'no',      width: 18 },
+    { header: '제목',        key: 'title',   width: 36 },
+    { header: '브랜드',      key: 'brand',   width: 18 },
+    { header: '제품',        key: 'product', width: 22 },
+    { header: '모집 타입',   key: 'rtype',   width: 10 },
+    { header: '상태',        key: 'status',  width: 10 },
+    { header: '모집 시작',   key: 'rstart',  width: 14 },
+    { header: '모집 마감',   key: 'deadline',width: 14 },
+    { header: '게시 마감',   key: 'pdead',   width: 14 },
+    { header: '슬롯',        key: 'slots',   width: 8 },
+    { header: '신청 수',     key: 'apps',    width: 10 },
+    { header: '승인 수',     key: 'approved',width: 10 }
+  ];
+  var header = ws.getRow(1);
+  header.font = { bold: true, color: { argb: 'FF222222' } };
+  header.alignment = { vertical: 'middle', horizontal: 'center' };
+  header.fill = { type: 'pattern', pattern: 'solid', fgColor: { argb: 'FFF2F2F2' } };
+  header.height = 22;
+  var rtypeLabel = function(t) { return t === 'monitor' ? '리뷰어' : t === 'gifting' ? '기프팅' : t === 'visit' ? '방문형' : (t || ''); };
+  var statusKo = function(s) { return s === 'draft' ? '준비' : s === 'scheduled' ? '모집예정' : s === 'active' ? '모집중' : s === 'closed' ? '종료' : s === 'expired' ? '노출마감' : (s || ''); };
+  campaigns.forEach(function(c) {
+    var campApps = (Array.isArray(allApps) ? allApps : []).filter(function(a){ return a.campaign_id === c.id; });
+    var approvedCnt = campApps.filter(function(a){ return a.status === 'approved'; }).length;
+    ws.addRow({
+      no:       c.campaign_no || '',
+      title:    c.title || '',
+      brand:    c.brand_ko || c.brand || '',
+      product:  c.product_ko || c.product || '',
+      rtype:    rtypeLabel(c.recruit_type),
+      status:   statusKo(c.status),
+      rstart:   c.recruit_start ? formatDate(c.recruit_start) : '',
+      deadline: c.deadline ? formatDate(c.deadline) : '',
+      pdead:    c.post_deadline ? formatDate(c.post_deadline) : '',
+      slots:    Number(c.slots || 0),
+      apps:     campApps.length,
+      approved: approvedCnt
+    });
+  });
+  return ws;
+}
+
+// 50개 이상 경고 모달
+function _confirmLargeExport(n) {
+  if (n < 50) return Promise.resolve(true);
+  return new Promise(function(resolve) {
+    var ok = confirm(n + '개 캠페인 선택했습니다.\n엑셀 생성에 수십 초~수 분 걸릴 수 있습니다.\n\n계속할까요?');
+    resolve(!!ok);
+  });
+}
+
+// 캠페인 다중 선택 신청자 엑셀 — 시트1 캠페인 정보 + 시트2 통합 신청자 리스트
+async function exportSelectedCampaignsApplicants() {
+  if (!_checkExportAllowed()) return;
+  var ids = Array.from(_selectedCampIds);
+  if (ids.length === 0) { toast('캠페인을 1개 이상 선택하세요', 'warn'); return; }
+  if (!(await _confirmLargeExport(ids.length))) return;
+
+  _markExportStart();
+  try {
+    toast('엑셀 생성 중...');
+    await loadExcelJS();
+    var camps = (Array.isArray(allCampaigns) ? allCampaigns : []).filter(function(c){ return ids.indexOf(c.id) !== -1; });
+    if (camps.length === 0) { toast('선택한 캠페인을 찾을 수 없습니다', 'error'); return; }
+    // 모든 캠페인의 신청자 + 인플루언서 한 번에 fetch
+    await ensureCancelReasonsCache();
+    var users = await fetchInfluencers();
+    var userByEmail = {};
+    (users || []).forEach(function(u){ if (u.email) userByEmail[u.email] = u; });
+    // 신청자: 캠페인별로 fetch (서버 round-trip)
+    var allCampApps = [];
+    for (var i = 0; i < camps.length; i++) {
+      var c = camps[i];
+      var apps = await fetchApplications({ campaign_id: c.id });
+      (apps || []).forEach(function(a){ a._campMeta = c; allCampApps.push(a); });
+    }
+
+    var wb = new ExcelJS.Workbook();
+    wb.creator = 'REVERB JP Admin';
+    wb.created = new Date();
+    _buildCampaignSummarySheet(wb, camps);
+
+    var ws = wb.addWorksheet('신청자');
+    ws.columns = [
+      { header: '캠페인 번호',   key: 'campNo',     width: 16 },
+      { header: '캠페인 제목',   key: 'campTitle',  width: 28 },
+      { header: '신청일',        key: 'created',    width: 20 },
+      { header: '상태',          key: 'status',     width: 10 },
+      { header: '인플루언서명',  key: 'name',       width: 16 },
+      { header: '이메일',        key: 'email',      width: 26 },
+      { header: '연락처',        key: 'phone',      width: 16 },
+      { header: 'Instagram',     key: 'ig',         width: 22 },
+      { header: 'Instagram 팔로워', key: 'igF',     width: 14 },
+      { header: 'TikTok',        key: 'tt',         width: 22 },
+      { header: 'TikTok 팔로워', key: 'ttF',        width: 14 },
+      { header: 'X',             key: 'x',          width: 22 },
+      { header: 'X 팔로워',      key: 'xF',         width: 14 },
+      { header: 'YouTube',       key: 'yt',         width: 22 },
+      { header: 'YouTube 팔로워',key: 'ytF',        width: 14 },
+      { header: '배송지',        key: 'address',    width: 36 },
+      { header: '신청 메시지',   key: 'message',    width: 32 },
+      { header: '심사일',        key: 'reviewedAt', width: 20 },
+      { header: '리뷰어',        key: 'reviewedBy', width: 14 },
+      { header: '취소일',        key: 'cancelledAt',width: 20 },
+      { header: '취소 사유',     key: 'cancelReason',width: 24 },
+      { header: '취소 카테고리', key: 'cancelCategory', width: 18 },
+      { header: '취소 시점',     key: 'cancelPhase', width: 12 }
+    ];
+    var hdr = ws.getRow(1);
+    hdr.font = { bold: true, color: { argb: 'FF222222' } };
+    hdr.alignment = { vertical: 'middle', horizontal: 'center' };
+    hdr.fill = { type: 'pattern', pattern: 'solid', fgColor: { argb: 'FFF2F2F2' } };
+    hdr.height = 22;
+
+    var snsHandleStr = function(channel, raw) {
+      if (!raw) return '';
+      if (typeof extractSnsHandle === 'function') { var h = extractSnsHandle(channel, raw); return h ? '@' + h : ''; }
+      return String(raw).trim();
+    };
+    var addrStr = function(u, fallbackAddress) {
+      if (u && u.zip) return '〒' + u.zip + ' ' + (u.prefecture || '') + (u.city || '') + (u.building ? ' ' + u.building : '');
+      return fallbackAddress || '';
+    };
+    var statusKo = function(s) { return s === 'approved' ? '승인' : s === 'pending' ? '심사중' : s === 'rejected' ? '미승인' : s === 'cancelled' ? '취소' : (s || ''); };
+    var fmtKR = function(iso) { if (!iso) return ''; try { return new Date(iso).toLocaleString('ko-KR', {timeZone:'Asia/Seoul'}); } catch(e) { return String(iso); } };
+
+    allCampApps.forEach(function(a) {
+      var u = userByEmail[a.user_email] || {};
+      var c = a._campMeta || {};
+      ws.addRow({
+        campNo:        c.campaign_no || '',
+        campTitle:     c.title || '',
+        created:       fmtKR(a.created_at),
+        status:        statusKo(a.status),
+        name:          u.name_kanji || u.name || a.user_name || '',
+        email:         a.user_email || '',
+        phone:         formatPhoneDisplay(u.phone),
+        ig:            snsHandleStr('instagram', u.ig || a.ig_id || a.user_ig),
+        igF:           Number(u.ig_followers || 0),
+        tt:            snsHandleStr('tiktok', u.tiktok),
+        ttF:           Number(u.tiktok_followers || 0),
+        x:             snsHandleStr('x', u.x),
+        xF:            Number(u.x_followers || 0),
+        yt:            snsHandleStr('youtube', u.youtube),
+        ytF:           Number(u.youtube_followers || 0),
+        address:       addrStr(u, a.address),
+        message:       a.message || '',
+        reviewedAt:    fmtKR(a.reviewed_at),
+        reviewedBy:    formatReviewer(a.reviewed_by),
+        cancelledAt:   fmtKR(a.cancelled_at),
+        cancelReason:  a.cancel_reason || '',
+        cancelCategory:a.cancel_reason_code ? cancelReasonLabelKo(a.cancel_reason_code) : '',
+        cancelPhase:   a.cancel_phase ? cancelPhaseLabelKo(a.cancel_phase) : ''
+      });
+    });
+    ['igF','ttF','xF','ytF'].forEach(function(k) {
+      ws.getColumn(k).numFmt = '#,##0';
+      ws.getColumn(k).alignment = { horizontal: 'right' };
+    });
+    ws.getColumn('message').alignment = { wrapText: true, vertical: 'top' };
+    ws.getColumn('address').alignment = { wrapText: true, vertical: 'top' };
+
+    var buf = await wb.xlsx.writeBuffer();
+    var blob = new Blob([buf], { type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' });
+    var url = URL.createObjectURL(blob);
+    var aEl = document.createElement('a');
+    aEl.href = url;
+    var ts = new Date();
+    var ymd = ts.getFullYear() + String(ts.getMonth()+1).padStart(2,'0') + String(ts.getDate()).padStart(2,'0');
+    aEl.download = 'applicants-' + camps.length + 'campaigns-' + ymd + '.xlsx';
+    document.body.appendChild(aEl); aEl.click(); document.body.removeChild(aEl);
+    URL.revokeObjectURL(url);
+    toast('엑셀 다운로드 완료 (' + camps.length + '개 캠페인, ' + allCampApps.length + '건 신청)');
+  } catch (e) {
+    console.error('[exportSelectedCampaignsApplicants]', e);
+    toast('엑셀 생성 실패: ' + (e?.message || e), 'error');
+  } finally {
+    _markExportEnd();
+  }
+}
+
+// 캠페인 다중 선택 결과물 엑셀 — 시트1 캠페인 정보 + 시트2 통합 결과물 리스트 (이미지 임베드 생략, URL만)
+async function exportSelectedCampaignsDeliverables() {
+  if (!_checkExportAllowed()) return;
+  var ids = Array.from(_selectedCampIds);
+  if (ids.length === 0) { toast('캠페인을 1개 이상 선택하세요', 'warn'); return; }
+  if (!(await _confirmLargeExport(ids.length))) return;
+
+  _markExportStart();
+  try {
+    toast('엑셀 생성 중...');
+    await loadExcelJS();
+    var camps = (Array.isArray(allCampaigns) ? allCampaigns : []).filter(function(c){ return ids.indexOf(c.id) !== -1; });
+    if (camps.length === 0) { toast('선택한 캠페인을 찾을 수 없습니다', 'error'); return; }
+
+    var users = await fetchInfluencers();
+    var userByEmail = {};
+    (users || []).forEach(function(u){ if (u.email) userByEmail[u.email] = u; });
+    var allDelivs = [];
+    for (var i = 0; i < camps.length; i++) {
+      var c = camps[i];
+      var dels = await fetchDeliverables({ campaign_id: c.id });
+      (dels || []).forEach(function(d){ d._campMeta = c; allDelivs.push(d); });
+    }
+
+    var wb = new ExcelJS.Workbook();
+    wb.creator = 'REVERB JP Admin';
+    wb.created = new Date();
+    _buildCampaignSummarySheet(wb, camps);
+
+    var ws = wb.addWorksheet('결과물');
+    ws.columns = [
+      { header: '캠페인 번호',   key: 'campNo',     width: 16 },
+      { header: '캠페인 제목',   key: 'campTitle',  width: 28 },
+      { header: '제출일',        key: 'submitted',  width: 20 },
+      { header: '종류',          key: 'kind',       width: 10 },
+      { header: '상태',          key: 'status',     width: 10 },
+      { header: '인플루언서명',  key: 'name',       width: 16 },
+      { header: '이메일',        key: 'email',      width: 26 },
+      { header: '결과물 URL',    key: 'url',        width: 50 },
+      { header: '채널',          key: 'channel',    width: 12 },
+      { header: '반려 사유',     key: 'rejectReason', width: 24 },
+      { header: '검수일',        key: 'reviewedAt', width: 20 },
+      { header: '리뷰어',        key: 'reviewedBy', width: 14 }
+    ];
+    var hdr = ws.getRow(1);
+    hdr.font = { bold: true, color: { argb: 'FF222222' } };
+    hdr.alignment = { vertical: 'middle', horizontal: 'center' };
+    hdr.fill = { type: 'pattern', pattern: 'solid', fgColor: { argb: 'FFF2F2F2' } };
+    hdr.height = 22;
+
+    var statusKo = function(s) { return s === 'approved' ? '승인' : s === 'pending' ? '검수대기' : s === 'rejected' ? '반려' : s === 'changed' ? '재제출요청' : (s || ''); };
+    var kindKo = function(k) { return k === 'receipt' ? '영수증' : k === 'post' ? '게시물' : (k || ''); };
+    var fmtKR = function(iso) { if (!iso) return ''; try { return new Date(iso).toLocaleString('ko-KR', {timeZone:'Asia/Seoul'}); } catch(e) { return String(iso); } };
+
+    allDelivs.forEach(function(d) {
+      var u = userByEmail[(d.influencers && d.influencers.email) || d.user_email] || {};
+      var c = d._campMeta || {};
+      ws.addRow({
+        campNo:       c.campaign_no || '',
+        campTitle:    c.title || '',
+        submitted:    fmtKR(d.submitted_at),
+        kind:         kindKo(d.kind),
+        status:       statusKo(d.status),
+        name:         u.name_kanji || u.name || (d.influencers && d.influencers.name) || '',
+        email:        (d.influencers && d.influencers.email) || u.email || '',
+        url:          d.receipt_url || d.post_url || '',
+        channel:      d.post_channel || '',
+        rejectReason: d.reject_reason || '',
+        reviewedAt:   fmtKR(d.reviewed_at),
+        reviewedBy:   formatReviewer(d.reviewed_by)
+      });
+    });
+    ws.getColumn('rejectReason').alignment = { wrapText: true, vertical: 'top' };
+
+    var buf = await wb.xlsx.writeBuffer();
+    var blob = new Blob([buf], { type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' });
+    var url = URL.createObjectURL(blob);
+    var aEl = document.createElement('a');
+    aEl.href = url;
+    var ts = new Date();
+    var ymd = ts.getFullYear() + String(ts.getMonth()+1).padStart(2,'0') + String(ts.getDate()).padStart(2,'0');
+    aEl.download = 'deliverables-' + camps.length + 'campaigns-' + ymd + '.xlsx';
+    document.body.appendChild(aEl); aEl.click(); document.body.removeChild(aEl);
+    URL.revokeObjectURL(url);
+    toast('엑셀 다운로드 완료 (' + camps.length + '개 캠페인, ' + allDelivs.length + '건 결과물)');
+  } catch (e) {
+    console.error('[exportSelectedCampaignsDeliverables]', e);
+    toast('엑셀 생성 실패: ' + (e?.message || e), 'error');
+  } finally {
+    _markExportEnd();
+  }
+}
+
 // 캠페인별 신청자 목록 엑셀 다운로드 (전체 상태, 4채널 SNS+팔로워 포함)
 async function exportCampaignApplicationsExcel(campId) {
+  if (!_checkExportAllowed()) return;
+  _markExportStart();
   try {
     document.querySelectorAll('.camp-more-menu').forEach(function(d){ d.remove(); });
 
@@ -18333,11 +18719,15 @@ async function exportCampaignApplicationsExcel(campId) {
   } catch (e) {
     console.error('[exportCampaignApplicationsExcel]', e);
     toast('엑셀 생성 실패: ' + (e?.message || e), 'error');
+  } finally {
+    _markExportEnd();
   }
 }
 
 
 async function exportCampaignDeliverables(campId) {
+  if (!_checkExportAllowed()) return;
+  _markExportStart();
   try {
     document.querySelectorAll('.camp-more-menu').forEach(function(d){ d.remove(); });
     toast('엑셀 생성 중...');

--- a/admin/index.html
+++ b/admin/index.html
@@ -12,7 +12,7 @@
 // 회귀(2026-05-12 PR #182 머지 직후 발생)를 방지하기 위한 자동 reload 가드.
 // sessionStorage 차단 환경(시크릿 모드 일부, 쿠키 차단)에서는 자연스럽게 skip.
 (function(){
-  var CURRENT_BUILD = 'v1778815709';
+  var CURRENT_BUILD = 'v1778816136';
   if (CURRENT_BUILD.indexOf('__') === 0) return; // 빌드 미적용 (dev/ 직접 열기) 시 skip
   try {
     var prev = sessionStorage.getItem('reverb.adminBuild');
@@ -1443,7 +1443,7 @@ textarea.form-input{resize:vertical;min-height:80px}
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-05-15 12:28 · cfd044b</span>
+          <span class="admin-build-text">2026-05-15 12:35 · 0b98258</span>
         </div>
       </div>
     </aside>
@@ -11185,8 +11185,9 @@ function syncCampMultiFilter(containerId, sortedCamps, onChange, counts) {
 }
 
 // ── 다중 선택 드롭다운 필터 ──
-// "전체" = 모든 항목 체크 표시 (시각). 일부 해제 시 "전체"는 indeterminate.
-// 데이터 모델: 전체(모두 체크) → 빈 배열 반환(=필터 없음). 일부만 체크 → 그 배열 반환.
+// 초기 상태: 모두 비체크 = 필터 없음 (전체 표시). 사용자가 체크한 항목만 필터 적용.
+// "전체" 체크박스 클릭 시 모든 옵션 토글. 일부만 체크 시 "전체" indeterminate.
+// 데이터 모델: 모두 비체크 또는 모두 체크 → 빈 배열 반환(=필터 없음). 일부만 체크 → 그 배열 반환.
 //
 // options = [{value, label, subLabel?, count?}]
 //   - subLabel(있으면): 라벨 아래 회색 작은 글씨 (예: 캠페인 번호 B0019-C001)
@@ -11197,14 +11198,14 @@ function createMultiFilter(containerId, allLabel, options, onChange) {
   const btn = wrap.querySelector('.mf-btn');
   const drop = wrap.querySelector('.mf-drop');
   if (!btn || !drop) return;
-  // 옵션 행 렌더 — subLabel·count 지원
+  // 옵션 행 렌더 — subLabel·count 지원. 초기 비체크 (사용자가 명시적으로 선택해야 필터 적용)
   const renderOptionItem = (o) => {
     const countHtml = (o.count != null) ? ` <span class="mf-item-count">(${o.count})</span>` : '';
     const subHtml = o.subLabel ? `<div class="mf-item-sub">${esc(o.subLabel)}</div>` : '';
-    return `<label class="mf-item${o.subLabel ? ' has-sub' : ''}"><input type="checkbox" value="${esc(o.value)}" checked data-label="${esc(o.label)}"><div class="mf-item-text"><div class="mf-item-label">${esc(o.label)}${countHtml}</div>${subHtml}</div></label>`;
+    return `<label class="mf-item${o.subLabel ? ' has-sub' : ''}"><input type="checkbox" value="${esc(o.value)}" data-label="${esc(o.label)}"><div class="mf-item-text"><div class="mf-item-label">${esc(o.label)}${countHtml}</div>${subHtml}</div></label>`;
   };
-  // 드롭다운 아이템 생성 — 초기 상태: 전체 체크 = 모든 항목 체크
-  drop.innerHTML = `<label class="mf-item all-item"><input type="checkbox" value="all" checked><div class="mf-item-text"><div class="mf-item-label">${esc(allLabel)}</div></div></label>`
+  // 드롭다운 아이템 생성 — 초기 상태: 모두 비체크 = 필터 없음 (전체 표시)
+  drop.innerHTML = `<label class="mf-item all-item"><input type="checkbox" value="all"><div class="mf-item-text"><div class="mf-item-label">${esc(allLabel)}</div></div></label>`
     + options.map(renderOptionItem).join('');
   btn.textContent = allLabel;
   // 토글

--- a/dev/admin/index.html
+++ b/dev/admin/index.html
@@ -259,7 +259,7 @@
             <div class="admin-table-wrap">
             <table class="data-table">
               <thead id="adminCampTableHead"><tr>
-  <th style="width:36px;text-align:center"><input type="checkbox" id="campSelectAll" onchange="toggleCampSelectAll(this.checked)" title="필터 결과 전체 선택"></th>
+  <th style="width:44px;min-width:44px;max-width:44px;text-align:center;padding:8px 4px"><input type="checkbox" id="campSelectAll" onchange="toggleCampSelectAll(this.checked)" title="필터 결과 전체 선택"></th>
   <th>캠페인</th>
   <th>브랜드</th>
   <th>제품</th>

--- a/dev/admin/index.html
+++ b/dev/admin/index.html
@@ -247,8 +247,11 @@
           </div>
           <div class="admin-card">
             <div class="admin-card-header">
-              <div style="display:flex;align-items:center;gap:8px"><span class="admin-card-title">캠페인 목록</span><span id="adminCampStatusCounts" style="font-size:12px;color:var(--muted)"></span></div>
+              <div style="display:flex;align-items:center;gap:8px"><span class="admin-card-title">캠페인 목록</span><span id="adminCampStatusCounts" style="font-size:12px;color:var(--muted)"></span><span id="adminCampSelectedCount" style="font-size:12px;color:var(--pink);font-weight:600;display:none"></span></div>
               <div style="display:flex;align-items:center;gap:6px">
+                <button class="btn btn-ghost btn-xs" id="btnCampSelectClear" onclick="clearCampSelection()" style="display:none">선택 초기화</button>
+                <button class="btn btn-ghost btn-xs" id="btnCampSelectApplicants" onclick="exportSelectedCampaignsApplicants()" disabled title="캠페인을 1개 이상 선택하세요"><span class="material-icons-round notranslate" translate="no" style="font-size:14px;vertical-align:middle">download</span> 신청자 엑셀</button>
+                <button class="btn btn-ghost btn-xs" id="btnCampSelectDeliverables" onclick="exportSelectedCampaignsDeliverables()" disabled title="캠페인을 1개 이상 선택하세요"><span class="material-icons-round notranslate" translate="no" style="font-size:14px;vertical-align:middle">download</span> 결과물 엑셀</button>
                 <button class="btn btn-ghost btn-xs" id="btnCampSortReset" onclick="resetCampSort()" style="display:none">정렬 초기화</button>
                 <button class="btn btn-ghost btn-xs" id="btnReorderMode" onclick="enterReorderMode()">순서 변경</button>
               </div>
@@ -256,6 +259,7 @@
             <div class="admin-table-wrap">
             <table class="data-table">
               <thead id="adminCampTableHead"><tr>
+  <th style="width:36px;text-align:center"><input type="checkbox" id="campSelectAll" onchange="toggleCampSelectAll(this.checked)" title="필터 결과 전체 선택"></th>
   <th>캠페인</th>
   <th>브랜드</th>
   <th>제품</th>
@@ -266,7 +270,7 @@
   <th>수정일 <span class="sort-arrows" data-sort="updated" onclick="toggleCampSort('updated')">▲▼</span></th>
   <th></th>
 </tr></thead>
-              <tbody id="adminCampsBody"><tr><td colspan="9" style="text-align:center;color:var(--muted);padding:24px"><span class="spinner" style="width:20px;height:20px;border-width:2px;border-color:rgba(200,120,163,.2);border-top-color:var(--pink)"></span></td></tr></tbody>
+              <tbody id="adminCampsBody"><tr><td colspan="10" style="text-align:center;color:var(--muted);padding:24px"><span class="spinner" style="width:20px;height:20px;border-width:2px;border-color:rgba(200,120,163,.2);border-top-color:var(--pink)"></span></td></tr></tbody>
             </table>
             </div>
           </div>

--- a/dev/js/admin.js
+++ b/dev/js/admin.js
@@ -759,7 +759,7 @@ function updateCampTableHead() {
     head.innerHTML = `<tr><th>순서</th><th>캠페인</th><th>브랜드</th><th>제품</th><th>상태 ${statusHelpIcon}</th><th>조회</th><th>신청</th><th>등록일</th><th>수정일</th></tr>`;
   } else {
     head.innerHTML = `<tr>
-      <th style="width:36px;text-align:center"><input type="checkbox" id="campSelectAll" onchange="toggleCampSelectAll(this.checked)" title="필터 결과 전체 선택"></th>
+      <th style="width:44px;min-width:44px;max-width:44px;text-align:center;padding:8px 4px"><input type="checkbox" id="campSelectAll" onchange="toggleCampSelectAll(this.checked)" title="필터 결과 전체 선택"></th>
       <th>캠페인</th>
       <th>브랜드</th>
       <th>제품</th>
@@ -924,7 +924,7 @@ async function loadAdminCampaigns(useCache) {
           <button class="btn btn-ghost btn-xs" ${i===0?'disabled':''} onclick="moveCampOrder('${c.id}',-1)" style="padding:2px 6px;font-size:13px">↑</button>
           <button class="btn btn-ghost btn-xs" ${i===totalLen-1?'disabled':''} onclick="moveCampOrder('${c.id}',1)" style="padding:2px 6px;font-size:13px">↓</button>
         </div>
-      </td>` : `<td style="text-align:center;width:36px"><input type="checkbox" class="camp-select-cb" data-camp-id="${esc(c.id)}" ${isSelected?'checked':''} onchange="toggleCampSelect('${c.id}', this.checked)"></td>`}
+      </td>` : `<td style="text-align:center;width:44px;min-width:44px;max-width:44px;padding:8px 4px"><input type="checkbox" class="camp-select-cb" data-camp-id="${esc(c.id)}" ${isSelected?'checked':''} onchange="toggleCampSelect('${c.id}', this.checked)"></td>`}
       <td style="max-width:280px">
         <div style="display:flex;align-items:center;gap:10px">
           <div style="position:relative;width:44px;height:44px;flex-shrink:0;border-radius:8px;overflow:hidden;background:var(--surface-dim)">

--- a/dev/js/admin.js
+++ b/dev/js/admin.js
@@ -808,6 +808,11 @@ function applyImageCropsToList(imgList, cropsMap) {
 var campsLazy = null;
 const CAMPS_PAGE_SIZE = 50;
 
+// 캠페인 다중 선택 — 현재 필터/정렬 적용된 캠페인 리스트 캐시
+// loadAdminCampaigns 가 매 호출마다 갱신. toggleCampSelectAll·updateCampSelectionUI 에서 참조
+var _currentFilteredCamps = [];
+function getCurrentFilteredCamps() { return _currentFilteredCamps; }
+
 async function loadAdminCampaigns(useCache) {
   updateCampTableHead();
   let camps = useCache ? allCampaigns.slice() : await fetchCampaigns();
@@ -897,6 +902,9 @@ async function loadAdminCampaigns(useCache) {
       <span class="badge ${cls}" style="cursor:pointer;${dashed}display:inline-flex;align-items:center;gap:3px" onclick="toggleStatusDropdown(this)">${statusLabel[s]||s}<span style="font-size:10px;opacity:.7">▾</span></span>
     </div>`;
   };
+  // 캠페인 다중 선택 — 현재 필터 결과를 전역 캐시 (전체 선택 헤더가 참조)
+  _currentFilteredCamps = camps.slice();
+
   const campsBody = $('adminCampsBody');
   if (!campsBody) return;
   const buildCampRow = (c, i, totalLen) => {
@@ -908,13 +916,14 @@ async function loadAdminCampaigns(useCache) {
     const imgs = [c.img1,c.img2,c.img3,c.img4,c.img5,c.img6,c.img7,c.img8,c.image_url].filter(Boolean).filter((v,idx,a)=>a.indexOf(v)===idx);
     const thumbUrl = imgs[0] || '';
     const imgCount = imgs.length;
+    const isSelected = (_selectedCampIds && _selectedCampIds.has(c.id));
     return `<tr data-camp-id="${c.id}" data-id="${esc(c.id)}">
       ${adminReorderMode ? `<td style="white-space:nowrap">
         <div style="display:flex;gap:3px">
           <button class="btn btn-ghost btn-xs" ${i===0?'disabled':''} onclick="moveCampOrder('${c.id}',-1)" style="padding:2px 6px;font-size:13px">↑</button>
           <button class="btn btn-ghost btn-xs" ${i===totalLen-1?'disabled':''} onclick="moveCampOrder('${c.id}',1)" style="padding:2px 6px;font-size:13px">↓</button>
         </div>
-      </td>` : ''}
+      </td>` : `<td style="text-align:center;width:36px"><input type="checkbox" class="camp-select-cb" data-camp-id="${esc(c.id)}" ${isSelected?'checked':''} onchange="toggleCampSelect('${c.id}', this.checked)"></td>`}
       <td style="max-width:280px">
         <div style="display:flex;align-items:center;gap:10px">
           <div style="position:relative;width:44px;height:44px;flex-shrink:0;border-radius:8px;overflow:hidden;background:var(--surface-dim)">
@@ -966,7 +975,7 @@ async function loadAdminCampaigns(useCache) {
       </td>`}
     </tr>`;
   };
-  const emptyHtml = `<tr><td colspan="9" style="text-align:center;color:var(--muted);padding:24px">캠페인 없음</td></tr>`;
+  const emptyHtml = `<tr><td colspan="10" style="text-align:center;color:var(--muted);padding:24px">캠페인 없음</td></tr>`;
   if (adminReorderMode) {
     // 순서변경 모드: 전체 DOM 필요 (↑↓ 위치 인덱스 기반). lazy 비활성.
     if (campsLazy) { campsLazy.destroy(); campsLazy = null; }
@@ -981,6 +990,10 @@ async function loadAdminCampaigns(useCache) {
       pageSize: CAMPS_PAGE_SIZE,
       emptyHtml,
     });
+  }
+  // 행 렌더 후 선택 UI (버튼/배지/select-all indeterminate) 동기화
+  if (typeof updateCampSelectionUI === 'function') {
+    setTimeout(updateCampSelectionUI, 0);
   }
 }
 
@@ -7639,8 +7652,377 @@ function imgToJpegArrayBuffer(url, maxW, maxH) {
   });
 }
 
+// ─── 캠페인 다중 선택 + 통합 엑셀 ────────────────────────────────────
+// _selectedCampIds: 사용자가 체크한 캠페인 id 집합. 페인 이동/새로고침 시 초기화.
+// 필터·정렬·lazy-load remount 와 무관하게 Set 기반 절대 선택 유지.
+var _selectedCampIds = new Set();
+
+// 다운로드 쿨다운 가드 — 단시간 다중 클릭 방지
+var _exportInProgress = false;
+var _lastExportAt = 0;
+var EXPORT_COOLDOWN_MS = 5000;
+
+function _checkExportAllowed() {
+  if (_exportInProgress) {
+    toast('다운로드가 진행 중입니다. 잠시 기다려주세요.', 'warn');
+    return false;
+  }
+  var now = Date.now();
+  var elapsed = now - _lastExportAt;
+  if (elapsed < EXPORT_COOLDOWN_MS) {
+    var wait = Math.ceil((EXPORT_COOLDOWN_MS - elapsed) / 1000);
+    toast(wait + '초 후 다시 시도해주세요', 'warn');
+    return false;
+  }
+  return true;
+}
+
+function _markExportStart() { _exportInProgress = true; }
+function _markExportEnd() { _exportInProgress = false; _lastExportAt = Date.now(); }
+
+function toggleCampSelect(campId, checked) {
+  if (checked) _selectedCampIds.add(campId);
+  else _selectedCampIds.delete(campId);
+  updateCampSelectionUI();
+}
+
+function toggleCampSelectAll(checked) {
+  // 필터 결과 전체 — getCurrentFilteredCamps() 반환을 우선, 없으면 캠페인 전체 캐시
+  var filtered = (typeof getCurrentFilteredCamps === 'function') ? getCurrentFilteredCamps() : null;
+  if (!filtered) filtered = (Array.isArray(allCampaigns) ? allCampaigns : []);
+  if (checked) {
+    filtered.forEach(function(c) { _selectedCampIds.add(c.id); });
+  } else {
+    filtered.forEach(function(c) { _selectedCampIds.delete(c.id); });
+  }
+  // DOM 행의 체크박스도 동기 (현재 렌더된 행만)
+  document.querySelectorAll('.camp-select-cb').forEach(function(cb) {
+    var id = cb.dataset.campId;
+    cb.checked = _selectedCampIds.has(id);
+  });
+  updateCampSelectionUI();
+}
+
+function clearCampSelection() {
+  _selectedCampIds.clear();
+  document.querySelectorAll('.camp-select-cb').forEach(function(cb) { cb.checked = false; });
+  var sa = document.getElementById('campSelectAll');
+  if (sa) { sa.checked = false; sa.indeterminate = false; }
+  updateCampSelectionUI();
+}
+
+function updateCampSelectionUI() {
+  var n = _selectedCampIds.size;
+  var btnApp = document.getElementById('btnCampSelectApplicants');
+  var btnDel = document.getElementById('btnCampSelectDeliverables');
+  var btnClr = document.getElementById('btnCampSelectClear');
+  var cntEl = document.getElementById('adminCampSelectedCount');
+  if (btnApp) {
+    btnApp.disabled = (n === 0);
+    btnApp.innerHTML = '<span class="material-icons-round notranslate" translate="no" style="font-size:14px;vertical-align:middle">download</span> ' + (n > 0 ? '선택 ' + n + '개 ' : '') + '신청자 엑셀';
+  }
+  if (btnDel) {
+    btnDel.disabled = (n === 0);
+    btnDel.innerHTML = '<span class="material-icons-round notranslate" translate="no" style="font-size:14px;vertical-align:middle">download</span> ' + (n > 0 ? '선택 ' + n + '개 ' : '') + '결과물 엑셀';
+  }
+  if (btnClr) btnClr.style.display = n > 0 ? '' : 'none';
+  if (cntEl) {
+    if (n > 0) { cntEl.textContent = '· ' + n + '개 선택'; cntEl.style.display = ''; }
+    else { cntEl.textContent = ''; cntEl.style.display = 'none'; }
+  }
+  // 전체 선택 체크박스 indeterminate
+  var sa = document.getElementById('campSelectAll');
+  if (sa) {
+    var filtered = (typeof getCurrentFilteredCamps === 'function') ? getCurrentFilteredCamps() : null;
+    if (!filtered) filtered = (Array.isArray(allCampaigns) ? allCampaigns : []);
+    var total = filtered.length;
+    var selectedInFiltered = filtered.filter(function(c) { return _selectedCampIds.has(c.id); }).length;
+    sa.checked = (total > 0 && selectedInFiltered === total);
+    sa.indeterminate = (selectedInFiltered > 0 && selectedInFiltered < total);
+  }
+}
+
+// 시트1 헬퍼: 선택한 캠페인 N개 요약 행
+function _buildCampaignSummarySheet(wb, campaigns) {
+  var ws = wb.addWorksheet('캠페인 정보');
+  ws.columns = [
+    { header: '캠페인 번호', key: 'no',      width: 18 },
+    { header: '제목',        key: 'title',   width: 36 },
+    { header: '브랜드',      key: 'brand',   width: 18 },
+    { header: '제품',        key: 'product', width: 22 },
+    { header: '모집 타입',   key: 'rtype',   width: 10 },
+    { header: '상태',        key: 'status',  width: 10 },
+    { header: '모집 시작',   key: 'rstart',  width: 14 },
+    { header: '모집 마감',   key: 'deadline',width: 14 },
+    { header: '게시 마감',   key: 'pdead',   width: 14 },
+    { header: '슬롯',        key: 'slots',   width: 8 },
+    { header: '신청 수',     key: 'apps',    width: 10 },
+    { header: '승인 수',     key: 'approved',width: 10 }
+  ];
+  var header = ws.getRow(1);
+  header.font = { bold: true, color: { argb: 'FF222222' } };
+  header.alignment = { vertical: 'middle', horizontal: 'center' };
+  header.fill = { type: 'pattern', pattern: 'solid', fgColor: { argb: 'FFF2F2F2' } };
+  header.height = 22;
+  var rtypeLabel = function(t) { return t === 'monitor' ? '리뷰어' : t === 'gifting' ? '기프팅' : t === 'visit' ? '방문형' : (t || ''); };
+  var statusKo = function(s) { return s === 'draft' ? '준비' : s === 'scheduled' ? '모집예정' : s === 'active' ? '모집중' : s === 'closed' ? '종료' : s === 'expired' ? '노출마감' : (s || ''); };
+  campaigns.forEach(function(c) {
+    var campApps = (Array.isArray(allApps) ? allApps : []).filter(function(a){ return a.campaign_id === c.id; });
+    var approvedCnt = campApps.filter(function(a){ return a.status === 'approved'; }).length;
+    ws.addRow({
+      no:       c.campaign_no || '',
+      title:    c.title || '',
+      brand:    c.brand_ko || c.brand || '',
+      product:  c.product_ko || c.product || '',
+      rtype:    rtypeLabel(c.recruit_type),
+      status:   statusKo(c.status),
+      rstart:   c.recruit_start ? formatDate(c.recruit_start) : '',
+      deadline: c.deadline ? formatDate(c.deadline) : '',
+      pdead:    c.post_deadline ? formatDate(c.post_deadline) : '',
+      slots:    Number(c.slots || 0),
+      apps:     campApps.length,
+      approved: approvedCnt
+    });
+  });
+  return ws;
+}
+
+// 50개 이상 경고 모달
+function _confirmLargeExport(n) {
+  if (n < 50) return Promise.resolve(true);
+  return new Promise(function(resolve) {
+    var ok = confirm(n + '개 캠페인 선택했습니다.\n엑셀 생성에 수십 초~수 분 걸릴 수 있습니다.\n\n계속할까요?');
+    resolve(!!ok);
+  });
+}
+
+// 캠페인 다중 선택 신청자 엑셀 — 시트1 캠페인 정보 + 시트2 통합 신청자 리스트
+async function exportSelectedCampaignsApplicants() {
+  if (!_checkExportAllowed()) return;
+  var ids = Array.from(_selectedCampIds);
+  if (ids.length === 0) { toast('캠페인을 1개 이상 선택하세요', 'warn'); return; }
+  if (!(await _confirmLargeExport(ids.length))) return;
+
+  _markExportStart();
+  try {
+    toast('엑셀 생성 중...');
+    await loadExcelJS();
+    var camps = (Array.isArray(allCampaigns) ? allCampaigns : []).filter(function(c){ return ids.indexOf(c.id) !== -1; });
+    if (camps.length === 0) { toast('선택한 캠페인을 찾을 수 없습니다', 'error'); return; }
+    // 모든 캠페인의 신청자 + 인플루언서 한 번에 fetch
+    await ensureCancelReasonsCache();
+    var users = await fetchInfluencers();
+    var userByEmail = {};
+    (users || []).forEach(function(u){ if (u.email) userByEmail[u.email] = u; });
+    // 신청자: 캠페인별로 fetch (서버 round-trip)
+    var allCampApps = [];
+    for (var i = 0; i < camps.length; i++) {
+      var c = camps[i];
+      var apps = await fetchApplications({ campaign_id: c.id });
+      (apps || []).forEach(function(a){ a._campMeta = c; allCampApps.push(a); });
+    }
+
+    var wb = new ExcelJS.Workbook();
+    wb.creator = 'REVERB JP Admin';
+    wb.created = new Date();
+    _buildCampaignSummarySheet(wb, camps);
+
+    var ws = wb.addWorksheet('신청자');
+    ws.columns = [
+      { header: '캠페인 번호',   key: 'campNo',     width: 16 },
+      { header: '캠페인 제목',   key: 'campTitle',  width: 28 },
+      { header: '신청일',        key: 'created',    width: 20 },
+      { header: '상태',          key: 'status',     width: 10 },
+      { header: '인플루언서명',  key: 'name',       width: 16 },
+      { header: '이메일',        key: 'email',      width: 26 },
+      { header: '연락처',        key: 'phone',      width: 16 },
+      { header: 'Instagram',     key: 'ig',         width: 22 },
+      { header: 'Instagram 팔로워', key: 'igF',     width: 14 },
+      { header: 'TikTok',        key: 'tt',         width: 22 },
+      { header: 'TikTok 팔로워', key: 'ttF',        width: 14 },
+      { header: 'X',             key: 'x',          width: 22 },
+      { header: 'X 팔로워',      key: 'xF',         width: 14 },
+      { header: 'YouTube',       key: 'yt',         width: 22 },
+      { header: 'YouTube 팔로워',key: 'ytF',        width: 14 },
+      { header: '배송지',        key: 'address',    width: 36 },
+      { header: '신청 메시지',   key: 'message',    width: 32 },
+      { header: '심사일',        key: 'reviewedAt', width: 20 },
+      { header: '리뷰어',        key: 'reviewedBy', width: 14 },
+      { header: '취소일',        key: 'cancelledAt',width: 20 },
+      { header: '취소 사유',     key: 'cancelReason',width: 24 },
+      { header: '취소 카테고리', key: 'cancelCategory', width: 18 },
+      { header: '취소 시점',     key: 'cancelPhase', width: 12 }
+    ];
+    var hdr = ws.getRow(1);
+    hdr.font = { bold: true, color: { argb: 'FF222222' } };
+    hdr.alignment = { vertical: 'middle', horizontal: 'center' };
+    hdr.fill = { type: 'pattern', pattern: 'solid', fgColor: { argb: 'FFF2F2F2' } };
+    hdr.height = 22;
+
+    var snsHandleStr = function(channel, raw) {
+      if (!raw) return '';
+      if (typeof extractSnsHandle === 'function') { var h = extractSnsHandle(channel, raw); return h ? '@' + h : ''; }
+      return String(raw).trim();
+    };
+    var addrStr = function(u, fallbackAddress) {
+      if (u && u.zip) return '〒' + u.zip + ' ' + (u.prefecture || '') + (u.city || '') + (u.building ? ' ' + u.building : '');
+      return fallbackAddress || '';
+    };
+    var statusKo = function(s) { return s === 'approved' ? '승인' : s === 'pending' ? '심사중' : s === 'rejected' ? '미승인' : s === 'cancelled' ? '취소' : (s || ''); };
+    var fmtKR = function(iso) { if (!iso) return ''; try { return new Date(iso).toLocaleString('ko-KR', {timeZone:'Asia/Seoul'}); } catch(e) { return String(iso); } };
+
+    allCampApps.forEach(function(a) {
+      var u = userByEmail[a.user_email] || {};
+      var c = a._campMeta || {};
+      ws.addRow({
+        campNo:        c.campaign_no || '',
+        campTitle:     c.title || '',
+        created:       fmtKR(a.created_at),
+        status:        statusKo(a.status),
+        name:          u.name_kanji || u.name || a.user_name || '',
+        email:         a.user_email || '',
+        phone:         formatPhoneDisplay(u.phone),
+        ig:            snsHandleStr('instagram', u.ig || a.ig_id || a.user_ig),
+        igF:           Number(u.ig_followers || 0),
+        tt:            snsHandleStr('tiktok', u.tiktok),
+        ttF:           Number(u.tiktok_followers || 0),
+        x:             snsHandleStr('x', u.x),
+        xF:            Number(u.x_followers || 0),
+        yt:            snsHandleStr('youtube', u.youtube),
+        ytF:           Number(u.youtube_followers || 0),
+        address:       addrStr(u, a.address),
+        message:       a.message || '',
+        reviewedAt:    fmtKR(a.reviewed_at),
+        reviewedBy:    formatReviewer(a.reviewed_by),
+        cancelledAt:   fmtKR(a.cancelled_at),
+        cancelReason:  a.cancel_reason || '',
+        cancelCategory:a.cancel_reason_code ? cancelReasonLabelKo(a.cancel_reason_code) : '',
+        cancelPhase:   a.cancel_phase ? cancelPhaseLabelKo(a.cancel_phase) : ''
+      });
+    });
+    ['igF','ttF','xF','ytF'].forEach(function(k) {
+      ws.getColumn(k).numFmt = '#,##0';
+      ws.getColumn(k).alignment = { horizontal: 'right' };
+    });
+    ws.getColumn('message').alignment = { wrapText: true, vertical: 'top' };
+    ws.getColumn('address').alignment = { wrapText: true, vertical: 'top' };
+
+    var buf = await wb.xlsx.writeBuffer();
+    var blob = new Blob([buf], { type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' });
+    var url = URL.createObjectURL(blob);
+    var aEl = document.createElement('a');
+    aEl.href = url;
+    var ts = new Date();
+    var ymd = ts.getFullYear() + String(ts.getMonth()+1).padStart(2,'0') + String(ts.getDate()).padStart(2,'0');
+    aEl.download = 'applicants-' + camps.length + 'campaigns-' + ymd + '.xlsx';
+    document.body.appendChild(aEl); aEl.click(); document.body.removeChild(aEl);
+    URL.revokeObjectURL(url);
+    toast('엑셀 다운로드 완료 (' + camps.length + '개 캠페인, ' + allCampApps.length + '건 신청)');
+  } catch (e) {
+    console.error('[exportSelectedCampaignsApplicants]', e);
+    toast('엑셀 생성 실패: ' + (e?.message || e), 'error');
+  } finally {
+    _markExportEnd();
+  }
+}
+
+// 캠페인 다중 선택 결과물 엑셀 — 시트1 캠페인 정보 + 시트2 통합 결과물 리스트 (이미지 임베드 생략, URL만)
+async function exportSelectedCampaignsDeliverables() {
+  if (!_checkExportAllowed()) return;
+  var ids = Array.from(_selectedCampIds);
+  if (ids.length === 0) { toast('캠페인을 1개 이상 선택하세요', 'warn'); return; }
+  if (!(await _confirmLargeExport(ids.length))) return;
+
+  _markExportStart();
+  try {
+    toast('엑셀 생성 중...');
+    await loadExcelJS();
+    var camps = (Array.isArray(allCampaigns) ? allCampaigns : []).filter(function(c){ return ids.indexOf(c.id) !== -1; });
+    if (camps.length === 0) { toast('선택한 캠페인을 찾을 수 없습니다', 'error'); return; }
+
+    var users = await fetchInfluencers();
+    var userByEmail = {};
+    (users || []).forEach(function(u){ if (u.email) userByEmail[u.email] = u; });
+    var allDelivs = [];
+    for (var i = 0; i < camps.length; i++) {
+      var c = camps[i];
+      var dels = await fetchDeliverables({ campaign_id: c.id });
+      (dels || []).forEach(function(d){ d._campMeta = c; allDelivs.push(d); });
+    }
+
+    var wb = new ExcelJS.Workbook();
+    wb.creator = 'REVERB JP Admin';
+    wb.created = new Date();
+    _buildCampaignSummarySheet(wb, camps);
+
+    var ws = wb.addWorksheet('결과물');
+    ws.columns = [
+      { header: '캠페인 번호',   key: 'campNo',     width: 16 },
+      { header: '캠페인 제목',   key: 'campTitle',  width: 28 },
+      { header: '제출일',        key: 'submitted',  width: 20 },
+      { header: '종류',          key: 'kind',       width: 10 },
+      { header: '상태',          key: 'status',     width: 10 },
+      { header: '인플루언서명',  key: 'name',       width: 16 },
+      { header: '이메일',        key: 'email',      width: 26 },
+      { header: '결과물 URL',    key: 'url',        width: 50 },
+      { header: '채널',          key: 'channel',    width: 12 },
+      { header: '반려 사유',     key: 'rejectReason', width: 24 },
+      { header: '검수일',        key: 'reviewedAt', width: 20 },
+      { header: '리뷰어',        key: 'reviewedBy', width: 14 }
+    ];
+    var hdr = ws.getRow(1);
+    hdr.font = { bold: true, color: { argb: 'FF222222' } };
+    hdr.alignment = { vertical: 'middle', horizontal: 'center' };
+    hdr.fill = { type: 'pattern', pattern: 'solid', fgColor: { argb: 'FFF2F2F2' } };
+    hdr.height = 22;
+
+    var statusKo = function(s) { return s === 'approved' ? '승인' : s === 'pending' ? '검수대기' : s === 'rejected' ? '반려' : s === 'changed' ? '재제출요청' : (s || ''); };
+    var kindKo = function(k) { return k === 'receipt' ? '영수증' : k === 'post' ? '게시물' : (k || ''); };
+    var fmtKR = function(iso) { if (!iso) return ''; try { return new Date(iso).toLocaleString('ko-KR', {timeZone:'Asia/Seoul'}); } catch(e) { return String(iso); } };
+
+    allDelivs.forEach(function(d) {
+      var u = userByEmail[(d.influencers && d.influencers.email) || d.user_email] || {};
+      var c = d._campMeta || {};
+      ws.addRow({
+        campNo:       c.campaign_no || '',
+        campTitle:    c.title || '',
+        submitted:    fmtKR(d.submitted_at),
+        kind:         kindKo(d.kind),
+        status:       statusKo(d.status),
+        name:         u.name_kanji || u.name || (d.influencers && d.influencers.name) || '',
+        email:        (d.influencers && d.influencers.email) || u.email || '',
+        url:          d.receipt_url || d.post_url || '',
+        channel:      d.post_channel || '',
+        rejectReason: d.reject_reason || '',
+        reviewedAt:   fmtKR(d.reviewed_at),
+        reviewedBy:   formatReviewer(d.reviewed_by)
+      });
+    });
+    ws.getColumn('rejectReason').alignment = { wrapText: true, vertical: 'top' };
+
+    var buf = await wb.xlsx.writeBuffer();
+    var blob = new Blob([buf], { type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' });
+    var url = URL.createObjectURL(blob);
+    var aEl = document.createElement('a');
+    aEl.href = url;
+    var ts = new Date();
+    var ymd = ts.getFullYear() + String(ts.getMonth()+1).padStart(2,'0') + String(ts.getDate()).padStart(2,'0');
+    aEl.download = 'deliverables-' + camps.length + 'campaigns-' + ymd + '.xlsx';
+    document.body.appendChild(aEl); aEl.click(); document.body.removeChild(aEl);
+    URL.revokeObjectURL(url);
+    toast('엑셀 다운로드 완료 (' + camps.length + '개 캠페인, ' + allDelivs.length + '건 결과물)');
+  } catch (e) {
+    console.error('[exportSelectedCampaignsDeliverables]', e);
+    toast('엑셀 생성 실패: ' + (e?.message || e), 'error');
+  } finally {
+    _markExportEnd();
+  }
+}
+
 // 캠페인별 신청자 목록 엑셀 다운로드 (전체 상태, 4채널 SNS+팔로워 포함)
 async function exportCampaignApplicationsExcel(campId) {
+  if (!_checkExportAllowed()) return;
+  _markExportStart();
   try {
     document.querySelectorAll('.camp-more-menu').forEach(function(d){ d.remove(); });
 
@@ -7790,11 +8172,15 @@ async function exportCampaignApplicationsExcel(campId) {
   } catch (e) {
     console.error('[exportCampaignApplicationsExcel]', e);
     toast('엑셀 생성 실패: ' + (e?.message || e), 'error');
+  } finally {
+    _markExportEnd();
   }
 }
 
 
 async function exportCampaignDeliverables(campId) {
+  if (!_checkExportAllowed()) return;
+  _markExportStart();
   try {
     document.querySelectorAll('.camp-more-menu').forEach(function(d){ d.remove(); });
     toast('엑셀 생성 중...');

--- a/dev/js/admin.js
+++ b/dev/js/admin.js
@@ -638,8 +638,9 @@ function syncCampMultiFilter(containerId, sortedCamps, onChange, counts) {
 }
 
 // ── 다중 선택 드롭다운 필터 ──
-// "전체" = 모든 항목 체크 표시 (시각). 일부 해제 시 "전체"는 indeterminate.
-// 데이터 모델: 전체(모두 체크) → 빈 배열 반환(=필터 없음). 일부만 체크 → 그 배열 반환.
+// 초기 상태: 모두 비체크 = 필터 없음 (전체 표시). 사용자가 체크한 항목만 필터 적용.
+// "전체" 체크박스 클릭 시 모든 옵션 토글. 일부만 체크 시 "전체" indeterminate.
+// 데이터 모델: 모두 비체크 또는 모두 체크 → 빈 배열 반환(=필터 없음). 일부만 체크 → 그 배열 반환.
 //
 // options = [{value, label, subLabel?, count?}]
 //   - subLabel(있으면): 라벨 아래 회색 작은 글씨 (예: 캠페인 번호 B0019-C001)
@@ -650,14 +651,14 @@ function createMultiFilter(containerId, allLabel, options, onChange) {
   const btn = wrap.querySelector('.mf-btn');
   const drop = wrap.querySelector('.mf-drop');
   if (!btn || !drop) return;
-  // 옵션 행 렌더 — subLabel·count 지원
+  // 옵션 행 렌더 — subLabel·count 지원. 초기 비체크 (사용자가 명시적으로 선택해야 필터 적용)
   const renderOptionItem = (o) => {
     const countHtml = (o.count != null) ? ` <span class="mf-item-count">(${o.count})</span>` : '';
     const subHtml = o.subLabel ? `<div class="mf-item-sub">${esc(o.subLabel)}</div>` : '';
-    return `<label class="mf-item${o.subLabel ? ' has-sub' : ''}"><input type="checkbox" value="${esc(o.value)}" checked data-label="${esc(o.label)}"><div class="mf-item-text"><div class="mf-item-label">${esc(o.label)}${countHtml}</div>${subHtml}</div></label>`;
+    return `<label class="mf-item${o.subLabel ? ' has-sub' : ''}"><input type="checkbox" value="${esc(o.value)}" data-label="${esc(o.label)}"><div class="mf-item-text"><div class="mf-item-label">${esc(o.label)}${countHtml}</div>${subHtml}</div></label>`;
   };
-  // 드롭다운 아이템 생성 — 초기 상태: 전체 체크 = 모든 항목 체크
-  drop.innerHTML = `<label class="mf-item all-item"><input type="checkbox" value="all" checked><div class="mf-item-text"><div class="mf-item-label">${esc(allLabel)}</div></div></label>`
+  // 드롭다운 아이템 생성 — 초기 상태: 모두 비체크 = 필터 없음 (전체 표시)
+  drop.innerHTML = `<label class="mf-item all-item"><input type="checkbox" value="all"><div class="mf-item-text"><div class="mf-item-label">${esc(allLabel)}</div></div></label>`
     + options.map(renderOptionItem).join('');
   btn.textContent = allLabel;
   // 토글

--- a/dev/js/admin.js
+++ b/dev/js/admin.js
@@ -759,6 +759,7 @@ function updateCampTableHead() {
     head.innerHTML = `<tr><th>순서</th><th>캠페인</th><th>브랜드</th><th>제품</th><th>상태 ${statusHelpIcon}</th><th>조회</th><th>신청</th><th>등록일</th><th>수정일</th></tr>`;
   } else {
     head.innerHTML = `<tr>
+      <th style="width:36px;text-align:center"><input type="checkbox" id="campSelectAll" onchange="toggleCampSelectAll(this.checked)" title="필터 결과 전체 선택"></th>
       <th>캠페인</th>
       <th>브랜드</th>
       <th>제품</th>
@@ -7743,7 +7744,8 @@ function updateCampSelectionUI() {
 }
 
 // 시트1 헬퍼: 선택한 캠페인 N개 요약 행
-function _buildCampaignSummarySheet(wb, campaigns) {
+//   appsByCampId: {campaignId: appsArray} — 시트2 export 시 이미 fetch한 결과 재사용 (round-trip 절약)
+function _buildCampaignSummarySheet(wb, campaigns, appsByCampId) {
   var ws = wb.addWorksheet('캠페인 정보');
   ws.columns = [
     { header: '캠페인 번호', key: 'no',      width: 18 },
@@ -7767,7 +7769,7 @@ function _buildCampaignSummarySheet(wb, campaigns) {
   var rtypeLabel = function(t) { return t === 'monitor' ? '리뷰어' : t === 'gifting' ? '기프팅' : t === 'visit' ? '방문형' : (t || ''); };
   var statusKo = function(s) { return s === 'draft' ? '준비' : s === 'scheduled' ? '모집예정' : s === 'active' ? '모집중' : s === 'closed' ? '종료' : s === 'expired' ? '노출마감' : (s || ''); };
   campaigns.forEach(function(c) {
-    var campApps = (Array.isArray(allApps) ? allApps : []).filter(function(a){ return a.campaign_id === c.id; });
+    var campApps = (appsByCampId && appsByCampId[c.id]) || [];
     var approvedCnt = campApps.filter(function(a){ return a.status === 'approved'; }).length;
     ws.addRow({
       no:       c.campaign_no || '',
@@ -7814,18 +7816,20 @@ async function exportSelectedCampaignsApplicants() {
     var users = await fetchInfluencers();
     var userByEmail = {};
     (users || []).forEach(function(u){ if (u.email) userByEmail[u.email] = u; });
-    // 신청자: 캠페인별로 fetch (서버 round-trip)
+    // 신청자: 캠페인별로 fetch (서버 round-trip) — appsByCampId 캐시도 동시 빌드
     var allCampApps = [];
+    var appsByCampId = {};
     for (var i = 0; i < camps.length; i++) {
       var c = camps[i];
       var apps = await fetchApplications({ campaign_id: c.id });
+      appsByCampId[c.id] = apps || [];
       (apps || []).forEach(function(a){ a._campMeta = c; allCampApps.push(a); });
     }
 
     var wb = new ExcelJS.Workbook();
     wb.creator = 'REVERB JP Admin';
     wb.created = new Date();
-    _buildCampaignSummarySheet(wb, camps);
+    _buildCampaignSummarySheet(wb, camps, appsByCampId);
 
     var ws = wb.addWorksheet('신청자');
     ws.columns = [
@@ -7943,6 +7947,13 @@ async function exportSelectedCampaignsDeliverables() {
     var users = await fetchInfluencers();
     var userByEmail = {};
     (users || []).forEach(function(u){ if (u.email) userByEmail[u.email] = u; });
+    // 시트1 캠페인 요약 「신청 수」 컬럼을 채우기 위해 신청 전체 fetch 1회 + groupBy
+    var allAppsForSummary = await fetchApplications();
+    var appsByCampId = {};
+    (allAppsForSummary || []).forEach(function(a){
+      if (!appsByCampId[a.campaign_id]) appsByCampId[a.campaign_id] = [];
+      appsByCampId[a.campaign_id].push(a);
+    });
     var allDelivs = [];
     for (var i = 0; i < camps.length; i++) {
       var c = camps[i];
@@ -7953,7 +7964,7 @@ async function exportSelectedCampaignsDeliverables() {
     var wb = new ExcelJS.Workbook();
     wb.creator = 'REVERB JP Admin';
     wb.created = new Date();
-    _buildCampaignSummarySheet(wb, camps);
+    _buildCampaignSummarySheet(wb, camps, appsByCampId);
 
     var ws = wb.addWorksheet('결과물');
     ws.columns = [


### PR DESCRIPTION
## 변경 요약

### 캠페인 다중 선택 + 통합 엑셀 (`145d367`)
- 캠페인 관리 페인에 행 체크박스 + 「전체 선택」 헤더 + 「선택 N개 신청자/결과물 엑셀」 버튼 2종 + 「선택 초기화」
- 엑셀 구조: 시트1 「캠페인 정보」 (선택 캠페인 N행 요약 12컬럼) + 시트2 「신청자」 또는 「결과물」 (통합 리스트, 첫 컬럼에 캠페인 번호/제목)
- 다운로드 가드 5초 쿨다운 + 동시 진행 차단 (단일 export 2종에도 동일 적용 — 단시간 다중 클릭 방지)
- 50개+ 선택 시 confirm 다이얼로그 안내
- 「전체 선택」 헤더는 필터 결과 전체 (lazy-load 미렌더 행 포함)
- 순서변경 모드 진입 시 체크박스 숨김 + ↑↓ 버튼만

### 후속 hotfix
- `cfd044b`: `updateCampTableHead` 가 thead 를 동적으로 재생성하면서 「선택」 컬럼을 빠뜨려 모든 컬럼이 1칸씩 밀린 회귀 수정 + `_buildCampaignSummarySheet` 의 `allApps` 미정의 오류 수정 (appsByCampId 인자 전달)
- `0b98258`: 체크박스 컬럼 폭 강제 (44px min/max + padding 축소) — data-table 균등 분배 방지

### multi-filter 드롭다운 UX 개선 (`5feaee4`)
- 드롭다운 열렸을 때 모든 옵션이 미리 체크된 상태가 어색 → 초기 모두 비체크로 변경
- 데이터 모델 동일 (비체크 = 모두 체크 = 필터 없음 → 빈 배열 반환)
- 「전체」 토글·indeterminate 표시 동작 유지
- 캠페인 관리·신청 관리·결과물 관리·광고주 신청 등 모든 페인의 multi-filter 에 일괄 적용

## 운영 DB 변경
없음. 코드만.

## 요청 외 추가 변경
없음.

## 관련 사양서
없음 (UI 폴리시 + 회귀 hotfix).

## Test plan
- [x] 개발서버 캠페인 관리 페인 다중 선택 동작 확인
- [x] 「선택 N개 신청자/결과물 엑셀」 다운로드 (시트1 캠페인 요약 + 시트2 통합 리스트) 정상 생성
- [x] 5초 쿨다운 + 동시 진행 lock 확인
- [x] 체크박스 컬럼 폭 정상 (UI drift 없음)
- [x] multi-filter 드롭다운 초기 비체크 + 선택 시 정상 필터 동작
- [x] reverb-reviewer: GO (qa-tester 권장: light)

🤖 Generated with [Claude Code](https://claude.com/claude-code)