### PR TITLE
fix(promo-email): record finished_at in terminal finalizeRun paths

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -221,7 +221,7 @@
 - `influencer_daily_digest_runs` / `application_received_admin_digest_runs` — 메일 파이프라인 운영 로그. `digest_date` UNIQUE
 - `deadline_reminder_email_sent` — 영수증/결과물 D-5·D-1 임박 메일 재발송 차단. UNIQUE 4-tuple `(influencer_id, campaign_id, kind, d_minus)`
 - 캠페인 홍보 메일 4종(주 2회 다이제스트, 마이그레이션 139 — PR 1 인프라, Edge Function·cron은 PR 2~5):
-  - `campaign_promo_digest_runs` — 다이제스트 run 로그. `digest_date` UNIQUE(중복 호출 차단 mutex) + `status CHECK(sent|partial|skipped_no_data|failed)` + `included_campaign_ids uuid[]` + `target_influencer_count`/`sent_count`/`skipped_count`/`failed_count` + `error_message` + `triggered_by`(향후 운영자 수동 트리거 대비)
+  - `campaign_promo_digest_runs` — 다이제스트 run 로그. `digest_date` UNIQUE(중복 호출 차단 mutex) + `status CHECK(sent|partial|skipped_no_data|failed)` + `included_campaign_ids uuid[]` + `target_influencer_count`/`sent_count`/`skipped_count`/`failed_count` + `error_message` + `started_at timestamptz DEFAULT now()` + `finished_at timestamptz NULL`(마지막 배치 또는 즉시 종료 시점에만 기록 — chained 중간은 NULL 유지) + `triggered_by`(향후 운영자 수동 트리거 대비)
   - `campaign_promo_digest_sent` — 인플별 발송 결과. `(influencer_id, digest_date)` UNIQUE 로 1통/cron 보장. `status CHECK(sent|skipped|failed)` + `skip_reason`(opt_out/no_email/no_matched_campaign/already_sent) + `included_campaign_ids uuid[]`
   - `campaign_promo_exposure` — 캠페인×인플×종류별 노출 기록. `(campaign_id, influencer_id, kind)` UNIQUE 로 인플당 캠페인당 최대 2회 보장(`kind CHECK(new|deadline_d1)`). 「관심 없는 캠페인 매일 노출」 방지
   - `campaign_promo_email_clicks` — CTA 클릭 추적. `(campaign_id, influencer_id)` UNIQUE + `click_count`/`first_clicked_at`/`last_clicked_at`. 클릭된 페어는 다음 다이제스트 매칭에서 자동 제외

--- a/supabase/functions/notify-campaign-promo-digest/index.ts
+++ b/supabase/functions/notify-campaign-promo-digest/index.ts
@@ -515,6 +515,7 @@ Deno.serve(async (req: Request) => {
   // 종료 시 runs UPDATE 헬퍼
   //   targetCount 는 첫 배치에서만 전달 (chained 배치는 잔여 인플만 반환하므로
   //   target_influencer_count 가 덮어씌워지면 실제 전체 대상자 수와 달라짐).
+  //   finishedAt 은 마지막 배치 또는 즉시 종료 시점에만 기록 (chained 중간은 NULL 유지).
   const finalizeRun = async (payload: {
     status: "sent" | "partial" | "skipped_no_data" | "failed";
     targetCount?: number; // 첫 배치만 전달 — chained 배치는 컬럼 유지
@@ -523,6 +524,7 @@ Deno.serve(async (req: Request) => {
     failedCount: number;
     includedCampaignIds: string[];
     errorMessage?: string | null;
+    finishedAt?: string; // hasMore 면 undefined (NULL 유지)
   }) => {
     const updateData: Record<string, unknown> = {
       status: payload.status,
@@ -534,6 +536,9 @@ Deno.serve(async (req: Request) => {
     };
     if (payload.targetCount !== undefined) {
       updateData.target_influencer_count = payload.targetCount;
+    }
+    if (payload.finishedAt !== undefined) {
+      updateData.finished_at = payload.finishedAt;
     }
     const { error } = await sb
       .from("campaign_promo_digest_runs")
@@ -556,6 +561,7 @@ Deno.serve(async (req: Request) => {
           targetCount: 0, sentCount: 0, skippedCount: 0, failedCount: 0,
           includedCampaignIds: [],
           errorMessage: `RPC get_promo_digest_targets: ${rpcError.message}`,
+          finishedAt: new Date().toISOString(),
         });
       }
       return new Response(JSON.stringify({ error: rpcError.message, stage: "rpc" }), {
@@ -572,6 +578,7 @@ Deno.serve(async (req: Request) => {
           status: "skipped_no_data",
           targetCount: 0, sentCount: 0, skippedCount: 0, failedCount: 0,
           includedCampaignIds: [],
+          finishedAt: new Date().toISOString(),
         });
       }
       return new Response(
@@ -813,6 +820,8 @@ Deno.serve(async (req: Request) => {
       failedCount: cumFailed,
       includedCampaignIds,
       errorMessage: errMsg,
+      // 마지막 배치(hasMore=false) 시점에만 finished_at 기록 — chained 중간은 NULL 유지
+      finishedAt: hasMore ? undefined : new Date().toISOString(),
     });
 
     console.log("[notify-campaign-promo] done", {
@@ -843,6 +852,7 @@ Deno.serve(async (req: Request) => {
           targetCount: 0, sentCount: 0, skippedCount: 0, failedCount: 0,
           includedCampaignIds: [],
           errorMessage: `unexpected: ${msg}`,
+          finishedAt: new Date().toISOString(),
         });
       } catch (_finalizeErr) {
         console.error("[notify-campaign-promo] could not finalize after unexpected error");


### PR DESCRIPTION
## Summary

`campaign_promo_digest_runs.finished_at` 컬럼이 첫 운영 가동 검증에서 NULL 로 기록된 이슈 fix.

- `finalizeRun` 헬퍼에 `finishedAt` 옵션 추가
- 4개 종료 경로(RPC 에러 / no_data / 정상 종료 / unexpected)에서 `new Date().toISOString()` 전달
- chained 배치 중간(`hasMore=true`)에서는 생략 → 다음 배치에서 마지막 마무리 시점에 기록
- CLAUDE.md DB Schema 의 `campaign_promo_digest_runs` 설명에 `started_at` + `finished_at` 컬럼 명시 (이전엔 admin_daily_digest_runs 의 `run_at` 표기가 빌려져 있어 SQL 작성 시 컬럼명 혼동 유발)

## 검증

운영 2026-05-19 KST 19:34 첫 수동 호출 결과:
- status=skipped_no_data 정상
- started_at=2026-05-19 10:34:22 UTC 기록
- **finished_at=NULL (본 PR fix 대상)**

운영 Edge Function 재배포 후 다음 호출부터 finished_at 정상 기록.

## Test plan

- [ ] 운영 Edge Function `notify-campaign-promo-digest` 재배포
- [ ] 운영 Dashboard Test function 1회 호출
- [ ] `campaign_promo_digest_runs` 새 행의 `finished_at` 비어있지 않은지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)