### PR TITLE
fix(email): widen admin daily digest body to 1000px

### DIFF
--- a/docs/email-templates/admin-daily-digest.html
+++ b/docs/email-templates/admin-daily-digest.html
@@ -32,7 +32,7 @@
     docs/specs/2026-05-18-mail-pipeline-consolidation.md §13~§14
     docs/specs/2026-05-18-HANDOFF-mail-pipeline-consolidation.md §5
 -->
-<div style="font-family:'Noto Sans KR',Arial,sans-serif;color:#222;max-width:680px">
+<div style="font-family:'Noto Sans KR',Arial,sans-serif;color:#222;max-width:1000px">
   <h2 style="color:#5B6BBF;margin:0 0 6px">관리자 일일 통합 요약</h2>
   <p style="margin:0 0 16px;color:#666;font-size:13px">REVERB JP 관리자 알림 · 매일 한국시간 오전 9시 발송</p>
 

--- a/docs/email-templates/admin-daily-digest.preview.html
+++ b/docs/email-templates/admin-daily-digest.preview.html
@@ -5,7 +5,7 @@
 <title>미리보기 — 관리자 일일 통합 다이제스트 (KO)</title>
 <style>
   body{font-family:'Noto Sans KR',Arial,sans-serif;background:#f5f5f5;padding:40px 20px;color:#222}
-  .preview-wrap{max-width:720px;margin:0 auto;background:#fff;border-radius:12px;box-shadow:0 4px 12px rgba(0,0,0,.08);padding:32px}
+  .preview-wrap{max-width:1060px;margin:0 auto;background:#fff;border-radius:12px;box-shadow:0 4px 12px rgba(0,0,0,.08);padding:32px}
   .preview-note{font-size:11px;color:#888;border-left:3px solid #5B6BBF;padding:8px 12px;margin-bottom:24px;background:#F5F7FC;line-height:1.6}
   .preview-subject{font-size:12px;color:#666;background:#FAFAFC;border:1px solid #E2E7F2;border-radius:6px;padding:8px 12px;margin-bottom:18px}
   .preview-subject b{color:#222}
@@ -23,7 +23,7 @@
   </div>
 
   <!-- 메인 wrapper (admin-daily-digest.html) -->
-  <div style="font-family:'Noto Sans KR',Arial,sans-serif;color:#222;max-width:680px">
+  <div style="font-family:'Noto Sans KR',Arial,sans-serif;color:#222;max-width:1000px">
     <h2 style="color:#5B6BBF;margin:0 0 6px">관리자 일일 통합 요약</h2>
     <p style="margin:0 0 16px;color:#666;font-size:13px">REVERB JP 관리자 알림 · 매일 한국시간 오전 9시 발송</p>
 

--- a/supabase/functions/notify-admin-daily-digest/_templates/admin-daily-digest.html
+++ b/supabase/functions/notify-admin-daily-digest/_templates/admin-daily-digest.html
@@ -32,7 +32,7 @@
     docs/specs/2026-05-18-mail-pipeline-consolidation.md §13~§14
     docs/specs/2026-05-18-HANDOFF-mail-pipeline-consolidation.md §5
 -->
-<div style="font-family:'Noto Sans KR',Arial,sans-serif;color:#222;max-width:680px">
+<div style="font-family:'Noto Sans KR',Arial,sans-serif;color:#222;max-width:1000px">
   <h2 style="color:#5B6BBF;margin:0 0 6px">관리자 일일 통합 요약</h2>
   <p style="margin:0 0 16px;color:#666;font-size:13px">REVERB JP 관리자 알림 · 매일 한국시간 오전 9시 발송</p>
 

--- a/supabase/functions/notify-admin-daily-digest/templates.ts
+++ b/supabase/functions/notify-admin-daily-digest/templates.ts
@@ -38,7 +38,7 @@ export const TEMPLATES: Record<string, string> = {
     docs/specs/2026-05-18-mail-pipeline-consolidation.md §13~§14
     docs/specs/2026-05-18-HANDOFF-mail-pipeline-consolidation.md §5
 -->
-<div style="font-family:'Noto Sans KR',Arial,sans-serif;color:#222;max-width:680px">
+<div style="font-family:'Noto Sans KR',Arial,sans-serif;color:#222;max-width:1000px">
   <h2 style="color:#5B6BBF;margin:0 0 6px">관리자 일일 통합 요약</h2>
   <p style="margin:0 0 16px;color:#666;font-size:13px">REVERB JP 관리자 알림 · 매일 한국시간 오전 9시 발송</p>
 


### PR DESCRIPTION
## 변경 요약
- 관리자 일일 통합 다이제스트 본문 max-width 680px → 1000px 확장
- 7컬럼 표가 좁아 발생하던 줄바꿈 해소

## 사전 배포
- 개발/운영 Supabase Edge Function 배포 완료

🤖 Generated with [Claude Code](https://claude.com/claude-code)