### PR TITLE
docs(email): KO preview for influencer daily digest

### DIFF
--- a/docs/email-templates/index.html
+++ b/docs/email-templates/index.html
@@ -78,6 +78,7 @@
     </div>
     <div class="card-actions">
       <a class="btn btn-primary" href="confirm-signup.preview.html">미리보기</a>
+      <a class="btn btn-ghost" href="confirm-signup.ko.preview.html">한국어 검수</a>
       <a class="btn btn-ghost" href="confirm-signup.html">원본</a>
     </div>
   </div>
@@ -98,6 +99,7 @@
     </div>
     <div class="card-actions">
       <a class="btn btn-primary" href="reset-password.preview.html">미리보기</a>
+      <a class="btn btn-ghost" href="reset-password.ko.preview.html">한국어 검수</a>
       <a class="btn btn-ghost" href="reset-password.html">원본</a>
     </div>
   </div>
@@ -318,6 +320,7 @@
     </div>
     <div class="card-actions">
       <a class="btn btn-primary" href="influencer-daily-digest.preview.html">미리보기</a>
+      <a class="btn btn-ghost" href="influencer-daily-digest.ko.preview.html">한국어 검수</a>
       <a class="btn btn-ghost" href="influencer-daily-digest.html">원본</a>
     </div>
   </div>

