### PR TITLE
feat(analytics): integrate Vercel Web Analytics + Speed Insights

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -12,7 +12,7 @@
 // 회귀(2026-05-12 PR #182 머지 직후 발생)를 방지하기 위한 자동 reload 가드.
 // sessionStorage 차단 환경(시크릿 모드 일부, 쿠키 차단)에서는 자연스럽게 skip.
 (function(){
-  var CURRENT_BUILD = 'v1779082513';
+  var CURRENT_BUILD = 'v1779174303';
   if (CURRENT_BUILD.indexOf('__') === 0) return; // 빌드 미적용 (dev/ 직접 열기) 시 skip
   try {
     var prev = sessionStorage.getItem('reverb.adminBuild');
@@ -52,6 +52,9 @@
 <script src="https://cdn.jsdelivr.net/npm/flatpickr@4.6.13/dist/flatpickr.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/flatpickr@4.6.13/dist/l10n/ko.js"></script>
 <style id="admin-cloak">body{visibility:hidden!important}</style>
+<!-- Vercel Web Analytics + Speed Insights (운영 사용자 실측 Core Web Vitals 수집) -->
+<script defer src="/_vercel/insights/script.js"></script>
+<script defer src="/_vercel/speed-insights/script.js"></script>
 <style>
 /* ══════════════════════════════════
    BASE — 초기화, 변수, 레이아웃 (Material Design 3)
@@ -1519,7 +1522,7 @@ textarea.form-input{resize:vertical;min-height:80px}
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-05-18 14:35 · 8a64274</span>
+          <span class="admin-build-text">2026-05-19 16:05 · 5740800</span>
         </div>
       </div>
     </aside>

--- a/dev/admin/index.html
+++ b/dev/admin/index.html
@@ -55,6 +55,9 @@
 <link rel="stylesheet" href="../css/components.css">
 <link rel="stylesheet" href="../css/admin.css">
 <style id="admin-cloak">body{visibility:hidden!important}</style>
+<!-- Vercel Web Analytics + Speed Insights (운영 사용자 실측 Core Web Vitals 수집) -->
+<script defer src="/_vercel/insights/script.js"></script>
+<script defer src="/_vercel/speed-insights/script.js"></script>
 </head>
 <body style="background:#F8F5F8">
 <!-- 글로벌 요소 -->

--- a/dev/index.html
+++ b/dev/index.html
@@ -36,6 +36,9 @@ window._supabaseLoaded = false;
 <link rel="stylesheet" href="css/campaign.css">
 <link rel="stylesheet" href="css/auth.css">
 <link rel="stylesheet" href="css/mypage.css">
+<!-- Vercel Web Analytics + Speed Insights (운영 사용자 실측 Core Web Vitals 수집) -->
+<script defer src="/_vercel/insights/script.js"></script>
+<script defer src="/_vercel/speed-insights/script.js"></script>
 </head>
 <body>
 <div id="appShell">

--- a/index.html
+++ b/index.html
@@ -31,6 +31,9 @@ window._supabaseLoaded = false;
 <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;700;900&family=Sora:wght@700;800&display=swap" rel="stylesheet">
 <link href="https://fonts.googleapis.com/icon?family=Material+Icons+Round" rel="stylesheet">
 <script src="https://cdn.jsdelivr.net/npm/dompurify@3.1.6/dist/purify.min.js"></script>
+<!-- Vercel Web Analytics + Speed Insights (운영 사용자 실측 Core Web Vitals 수집) -->
+<script defer src="/_vercel/insights/script.js"></script>
+<script defer src="/_vercel/speed-insights/script.js"></script>
 <style>
 /* ══════════════════════════════════
    BASE — 초기화, 변수, 레이아웃 (Material Design 3)


### PR DESCRIPTION
## 변경 요약
- `dev/index.html` + `dev/admin/index.html` 양쪽 `<head>` 에 두 script 추가:
  - `/_vercel/insights/script.js` (Web Analytics — 방문자·트래픽)
  - `/_vercel/speed-insights/script.js` (Speed Insights — 실측 LCP/INP/CLS)
- bash dev/build.sh 실행 → 루트 index.html / admin/index.html 동일 반영
- 사용자가 Vercel 대시보드에서 두 도구 모두 Enable 완료

## 목적
도쿄 리전 이전 (사양서 docs/specs/2026-05-19-supabase-tokyo-region-migration.md) 전에 일본 사용자 실측 baseline 확보. 이전 전후 효과를 LCP·INP 수치로 입증.

## 사전 효과
- 24~48시간 트래픽 누적 후 Vercel Speed Insights 대시보드에서 일본 사용자 실측 Core Web Vitals 확인 가능

🤖 Generated with [Claude Code](https://claude.com/claude-code)