### PR TITLE
feat(analytics): track per-page views in influencer + admin SPAs

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -12,7 +12,7 @@
 // 회귀(2026-05-12 PR #182 머지 직후 발생)를 방지하기 위한 자동 reload 가드.
 // sessionStorage 차단 환경(시크릿 모드 일부, 쿠키 차단)에서는 자연스럽게 skip.
 (function(){
-  var CURRENT_BUILD = 'v1779174303';
+  var CURRENT_BUILD = 'v1779174727';
   if (CURRENT_BUILD.indexOf('__') === 0) return; // 빌드 미적용 (dev/ 직접 열기) 시 skip
   try {
     var prev = sessionStorage.getItem('reverb.adminBuild');
@@ -1522,7 +1522,7 @@ textarea.form-input{resize:vertical;min-height:80px}
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-05-19 16:05 · 5740800</span>
+          <span class="admin-build-text">2026-05-19 16:12 · da03fdf</span>
         </div>
       </div>
     </aside>
@@ -10846,6 +10846,13 @@ function friendlyError(msg) {
 // ════════════════════════════════════════════════════════════════════
 
 function switchAdminPane(pane, el, pushHistory) {
+  // Vercel Web Analytics — 관리자 앱 페인별 접속 카운트
+  try {
+    if (typeof window.va === 'function') {
+      window.va('event', { name: 'pv_admin', page: pane });
+    }
+  } catch (e) { /* analytics 실패 무시 */ }
+
   initMultiFilters();
   document.querySelectorAll('.admin-pane').forEach(p=>p.classList.remove('on'));
   document.querySelectorAll('.admin-si').forEach(s=>s.classList.remove('on'));

--- a/dev/js/admin.js
+++ b/dev/js/admin.js
@@ -152,6 +152,13 @@ function friendlyError(msg) {
 // ════════════════════════════════════════════════════════════════════
 
 function switchAdminPane(pane, el, pushHistory) {
+  // Vercel Web Analytics — 관리자 앱 페인별 접속 카운트
+  try {
+    if (typeof window.va === 'function') {
+      window.va('event', { name: 'pv_admin', page: pane });
+    }
+  } catch (e) { /* analytics 실패 무시 */ }
+
   initMultiFilters();
   document.querySelectorAll('.admin-pane').forEach(p=>p.classList.remove('on'));
   document.querySelectorAll('.admin-si').forEach(s=>s.classList.remove('on'));

--- a/dev/js/app.js
+++ b/dev/js/app.js
@@ -35,6 +35,13 @@ function navigate(page, pushHistory) {
     pageName = 'detail';
   }
 
+  // Vercel Web Analytics — 인플 앱 페이지별 접속 카운트
+  try {
+    if (typeof window.va === 'function') {
+      window.va('event', { name: 'pv_inf', page: pageName });
+    }
+  } catch (e) { /* analytics 실패 무시 */ }
+
   // 브라우저 히스토리에 기록 (뒤로가기 지원)
   if (pushHistory !== false) {
     history.pushState({page}, '', '#' + page);

--- a/index.html
+++ b/index.html
@@ -9130,6 +9130,13 @@ function navigate(page, pushHistory) {
     pageName = 'detail';
   }
 
+  // Vercel Web Analytics — 인플 앱 페이지별 접속 카운트
+  try {
+    if (typeof window.va === 'function') {
+      window.va('event', { name: 'pv_inf', page: pageName });
+    }
+  } catch (e) { /* analytics 실패 무시 */ }
+
   // 브라우저 히스토리에 기록 (뒤로가기 지원)
   if (pushHistory !== false) {
     history.pushState({page}, '', '#' + page);


### PR DESCRIPTION
## 변경 요약
- 인플 앱 `navigate(page)` 안에 `va('event', { name: 'pv_inf', page })` 1줄 추가
- 관리자 앱 `switchAdminPane(pane)` 안에 `va('event', { name: 'pv_admin', page })` 1줄 추가
- bash dev/build.sh 실행 → 루트 빌드 완료

## 목적
사용자 요청: 「페이지 접속을 추적해서 페이지 개선에 도움을 받았으면」
- hash 라우팅(SPA) 때문에 Vercel Web Analytics 기본 Pages 탭은 `/`·`/admin/` 만 카운트
- Custom Events 로 페인별 정확한 카운트 가능 → 사용 빈도 높은 페이지부터 UX 개선 우선순위

## 호환성
- Web Analytics Free Tier (2 properties) 호환 — properties 1개(page)만 전송
- try-catch 로 analytics 실패가 navigation 망가뜨리지 않게 격리

🤖 Generated with [Claude Code](https://claude.com/claude-code)