--- a/docs/email-templates/influencer-daily-digest.ko.preview.html
+++ b/docs/email-templates/influencer-daily-digest.ko.preview.html
@@ -1,0 +1,100 @@
+<!DOCTYPE html>
+<!--
+  미리보기 전용 한국어 번역본 (운영자 검수용).
+  실제 메일 발송에는 사용되지 않습니다 — Edge Function notify-influencer-daily-digest 는
+  influencer-daily-digest.html(일본어 원본) + row partial 4종을 사용합니다.
+
+  본 파일은 사양서 docs/specs/2026-05-18-application-email-pipeline.md 의 본문 검수용으로
+  일본어 원본 .preview.html 의 내용을 한국어로 직역해 운영자가 내용을 빠르게 검수할 수
+  있도록 합니다. 일본어 원본 수정 시 이 파일도 함께 갱신해주세요.
+-->
+<html lang="ko">
+<head>
+<meta charset="UTF-8">
+<title>한국어 검수 — 인플루언서 일일 다이제스트 (실제 메일은 JA)</title>
+<style>
+  body{font-family:'Noto Sans KR',Arial,sans-serif;background:#f5f5f5;padding:40px 20px;color:#222}
+  .preview-wrap{max-width:680px;margin:0 auto;background:#fff;border-radius:12px;box-shadow:0 4px 12px rgba(0,0,0,.08);padding:32px}
+  .preview-note{font-size:11px;color:#888;border-left:3px solid #C8789C;padding:8px 12px;margin-bottom:24px;background:#FFF5F8}
+  .ja-original{display:inline-block;color:#999;font-size:11px;margin-left:6px;font-style:italic}
+</style>
+</head>
+<body>
+<div class="preview-wrap">
+  <div class="preview-note">
+    <strong>운영자 한국어 검수용</strong> — 실제 메일은 일본어로 발송됩니다.
+    이 페이지는 일본어 원본 본문을 한국어로 직역해 운영자가 내용을 빠르게 확인하도록 만든 것입니다.
+    레이아웃·CTA 버튼·색상은 일본어 메일과 동일.
+  </div>
+
+  <div style="font-family:'Noto Sans KR',Arial,sans-serif;color:#222;max-width:640px">
+    <h2 style="color:#C8789C;margin:0 0 6px">오늘의 응모 현황 안내 <span class="ja-original">(本日の応募状況のお知らせ)</span></h2>
+    <p style="margin:0 0 18px;color:#666;font-size:13px">2026년 5월 19일 · 4건의 알림</p>
+
+    <!-- 섹션 1: 어제 신청 -->
+    <h3 style="font-size:14px;color:#333;border-left:4px solid #C8789C;padding-left:10px;margin:24px 0 12px">신규 응모 접수 (1건) <span class="ja-original">(新規応募の受付)</span></h3>
+    <div style="border:1px solid #F0E1E4;border-radius:10px;padding:12px 14px;margin-bottom:10px;background:#FFFAFC">
+      <div style="font-size:11px;color:#888;margin-bottom:3px">
+        <span style="font-family:monospace">【CAMP-2026-0042】</span> · 리뷰어
+      </div>
+      <div style="font-size:13px;font-weight:700;line-height:1.4;margin-bottom:4px">바이오움 8X 모공 보습 미용액</div>
+      <div style="font-size:11px;color:#888">응모 일시 2026년 5월 18일 21:34</div>
+    </div>
+
+    <!-- 섹션 2: 어제 승인 -->
+    <h3 style="font-size:14px;color:#333;border-left:4px solid #16A34A;padding-left:10px;margin:24px 0 12px">응모가 승인되었습니다 (1건) <span class="ja-original">(応募が承認されました)</span></h3>
+    <div style="border:1.5px solid #C8EFC8;border-radius:10px;padding:14px 16px;margin-bottom:10px;background:#F4FBF4">
+      <div style="font-size:11px;color:#16A34A;font-weight:700;margin-bottom:4px">승인되었습니다 <span class="ja-original">(承認されました)</span></div>
+      <div style="font-size:11px;color:#888;margin-bottom:3px">
+        <span style="font-family:monospace">【CAMP-2026-0038】</span> · 기프팅
+      </div>
+      <div style="font-size:13px;font-weight:700;line-height:1.4;margin-bottom:6px">엔모드프로 페이스라인 케어</div>
+      <table style="border-collapse:collapse;width:100%;font-size:12px">
+        <tr><td style="padding:3px 0;color:#888;width:96px">승인 일시 <span class="ja-original">(承認日時)</span></td><td style="padding:3px 0">2026년 5월 18일 14:22</td></tr>
+        <tr><td style="padding:3px 0;color:#888">보상 <span class="ja-original">(報酬)</span></td><td style="padding:3px 0;font-weight:700">¥1,500</td></tr>
+        <tr><td style="padding:3px 0;color:#888;vertical-align:top">제출 마감 <span class="ja-original">(提出期限)</span></td><td style="padding:3px 0">결과물 6월 5일까지 <span class="ja-original">(投稿物 6月5日 まで)</span></td></tr>
+      </table>
+    </div>
+    <p style="margin:8px 0 0"><a href="#" style="color:#C8789C;font-size:12px">활동관리에서 제출 시작 → <span class="ja-original">(活動管理で提出を始める)</span></a></p>
+
+    <!-- 섹션 3: 어제 반려 -->
+    <h3 style="font-size:14px;color:#333;border-left:4px solid #999;padding-left:10px;margin:24px 0 12px">응모 결과 안내 (1건) <span class="ja-original">(応募結果のお知らせ)</span></h3>
+    <div style="border:1px solid #E0E0E0;border-radius:10px;padding:12px 14px;margin-bottom:10px;background:#FAFAFA">
+      <div style="font-size:11px;color:#888;font-weight:700;margin-bottom:4px">이번에는 선정에 이르지 못했습니다 <span class="ja-original">(今回は選考に至りませんでした)</span></div>
+      <div style="font-size:11px;color:#888;margin-bottom:3px">
+        <span style="font-family:monospace">【CAMP-2026-0036】</span>
+      </div>
+      <div style="font-size:13px;font-weight:700;line-height:1.4;margin-bottom:4px">라비엘 애프터셰이브</div>
+      <div style="font-size:11px;color:#888">심사 일시 2026년 5월 18일 16:01</div>
+    </div>
+    <p style="margin:8px 0 0"><a href="#" style="color:#C8789C;font-size:12px">다른 캠페인 보기 → <span class="ja-original">(他のキャンペーンを見る)</span></a></p>
+
+    <!-- 섹션 4: 마감 임박 -->
+    <h3 style="font-size:14px;color:#333;border-left:4px solid #A06A14;padding-left:10px;margin:24px 0 12px">제출 마감이 다가오고 있습니다 (1건) <span class="ja-original">(提出期限が近づいています)</span></h3>
+    <div style="border:1.5px solid #FFE0A8;border-radius:10px;padding:14px 16px;margin-bottom:10px;background:#FFFAF0">
+      <div style="display:flex;align-items:center;gap:8px;margin-bottom:6px">
+        <span style="background:#FFE4E9;color:#E8344E;padding:3px 10px;border-radius:4px;font-weight:700;font-size:11px">D-1</span>
+        <span style="font-size:11px;color:#A06A14;font-weight:700">영수증 <span class="ja-original">(レシート)</span></span>
+      </div>
+      <div style="font-size:11px;color:#888;margin-bottom:3px">
+        <span style="font-family:monospace">【CAMP-2026-0030】</span>
+      </div>
+      <div style="font-size:13px;font-weight:700;line-height:1.4;margin-bottom:6px">민감한 제품 80ml</div>
+      <div style="font-size:12px;color:#333;margin-bottom:8px">제출 마감 <strong>5월 20일 (D-1)</strong></div>
+      <a href="#" style="display:inline-block;background:#C8789C;color:#fff;padding:6px 14px;border-radius:6px;text-decoration:none;font-weight:700;font-size:12px">제출하러 가기 <span class="ja-original" style="color:#fff;opacity:.8">(提出に進む)</span></a>
+    </div>
+
+    <div style="margin-top:28px;padding-top:18px;border-top:1px solid #F0E1E4">
+      <a href="#" style="display:inline-block;background:#C8789C;color:#fff;padding:10px 18px;border-radius:8px;text-decoration:none;font-weight:700;font-size:13px;margin-right:8px">응모 이력 확인 <span class="ja-original" style="color:#fff;opacity:.8">(応募履歴を確認)</span></a>
+      <a href="#" style="display:inline-block;background:#fff;border:1.5px solid #C8789C;color:#C8789C;padding:9px 18px;border-radius:8px;text-decoration:none;font-weight:700;font-size:13px">캠페인 목록 <span class="ja-original">(キャンペーン一覧)</span></a>
+    </div>
+
+    <p style="margin:24px 0 0;color:#999;font-size:11px;line-height:1.6">
+      본 메일은 응모 활동에 관한 중요한 안내입니다. <span class="ja-original">(このメールは応募活動に関する重要なお知らせです)</span><br>
+      REVERB JP 멤버십에 연계되어 자동 발송됩니다.<br>
+      문의는 LINE @reverb.jp 으로 보내주세요.
+    </p>
+  </div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## 변경 요약
- 인플루언서 일일 다이제스트 한국어 검수용 미리보기 추가 (`influencer-daily-digest.ko.preview.html`)
- 카탈로그 페이지의 일본어 메일 3장(confirm-signup, reset-password, 인플 다이제스트) 카드에 「한국어 검수」 버튼 노출

## 배경
운영자가 실제 메일 발송 전에 본문 검수하는 데 한국어 번역이 필요. 기존 ko.preview 파일이 confirm-signup·reset-password 에 있었으나 카탈로그에서 노출 안 됐던 점도 같이 정리.

## 요청 외 추가 변경
- 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)