### PR TITLE
feat(messaging): PR 1 — 응모건 메시지 기반 인프라 + 인플루언서 발신

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,6 +107,7 @@
 - **알림 모달**: deliverables.status 트리거로 생성된 rejected/changed/approved 3종. 항목 클릭 시 읽음 처리 + 활동관리로 이동. "모두 읽음" 버튼
 - **활동관리**: 승인된 캠페인에서 결과물 제출. recruit_type 분기 — monitor=영수증(이미지 + 주문번호·구매일·구매금액 3종 필수), gifting/visit=SNS 게시물 URL(자동 채널 판별 + 실패 시 수동 드롭다운). 모두 `deliverables` 직접 INSERT + `submit_deliverable` RPC. 반려된 결과물은 상단 빨간 배너에 사유 표시, 재제출 시 pending 복귀 (동일 URL 은 `post_submissions` 배열에 날짜 누적). `submission_end` 경과 시 폼 비활성
 - **응모이력**: 상태별 탭 필터(전체/심사중/승인/비승인), 캠페인상태/정렬 필터. 승인 캠페인 클릭→활동관리, 기타→캠페인 상세
+- **응모건 메시지**(PR 1, 개발 검증 중): 응모이력 카드의 메시지 버튼(미읽음 배지) → 게시판형 풀스크린 모달. 운영팀에 텍스트+이미지(자동 압축/HEIC 변환, 최대 5장) 발송, 25분 내 본인 회수, 숨김·회수 메시지는 가림(placeholder) 표시. 본문/첨부 마스킹은 서버(`get_application_messages` RPC). `dev/js/messaging.js`. 관리자 발신·GNB 메뉴·알림은 PR 2
 - **본인 응모 취소**: `cancel_application(uuid, reason_code, reason_note, acknowledged)` RPC — 본인 검증·결과물 승인 차단·구매기간 이후 사유·동의 강제
 - **홈 하단 푸터**: 株式会社ジェイファン 회사 정보 + 会社紹介/利用規約/個人情報処理方針 링크 (슬라이드업 모달), Instagram·X SNS 아이콘
 - **성능 최적화**: preconnect(Supabase/Fonts/jsDelivr), 캠페인 카드/마이페이지 썸네일 lazy loading + decoding=async, Supabase Storage 이미지 transform(`/render/image/public/?width=&quality=`)으로 썸네일 용량 축소, 이미지 로드 실패 시 원본 URL 자동 폴백
@@ -212,6 +213,16 @@
 - `admin_notices` — 관리자 공지. `category`(system_update/release/warning/general), `pin`(bool), `title`, `body_html`(Quill rich), `created_by`/`created_at`/`updated_at`, `status CHECK(draft|published)`, `published_at`/`published_by`/`published_by_name`. SELECT RLS 는 published OR `is_super_admin()` OR `created_by=auth.uid()` (draft 는 작성자/super 한정). XSS 방어는 저장+렌더 이중 sanitize
 - `admin_notice_reads` — 관리자별 읽음 기록. `(admin_id, notice_id, read_at)` UNIQUE. `upsert_admin_notice_read` RPC. 미읽음 카운트 = published - reads(by admin)
 - `influencer_flags` — 인플루언서 관리자 마킹 이력. `influencer_id`, `action`(verify/violation/blacklist/clear), `reasons text[]` (blacklist_reason ∪ violation_reason lookup), `memo`, `evidence_paths text[]`, `updated_at/by/by_name`. 위반 행만 UPDATE RLS
+
+### 응모건 메시지 (인플루언서 ↔ 관리자, PR 1 — 개발 검증 중, 마이그레이션 144)
+> 응모(신청)건 단위 양방향 메시지. PR 1 은 인플루언서 발신 + 모달 + 응모이력 진입. 관리자 발신 UI·GNB 메뉴·알림(`message_received`)은 PR 2. 사양서 `docs/specs/2026-05-15-application-messaging.md`. 약관 중대 변경(D-7 사전 통지)은 PR 5 운영 배포 직전 집행(현재 보류).
+- `application_messages` — 메시지 본문. `application_id` FK CASCADE, `sender_kind`(influencer|admin), `sender_id/name`, `body`, `attachments jsonb`(`[{path,name,size,mime}]`), `read_by_influencer_at`, 강제숨김 4컬럼(`hidden_by_admin_at/_id/_reason_code/_memo`), 본인회수(`self_withdrawn_at`/`_by_kind`), 메일큐(`email_send_at`/`email_sent_at`/`email_skip_reason`), `broadcast_id` FK. RLS SELECT 본인 응모건 또는 `is_admin()`, INSERT/UPDATE 는 RPC 만 (sender_kind 변조 차단)
+- `application_message_admin_reads` — 관리자 개인별 읽음. `(message_id, admin_auth_id)` PK
+- `application_message_resolutions` — 응모건 응대 완료. `application_id` PK, `resolution_method`(auto_replied|manual)
+- `application_message_broadcasts` — 일괄 발송 그룹 (테이블만 PR 1, bulk/withdraw RPC 는 PR 3)
+- `application_message_hide_history` — 숨김/회수 audit (append-only, SELECT super_admin)
+- 뷰 `application_message_summary`(`security_invoker=true` — 인플 본인 행만 RLS 상속) + RPC: `get_application_messages`(호출자 역할별 4종 마스킹), `send_application_message`(rate limit 100/h + 자동 응대/reopen + 메일큐 계산), `mark_application_messages_read`, `withdraw_own_message`(25분 한도 + rate limit 50/h + 첨부 클라 삭제), `application_message_admin_unread_counts`(is_admin 가드). 모두 SECURITY DEFINER + `search_path=''`
+- lookup `message_hide_reason` 7종 시드 + Storage 버킷 `application-message-attachments`(비공개, 응모건 폴더 기반 정책). 첨부는 클라 압축(`dev/lib/image-compress.js`, HEIC→JPEG/2048px) 후 업로드
 
 ### 메일·기준 데이터·알림
 - `lookup_values` — 캠페인 기준 데이터. `kind`(channel/category/content_type/ng_item/reject_reason/blacklist_reason/violation_reason/caution/admin_email_kind/cancel_reason), `code`, `name_ko`, `name_ja`, `sort_order`, `active`, `recruit_types[]`. channel 만 recruit_types 사용

--- a/admin/index.html
+++ b/admin/index.html
@@ -12,7 +12,7 @@
 // 회귀(2026-05-12 PR #182 머지 직후 발생)를 방지하기 위한 자동 reload 가드.
 // sessionStorage 차단 환경(시크릿 모드 일부, 쿠키 차단)에서는 자연스럽게 skip.
 (function(){
-  var CURRENT_BUILD = 'v1779260582';
+  var CURRENT_BUILD = 'v1779262296';
   if (CURRENT_BUILD.indexOf('__') === 0) return; // 빌드 미적용 (dev/ 직접 열기) 시 skip
   try {
     var prev = sessionStorage.getItem('reverb.adminBuild');
@@ -1522,7 +1522,7 @@ textarea.form-input{resize:vertical;min-height:80px}
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-05-20 16:03 · c07049c</span>
+          <span class="admin-build-text">2026-05-20 16:31 · 95cbb41</span>
         </div>
       </div>
     </aside>

--- a/admin/index.html
+++ b/admin/index.html
@@ -12,7 +12,7 @@
 // 회귀(2026-05-12 PR #182 머지 직후 발생)를 방지하기 위한 자동 reload 가드.
 // sessionStorage 차단 환경(시크릿 모드 일부, 쿠키 차단)에서는 자연스럽게 skip.
 (function(){
-  var CURRENT_BUILD = 'v1779262296';
+  var CURRENT_BUILD = 'v1779263277';
   if (CURRENT_BUILD.indexOf('__') === 0) return; // 빌드 미적용 (dev/ 직접 열기) 시 skip
   try {
     var prev = sessionStorage.getItem('reverb.adminBuild');
@@ -1522,7 +1522,7 @@ textarea.form-input{resize:vertical;min-height:80px}
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-05-20 16:31 · 95cbb41</span>
+          <span class="admin-build-text">2026-05-20 16:47 · a0e5f20</span>
         </div>
       </div>
     </aside>

--- a/admin/index.html
+++ b/admin/index.html
@@ -12,7 +12,7 @@
 // 회귀(2026-05-12 PR #182 머지 직후 발생)를 방지하기 위한 자동 reload 가드.
 // sessionStorage 차단 환경(시크릿 모드 일부, 쿠키 차단)에서는 자연스럽게 skip.
 (function(){
-  var CURRENT_BUILD = 'v1779246908';
+  var CURRENT_BUILD = 'v1779260582';
   if (CURRENT_BUILD.indexOf('__') === 0) return; // 빌드 미적용 (dev/ 직접 열기) 시 skip
   try {
     var prev = sessionStorage.getItem('reverb.adminBuild');
@@ -1522,7 +1522,7 @@ textarea.form-input{resize:vertical;min-height:80px}
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-05-20 12:15 · a71b423</span>
+          <span class="admin-build-text">2026-05-20 16:03 · c07049c</span>
         </div>
       </div>
     </aside>
@@ -6206,6 +6206,94 @@ async function updateMarketingOptIn(value) {
     console.error('[updateMarketingOptIn]', e);
     return {ok: false, error: e?.message || 'unknown'};
   }
+}
+
+// ════════════════════════════════════════════════════════════════════
+// 응모건 단위 메시지 (인플루언서 ↔ 관리자) — PR 1
+//   사양서 docs/specs/2026-05-15-application-messaging.md §4
+//   마이그레이션 144. 본문/첨부 마스킹은 get_application_messages RPC 서버측 처리.
+// ════════════════════════════════════════════════════════════════════
+const MSG_ATTACH_BUCKET = 'application-message-attachments';
+
+// 응모건의 메시지 목록 (마스킹 적용된 행) — 인플루언서·관리자 공용.
+// get_application_messages RPC 가 호출자 역할(본인 인플 / is_admin)에 따라 마스킹.
+async function fetchApplicationMessages(applicationId) {
+  if (!db || !applicationId) return [];
+  const {data, error} = await db.rpc('get_application_messages', { p_application_id: applicationId });
+  if (error) throw error;
+  return data || [];
+}
+
+// 메시지 발송 (인플루언서·관리자 공용, sender_kind 는 서버가 판별).
+// attachments: [{path, name, size, mime}] — uploadMessageAttachment() 반환값 배열
+async function sendApplicationMessage(applicationId, body, attachments = []) {
+  if (!db) throw new Error('DB 미연결');
+  return await retryWithRefresh(async () => {
+    const {data, error} = await db.rpc('send_application_message', {
+      p_application_id: applicationId,
+      p_body: body || '',
+      p_attachments: attachments,
+    });
+    if (error) throw error;
+    return data;
+  });
+}
+
+// 본인 미열람 메시지를 읽음 처리 (관리자: 개인별 / 인플루언서: read_by_influencer_at).
+async function markApplicationMessagesRead(applicationId) {
+  if (!db || !applicationId) return;
+  await retryWithRefresh(async () => {
+    const {error} = await db.rpc('mark_application_messages_read', { p_application_id: applicationId });
+    if (error) throw error;
+  });
+}
+
+// 본인 메시지 회수 (25분 한도, RPC 가 시간/본인 검증). 성공 후 첨부 Storage 즉시 삭제 (§3-5 ②).
+// attachmentPaths: 회수할 메시지의 attachments[].path 배열 (없으면 빈 배열)
+async function withdrawOwnMessage(messageId, attachmentPaths = []) {
+  if (!db || !messageId) return;
+  await retryWithRefresh(async () => {
+    const {error} = await db.rpc('withdraw_own_message', { p_message_id: messageId });
+    if (error) throw error;
+  });
+  if (attachmentPaths && attachmentPaths.length) {
+    // 본인 회수는 첨부 즉시 삭제 (개인정보 최소화). 실패해도 회수 자체는 성공이므로 경고만.
+    try { await db.storage.from(MSG_ATTACH_BUCKET).remove(attachmentPaths); }
+    catch (e) { console.warn('[withdrawOwnMessage] 첨부 삭제 실패', e); }
+  }
+}
+
+// 첨부 이미지 업로드 — 압축/HEIC 변환(image-compress.js) 후 비공개 버킷에 저장.
+// 반환: {path, name, size, mime} (send 의 attachments 배열에 그대로 push)
+async function uploadMessageAttachment(file, applicationId) {
+  if (!db) throw new Error('DB 미연결');
+  const compressed = await compressImageFile(file);  // image-compress.js — too_large/decode_failed 등 예외 가능
+  const uuid = crypto.randomUUID ? crypto.randomUUID()
+    : (Date.now().toString(36) + Math.random().toString(36).substring(2));
+  const path = `${applicationId}/${uuid}.jpg`;
+  const {error} = await db.storage.from(MSG_ATTACH_BUCKET)
+    .upload(path, compressed, { contentType: 'image/jpeg', upsert: false, cacheControl: '3600' });
+  if (error) throw error;
+  return { path, name: file.name || 'image.jpg', size: compressed.size, mime: 'image/jpeg' };
+}
+
+// 첨부 이미지 signed URL (5분 시한, §9). 라이트박스/썸네일 표시용
+async function getMessageAttachmentSignedUrl(path, expiresIn = 300) {
+  if (!db || !path) return null;
+  const {data, error} = await db.storage.from(MSG_ATTACH_BUCKET).createSignedUrl(path, expiresIn);
+  if (error) throw error;
+  return data?.signedUrl || null;
+}
+
+// 인플루언서 GNB 미읽음 메시지 응모건 목록 (security_invoker 뷰 — 본인 행만 RLS 적용).
+async function fetchInfluencerUnreadMessageThreads() {
+  if (!db || typeof currentUser === 'undefined' || !currentUser) return [];
+  const {data, error} = await db.from('application_message_summary')
+    .select('application_id, campaign_id, unread_for_influencer, last_message_at')
+    .gt('unread_for_influencer', 0)
+    .order('last_message_at', { ascending: false });
+  if (error) { console.warn('[fetchInfluencerUnreadMessageThreads]', error); return []; }
+  return data || [];
 }
 
 

--- a/dev/build.sh
+++ b/dev/build.sh
@@ -24,7 +24,7 @@ echo "🔨 REVERB JP 빌드 시작..."
 # 1. CLIENT 빌드 → ../index.html
 # ══════════════════════════════════════
 CLIENT_CSS_FILES=("css/base.css" "css/components.css" "css/campaign.css" "css/auth.css" "css/mypage.css")
-CLIENT_JS_FILES=("lib/supabase.js" "lib/shared.js" "lib/i18n/ja.js" "lib/i18n/ko.js" "lib/i18n/index.js" "lib/image-compress.js" "lib/storage.js" "lib/legal.js" "js/ui.js" "js/campaign.js" "js/auth.js" "js/application.js" "js/notifications.js" "js/mypage.js" "js/app.js")
+CLIENT_JS_FILES=("lib/supabase.js" "lib/shared.js" "lib/i18n/ja.js" "lib/i18n/ko.js" "lib/i18n/index.js" "lib/image-compress.js" "lib/storage.js" "lib/legal.js" "js/ui.js" "js/campaign.js" "js/auth.js" "js/application.js" "js/notifications.js" "js/mypage.js" "js/messaging.js" "js/app.js")
 
 : > "$BUILD_TMP/client.css"
 for f in "${CLIENT_CSS_FILES[@]}"; do

--- a/dev/build.sh
+++ b/dev/build.sh
@@ -24,7 +24,7 @@ echo "🔨 REVERB JP 빌드 시작..."
 # 1. CLIENT 빌드 → ../index.html
 # ══════════════════════════════════════
 CLIENT_CSS_FILES=("css/base.css" "css/components.css" "css/campaign.css" "css/auth.css" "css/mypage.css")
-CLIENT_JS_FILES=("lib/supabase.js" "lib/shared.js" "lib/i18n/ja.js" "lib/i18n/ko.js" "lib/i18n/index.js" "lib/storage.js" "lib/legal.js" "js/ui.js" "js/campaign.js" "js/auth.js" "js/application.js" "js/notifications.js" "js/mypage.js" "js/app.js")
+CLIENT_JS_FILES=("lib/supabase.js" "lib/shared.js" "lib/i18n/ja.js" "lib/i18n/ko.js" "lib/i18n/index.js" "lib/image-compress.js" "lib/storage.js" "lib/legal.js" "js/ui.js" "js/campaign.js" "js/auth.js" "js/application.js" "js/notifications.js" "js/mypage.js" "js/app.js")
 
 : > "$BUILD_TMP/client.css"
 for f in "${CLIENT_CSS_FILES[@]}"; do

--- a/dev/css/mypage.css
+++ b/dev/css/mypage.css
@@ -60,3 +60,44 @@
 .lang-toggle .lang-btn{border:0;background:transparent;color:var(--muted);font-size:12px;font-weight:600;padding:5px 10px;cursor:pointer;transition:.15s}
 .lang-toggle .lang-btn.on{background:var(--primary);color:#fff}
 .lang-toggle .lang-btn:not(.on):hover{background:var(--outline)}
+
+/* ── 응모이력 메시지 버튼/배지 ── */
+.apply-item-actions{display:flex;align-items:center;gap:2px}
+.apply-msg-btn{position:relative;min-width:40px;min-height:40px;display:inline-flex;align-items:center;justify-content:center;border:none;background:transparent;border-radius:20px;cursor:pointer;color:var(--muted)}
+.apply-msg-btn:hover{background:var(--surface-dim)}
+.apply-msg-badge{position:absolute;top:2px;right:2px;min-width:16px;height:16px;padding:0 4px;background:var(--pink,#e84a7f);color:#fff;font-size:10px;font-weight:700;line-height:16px;text-align:center;border-radius:8px}
+
+/* ── 응모건 메시지 모달 (게시판형) ── */
+.msg-modal{position:fixed;inset:0;z-index:1200;display:none}
+.msg-modal.on{display:block}
+.msg-modal-backdrop{position:absolute;inset:0;background:rgba(0,0,0,.4)}
+.msg-modal-body{position:absolute;left:0;right:0;bottom:0;top:0;max-width:480px;margin:0 auto;background:var(--bg,#fff);display:flex;flex-direction:column}
+.msg-modal-header{flex-shrink:0;display:flex;align-items:center;gap:8px;padding:14px 16px;border-bottom:1px solid var(--outline);background:var(--surface,#fff)}
+.msg-modal-title{flex:1;font-size:15px;font-weight:700;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.msg-close-btn{border:none;background:transparent;cursor:pointer;color:var(--muted);display:inline-flex;min-width:40px;min-height:40px;align-items:center;justify-content:center}
+.msg-modal-thread{flex:1;overflow-y:auto;padding:16px;display:flex;flex-direction:column;gap:12px;background:var(--surface-dim,#f7f7f8)}
+.msg-empty{text-align:center;color:var(--muted);font-size:13px;padding:32px 16px;line-height:1.6}
+.msg-card{background:#fff;border:1px solid var(--outline);border-radius:10px;padding:10px 12px;max-width:88%;align-self:flex-start}
+.msg-card.mine{align-self:flex-end;background:#eef4ff;border-color:#cfe0ff}
+.msg-card-head{display:flex;align-items:center;gap:8px;margin-bottom:4px}
+.msg-sender{font-size:12px;font-weight:700;color:var(--text)}
+.msg-time{font-size:11px;color:var(--muted)}
+.msg-card-body{font-size:14px;line-height:1.6;color:var(--text);word-break:break-word}
+.msg-card-masked .msg-masked-body{font-size:13px;color:var(--muted);font-style:italic}
+.msg-withdraw-btn{margin-left:auto;border:none;background:transparent;color:var(--pink,#e84a7f);font-size:12px;font-weight:600;cursor:pointer;padding:2px 6px;border-radius:6px}
+.msg-withdraw-btn:hover{background:rgba(232,74,127,.1)}
+.msg-attachments{display:flex;flex-wrap:wrap;gap:6px;margin-top:8px}
+.msg-attach-thumb{width:72px;height:72px;border-radius:8px;overflow:hidden;background:var(--surface-dim);display:flex;align-items:center;justify-content:center;cursor:pointer;color:var(--muted)}
+.msg-attach-thumb img{width:100%;height:100%;object-fit:cover}
+.msg-modal-input-area{flex-shrink:0;border-top:1px solid var(--outline);padding:10px 12px;background:var(--surface,#fff)}
+.msg-attach-preview{display:flex;flex-wrap:wrap;gap:6px}
+.msg-attach-preview:not(:empty){margin-bottom:8px}
+.msg-attach-pending{position:relative;width:56px;height:56px;border-radius:8px;overflow:hidden}
+.msg-attach-pending img{width:100%;height:100%;object-fit:cover}
+.msg-attach-remove{position:absolute;top:2px;right:2px;width:20px;height:20px;border:none;border-radius:10px;background:rgba(0,0,0,.6);color:#fff;cursor:pointer;display:flex;align-items:center;justify-content:center;padding:0}
+.msg-attach-remove .material-icons-round{font-size:14px}
+.msg-input-row{display:flex;align-items:flex-end;gap:8px}
+.msg-attach-btn{flex-shrink:0;width:40px;height:40px;border-radius:20px;display:flex;align-items:center;justify-content:center;cursor:pointer;color:var(--muted);background:var(--surface-dim)}
+.msg-input{flex:1;resize:none;border:1px solid var(--outline);border-radius:12px;padding:9px 12px;font-size:16px;line-height:1.5;max-height:120px;font-family:inherit}
+.msg-send-btn{flex-shrink:0;width:40px;height:40px;border-radius:20px;border:none;background:var(--primary);color:#fff;cursor:pointer;display:flex;align-items:center;justify-content:center}
+.msg-send-btn:disabled{opacity:.5;cursor:default}

--- a/dev/index.html
+++ b/dev/index.html
@@ -1166,6 +1166,7 @@ window._supabaseLoaded = false;
 <script src="lib/i18n/ja.js"></script>
 <script src="lib/i18n/ko.js"></script>
 <script src="lib/i18n/index.js"></script>
+<script src="lib/image-compress.js"></script>
 <script src="lib/storage.js"></script>
 <script src="lib/legal.js"></script>
 <script src="js/ui.js"></script>

--- a/dev/index.html
+++ b/dev/index.html
@@ -246,6 +246,33 @@ window._supabaseLoaded = false;
   </div>
 </div>
 
+<!-- 응모건 메시지 모달 (인플루언서 ↔ 관리자, 게시판형) -->
+<div id="msgModal" class="msg-modal" aria-hidden="true">
+  <div class="msg-modal-backdrop" onclick="closeMessageModal()"></div>
+  <div class="msg-modal-body">
+    <div class="msg-modal-header">
+      <div id="msgModalTitle" class="msg-modal-title"></div>
+      <button class="msg-close-btn" onclick="closeMessageModal()" aria-label="Close">
+        <span class="material-icons-round notranslate" translate="no">close</span>
+      </button>
+    </div>
+    <div id="msgModalThread" class="msg-modal-thread"></div>
+    <div class="msg-modal-input-area">
+      <div id="msgModalAttachPreview" class="msg-attach-preview"></div>
+      <div class="msg-input-row">
+        <label class="msg-attach-btn" aria-label="attach image">
+          <span class="material-icons-round notranslate" translate="no">image</span>
+          <input id="msgModalAttachInput" type="file" accept="image/*" multiple style="display:none" onchange="onMsgAttachSelected(this)">
+        </label>
+        <textarea id="msgModalInput" class="msg-input" rows="2"></textarea>
+        <button id="msgModalSendBtn" class="msg-send-btn" onclick="sendMessageFromModal()" aria-label="send">
+          <span class="material-icons-round notranslate" translate="no">send</span>
+        </button>
+      </div>
+    </div>
+  </div>
+</div>
+
 <!-- ══════════════════════════════════
      PAGE: HOME (キャンペーン一覧)
 ══════════════════════════════════ -->
@@ -1174,6 +1201,7 @@ window._supabaseLoaded = false;
 <script src="js/auth.js"></script>
 <script src="js/application.js"></script>
 <script src="js/mypage.js"></script>
+<script src="js/messaging.js"></script>
 <script src="js/app.js"></script>
 </body>
 </html>

--- a/dev/js/messaging.js
+++ b/dev/js/messaging.js
@@ -83,7 +83,7 @@ function renderMessageThread(messages) {
       </div>`;
     }
 
-    // 본문 (esc 후 줄바꿈 보존)
+    // 본문: esc() 선적용 후 줄바꿈만 <br> 치환 — 다른 HTML 태그는 이스케이프되어 XSS 안전
     const bodyHtml = esc(msg.body || '').replace(/\n/g, '<br>');
 
     // 첨부 썸네일 (signed URL 비동기 로드)

--- a/dev/js/messaging.js
+++ b/dev/js/messaging.js
@@ -1,0 +1,219 @@
+// ════════════════════════════════════════════════════════════════════
+// messaging.js — 인플루언서 ↔ 관리자 메시지 모달 (PR 1, 인플루언서 화면)
+//   사양서 docs/specs/2026-05-15-application-messaging.md §5-1 (게시판형)
+//   DB 함수: storage.js (fetchApplicationMessages / sendApplicationMessage /
+//            markApplicationMessagesRead / withdrawOwnMessage / uploadMessageAttachment)
+//   본문/첨부 마스킹은 서버(get_application_messages RPC)에서 처리 — 클라는 mask_state 로 표시만.
+// ════════════════════════════════════════════════════════════════════
+
+const MSG_WITHDRAW_LIMIT_MS = 25 * 60 * 1000;  // 본인 회수 25분 (§3-5 ②)
+const MSG_MAX_ATTACH = 5;                       // 메시지당 첨부 최대 5장 (§3-2)
+
+let _msgCurrentAppId = null;
+let _msgPendingFiles = [];   // 업로드 대기 File 배열 (압축 전 원본)
+let _msgSending = false;
+
+// 응모건 메시지 모달 열기
+async function openMessageModal(applicationId) {
+  if (!applicationId) return;
+  _msgCurrentAppId = applicationId;
+  _msgPendingFiles = [];
+  const m = $('msgModal');
+  if (!m) return;
+
+  // 헤더 제목: 「{캠페인명}に関するお問い合わせ」
+  const app = (typeof _myApps !== 'undefined' ? _myApps : []).find(a => a.id === applicationId);
+  const camp = (typeof allCampaigns !== 'undefined' ? allCampaigns : []).find(c => c.id === app?.campaign_id) || {};
+  const titleEl = $('msgModalTitle');
+  if (titleEl) titleEl.textContent = t('messaging.titleFor').replace('{name}', camp.title || '');
+
+  m.classList.add('on');
+  document.body.style.overflow = 'hidden';
+  renderMsgAttachPreview();
+  const inputEl = $('msgModalInput');
+  if (inputEl) { inputEl.value = ''; inputEl.placeholder = t('messaging.placeholder'); }
+
+  const thread = $('msgModalThread');
+  if (thread) thread.innerHTML = `<div class="msg-empty">${esc(t('messaging.loading'))}</div>`;
+
+  try {
+    const msgs = await fetchApplicationMessages(applicationId);
+    renderMessageThread(msgs);
+    // 열람 시 본인 미열람 읽음 처리 후 응모이력 배지 갱신
+    await markApplicationMessagesRead(applicationId);
+    if (typeof refreshMyMsgUnread === 'function') await refreshMyMsgUnread();
+  } catch (e) {
+    console.error('[openMessageModal]', e);
+    if (thread) thread.innerHTML = `<div class="msg-empty">${esc(t('messaging.loadError'))}</div>`;
+  }
+}
+
+function closeMessageModal() {
+  const m = $('msgModal');
+  if (m) m.classList.remove('on');
+  document.body.style.overflow = '';
+  _msgCurrentAppId = null;
+  _msgPendingFiles = [];
+}
+
+// 메시지 스레드 렌더 (게시판형 — 위→아래 누적 카드)
+function renderMessageThread(messages) {
+  const thread = $('msgModalThread');
+  if (!thread) return;
+  if (!messages || !messages.length) {
+    thread.innerHTML = `<div class="msg-empty">${esc(t('messaging.emptyThread'))}</div>`;
+    return;
+  }
+  const now = Date.now();
+  thread.innerHTML = messages.map(msg => {
+    const mine = msg.sender_kind === 'influencer';
+    const senderLabel = mine ? t('messaging.you') : t('messaging.adminTeam');
+    const timeStr = formatDate(msg.created_at);
+
+    // 마스킹 상태별 placeholder (§3-5)
+    if (msg.mask_state && msg.mask_state !== 'visible') {
+      const phKey = {
+        hidden_by_admin: 'messaging.maskHiddenByAdmin',
+        self_withdrawn_influencer: 'messaging.maskSelfWithdrawn',
+        self_withdrawn_admin: 'messaging.maskAdminWithdrawn',
+      }[msg.mask_state] || 'messaging.maskHiddenByAdmin';
+      return `<div class="msg-card msg-card-masked ${mine ? 'mine' : ''}">
+        <div class="msg-card-head"><span class="msg-sender">${esc(senderLabel)}</span><span class="msg-time">${esc(timeStr)}</span></div>
+        <div class="msg-masked-body">${esc(t(phKey))}</div>
+      </div>`;
+    }
+
+    // 본문 (esc 후 줄바꿈 보존)
+    const bodyHtml = esc(msg.body || '').replace(/\n/g, '<br>');
+
+    // 첨부 썸네일 (signed URL 비동기 로드)
+    let attachHtml = '';
+    const atts = Array.isArray(msg.attachments) ? msg.attachments : [];
+    if (atts.length) {
+      attachHtml = `<div class="msg-attachments">${atts.map((a, i) => {
+        const elId = `msgatt-${msg.id}-${i}`;
+        loadMsgAttachThumb(elId, a.path);
+        return `<div class="msg-attach-thumb" id="${elId}" onclick="openMsgLightbox('${esc(a.path)}')"><span class="material-icons-round notranslate" translate="no">image</span></div>`;
+      }).join('')}</div>`;
+    }
+
+    // 본인 메시지 + 25분 이내 → 회수 버튼
+    let withdrawBtn = '';
+    if (mine) {
+      const elapsed = now - new Date(msg.created_at).getTime();
+      if (elapsed < MSG_WITHDRAW_LIMIT_MS) {
+        const pathsJson = esc(JSON.stringify(atts.map(a => a.path)));
+        withdrawBtn = `<button type="button" class="msg-withdraw-btn" onclick='confirmWithdrawMessage("${esc(msg.id)}", ${pathsJson})'>${esc(t('messaging.withdraw'))}</button>`;
+      }
+    }
+
+    return `<div class="msg-card ${mine ? 'mine' : ''}">
+      <div class="msg-card-head"><span class="msg-sender">${esc(senderLabel)}</span><span class="msg-time">${esc(timeStr)}</span>${withdrawBtn}</div>
+      <div class="msg-card-body">${bodyHtml}</div>
+      ${attachHtml}
+    </div>`;
+  }).join('');
+  // 최신 메시지로 스크롤
+  thread.scrollTop = thread.scrollHeight;
+}
+
+// 첨부 썸네일 signed URL 비동기 로드 (5분 시한)
+async function loadMsgAttachThumb(elId, path) {
+  try {
+    const url = await getMessageAttachmentSignedUrl(path);
+    const el = $(elId);
+    if (el && url) {
+      el.innerHTML = `<img src="${esc(url)}" loading="lazy" decoding="async" alt="">`;
+    }
+  } catch (e) { /* 썸네일 실패 시 아이콘 유지 */ }
+}
+
+// 첨부 라이트박스 (원본 보기)
+async function openMsgLightbox(path) {
+  try {
+    const url = await getMessageAttachmentSignedUrl(path);
+    if (url) window.open(url, '_blank', 'noopener');
+  } catch (e) { toast(t('messaging.attachError')); }
+}
+
+// 회수 확인 → 실행
+async function confirmWithdrawMessage(messageId, attachmentPaths) {
+  if (!confirm(t('messaging.withdrawConfirm'))) return;
+  try {
+    await withdrawOwnMessage(messageId, attachmentPaths || []);
+    // 스레드 재로드
+    const msgs = await fetchApplicationMessages(_msgCurrentAppId);
+    renderMessageThread(msgs);
+  } catch (e) {
+    console.error('[confirmWithdrawMessage]', e);
+    toast(t('messaging.withdrawFailed'));
+  }
+}
+
+// ── 첨부 선택/미리보기 ──
+function onMsgAttachSelected(input) {
+  const files = Array.from(input.files || []);
+  input.value = '';  // 같은 파일 재선택 허용
+  for (const f of files) {
+    if (_msgPendingFiles.length >= MSG_MAX_ATTACH) { toast(t('messaging.attachMax').replace('{n}', MSG_MAX_ATTACH)); break; }
+    _msgPendingFiles.push(f);
+  }
+  renderMsgAttachPreview();
+}
+
+function removeMsgAttach(idx) {
+  _msgPendingFiles.splice(idx, 1);
+  renderMsgAttachPreview();
+}
+
+function renderMsgAttachPreview() {
+  const wrap = $('msgModalAttachPreview');
+  if (!wrap) return;
+  if (!_msgPendingFiles.length) { wrap.innerHTML = ''; return; }
+  wrap.innerHTML = _msgPendingFiles.map((f, i) => {
+    const url = URL.createObjectURL(f);
+    return `<div class="msg-attach-pending"><img src="${url}" alt=""><button type="button" class="msg-attach-remove" onclick="removeMsgAttach(${i})" aria-label="remove"><span class="material-icons-round notranslate" translate="no">close</span></button></div>`;
+  }).join('');
+}
+
+// ── 전송 ──
+async function sendMessageFromModal() {
+  if (_msgSending || !_msgCurrentAppId) return;
+  const inputEl = $('msgModalInput');
+  const body = (inputEl?.value || '').trim();
+  if (!body && !_msgPendingFiles.length) { toast(t('messaging.emptyInput')); return; }
+
+  _msgSending = true;
+  const sendBtn = $('msgModalSendBtn');
+  if (sendBtn) sendBtn.disabled = true;
+
+  try {
+    // 첨부 압축·업로드 (순차 — 실패 시 즉시 중단)
+    const attachments = [];
+    for (const f of _msgPendingFiles) {
+      try {
+        attachments.push(await uploadMessageAttachment(f, _msgCurrentAppId));
+      } catch (e) {
+        console.error('[sendMessageFromModal] 첨부 업로드', e);
+        toast(e?.message === 'too_large' ? t('messaging.attachTooLarge') : t('messaging.attachUploadFailed'));
+        _msgSending = false;
+        if (sendBtn) sendBtn.disabled = false;
+        return;
+      }
+    }
+    await sendApplicationMessage(_msgCurrentAppId, body, attachments);
+    // 입력 초기화 + 재로드
+    if (inputEl) inputEl.value = '';
+    _msgPendingFiles = [];
+    renderMsgAttachPreview();
+    const msgs = await fetchApplicationMessages(_msgCurrentAppId);
+    renderMessageThread(msgs);
+  } catch (e) {
+    console.error('[sendMessageFromModal]', e);
+    // 90일 경과·rate limit 등 RPC 예외 메시지 노출
+    toast(e?.message || t('messaging.sendFailed'));
+  } finally {
+    _msgSending = false;
+    if (sendBtn) sendBtn.disabled = false;
+  }
+}

--- a/dev/js/mypage.js
+++ b/dev/js/mypage.js
@@ -131,6 +131,7 @@ function renderMyApplyTabs() {
 }
 
 let _myDelivsByApp = {};
+let _myMsgUnreadByApp = {};  // 응모건별 인플루언서 미읽음 메시지 수 (배지용)
 
 async function renderMyApplyList() {
   const container = $('myApplicationsList');
@@ -147,6 +148,12 @@ async function renderMyApplyList() {
       _myDelivsByApp = {};
       delivs.forEach(d => { (_myDelivsByApp[d.application_id] ||= []).push(d); });
     } catch(e) { _myDelivsByApp = {}; }
+    // 메시지 미읽음 배지 — application_message_summary 뷰 (security_invoker, 본인 행만)
+    try {
+      const threads = await fetchInfluencerUnreadMessageThreads();
+      _myMsgUnreadByApp = {};
+      threads.forEach(th => { _myMsgUnreadByApp[th.application_id] = th.unread_for_influencer; });
+    } catch(e) { _myMsgUnreadByApp = {}; }
   }
 
   // 캠페인 상태 필터
@@ -241,6 +248,9 @@ async function renderMyApplyList() {
     const cautionLine = a.caution_agreed_at
       ? `<div class="apply-item-caution" style="font-size:11px;color:var(--green);margin-top:2px;display:inline-flex;align-items:center;gap:3px;flex-wrap:wrap"><span class="material-icons-round notranslate" translate="no" style="font-size:13px">check_circle</span>${t('appHistory.cautionAgreed')} ${formatDate(a.caution_agreed_at)}${cautionCompareButton(a, camp)}</div>`
       : '';
+    // 메시지 버튼 + 미읽음 배지 (모든 응모 카드 — 응모건 단위 운영팀 문의)
+    const msgUnread = _myMsgUnreadByApp[a.id] || 0;
+    const msgBtn = `<button type="button" class="apply-msg-btn" onclick="event.stopPropagation();openMessageModal('${a.id}')" aria-label="${esc(t('messaging.btnLabel'))}"><span class="material-icons-round notranslate" translate="no" style="font-size:22px">chat_bubble_outline</span>${msgUnread>0?`<span class="apply-msg-badge">${msgUnread>9?'9+':msgUnread}</span>`:''}</button>`;
     return `<div class="apply-item" style="cursor:pointer;position:relative" ${clickAction}>
       <div class="apply-thumb">${thumb}</div>
       <div class="apply-item-info">
@@ -250,9 +260,23 @@ async function renderMyApplyList() {
         ${cautionLine}
         ${cancelledLine}
       </div>
-      <div class="apply-item-status" style="display:flex;flex-direction:column;align-items:flex-end;gap:4px">${delivBadgeLine}${menuHtml ? `<div class="apply-item-menu">${menuHtml}</div>` : ''}</div>
+      <div class="apply-item-status" style="display:flex;flex-direction:column;align-items:flex-end;gap:4px">${delivBadgeLine}<div class="apply-item-actions" style="display:flex;align-items:center;gap:2px">${msgBtn}${menuHtml}</div></div>
     </div>`;
   }).join('');
+}
+
+// 메시지 모달에서 읽음 처리/닫은 뒤 응모이력 미읽음 배지 갱신
+async function refreshMyMsgUnread() {
+  if (typeof currentUser === 'undefined' || !currentUser) return;
+  try {
+    const threads = await fetchInfluencerUnreadMessageThreads();
+    _myMsgUnreadByApp = {};
+    threads.forEach(th => { _myMsgUnreadByApp[th.application_id] = th.unread_for_influencer; });
+  } catch(e) { /* 무시 */ }
+  // 응모이력 화면이 떠 있을 때만 재렌더 (배지 갱신)
+  if ($('myApplicationsList') && typeof renderMyApplyList === 'function') {
+    try { await renderMyApplyList(); } catch(e) { /* 무시 */ }
+  }
 }
 
 // ── Phase 2: 주의사항 비교 (응모이력 셀 토글) ──

--- a/dev/lib/i18n/ja.js
+++ b/dev/lib/i18n/ja.js
@@ -563,4 +563,29 @@ window.I18N_JA = {
   channelLabel: {
     other: 'その他',
   },
+
+  // 응모건 메시지 (인플루언서 ↔ 관리자)
+  messaging: {
+    titleFor: '{name}に関するお問い合わせ',
+    loading: '読み込み中...',
+    loadError: 'メッセージの読み込みに失敗しました',
+    emptyThread: 'まだメッセージはありません。下の入力欄からお問い合わせできます。',
+    you: '本人',
+    adminTeam: '運営チーム',
+    maskHiddenByAdmin: '[管理者により非表示処理されたメッセージ]',
+    maskSelfWithdrawn: '[本人が取り消したメッセージ]',
+    maskAdminWithdrawn: '[管理者が取り消したメッセージ]',
+    withdraw: '取り消す',
+    withdrawConfirm: 'このメッセージを取り消しますか？',
+    withdrawFailed: 'メッセージの取り消しに失敗しました',
+    placeholder: 'メッセージを入力...',
+    attachMax: '添付は最大{n}枚までです',
+    attachTooLarge: '画像が大きすぎます。別の画像をお試しください',
+    attachUploadFailed: '画像のアップロードに失敗しました',
+    attachError: '画像を開けませんでした',
+    emptyInput: 'メッセージを入力してください',
+    sendFailed: '送信に失敗しました',
+    btnLabel: 'メッセージ',
+    unreadBadge: '未読',
+  },
 };

--- a/dev/lib/i18n/ko.js
+++ b/dev/lib/i18n/ko.js
@@ -543,4 +543,29 @@ window.I18N_KO = {
   channelLabel: {
     other: '기타',
   },
+
+  // 응모건 메시지 (인플루언서 ↔ 관리자)
+  messaging: {
+    titleFor: '{name} 관련 문의',
+    loading: '불러오는 중...',
+    loadError: '메시지를 불러오지 못했습니다',
+    emptyThread: '아직 메시지가 없습니다. 아래 입력란에서 문의할 수 있습니다.',
+    you: '본인',
+    adminTeam: '운영팀',
+    maskHiddenByAdmin: '[관리자에 의해 숨김 처리된 메시지]',
+    maskSelfWithdrawn: '[본인이 취소한 메시지]',
+    maskAdminWithdrawn: '[관리자가 취소한 메시지]',
+    withdraw: '취소',
+    withdrawConfirm: '이 메시지를 취소할까요?',
+    withdrawFailed: '메시지 취소에 실패했습니다',
+    placeholder: '메시지를 입력...',
+    attachMax: '첨부는 최대 {n}장까지입니다',
+    attachTooLarge: '이미지가 너무 큽니다. 다른 이미지를 시도해 주세요',
+    attachUploadFailed: '이미지 업로드에 실패했습니다',
+    attachError: '이미지를 열 수 없습니다',
+    emptyInput: '메시지를 입력해 주세요',
+    sendFailed: '전송에 실패했습니다',
+    btnLabel: '메시지',
+    unreadBadge: '미읽음',
+  },
 };

--- a/dev/lib/image-compress.js
+++ b/dev/lib/image-compress.js
@@ -1,0 +1,89 @@
+// ════════════════════════════════════════════════════════════════════
+// image-compress.js — 클라이언트 이미지 압축/HEIC 변환 공통 헬퍼
+//   메시지 첨부(application-message-attachments) 업로드 전처리.
+//   사양서 docs/specs/2026-05-15-application-messaging.md §3-2.
+//   추후 영수증·캠페인 이미지 업로드에도 확산 적용 예정(§10).
+//
+//   - HEIC(iPhone 사진) 자동 감지 → JPEG 변환 (heic2any CDN lazy-load)
+//   - Canvas 리사이즈: 긴 변 2048px, JPEG quality 0.85
+//   - EXIF Orientation 자동 보정 (createImageBitmap imageOrientation)
+//   - 압축 후 2MB 초과 시 예외
+// ════════════════════════════════════════════════════════════════════
+
+const IMG_COMPRESS_DEFAULTS = {
+  maxEdge: 2048,        // 긴 변 최대 픽셀 (영수증 작은 글씨 가독)
+  quality: 0.85,        // JPEG 품질
+  maxBytes: 2 * 1024 * 1024,  // 압축 후 한도 2MB
+};
+
+const HEIC2ANY_CDN = 'https://cdn.jsdelivr.net/npm/heic2any@0.0.4/dist/heic2any.min.js';
+let _heic2anyLoading = null;
+
+// heic2any 라이브러리 lazy-load (한 번만)
+function loadHeic2any() {
+  if (typeof window.heic2any === 'function') return Promise.resolve();
+  if (_heic2anyLoading) return _heic2anyLoading;
+  _heic2anyLoading = new Promise((resolve, reject) => {
+    const s = document.createElement('script');
+    s.src = HEIC2ANY_CDN;
+    s.onload = () => resolve();
+    s.onerror = () => { _heic2anyLoading = null; reject(new Error('heic2any_load_failed')); };
+    document.head.appendChild(s);
+  });
+  return _heic2anyLoading;
+}
+
+// HEIC/HEIF 여부 판별 (MIME 또는 확장자)
+function isHeicFile(file) {
+  const type = (file.type || '').toLowerCase();
+  const name = (file.name || '').toLowerCase();
+  return /image\/(heic|heif)/.test(type) || /\.(heic|heif)$/.test(name);
+}
+
+// 메인 압축 함수. file(File/Blob) → 압축된 JPEG File 반환.
+// 실패 코드: 'heic_convert_failed' | 'decode_failed' | 'compress_failed' | 'too_large'
+async function compressImageFile(file, opts = {}) {
+  const cfg = Object.assign({}, IMG_COMPRESS_DEFAULTS, opts);
+  let workBlob = file;
+
+  // 1) HEIC → JPEG 선변환
+  if (isHeicFile(file)) {
+    try {
+      await loadHeic2any();
+      const converted = await window.heic2any({ blob: file, toType: 'image/jpeg', quality: cfg.quality });
+      workBlob = Array.isArray(converted) ? converted[0] : converted;
+    } catch (e) {
+      console.error('[compressImageFile] HEIC 변환 실패', e);
+      throw new Error('heic_convert_failed');
+    }
+  }
+
+  // 2) 디코드 (EXIF Orientation 보정 — imageOrientation:'from-image')
+  let bitmap;
+  try {
+    bitmap = await createImageBitmap(workBlob, { imageOrientation: 'from-image' });
+  } catch (e) {
+    // 일부 브라우저는 옵션 미지원 → 폴백
+    try { bitmap = await createImageBitmap(workBlob); }
+    catch (e2) { console.error('[compressImageFile] 디코드 실패', e2); throw new Error('decode_failed'); }
+  }
+
+  // 3) Canvas 리사이즈 (긴 변 maxEdge)
+  const scale = Math.min(1, cfg.maxEdge / Math.max(bitmap.width, bitmap.height));
+  const w = Math.max(1, Math.round(bitmap.width * scale));
+  const h = Math.max(1, Math.round(bitmap.height * scale));
+  const canvas = document.createElement('canvas');
+  canvas.width = w;
+  canvas.height = h;
+  const ctx = canvas.getContext('2d');
+  ctx.drawImage(bitmap, 0, 0, w, h);
+  if (bitmap.close) bitmap.close();
+
+  // 4) JPEG 인코딩
+  const blob = await new Promise((res) => canvas.toBlob(res, 'image/jpeg', cfg.quality));
+  if (!blob) throw new Error('compress_failed');
+  if (blob.size > cfg.maxBytes) throw new Error('too_large');
+
+  const baseName = (file.name || 'image').replace(/\.[^.]+$/, '');
+  return new File([blob], baseName + '.jpg', { type: 'image/jpeg' });
+}

--- a/dev/lib/storage.js
+++ b/dev/lib/storage.js
@@ -1994,3 +1994,91 @@ async function updateMarketingOptIn(value) {
   }
 }
 
+// ════════════════════════════════════════════════════════════════════
+// 응모건 단위 메시지 (인플루언서 ↔ 관리자) — PR 1
+//   사양서 docs/specs/2026-05-15-application-messaging.md §4
+//   마이그레이션 144. 본문/첨부 마스킹은 get_application_messages RPC 서버측 처리.
+// ════════════════════════════════════════════════════════════════════
+const MSG_ATTACH_BUCKET = 'application-message-attachments';
+
+// 응모건의 메시지 목록 (마스킹 적용된 행) — 인플루언서·관리자 공용.
+// get_application_messages RPC 가 호출자 역할(본인 인플 / is_admin)에 따라 마스킹.
+async function fetchApplicationMessages(applicationId) {
+  if (!db || !applicationId) return [];
+  const {data, error} = await db.rpc('get_application_messages', { p_application_id: applicationId });
+  if (error) throw error;
+  return data || [];
+}
+
+// 메시지 발송 (인플루언서·관리자 공용, sender_kind 는 서버가 판별).
+// attachments: [{path, name, size, mime}] — uploadMessageAttachment() 반환값 배열
+async function sendApplicationMessage(applicationId, body, attachments = []) {
+  if (!db) throw new Error('DB 미연결');
+  return await retryWithRefresh(async () => {
+    const {data, error} = await db.rpc('send_application_message', {
+      p_application_id: applicationId,
+      p_body: body || '',
+      p_attachments: attachments,
+    });
+    if (error) throw error;
+    return data;
+  });
+}
+
+// 본인 미열람 메시지를 읽음 처리 (관리자: 개인별 / 인플루언서: read_by_influencer_at).
+async function markApplicationMessagesRead(applicationId) {
+  if (!db || !applicationId) return;
+  await retryWithRefresh(async () => {
+    const {error} = await db.rpc('mark_application_messages_read', { p_application_id: applicationId });
+    if (error) throw error;
+  });
+}
+
+// 본인 메시지 회수 (25분 한도, RPC 가 시간/본인 검증). 성공 후 첨부 Storage 즉시 삭제 (§3-5 ②).
+// attachmentPaths: 회수할 메시지의 attachments[].path 배열 (없으면 빈 배열)
+async function withdrawOwnMessage(messageId, attachmentPaths = []) {
+  if (!db || !messageId) return;
+  await retryWithRefresh(async () => {
+    const {error} = await db.rpc('withdraw_own_message', { p_message_id: messageId });
+    if (error) throw error;
+  });
+  if (attachmentPaths && attachmentPaths.length) {
+    // 본인 회수는 첨부 즉시 삭제 (개인정보 최소화). 실패해도 회수 자체는 성공이므로 경고만.
+    try { await db.storage.from(MSG_ATTACH_BUCKET).remove(attachmentPaths); }
+    catch (e) { console.warn('[withdrawOwnMessage] 첨부 삭제 실패', e); }
+  }
+}
+
+// 첨부 이미지 업로드 — 압축/HEIC 변환(image-compress.js) 후 비공개 버킷에 저장.
+// 반환: {path, name, size, mime} (send 의 attachments 배열에 그대로 push)
+async function uploadMessageAttachment(file, applicationId) {
+  if (!db) throw new Error('DB 미연결');
+  const compressed = await compressImageFile(file);  // image-compress.js — too_large/decode_failed 등 예외 가능
+  const uuid = crypto.randomUUID ? crypto.randomUUID()
+    : (Date.now().toString(36) + Math.random().toString(36).substring(2));
+  const path = `${applicationId}/${uuid}.jpg`;
+  const {error} = await db.storage.from(MSG_ATTACH_BUCKET)
+    .upload(path, compressed, { contentType: 'image/jpeg', upsert: false, cacheControl: '3600' });
+  if (error) throw error;
+  return { path, name: file.name || 'image.jpg', size: compressed.size, mime: 'image/jpeg' };
+}
+
+// 첨부 이미지 signed URL (5분 시한, §9). 라이트박스/썸네일 표시용
+async function getMessageAttachmentSignedUrl(path, expiresIn = 300) {
+  if (!db || !path) return null;
+  const {data, error} = await db.storage.from(MSG_ATTACH_BUCKET).createSignedUrl(path, expiresIn);
+  if (error) throw error;
+  return data?.signedUrl || null;
+}
+
+// 인플루언서 GNB 미읽음 메시지 응모건 목록 (security_invoker 뷰 — 본인 행만 RLS 적용).
+async function fetchInfluencerUnreadMessageThreads() {
+  if (!db || typeof currentUser === 'undefined' || !currentUser) return [];
+  const {data, error} = await db.from('application_message_summary')
+    .select('application_id, campaign_id, unread_for_influencer, last_message_at')
+    .gt('unread_for_influencer', 0)
+    .order('last_message_at', { ascending: false });
+  if (error) { console.warn('[fetchInfluencerUnreadMessageThreads]', error); return []; }
+  return data || [];
+}
+

--- a/docs/FEATURE_SPEC.md
+++ b/docs/FEATURE_SPEC.md
@@ -151,6 +151,15 @@
 | INF-080 | 햄버거 메뉴    | 홈 / キャンペーン / マイページ / 通知(미읽음 배지 9+) / ログアウト (우측 슬라이드 패널, 인증 페이지에선 숨김) |
 | INF-081 | 바텀탭 (deprecated) | 2026-04 햄버거 메뉴로 대체. 키보드 간섭 제거 목적                          |
 
+### 2.10 응모건 메시지 (인플루언서 ↔ 관리자, PR 1 — 개발 검증 중)
+- 응모이력 카드의 「メッセージ」 버튼(미읽음 배지) → 게시판형 풀스크린 모달 (`#msgModal`, `dev/js/messaging.js`)
+- 발송: 텍스트 + 이미지 첨부 (클라이언트 자동 압축 2048px·HEIC→JPEG 변환, 메시지당 최대 5장). 본인 메시지 25분 내 회수 (회수 시 첨부 즉시 삭제)
+- 숨김·회수 메시지는 본문/첨부 가림(placeholder) — 서버 `get_application_messages` RPC 가 호출자 역할별 4종 마스킹
+- 첨부는 비공개 버킷 `application-message-attachments` + 5분 시한 signed URL
+- DB: 마이그레이션 144 — 테이블 5개(`application_messages` 외) + 마스킹/발송(rate limit 100/h)/읽음/회수(25분, rate limit 50/h) RPC + `security_invoker` 집계 뷰 + 숨김사유 7종 시드
+- **PR 2 예정**: 관리자 발신 UI, GNB 「메시지」 메뉴, 알림(`message_received`), 강제 숨김. **약관 중대 변경(D-7 사전 통지)은 PR 5 운영 배포 직전 집행** (현재 보류)
+- 사양서: `docs/specs/2026-05-15-application-messaging.md`
+
 ---
 
 ## 3. 관리자 앱 (PC 전체폭)

--- a/docs/specs/2026-05-15-application-messaging.md
+++ b/docs/specs/2026-05-15-application-messaging.md
@@ -1328,14 +1328,29 @@ PRIVACY_ja §5 同等行 (동일 컬럼 구조).
 
 ## 구현 결과
 
-**구현일:** (개발 세션이 채울 것)
-**관련 커밋:** (개발 세션이 채울 것)
-**PR:** (PR-1~4 링크 차례로)
+### PR 1 — 기반 인프라 + 인플루언서 메시지 (2026-05-20)
 
-### 초안 대비 변경 사항
-- 추가된 것:
-- 빠진 것:
-- 달라진 것:
+**구현일:** 2026-05-20
+**관련 커밋:** 95cbb41 (DB+연동 계층), 0e47156 (인플 모달 UI) — feature/application-messaging
+**PR:** (작업 폴더 PR 생성 예정)
 
-### 구현 중 기술 결정 사항
--
+#### 초안 대비 변경 사항
+- **추가된 것**:
+  - 마스킹 조회 RPC `get_application_messages(uuid)` — 사양서엔 "뷰 또는 RPC" 선택으로 열려 있었으나, 호출자 역할별 4종 마스킹 분기를 RPC 로 구현(클라 마스킹은 본문이 네트워크로 노출돼 부적합). §9 비대칭 그대로.
+  - 공통 이미지 압축 헬퍼 `dev/lib/image-compress.js` (HEIC→JPEG + Canvas 2048px/0.85) — §10 에 신규 파일로 예고됐던 것을 PR 1 에서 선구현.
+  - `application_message_summary` 뷰에 `security_invoker=true` (인플루언서 직접 조회 시 RLS 상속), `application_message_admin_unread_counts` 에 is_admin 가드 — 초안에 명시 안 됐던 보안 보강.
+- **빠진 것 (PR 2 로 이동)**:
+  - GNB 햄버거 「メッセージ」 메뉴(§5-2) + 알림 `message_received`(§5-5): 관리자 발신이 있어야 인플루언서 미읽음·알림이 생기는데 관리자 발신 UI 가 PR 2 → PR 2(관리자 발신)와 함께 연동하기로 사용자 결정(2026-05-20). PR 1 에 빈 껍데기만 넣으면 표시 데이터·테스트 불가.
+  - 응모 종료 후 90일 입력창 비활성 UX: send RPC 가 90일 차단하므로 PR 1 은 발송 실패 토스트로 처리, 입력창 자동 비활성 UX 는 후속.
+- **달라진 것**:
+  - PR 1 테이블 5개 전부 생성(broadcast/hide_history 포함). 관련 RPC(bulk/hide/unhide/withdraw_broadcast/mark_resolved)는 PR 2·3 에서 추가.
+  - Storage 버킷·정책을 마이그레이션 SQL 안에 포함(Dashboard 수동 아님).
+
+#### 구현 중 기술 결정 사항
+- 마이그레이션 **144** 단일 파일(테이블 5개 + 컬럼 + 뷰 + 마스킹/발송/읽음/회수 RPC + rate limit + lookup 시드 + Storage). 보안 보강을 별도 145 로 했다가 미적용 상태라 144 에 통합.
+- 본인 회수 첨부 삭제: SQL RPC 에서 storage 삭제 불가 → `withdrawOwnMessage()` 가 RPC 성공 후 클라이언트에서 `storage.remove()` 호출(§9 채택안).
+- Rate limit: send 100/시간, withdraw 50/시간 (함수 내 최근 1시간 count 가드).
+- 인플 메시지 로직은 `dev/js/messaging.js` 신규 파일로 분리(인플 코드 비대화 방지).
+
+### PR 2~5
+(미진행)

--- a/index.html
+++ b/index.html
@@ -568,6 +568,47 @@ textarea.form-input{resize:vertical;min-height:80px}
 .lang-toggle .lang-btn.on{background:var(--primary);color:#fff}
 .lang-toggle .lang-btn:not(.on):hover{background:var(--outline)}
 
+/* ── 응모이력 메시지 버튼/배지 ── */
+.apply-item-actions{display:flex;align-items:center;gap:2px}
+.apply-msg-btn{position:relative;min-width:40px;min-height:40px;display:inline-flex;align-items:center;justify-content:center;border:none;background:transparent;border-radius:20px;cursor:pointer;color:var(--muted)}
+.apply-msg-btn:hover{background:var(--surface-dim)}
+.apply-msg-badge{position:absolute;top:2px;right:2px;min-width:16px;height:16px;padding:0 4px;background:var(--pink,#e84a7f);color:#fff;font-size:10px;font-weight:700;line-height:16px;text-align:center;border-radius:8px}
+
+/* ── 응모건 메시지 모달 (게시판형) ── */
+.msg-modal{position:fixed;inset:0;z-index:1200;display:none}
+.msg-modal.on{display:block}
+.msg-modal-backdrop{position:absolute;inset:0;background:rgba(0,0,0,.4)}
+.msg-modal-body{position:absolute;left:0;right:0;bottom:0;top:0;max-width:480px;margin:0 auto;background:var(--bg,#fff);display:flex;flex-direction:column}
+.msg-modal-header{flex-shrink:0;display:flex;align-items:center;gap:8px;padding:14px 16px;border-bottom:1px solid var(--outline);background:var(--surface,#fff)}
+.msg-modal-title{flex:1;font-size:15px;font-weight:700;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.msg-close-btn{border:none;background:transparent;cursor:pointer;color:var(--muted);display:inline-flex;min-width:40px;min-height:40px;align-items:center;justify-content:center}
+.msg-modal-thread{flex:1;overflow-y:auto;padding:16px;display:flex;flex-direction:column;gap:12px;background:var(--surface-dim,#f7f7f8)}
+.msg-empty{text-align:center;color:var(--muted);font-size:13px;padding:32px 16px;line-height:1.6}
+.msg-card{background:#fff;border:1px solid var(--outline);border-radius:10px;padding:10px 12px;max-width:88%;align-self:flex-start}
+.msg-card.mine{align-self:flex-end;background:#eef4ff;border-color:#cfe0ff}
+.msg-card-head{display:flex;align-items:center;gap:8px;margin-bottom:4px}
+.msg-sender{font-size:12px;font-weight:700;color:var(--text)}
+.msg-time{font-size:11px;color:var(--muted)}
+.msg-card-body{font-size:14px;line-height:1.6;color:var(--text);word-break:break-word}
+.msg-card-masked .msg-masked-body{font-size:13px;color:var(--muted);font-style:italic}
+.msg-withdraw-btn{margin-left:auto;border:none;background:transparent;color:var(--pink,#e84a7f);font-size:12px;font-weight:600;cursor:pointer;padding:2px 6px;border-radius:6px}
+.msg-withdraw-btn:hover{background:rgba(232,74,127,.1)}
+.msg-attachments{display:flex;flex-wrap:wrap;gap:6px;margin-top:8px}
+.msg-attach-thumb{width:72px;height:72px;border-radius:8px;overflow:hidden;background:var(--surface-dim);display:flex;align-items:center;justify-content:center;cursor:pointer;color:var(--muted)}
+.msg-attach-thumb img{width:100%;height:100%;object-fit:cover}
+.msg-modal-input-area{flex-shrink:0;border-top:1px solid var(--outline);padding:10px 12px;background:var(--surface,#fff)}
+.msg-attach-preview{display:flex;flex-wrap:wrap;gap:6px}
+.msg-attach-preview:not(:empty){margin-bottom:8px}
+.msg-attach-pending{position:relative;width:56px;height:56px;border-radius:8px;overflow:hidden}
+.msg-attach-pending img{width:100%;height:100%;object-fit:cover}
+.msg-attach-remove{position:absolute;top:2px;right:2px;width:20px;height:20px;border:none;border-radius:10px;background:rgba(0,0,0,.6);color:#fff;cursor:pointer;display:flex;align-items:center;justify-content:center;padding:0}
+.msg-attach-remove .material-icons-round{font-size:14px}
+.msg-input-row{display:flex;align-items:flex-end;gap:8px}
+.msg-attach-btn{flex-shrink:0;width:40px;height:40px;border-radius:20px;display:flex;align-items:center;justify-content:center;cursor:pointer;color:var(--muted);background:var(--surface-dim)}
+.msg-input{flex:1;resize:none;border:1px solid var(--outline);border-radius:12px;padding:9px 12px;font-size:16px;line-height:1.5;max-height:120px;font-family:inherit}
+.msg-send-btn{flex-shrink:0;width:40px;height:40px;border-radius:20px;border:none;background:var(--primary);color:#fff;cursor:pointer;display:flex;align-items:center;justify-content:center}
+.msg-send-btn:disabled{opacity:.5;cursor:default}
+
 </style>
 </head>
 <body>
@@ -773,6 +814,33 @@ textarea.form-input{resize:vertical;min-height:80px}
       </div>
     </div>
     <div id="notifModalBody" class="notif-modal-list"></div>
+  </div>
+</div>
+
+<!-- 응모건 메시지 모달 (인플루언서 ↔ 관리자, 게시판형) -->
+<div id="msgModal" class="msg-modal" aria-hidden="true">
+  <div class="msg-modal-backdrop" onclick="closeMessageModal()"></div>
+  <div class="msg-modal-body">
+    <div class="msg-modal-header">
+      <div id="msgModalTitle" class="msg-modal-title"></div>
+      <button class="msg-close-btn" onclick="closeMessageModal()" aria-label="Close">
+        <span class="material-icons-round notranslate" translate="no">close</span>
+      </button>
+    </div>
+    <div id="msgModalThread" class="msg-modal-thread"></div>
+    <div class="msg-modal-input-area">
+      <div id="msgModalAttachPreview" class="msg-attach-preview"></div>
+      <div class="msg-input-row">
+        <label class="msg-attach-btn" aria-label="attach image">
+          <span class="material-icons-round notranslate" translate="no">image</span>
+          <input id="msgModalAttachInput" type="file" accept="image/*" multiple style="display:none" onchange="onMsgAttachSelected(this)">
+        </label>
+        <textarea id="msgModalInput" class="msg-input" rows="2"></textarea>
+        <button id="msgModalSendBtn" class="msg-send-btn" onclick="sendMessageFromModal()" aria-label="send">
+          <span class="material-icons-round notranslate" translate="no">send</span>
+        </button>
+      </div>
+    </div>
   </div>
 </div>
 
@@ -2717,6 +2785,31 @@ window.I18N_JA = {
   channelLabel: {
     other: 'その他',
   },
+
+  // 응모건 메시지 (인플루언서 ↔ 관리자)
+  messaging: {
+    titleFor: '{name}に関するお問い合わせ',
+    loading: '読み込み中...',
+    loadError: 'メッセージの読み込みに失敗しました',
+    emptyThread: 'まだメッセージはありません。下の入力欄からお問い合わせできます。',
+    you: '本人',
+    adminTeam: '運営チーム',
+    maskHiddenByAdmin: '[管理者により非表示処理されたメッセージ]',
+    maskSelfWithdrawn: '[本人が取り消したメッセージ]',
+    maskAdminWithdrawn: '[管理者が取り消したメッセージ]',
+    withdraw: '取り消す',
+    withdrawConfirm: 'このメッセージを取り消しますか？',
+    withdrawFailed: 'メッセージの取り消しに失敗しました',
+    placeholder: 'メッセージを入力...',
+    attachMax: '添付は最大{n}枚までです',
+    attachTooLarge: '画像が大きすぎます。別の画像をお試しください',
+    attachUploadFailed: '画像のアップロードに失敗しました',
+    attachError: '画像を開けませんでした',
+    emptyInput: 'メッセージを入力してください',
+    sendFailed: '送信に失敗しました',
+    btnLabel: 'メッセージ',
+    unreadBadge: '未読',
+  },
 };
 
 // ══════════════════════════════════════
@@ -3263,6 +3356,31 @@ window.I18N_KO = {
 
   channelLabel: {
     other: '기타',
+  },
+
+  // 응모건 메시지 (인플루언서 ↔ 관리자)
+  messaging: {
+    titleFor: '{name} 관련 문의',
+    loading: '불러오는 중...',
+    loadError: '메시지를 불러오지 못했습니다',
+    emptyThread: '아직 메시지가 없습니다. 아래 입력란에서 문의할 수 있습니다.',
+    you: '본인',
+    adminTeam: '운영팀',
+    maskHiddenByAdmin: '[관리자에 의해 숨김 처리된 메시지]',
+    maskSelfWithdrawn: '[본인이 취소한 메시지]',
+    maskAdminWithdrawn: '[관리자가 취소한 메시지]',
+    withdraw: '취소',
+    withdrawConfirm: '이 메시지를 취소할까요?',
+    withdrawFailed: '메시지 취소에 실패했습니다',
+    placeholder: '메시지를 입력...',
+    attachMax: '첨부는 최대 {n}장까지입니다',
+    attachTooLarge: '이미지가 너무 큽니다. 다른 이미지를 시도해 주세요',
+    attachUploadFailed: '이미지 업로드에 실패했습니다',
+    attachError: '이미지를 열 수 없습니다',
+    emptyInput: '메시지를 입력해 주세요',
+    sendFailed: '전송에 실패했습니다',
+    btnLabel: '메시지',
+    unreadBadge: '미읽음',
   },
 };
 
@@ -8841,6 +8959,7 @@ function renderMyApplyTabs() {
 }
 
 let _myDelivsByApp = {};
+let _myMsgUnreadByApp = {};  // 응모건별 인플루언서 미읽음 메시지 수 (배지용)
 
 async function renderMyApplyList() {
   const container = $('myApplicationsList');
@@ -8857,6 +8976,12 @@ async function renderMyApplyList() {
       _myDelivsByApp = {};
       delivs.forEach(d => { (_myDelivsByApp[d.application_id] ||= []).push(d); });
     } catch(e) { _myDelivsByApp = {}; }
+    // 메시지 미읽음 배지 — application_message_summary 뷰 (security_invoker, 본인 행만)
+    try {
+      const threads = await fetchInfluencerUnreadMessageThreads();
+      _myMsgUnreadByApp = {};
+      threads.forEach(th => { _myMsgUnreadByApp[th.application_id] = th.unread_for_influencer; });
+    } catch(e) { _myMsgUnreadByApp = {}; }
   }
 
   // 캠페인 상태 필터
@@ -8951,6 +9076,9 @@ async function renderMyApplyList() {
     const cautionLine = a.caution_agreed_at
       ? `<div class="apply-item-caution" style="font-size:11px;color:var(--green);margin-top:2px;display:inline-flex;align-items:center;gap:3px;flex-wrap:wrap"><span class="material-icons-round notranslate" translate="no" style="font-size:13px">check_circle</span>${t('appHistory.cautionAgreed')} ${formatDate(a.caution_agreed_at)}${cautionCompareButton(a, camp)}</div>`
       : '';
+    // 메시지 버튼 + 미읽음 배지 (모든 응모 카드 — 응모건 단위 운영팀 문의)
+    const msgUnread = _myMsgUnreadByApp[a.id] || 0;
+    const msgBtn = `<button type="button" class="apply-msg-btn" onclick="event.stopPropagation();openMessageModal('${a.id}')" aria-label="${esc(t('messaging.btnLabel'))}"><span class="material-icons-round notranslate" translate="no" style="font-size:22px">chat_bubble_outline</span>${msgUnread>0?`<span class="apply-msg-badge">${msgUnread>9?'9+':msgUnread}</span>`:''}</button>`;
     return `<div class="apply-item" style="cursor:pointer;position:relative" ${clickAction}>
       <div class="apply-thumb">${thumb}</div>
       <div class="apply-item-info">
@@ -8960,9 +9088,23 @@ async function renderMyApplyList() {
         ${cautionLine}
         ${cancelledLine}
       </div>
-      <div class="apply-item-status" style="display:flex;flex-direction:column;align-items:flex-end;gap:4px">${delivBadgeLine}${menuHtml ? `<div class="apply-item-menu">${menuHtml}</div>` : ''}</div>
+      <div class="apply-item-status" style="display:flex;flex-direction:column;align-items:flex-end;gap:4px">${delivBadgeLine}<div class="apply-item-actions" style="display:flex;align-items:center;gap:2px">${msgBtn}${menuHtml}</div></div>
     </div>`;
   }).join('');
+}
+
+// 메시지 모달에서 읽음 처리/닫은 뒤 응모이력 미읽음 배지 갱신
+async function refreshMyMsgUnread() {
+  if (typeof currentUser === 'undefined' || !currentUser) return;
+  try {
+    const threads = await fetchInfluencerUnreadMessageThreads();
+    _myMsgUnreadByApp = {};
+    threads.forEach(th => { _myMsgUnreadByApp[th.application_id] = th.unread_for_influencer; });
+  } catch(e) { /* 무시 */ }
+  // 응모이력 화면이 떠 있을 때만 재렌더 (배지 갱신)
+  if ($('myApplicationsList') && typeof renderMyApplyList === 'function') {
+    try { await renderMyApplyList(); } catch(e) { /* 무시 */ }
+  }
 }
 
 // ── Phase 2: 주의사항 비교 (응모이력 셀 토글) ──
@@ -9475,6 +9617,226 @@ function closeCancelDetailModal() {
 function isApplicationCancelled(appId) {
   const app = _myApps.find(a => a.id === appId);
   return !!(app && app.status === 'cancelled');
+}
+
+// ════════════════════════════════════════════════════════════════════
+// messaging.js — 인플루언서 ↔ 관리자 메시지 모달 (PR 1, 인플루언서 화면)
+//   사양서 docs/specs/2026-05-15-application-messaging.md §5-1 (게시판형)
+//   DB 함수: storage.js (fetchApplicationMessages / sendApplicationMessage /
+//            markApplicationMessagesRead / withdrawOwnMessage / uploadMessageAttachment)
+//   본문/첨부 마스킹은 서버(get_application_messages RPC)에서 처리 — 클라는 mask_state 로 표시만.
+// ════════════════════════════════════════════════════════════════════
+
+const MSG_WITHDRAW_LIMIT_MS = 25 * 60 * 1000;  // 본인 회수 25분 (§3-5 ②)
+const MSG_MAX_ATTACH = 5;                       // 메시지당 첨부 최대 5장 (§3-2)
+
+let _msgCurrentAppId = null;
+let _msgPendingFiles = [];   // 업로드 대기 File 배열 (압축 전 원본)
+let _msgSending = false;
+
+// 응모건 메시지 모달 열기
+async function openMessageModal(applicationId) {
+  if (!applicationId) return;
+  _msgCurrentAppId = applicationId;
+  _msgPendingFiles = [];
+  const m = $('msgModal');
+  if (!m) return;
+
+  // 헤더 제목: 「{캠페인명}に関するお問い合わせ」
+  const app = (typeof _myApps !== 'undefined' ? _myApps : []).find(a => a.id === applicationId);
+  const camp = (typeof allCampaigns !== 'undefined' ? allCampaigns : []).find(c => c.id === app?.campaign_id) || {};
+  const titleEl = $('msgModalTitle');
+  if (titleEl) titleEl.textContent = t('messaging.titleFor').replace('{name}', camp.title || '');
+
+  m.classList.add('on');
+  document.body.style.overflow = 'hidden';
+  renderMsgAttachPreview();
+  const inputEl = $('msgModalInput');
+  if (inputEl) { inputEl.value = ''; inputEl.placeholder = t('messaging.placeholder'); }
+
+  const thread = $('msgModalThread');
+  if (thread) thread.innerHTML = `<div class="msg-empty">${esc(t('messaging.loading'))}</div>`;
+
+  try {
+    const msgs = await fetchApplicationMessages(applicationId);
+    renderMessageThread(msgs);
+    // 열람 시 본인 미열람 읽음 처리 후 응모이력 배지 갱신
+    await markApplicationMessagesRead(applicationId);
+    if (typeof refreshMyMsgUnread === 'function') await refreshMyMsgUnread();
+  } catch (e) {
+    console.error('[openMessageModal]', e);
+    if (thread) thread.innerHTML = `<div class="msg-empty">${esc(t('messaging.loadError'))}</div>`;
+  }
+}
+
+function closeMessageModal() {
+  const m = $('msgModal');
+  if (m) m.classList.remove('on');
+  document.body.style.overflow = '';
+  _msgCurrentAppId = null;
+  _msgPendingFiles = [];
+}
+
+// 메시지 스레드 렌더 (게시판형 — 위→아래 누적 카드)
+function renderMessageThread(messages) {
+  const thread = $('msgModalThread');
+  if (!thread) return;
+  if (!messages || !messages.length) {
+    thread.innerHTML = `<div class="msg-empty">${esc(t('messaging.emptyThread'))}</div>`;
+    return;
+  }
+  const now = Date.now();
+  thread.innerHTML = messages.map(msg => {
+    const mine = msg.sender_kind === 'influencer';
+    const senderLabel = mine ? t('messaging.you') : t('messaging.adminTeam');
+    const timeStr = formatDate(msg.created_at);
+
+    // 마스킹 상태별 placeholder (§3-5)
+    if (msg.mask_state && msg.mask_state !== 'visible') {
+      const phKey = {
+        hidden_by_admin: 'messaging.maskHiddenByAdmin',
+        self_withdrawn_influencer: 'messaging.maskSelfWithdrawn',
+        self_withdrawn_admin: 'messaging.maskAdminWithdrawn',
+      }[msg.mask_state] || 'messaging.maskHiddenByAdmin';
+      return `<div class="msg-card msg-card-masked ${mine ? 'mine' : ''}">
+        <div class="msg-card-head"><span class="msg-sender">${esc(senderLabel)}</span><span class="msg-time">${esc(timeStr)}</span></div>
+        <div class="msg-masked-body">${esc(t(phKey))}</div>
+      </div>`;
+    }
+
+    // 본문 (esc 후 줄바꿈 보존)
+    const bodyHtml = esc(msg.body || '').replace(/\n/g, '<br>');
+
+    // 첨부 썸네일 (signed URL 비동기 로드)
+    let attachHtml = '';
+    const atts = Array.isArray(msg.attachments) ? msg.attachments : [];
+    if (atts.length) {
+      attachHtml = `<div class="msg-attachments">${atts.map((a, i) => {
+        const elId = `msgatt-${msg.id}-${i}`;
+        loadMsgAttachThumb(elId, a.path);
+        return `<div class="msg-attach-thumb" id="${elId}" onclick="openMsgLightbox('${esc(a.path)}')"><span class="material-icons-round notranslate" translate="no">image</span></div>`;
+      }).join('')}</div>`;
+    }
+
+    // 본인 메시지 + 25분 이내 → 회수 버튼
+    let withdrawBtn = '';
+    if (mine) {
+      const elapsed = now - new Date(msg.created_at).getTime();
+      if (elapsed < MSG_WITHDRAW_LIMIT_MS) {
+        const pathsJson = esc(JSON.stringify(atts.map(a => a.path)));
+        withdrawBtn = `<button type="button" class="msg-withdraw-btn" onclick='confirmWithdrawMessage("${esc(msg.id)}", ${pathsJson})'>${esc(t('messaging.withdraw'))}</button>`;
+      }
+    }
+
+    return `<div class="msg-card ${mine ? 'mine' : ''}">
+      <div class="msg-card-head"><span class="msg-sender">${esc(senderLabel)}</span><span class="msg-time">${esc(timeStr)}</span>${withdrawBtn}</div>
+      <div class="msg-card-body">${bodyHtml}</div>
+      ${attachHtml}
+    </div>`;
+  }).join('');
+  // 최신 메시지로 스크롤
+  thread.scrollTop = thread.scrollHeight;
+}
+
+// 첨부 썸네일 signed URL 비동기 로드 (5분 시한)
+async function loadMsgAttachThumb(elId, path) {
+  try {
+    const url = await getMessageAttachmentSignedUrl(path);
+    const el = $(elId);
+    if (el && url) {
+      el.innerHTML = `<img src="${esc(url)}" loading="lazy" decoding="async" alt="">`;
+    }
+  } catch (e) { /* 썸네일 실패 시 아이콘 유지 */ }
+}
+
+// 첨부 라이트박스 (원본 보기)
+async function openMsgLightbox(path) {
+  try {
+    const url = await getMessageAttachmentSignedUrl(path);
+    if (url) window.open(url, '_blank', 'noopener');
+  } catch (e) { toast(t('messaging.attachError')); }
+}
+
+// 회수 확인 → 실행
+async function confirmWithdrawMessage(messageId, attachmentPaths) {
+  if (!confirm(t('messaging.withdrawConfirm'))) return;
+  try {
+    await withdrawOwnMessage(messageId, attachmentPaths || []);
+    // 스레드 재로드
+    const msgs = await fetchApplicationMessages(_msgCurrentAppId);
+    renderMessageThread(msgs);
+  } catch (e) {
+    console.error('[confirmWithdrawMessage]', e);
+    toast(t('messaging.withdrawFailed'));
+  }
+}
+
+// ── 첨부 선택/미리보기 ──
+function onMsgAttachSelected(input) {
+  const files = Array.from(input.files || []);
+  input.value = '';  // 같은 파일 재선택 허용
+  for (const f of files) {
+    if (_msgPendingFiles.length >= MSG_MAX_ATTACH) { toast(t('messaging.attachMax').replace('{n}', MSG_MAX_ATTACH)); break; }
+    _msgPendingFiles.push(f);
+  }
+  renderMsgAttachPreview();
+}
+
+function removeMsgAttach(idx) {
+  _msgPendingFiles.splice(idx, 1);
+  renderMsgAttachPreview();
+}
+
+function renderMsgAttachPreview() {
+  const wrap = $('msgModalAttachPreview');
+  if (!wrap) return;
+  if (!_msgPendingFiles.length) { wrap.innerHTML = ''; return; }
+  wrap.innerHTML = _msgPendingFiles.map((f, i) => {
+    const url = URL.createObjectURL(f);
+    return `<div class="msg-attach-pending"><img src="${url}" alt=""><button type="button" class="msg-attach-remove" onclick="removeMsgAttach(${i})" aria-label="remove"><span class="material-icons-round notranslate" translate="no">close</span></button></div>`;
+  }).join('');
+}
+
+// ── 전송 ──
+async function sendMessageFromModal() {
+  if (_msgSending || !_msgCurrentAppId) return;
+  const inputEl = $('msgModalInput');
+  const body = (inputEl?.value || '').trim();
+  if (!body && !_msgPendingFiles.length) { toast(t('messaging.emptyInput')); return; }
+
+  _msgSending = true;
+  const sendBtn = $('msgModalSendBtn');
+  if (sendBtn) sendBtn.disabled = true;
+
+  try {
+    // 첨부 압축·업로드 (순차 — 실패 시 즉시 중단)
+    const attachments = [];
+    for (const f of _msgPendingFiles) {
+      try {
+        attachments.push(await uploadMessageAttachment(f, _msgCurrentAppId));
+      } catch (e) {
+        console.error('[sendMessageFromModal] 첨부 업로드', e);
+        toast(e?.message === 'too_large' ? t('messaging.attachTooLarge') : t('messaging.attachUploadFailed'));
+        _msgSending = false;
+        if (sendBtn) sendBtn.disabled = false;
+        return;
+      }
+    }
+    await sendApplicationMessage(_msgCurrentAppId, body, attachments);
+    // 입력 초기화 + 재로드
+    if (inputEl) inputEl.value = '';
+    _msgPendingFiles = [];
+    renderMsgAttachPreview();
+    const msgs = await fetchApplicationMessages(_msgCurrentAppId);
+    renderMessageThread(msgs);
+  } catch (e) {
+    console.error('[sendMessageFromModal]', e);
+    // 90일 경과·rate limit 등 RPC 예외 메시지 노출
+    toast(e?.message || t('messaging.sendFailed'));
+  } finally {
+    _msgSending = false;
+    if (sendBtn) sendBtn.disabled = false;
+  }
 }
 
 // ══════════════════════════════════════

--- a/index.html
+++ b/index.html
@@ -9704,7 +9704,7 @@ function renderMessageThread(messages) {
       </div>`;
     }
 
-    // 본문 (esc 후 줄바꿈 보존)
+    // 본문: esc() 선적용 후 줄바꿈만 <br> 치환 — 다른 HTML 태그는 이스케이프되어 XSS 안전
     const bodyHtml = esc(msg.body || '').replace(/\n/g, '<br>');
 
     // 첨부 썸네일 (signed URL 비동기 로드)

--- a/index.html
+++ b/index.html
@@ -3364,6 +3364,96 @@ window.I18N_KO = {
   }
 })();
 
+// ════════════════════════════════════════════════════════════════════
+// image-compress.js — 클라이언트 이미지 압축/HEIC 변환 공통 헬퍼
+//   메시지 첨부(application-message-attachments) 업로드 전처리.
+//   사양서 docs/specs/2026-05-15-application-messaging.md §3-2.
+//   추후 영수증·캠페인 이미지 업로드에도 확산 적용 예정(§10).
+//
+//   - HEIC(iPhone 사진) 자동 감지 → JPEG 변환 (heic2any CDN lazy-load)
+//   - Canvas 리사이즈: 긴 변 2048px, JPEG quality 0.85
+//   - EXIF Orientation 자동 보정 (createImageBitmap imageOrientation)
+//   - 압축 후 2MB 초과 시 예외
+// ════════════════════════════════════════════════════════════════════
+
+const IMG_COMPRESS_DEFAULTS = {
+  maxEdge: 2048,        // 긴 변 최대 픽셀 (영수증 작은 글씨 가독)
+  quality: 0.85,        // JPEG 품질
+  maxBytes: 2 * 1024 * 1024,  // 압축 후 한도 2MB
+};
+
+const HEIC2ANY_CDN = 'https://cdn.jsdelivr.net/npm/heic2any@0.0.4/dist/heic2any.min.js';
+let _heic2anyLoading = null;
+
+// heic2any 라이브러리 lazy-load (한 번만)
+function loadHeic2any() {
+  if (typeof window.heic2any === 'function') return Promise.resolve();
+  if (_heic2anyLoading) return _heic2anyLoading;
+  _heic2anyLoading = new Promise((resolve, reject) => {
+    const s = document.createElement('script');
+    s.src = HEIC2ANY_CDN;
+    s.onload = () => resolve();
+    s.onerror = () => { _heic2anyLoading = null; reject(new Error('heic2any_load_failed')); };
+    document.head.appendChild(s);
+  });
+  return _heic2anyLoading;
+}
+
+// HEIC/HEIF 여부 판별 (MIME 또는 확장자)
+function isHeicFile(file) {
+  const type = (file.type || '').toLowerCase();
+  const name = (file.name || '').toLowerCase();
+  return /image\/(heic|heif)/.test(type) || /\.(heic|heif)$/.test(name);
+}
+
+// 메인 압축 함수. file(File/Blob) → 압축된 JPEG File 반환.
+// 실패 코드: 'heic_convert_failed' | 'decode_failed' | 'compress_failed' | 'too_large'
+async function compressImageFile(file, opts = {}) {
+  const cfg = Object.assign({}, IMG_COMPRESS_DEFAULTS, opts);
+  let workBlob = file;
+
+  // 1) HEIC → JPEG 선변환
+  if (isHeicFile(file)) {
+    try {
+      await loadHeic2any();
+      const converted = await window.heic2any({ blob: file, toType: 'image/jpeg', quality: cfg.quality });
+      workBlob = Array.isArray(converted) ? converted[0] : converted;
+    } catch (e) {
+      console.error('[compressImageFile] HEIC 변환 실패', e);
+      throw new Error('heic_convert_failed');
+    }
+  }
+
+  // 2) 디코드 (EXIF Orientation 보정 — imageOrientation:'from-image')
+  let bitmap;
+  try {
+    bitmap = await createImageBitmap(workBlob, { imageOrientation: 'from-image' });
+  } catch (e) {
+    // 일부 브라우저는 옵션 미지원 → 폴백
+    try { bitmap = await createImageBitmap(workBlob); }
+    catch (e2) { console.error('[compressImageFile] 디코드 실패', e2); throw new Error('decode_failed'); }
+  }
+
+  // 3) Canvas 리사이즈 (긴 변 maxEdge)
+  const scale = Math.min(1, cfg.maxEdge / Math.max(bitmap.width, bitmap.height));
+  const w = Math.max(1, Math.round(bitmap.width * scale));
+  const h = Math.max(1, Math.round(bitmap.height * scale));
+  const canvas = document.createElement('canvas');
+  canvas.width = w;
+  canvas.height = h;
+  const ctx = canvas.getContext('2d');
+  ctx.drawImage(bitmap, 0, 0, w, h);
+  if (bitmap.close) bitmap.close();
+
+  // 4) JPEG 인코딩
+  const blob = await new Promise((res) => canvas.toBlob(res, 'image/jpeg', cfg.quality));
+  if (!blob) throw new Error('compress_failed');
+  if (blob.size > cfg.maxBytes) throw new Error('too_large');
+
+  const baseName = (file.name || 'image').replace(/\.[^.]+$/, '');
+  return new File([blob], baseName + '.jpg', { type: 'image/jpeg' });
+}
+
 // ══════════════════════════════════════
 // STORAGE — Supabase API 호출 함수 모음
 // localStorage는 세션 캐시에만 사용
@@ -5358,6 +5448,94 @@ async function updateMarketingOptIn(value) {
     console.error('[updateMarketingOptIn]', e);
     return {ok: false, error: e?.message || 'unknown'};
   }
+}
+
+// ════════════════════════════════════════════════════════════════════
+// 응모건 단위 메시지 (인플루언서 ↔ 관리자) — PR 1
+//   사양서 docs/specs/2026-05-15-application-messaging.md §4
+//   마이그레이션 144. 본문/첨부 마스킹은 get_application_messages RPC 서버측 처리.
+// ════════════════════════════════════════════════════════════════════
+const MSG_ATTACH_BUCKET = 'application-message-attachments';
+
+// 응모건의 메시지 목록 (마스킹 적용된 행) — 인플루언서·관리자 공용.
+// get_application_messages RPC 가 호출자 역할(본인 인플 / is_admin)에 따라 마스킹.
+async function fetchApplicationMessages(applicationId) {
+  if (!db || !applicationId) return [];
+  const {data, error} = await db.rpc('get_application_messages', { p_application_id: applicationId });
+  if (error) throw error;
+  return data || [];
+}
+
+// 메시지 발송 (인플루언서·관리자 공용, sender_kind 는 서버가 판별).
+// attachments: [{path, name, size, mime}] — uploadMessageAttachment() 반환값 배열
+async function sendApplicationMessage(applicationId, body, attachments = []) {
+  if (!db) throw new Error('DB 미연결');
+  return await retryWithRefresh(async () => {
+    const {data, error} = await db.rpc('send_application_message', {
+      p_application_id: applicationId,
+      p_body: body || '',
+      p_attachments: attachments,
+    });
+    if (error) throw error;
+    return data;
+  });
+}
+
+// 본인 미열람 메시지를 읽음 처리 (관리자: 개인별 / 인플루언서: read_by_influencer_at).
+async function markApplicationMessagesRead(applicationId) {
+  if (!db || !applicationId) return;
+  await retryWithRefresh(async () => {
+    const {error} = await db.rpc('mark_application_messages_read', { p_application_id: applicationId });
+    if (error) throw error;
+  });
+}
+
+// 본인 메시지 회수 (25분 한도, RPC 가 시간/본인 검증). 성공 후 첨부 Storage 즉시 삭제 (§3-5 ②).
+// attachmentPaths: 회수할 메시지의 attachments[].path 배열 (없으면 빈 배열)
+async function withdrawOwnMessage(messageId, attachmentPaths = []) {
+  if (!db || !messageId) return;
+  await retryWithRefresh(async () => {
+    const {error} = await db.rpc('withdraw_own_message', { p_message_id: messageId });
+    if (error) throw error;
+  });
+  if (attachmentPaths && attachmentPaths.length) {
+    // 본인 회수는 첨부 즉시 삭제 (개인정보 최소화). 실패해도 회수 자체는 성공이므로 경고만.
+    try { await db.storage.from(MSG_ATTACH_BUCKET).remove(attachmentPaths); }
+    catch (e) { console.warn('[withdrawOwnMessage] 첨부 삭제 실패', e); }
+  }
+}
+
+// 첨부 이미지 업로드 — 압축/HEIC 변환(image-compress.js) 후 비공개 버킷에 저장.
+// 반환: {path, name, size, mime} (send 의 attachments 배열에 그대로 push)
+async function uploadMessageAttachment(file, applicationId) {
+  if (!db) throw new Error('DB 미연결');
+  const compressed = await compressImageFile(file);  // image-compress.js — too_large/decode_failed 등 예외 가능
+  const uuid = crypto.randomUUID ? crypto.randomUUID()
+    : (Date.now().toString(36) + Math.random().toString(36).substring(2));
+  const path = `${applicationId}/${uuid}.jpg`;
+  const {error} = await db.storage.from(MSG_ATTACH_BUCKET)
+    .upload(path, compressed, { contentType: 'image/jpeg', upsert: false, cacheControl: '3600' });
+  if (error) throw error;
+  return { path, name: file.name || 'image.jpg', size: compressed.size, mime: 'image/jpeg' };
+}
+
+// 첨부 이미지 signed URL (5분 시한, §9). 라이트박스/썸네일 표시용
+async function getMessageAttachmentSignedUrl(path, expiresIn = 300) {
+  if (!db || !path) return null;
+  const {data, error} = await db.storage.from(MSG_ATTACH_BUCKET).createSignedUrl(path, expiresIn);
+  if (error) throw error;
+  return data?.signedUrl || null;
+}
+
+// 인플루언서 GNB 미읽음 메시지 응모건 목록 (security_invoker 뷰 — 본인 행만 RLS 적용).
+async function fetchInfluencerUnreadMessageThreads() {
+  if (!db || typeof currentUser === 'undefined' || !currentUser) return [];
+  const {data, error} = await db.from('application_message_summary')
+    .select('application_id, campaign_id, unread_for_influencer, last_message_at')
+    .gt('unread_for_influencer', 0)
+    .order('last_message_at', { ascending: false });
+  if (error) { console.warn('[fetchInfluencerUnreadMessageThreads]', error); return []; }
+  return data || [];
 }
 
 

--- a/supabase/migrations/144_application_messages.sql
+++ b/supabase/migrations/144_application_messages.sql
@@ -1,0 +1,942 @@
+-- ============================================================
+-- 144_application_messages.sql
+-- 2026-05-20
+--
+-- 목적:
+--   인플루언서 ↔ 관리자 양방향 메시지 기능 — PR 1 DB 인프라.
+--   응모건(applications) 단위 1:1 메시지 채널 + 관리자 일괄 발송(BCC) 지원.
+--
+-- 사양서:
+--   docs/specs/2026-05-15-application-messaging.md §4
+--
+-- 신설 테이블 5개:
+--   1. application_messages          — 메시지 본체
+--   2. application_message_admin_reads — 관리자 개인별 읽음 추적
+--   3. application_message_resolutions — 응모건 응대 완료 상태
+--   4. application_message_broadcasts  — 일괄 발송 그룹 메타
+--   5. application_message_hide_history — 숨김·회수 감사 이력
+--
+-- 신설 뷰:
+--   application_message_summary — 응모건별 미읽음·미응대 집계
+--
+-- 신설 함수 4개:
+--   application_message_admin_unread_counts — 관리자 본인 미읽음 수 집계
+--   send_application_message                — 메시지 발송 (인플루언서·관리자 공용)
+--   mark_application_messages_read         — 읽음 처리
+--   withdraw_own_message                    — 본인 메시지 회수 (25분 한도)
+--
+-- lookup_values 시드:
+--   kind='message_hide_reason' 7건 (숨김 사유 카테고리)
+--
+-- Storage:
+--   버킷 'application-message-attachments' (비공개, 2MB, jpg/png/webp)
+--   + Storage 정책 4개
+--
+-- PR 1 제외 (PR 2/3 에서 추가):
+--   mark_application_resolved (수동 응대 완료, PR 2)
+--   hide_application_message / unhide_application_message (PR 2)
+--   send_application_message_bulk (일괄 발송, PR 3)
+--   withdraw_broadcast (일괄 회수, PR 3)
+--
+-- 전제 조건:
+--   마이그레이션 143 (campaign_promo_digest) 적용 완료
+--   public.applications, public.campaigns, public.influencers, public.admins 존재
+--   public.is_admin() / public.is_super_admin() / public.is_campaign_admin() 함수 존재
+--
+-- 보안 반영 (145 통합):
+--   뷰 application_message_summary — WITH (security_invoker = true) 포함
+--   함수 application_message_admin_unread_counts — is_admin() 가드 + LANGUAGE plpgsql 포함
+--
+-- 적용 순서:
+--   1. 개발서버(qysmxtipobomefudyixw) SQL Editor 실행 + 검증
+--   2. 운영서버(twofagomeizrtkwlhsuv) SQL Editor 실행
+--
+-- 롤백:
+--   BEGIN;
+--   DROP FUNCTION IF EXISTS public.withdraw_own_message(uuid);
+--   DROP FUNCTION IF EXISTS public.mark_application_messages_read(uuid);
+--   DROP FUNCTION IF EXISTS public.send_application_message(uuid, text, jsonb);
+--   DROP FUNCTION IF EXISTS public.application_message_admin_unread_counts(uuid);
+--   DROP VIEW  IF EXISTS public.application_message_summary;
+--   DROP TABLE IF EXISTS public.application_message_hide_history;
+--   DROP TABLE IF EXISTS public.application_message_admin_reads;
+--   DROP TABLE IF EXISTS public.application_message_resolutions;
+--   -- application_messages.broadcast_id 컬럼 제거 후 broadcasts 테이블 DROP
+--   ALTER TABLE public.application_messages DROP COLUMN IF EXISTS broadcast_id;
+--   DROP TABLE IF EXISTS public.application_message_broadcasts;
+--   DROP TABLE IF EXISTS public.application_messages;
+--   DELETE FROM public.lookup_values WHERE kind = 'message_hide_reason';
+--   DELETE FROM storage.objects WHERE bucket_id = 'application-message-attachments';
+--   DELETE FROM storage.buckets WHERE id = 'application-message-attachments';
+--   COMMIT;
+-- ============================================================
+
+BEGIN;
+
+
+-- ============================================================
+-- 1. application_messages — 메시지 본체
+-- ============================================================
+CREATE TABLE public.application_messages (
+  id              uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  application_id  uuid        NOT NULL REFERENCES public.applications(id) ON DELETE CASCADE,
+  sender_kind     text        NOT NULL CHECK (sender_kind IN ('influencer','admin')),
+  sender_id       uuid        NOT NULL,        -- auth.uid
+  sender_name     text        NOT NULL,        -- 스냅샷 (관리자 이름 / 인플루언서 이름)
+  body            text        NOT NULL
+    CHECK (btrim(body) <> '' OR attachments <> '[]'::jsonb),
+  attachments     jsonb       NOT NULL DEFAULT '[]'::jsonb,  -- [{path, name, size, mime}]
+  created_at      timestamptz NOT NULL DEFAULT now(),
+  read_by_influencer_at timestamptz NULL,
+  -- 강제 숨김 (관리자 행위) — 마지막 상태 캐시. 상세 이력은 application_message_hide_history
+  hidden_by_admin_at  timestamptz NULL,
+  hidden_by_admin_id  uuid        NULL,
+  hidden_reason_code  text        NULL,   -- lookup_values(kind='message_hide_reason').code
+  hidden_reason_memo  text        NULL,   -- 자유 메모
+  -- 본인 회수 (25분 한도) — sender_kind 별로 인플루언서·관리자 화면 노출 비대칭
+  self_withdrawn_at      timestamptz NULL,
+  self_withdrawn_by_kind text        NULL CHECK (self_withdrawn_by_kind IN ('influencer','admin')),
+  -- 메일 발송 큐 (지연 발송 정책) — 관리자 메시지 INSERT 시 계산.
+  -- 인플루언서 → 관리자 메시지는 모두 NULL (관리자는 사이드바 배지·일별 다이제스트로 처리)
+  email_send_at     timestamptz NULL,
+  email_sent_at     timestamptz NULL,
+  email_skip_reason text        NULL CHECK (email_skip_reason IN
+    ('read_in_time','rate_limited_24h','cancelled','merged_into_other'))
+);
+
+CREATE INDEX idx_application_messages_app_created
+  ON public.application_messages (application_id, created_at);
+
+ALTER TABLE public.application_messages ENABLE ROW LEVEL SECURITY;
+
+-- SELECT 정책 — 행 가시성만 RLS. 본문·첨부 마스킹은 get_application_messages RPC 경유
+CREATE POLICY "influencer_read_own_application_messages"
+  ON public.application_messages FOR SELECT
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.applications a
+       WHERE a.id = application_id
+         AND a.user_id = auth.uid()
+    )
+  );
+
+CREATE POLICY "admin_read_all_messages"
+  ON public.application_messages FOR SELECT
+  USING (public.is_admin());
+
+-- INSERT/UPDATE/DELETE 는 SECURITY DEFINER RPC 경유만 (sender_kind 변조 방지)
+-- 직접 INSERT/UPDATE 정책 없음 — RPC 함수 owner(postgres role)가 BYPASSRLS 보유
+
+
+-- ============================================================
+-- 2. application_message_broadcasts — 일괄 발송 그룹 메타
+--    (broadcast_id 참조 외래 키를 application_messages 가 참조하므로 선행 생성)
+-- ============================================================
+CREATE TABLE public.application_message_broadcasts (
+  id              uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  sender_id       uuid        NOT NULL,
+  sender_name     text        NOT NULL,
+  body            text        NOT NULL,
+  attachments     jsonb       NOT NULL DEFAULT '[]'::jsonb,
+  recipient_count integer     NOT NULL,
+  created_at      timestamptz NOT NULL DEFAULT now(),
+  -- 발송 컨텍스트 추적
+  context_kind        text NOT NULL CHECK (context_kind IN ('campaign','manual')),
+  context_campaign_id uuid NULL REFERENCES public.campaigns(id) ON DELETE SET NULL,
+  context_filter      jsonb NULL,  -- 적용한 필터 스냅샷 (status·channel·follower_min 등)
+  -- 일괄 회수 (withdraw_broadcast RPC 가 함께 UPDATE, PR 3 구현)
+  withdrawn_at          timestamptz NULL,
+  withdrawn_by          uuid        NULL,
+  withdrawn_reason_code text        NULL,  -- lookup_values(kind='message_hide_reason').code
+  withdrawn_reason_memo text        NULL
+);
+
+CREATE INDEX idx_broadcasts_sender_created
+  ON public.application_message_broadcasts (sender_id, created_at DESC);
+
+CREATE INDEX idx_broadcasts_campaign
+  ON public.application_message_broadcasts (context_campaign_id, created_at DESC)
+  WHERE context_campaign_id IS NOT NULL;
+
+ALTER TABLE public.application_message_broadcasts ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "admin_read_broadcasts"
+  ON public.application_message_broadcasts FOR SELECT
+  USING (public.is_admin());
+
+-- INSERT 는 send_application_message_bulk RPC 경유만 (PR 3 구현)
+-- UPDATE 는 withdraw_broadcast RPC 경유만 (PR 3 구현)
+
+
+-- ============================================================
+-- 3. application_messages.broadcast_id 컬럼 추가
+--    (broadcasts 테이블 생성 후 참조 가능)
+-- ============================================================
+ALTER TABLE public.application_messages
+  ADD COLUMN broadcast_id uuid NULL
+  REFERENCES public.application_message_broadcasts(id) ON DELETE SET NULL;
+
+CREATE INDEX idx_application_messages_broadcast
+  ON public.application_messages (broadcast_id)
+  WHERE broadcast_id IS NOT NULL;
+
+COMMENT ON COLUMN public.application_messages.broadcast_id IS
+  '[144] 일괄 발송으로 생성된 메시지면 broadcast 그룹 ID. 개별 발송이면 NULL';
+
+
+-- ============================================================
+-- 4. application_message_admin_reads — 관리자 개인별 읽음 추적
+-- ============================================================
+CREATE TABLE public.application_message_admin_reads (
+  message_id    uuid        NOT NULL REFERENCES public.application_messages(id) ON DELETE CASCADE,
+  admin_auth_id uuid        NOT NULL,
+  read_at       timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (message_id, admin_auth_id)
+);
+
+CREATE INDEX idx_admin_reads_admin
+  ON public.application_message_admin_reads (admin_auth_id, read_at DESC);
+
+ALTER TABLE public.application_message_admin_reads ENABLE ROW LEVEL SECURITY;
+
+-- 본인 읽음 기록만 SELECT (다른 관리자가 언제 봤는지는 노출 안 함)
+CREATE POLICY "admin_read_own_reads"
+  ON public.application_message_admin_reads FOR SELECT
+  USING (admin_auth_id = auth.uid() AND public.is_admin());
+
+-- INSERT 는 mark_application_messages_read RPC 경유만
+-- (직접 INSERT 정책 추가 시 RPC 우회 위험)
+
+
+-- ============================================================
+-- 5. application_message_resolutions — 응모건 응대 완료 상태
+-- ============================================================
+CREATE TABLE public.application_message_resolutions (
+  application_id            uuid        PRIMARY KEY
+    REFERENCES public.applications(id) ON DELETE CASCADE,
+  resolved_at               timestamptz NOT NULL DEFAULT now(),
+  resolved_by               uuid        NOT NULL,
+  resolved_by_name          text        NOT NULL,
+  resolved_after_message_at timestamptz NOT NULL,  -- 응대 완료 시점의 마지막 메시지 시각
+  resolution_method         text        NOT NULL
+    CHECK (resolution_method IN ('auto_replied','manual'))
+);
+
+ALTER TABLE public.application_message_resolutions ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "admin_read_resolutions"
+  ON public.application_message_resolutions FOR SELECT
+  USING (public.is_admin());
+
+-- INSERT/UPDATE/DELETE 는 RPC 경유만
+-- 자동 처리: send_application_message RPC 끝부분 (결정 J)
+-- 수동 처리: mark_application_resolved RPC (PR 2 구현)
+
+
+-- ============================================================
+-- 6. application_message_hide_history — 숨김·회수 감사 이력
+-- ============================================================
+CREATE TABLE public.application_message_hide_history (
+  id           uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  message_id   uuid        NOT NULL
+    REFERENCES public.application_messages(id) ON DELETE CASCADE,
+  action       text        NOT NULL
+    CHECK (action IN ('hide','unhide','self_withdraw','broadcast_withdraw')),
+  by_user_kind text        NOT NULL CHECK (by_user_kind IN ('influencer','admin')),
+  by_user_id   uuid        NOT NULL,
+  by_name      text        NOT NULL,
+  reason_code  text        NULL,  -- lookup_values(kind='message_hide_reason').code. self_withdraw 는 NULL
+  reason_memo  text        NULL,
+  at           timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_message_hide_history_message_at
+  ON public.application_message_hide_history (message_id, at);
+
+ALTER TABLE public.application_message_hide_history ENABLE ROW LEVEL SECURITY;
+
+-- super_admin 만 SELECT — 운영팀 내부 부당 숨김 사례 감지·분쟁 대응용
+CREATE POLICY "super_admin_read_hide_history"
+  ON public.application_message_hide_history FOR SELECT
+  USING (public.is_super_admin());
+
+-- INSERT 는 hide/unhide/withdraw RPC 경유만 (SECURITY DEFINER, BYPASSRLS)
+
+
+-- ============================================================
+-- 7. 뷰 application_message_summary — 응모건별 집계
+-- ============================================================
+CREATE OR REPLACE VIEW public.application_message_summary
+  WITH (security_invoker = true)
+AS
+SELECT
+  a.id          AS application_id,
+  a.user_id     AS influencer_id,
+  a.campaign_id,
+  -- message_count: 강제 숨김 제외 (self_withdrawn 포함 — placeholder 표시됨)
+  count(m.*) FILTER (WHERE m.hidden_by_admin_at IS NULL) AS message_count,
+  -- 인플루언서 미열람: 관리자 회수 메시지는 본문 못 보므로 제외
+  count(m.*) FILTER (
+    WHERE m.sender_kind = 'admin'
+      AND m.read_by_influencer_at IS NULL
+      AND m.hidden_by_admin_at IS NULL
+      AND m.self_withdrawn_at IS NULL
+  ) AS unread_for_influencer,
+  -- 미응대: resolutions 없거나 마지막 인플루언서 메시지(살아있는 것)가 응대 완료 시점 이후
+  CASE
+    WHEN max(m.created_at) FILTER (
+      WHERE m.sender_kind = 'influencer'
+        AND m.hidden_by_admin_at IS NULL
+        AND m.self_withdrawn_at IS NULL
+    ) IS NULL THEN false
+    WHEN r.resolved_after_message_at IS NULL THEN true
+    WHEN max(m.created_at) FILTER (
+      WHERE m.sender_kind = 'influencer'
+        AND m.hidden_by_admin_at IS NULL
+        AND m.self_withdrawn_at IS NULL
+    ) > r.resolved_after_message_at THEN true
+    ELSE false
+  END AS unresolved_for_admin_team,
+  max(m.created_at) FILTER (WHERE m.hidden_by_admin_at IS NULL) AS last_message_at
+FROM public.applications a
+LEFT JOIN public.application_messages m ON m.application_id = a.id
+LEFT JOIN public.application_message_resolutions r ON r.application_id = a.id
+GROUP BY a.id, a.user_id, a.campaign_id, r.resolved_after_message_at;
+
+
+-- ============================================================
+-- 8. 함수 application_message_admin_unread_counts
+--    관리자 본인 기준 응모건별 미읽음 수 집계
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.application_message_admin_unread_counts(
+  p_admin_auth_id uuid DEFAULT NULL  -- NULL 이면 auth.uid() 사용
+) RETURNS TABLE (application_id uuid, unread_count bigint)
+LANGUAGE plpgsql STABLE SECURITY DEFINER SET search_path = ''
+AS $$
+BEGIN
+  -- 관리자 전용 가드: 인플루언서가 호출하면 전체 미읽음 집계가 노출되는 취약점 차단
+  IF NOT public.is_admin() THEN
+    RAISE EXCEPTION '관리자 전용 함수입니다'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  RETURN QUERY
+  SELECT
+    m.application_id,
+    count(*) AS unread_count
+  FROM public.application_messages m
+  LEFT JOIN public.application_message_admin_reads r
+    ON r.message_id = m.id
+   AND r.admin_auth_id = COALESCE(p_admin_auth_id, auth.uid())
+  WHERE m.sender_kind = 'influencer'
+    AND m.hidden_by_admin_at IS NULL
+    AND m.self_withdrawn_at IS NULL  -- 인플루언서 본인 회수 메시지는 관리자 미읽음 집계에서 제외
+    AND r.message_id IS NULL         -- 본인이 안 읽음
+  GROUP BY m.application_id;
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.application_message_admin_unread_counts(uuid) FROM PUBLIC, anon;
+GRANT  EXECUTE ON FUNCTION public.application_message_admin_unread_counts(uuid) TO authenticated;
+
+COMMENT ON FUNCTION public.application_message_admin_unread_counts(uuid) IS
+  '[144] 관리자 본인 기준 응모건별 미읽음 인플루언서 메시지 수 집계. '
+  'is_admin() 가드 포함 — 비관리자 호출 시 insufficient_privilege 예외. '
+  'LANGUAGE plpgsql (RAISE EXCEPTION 사용 위해). 집계 로직은 설계 원안과 동일. '
+  'p_admin_auth_id NULL = auth.uid(). SECURITY DEFINER + search_path 고정. '
+  '인플루언서 GNB 미읽음 배지는 application_message_summary 뷰(security_invoker=true)로 직접 조회.';
+
+
+-- ============================================================
+-- 9. RPC send_application_message
+--    메시지 발송 (인플루언서·관리자 공용, sender_kind 자동 판별)
+--    결정 J: 관리자 답장 → resolutions 자동 UPSERT
+--            인플루언서 새 메시지 → resolutions 자동 DELETE (reopen)
+--    Rate limit: 사용자별 100건/시간 (사양서 §9 행 1310)
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.send_application_message(
+  p_application_id uuid,
+  p_body           text,
+  p_attachments    jsonb DEFAULT '[]'::jsonb
+) RETURNS uuid  -- new message id
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = ''
+AS $$
+DECLARE
+  v_sender_kind text;
+  v_sender_name text;
+  v_app_owner   uuid;
+  v_app_status  text;
+  v_msg_id      uuid;
+  v_rate_count  bigint;
+BEGIN
+  -- 응모 소유자 확인
+  SELECT user_id, status INTO v_app_owner, v_app_status
+    FROM public.applications WHERE id = p_application_id;
+
+  IF v_app_owner IS NULL THEN
+    RAISE EXCEPTION '応募が見つかりません';
+  END IF;
+
+  -- sender_kind 판별 (관리자 먼저 검사 — 관리자가 본인 응모도 있을 수 있음)
+  IF public.is_admin() THEN
+    v_sender_kind := 'admin';
+    SELECT name INTO v_sender_name FROM public.admins WHERE auth_id = auth.uid();
+  ELSIF v_app_owner = auth.uid() THEN
+    v_sender_kind := 'influencer';
+    SELECT name INTO v_sender_name FROM public.influencers WHERE id = auth.uid();
+  ELSE
+    RAISE EXCEPTION '権限がありません';
+  END IF;
+
+  -- 본문/첨부 빈값 검증
+  IF (p_body IS NULL OR btrim(p_body) = '') AND (p_attachments IS NULL OR p_attachments = '[]'::jsonb) THEN
+    RAISE EXCEPTION 'メッセージ本文または添付が必要です';
+  END IF;
+
+  -- Rate limit: 사용자별 100건/시간 (사양서 §9 행 1310)
+  SELECT count(*) INTO v_rate_count
+    FROM public.application_messages
+   WHERE sender_id = auth.uid()
+     AND created_at > now() - interval '1 hour';
+
+  IF v_rate_count >= 100 THEN
+    RAISE EXCEPTION 'メッセージの送信上限（1時間に100件）に達しました。しばらく経ってからお試しください';
+  END IF;
+
+  -- 응모 종료 90일 경과 차단 (사양서 §3-3)
+  -- 관리자는 90일 경과 후에도 발송 허용 (사후 안내 필요 케이스 대응)
+  -- 종료 시각 계산:
+  --   1) cancelled_at IS NOT NULL → cancelled_at
+  --   2) status='rejected' → reviewed_at
+  --   3) status='approved' + 해당 응모의 모든 deliverables 가 approved → 마지막 deliverable.reviewed_at
+  --   4) 위 모두 아니면 (진행 중) → NULL (차단 없음)
+  IF NOT public.is_admin() THEN
+    DECLARE
+      v_ended_at timestamptz;
+    BEGIN
+      SELECT CASE
+        WHEN a.cancelled_at IS NOT NULL THEN a.cancelled_at
+        WHEN a.status = 'rejected'      THEN a.reviewed_at
+        WHEN a.status = 'approved' AND NOT EXISTS (
+          SELECT 1 FROM public.deliverables d
+           WHERE d.application_id = p_application_id
+             AND d.status <> 'approved'
+        ) AND EXISTS (
+          SELECT 1 FROM public.deliverables d
+           WHERE d.application_id = p_application_id
+        ) THEN (
+          SELECT max(d.reviewed_at) FROM public.deliverables d
+           WHERE d.application_id = p_application_id
+        )
+        ELSE NULL
+      END
+      INTO v_ended_at
+      FROM public.applications a
+      WHERE a.id = p_application_id;
+
+      IF v_ended_at IS NOT NULL AND v_ended_at < now() - interval '90 days' THEN
+        RAISE EXCEPTION '応募終了から90日経過しました。閲覧のみ可能です';
+      END IF;
+    END;
+  END IF;
+
+  INSERT INTO public.application_messages (
+    application_id, sender_kind, sender_id, sender_name, body, attachments
+  ) VALUES (
+    p_application_id,
+    v_sender_kind,
+    auth.uid(),
+    COALESCE(v_sender_name, '(이름미상)'),
+    COALESCE(p_body, ''),
+    COALESCE(p_attachments, '[]'::jsonb)
+  )
+  RETURNING id INTO v_msg_id;
+
+  -- 자동 응대 처리 (결정 J, 사양서 §3-4 + §4-1-3):
+  --   인플루언서 새 메시지 → application_message_resolutions 행 자동 DELETE (reopen)
+  --   관리자 답장 → application_message_resolutions 자동 UPSERT (auto_replied)
+  IF v_sender_kind = 'influencer' THEN
+    DELETE FROM public.application_message_resolutions
+     WHERE application_id = p_application_id;
+  ELSE  -- v_sender_kind = 'admin'
+    INSERT INTO public.application_message_resolutions (
+      application_id,
+      resolved_at,
+      resolved_by,
+      resolved_by_name,
+      resolved_after_message_at,
+      resolution_method
+    ) VALUES (
+      p_application_id,
+      now(),
+      auth.uid(),
+      COALESCE(v_sender_name, '(이름미상)'),
+      COALESCE(
+        (SELECT max(created_at)
+           FROM public.application_messages
+          WHERE application_id = p_application_id
+            AND sender_kind = 'influencer'
+            AND hidden_by_admin_at IS NULL
+            AND self_withdrawn_at IS NULL),
+        now()  -- 인플루언서 메시지 없을 때 (관리자가 먼저 시작한 케이스) now() 폴백
+      ),
+      'auto_replied'
+    )
+    ON CONFLICT (application_id) DO UPDATE
+      SET resolved_at               = EXCLUDED.resolved_at,
+          resolved_by               = EXCLUDED.resolved_by,
+          resolved_by_name          = EXCLUDED.resolved_by_name,
+          resolved_after_message_at = EXCLUDED.resolved_after_message_at,
+          resolution_method         = 'auto_replied';
+  END IF;
+
+  RETURN v_msg_id;
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.send_application_message(uuid, text, jsonb) FROM PUBLIC, anon;
+GRANT  EXECUTE ON FUNCTION public.send_application_message(uuid, text, jsonb) TO authenticated;
+
+COMMENT ON FUNCTION public.send_application_message(uuid, text, jsonb) IS
+  '[144] 메시지 발송 RPC. 인플루언서·관리자 공용, sender_kind 자동 판별. '
+  'Rate limit: 사용자별 100건/시간 (사양서 §9 행 1310, application_messages 집계). '
+  '관리자 답장 시 resolutions 자동 UPSERT, 인플루언서 새 메시지 시 자동 DELETE(reopen). '
+  '인플루언서는 응모 종료 90일 초과 시 발송 차단. SECURITY DEFINER + search_path 고정.';
+
+
+-- ============================================================
+-- 10. RPC mark_application_messages_read
+--     읽음 처리 (인플루언서·관리자 공용)
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.mark_application_messages_read(
+  p_application_id uuid
+) RETURNS void
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = ''
+AS $$
+DECLARE
+  v_role  text;
+  v_owner uuid;
+BEGIN
+  SELECT user_id INTO v_owner FROM public.applications WHERE id = p_application_id;
+
+  IF public.is_admin() THEN
+    v_role := 'admin';
+  ELSIF v_owner = auth.uid() THEN
+    v_role := 'influencer';
+  ELSE
+    RAISE EXCEPTION '권한이 없습니다';
+  END IF;
+
+  IF v_role = 'admin' THEN
+    -- 관리자: 본인이 안 읽은 인플루언서 메시지를 application_message_admin_reads 에 UPSERT
+    INSERT INTO public.application_message_admin_reads (message_id, admin_auth_id, read_at)
+    SELECT m.id, auth.uid(), now()
+      FROM public.application_messages m
+     WHERE m.application_id = p_application_id
+       AND m.sender_kind = 'influencer'
+       AND m.hidden_by_admin_at IS NULL
+    ON CONFLICT (message_id, admin_auth_id) DO NOTHING;
+  ELSE
+    -- 인플루언서: 관리자 메시지를 read_by_influencer_at 일괄 UPDATE
+    UPDATE public.application_messages
+       SET read_by_influencer_at = now()
+     WHERE application_id = p_application_id
+       AND sender_kind = 'admin'
+       AND read_by_influencer_at IS NULL
+       AND hidden_by_admin_at IS NULL;
+  END IF;
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.mark_application_messages_read(uuid) FROM PUBLIC, anon;
+GRANT  EXECUTE ON FUNCTION public.mark_application_messages_read(uuid) TO authenticated;
+
+COMMENT ON FUNCTION public.mark_application_messages_read(uuid) IS
+  '[144] 읽음 처리 RPC. '
+  '관리자: application_message_admin_reads UPSERT. '
+  '인플루언서: application_messages.read_by_influencer_at 일괄 UPDATE. '
+  'SECURITY DEFINER + search_path 고정.';
+
+
+-- ============================================================
+-- 11. RPC withdraw_own_message
+--     본인 메시지 회수 (25분 한도, 인플루언서·관리자 공용)
+--     Rate limit: 사용자별 50건/시간 (사양서 §9 행 1309)
+--                 application_message_hide_history(action='self_withdraw') 집계
+--     첨부 Storage 삭제는 클라이언트가 RPC 반환 후 별도 처리:
+--       1안: 클라이언트가 storage.from('application-message-attachments').remove([...])
+--       2안: pg_cron 5분 주기 cleanup Edge Function (개발 세션 결정)
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.withdraw_own_message(
+  p_message_id uuid
+) RETURNS void
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = ''
+AS $$
+DECLARE
+  v_sender_id   uuid;
+  v_sender_kind text;
+  v_created_at  timestamptz;
+  v_sender_name text;
+  v_rate_count  bigint;
+BEGIN
+  SELECT sender_id, sender_kind, created_at, sender_name
+    INTO v_sender_id, v_sender_kind, v_created_at, v_sender_name
+    FROM public.application_messages
+   WHERE id = p_message_id;
+
+  IF v_sender_id IS NULL THEN
+    RAISE EXCEPTION 'メッセージが見つかりません';
+  END IF;
+
+  -- 발신자 본인 검증
+  IF v_sender_id <> auth.uid() THEN
+    RAISE EXCEPTION '自分のメッセージのみ取り消し可能です';
+  END IF;
+
+  -- 25분 한도 검증
+  IF v_created_at < now() - interval '25 minutes' THEN
+    RAISE EXCEPTION '取り消し可能時間（25分）を過ぎています';
+  END IF;
+
+  -- 이미 처리된 메시지 차단
+  IF EXISTS (
+    SELECT 1 FROM public.application_messages
+     WHERE id = p_message_id
+       AND (hidden_by_admin_at IS NOT NULL OR self_withdrawn_at IS NOT NULL)
+  ) THEN
+    RAISE EXCEPTION '既に取り消し・非表示処理済みのメッセージです';
+  END IF;
+
+  -- Rate limit: 사용자별 50건/시간 (사양서 §9 행 1309)
+  -- application_message_hide_history 에서 최근 1시간 self_withdraw 건수 집계
+  SELECT count(*) INTO v_rate_count
+    FROM public.application_message_hide_history
+   WHERE by_user_id = auth.uid()
+     AND action = 'self_withdraw'
+     AND at > now() - interval '1 hour';
+
+  IF v_rate_count >= 50 THEN
+    RAISE EXCEPTION 'メッセージ取り消しの上限（1時間に50件）に達しました。しばらく経ってからお試しください';
+  END IF;
+
+  UPDATE public.application_messages
+     SET self_withdrawn_at      = now(),
+         self_withdrawn_by_kind = v_sender_kind
+   WHERE id = p_message_id;
+
+  -- 감사 이력 추가 (hide_history 에 기록 — rate limit 집계 소스이기도 함)
+  INSERT INTO public.application_message_hide_history (
+    message_id, action, by_user_kind, by_user_id, by_name, reason_code, reason_memo
+  ) VALUES (
+    p_message_id, 'self_withdraw', v_sender_kind, auth.uid(), v_sender_name, NULL, NULL
+  );
+
+  -- 메일 발송 자동 cancel (email_send_at 도래 전이면)
+  UPDATE public.application_messages
+     SET email_skip_reason = 'cancelled'
+   WHERE id = p_message_id
+     AND email_send_at IS NOT NULL
+     AND email_send_at > now()
+     AND email_sent_at IS NULL;
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.withdraw_own_message(uuid) FROM PUBLIC, anon;
+GRANT  EXECUTE ON FUNCTION public.withdraw_own_message(uuid) TO authenticated;
+
+COMMENT ON FUNCTION public.withdraw_own_message(uuid) IS
+  '[144] 본인 메시지 회수 RPC. 25분 한도, 인플루언서·관리자 공용. '
+  'Rate limit: 사용자별 50건/시간 (사양서 §9 행 1309, hide_history action=self_withdraw 집계). '
+  '첨부 Storage 삭제는 클라이언트 또는 cleanup Edge Function 에서 별도 처리. '
+  'SECURITY DEFINER + search_path 고정.';
+
+
+-- ============================================================
+-- 12. lookup_values — message_hide_reason 시드 7건
+--     숨김·강제회수 사유 카테고리 (사양서 §3-5)
+-- ============================================================
+INSERT INTO public.lookup_values (kind, code, name_ko, name_ja, sort_order, active)
+VALUES
+  ('message_hide_reason', 'inappropriate_expression', '부적절한 표현',    '不適切な表現',         10, true),
+  ('message_hide_reason', 'personal_info_leak',       '개인정보 노출',     '個人情報の漏洩',       20, true),
+  ('message_hide_reason', 'defamation',               '명예훼손',          '名誉毀損',             30, true),
+  ('message_hide_reason', 'spam',                     '스팸·광고',         'スパム・広告',         40, true),
+  ('message_hide_reason', 'wrong_recipient',          '잘못 발송',         '誤送信',               50, true),
+  ('message_hide_reason', 'influencer_request',       '인플루언서 요청',   'インフルエンサーからの依頼', 60, true),
+  ('message_hide_reason', 'other',                    '기타',              'その他',               70, true)
+ON CONFLICT DO NOTHING;
+
+
+-- ============================================================
+-- 13. Storage — application-message-attachments 버킷 (비공개)
+--     경로 컨벤션: {application_id}/{message_id}/{filename}
+--     최대 2MB / MIME: jpg·png·webp (HEIC 는 클라이언트에서 jpg 변환 후 업로드)
+--     메시지 1건당 첨부 최대 5장은 클라이언트 단에서 제한
+-- ============================================================
+INSERT INTO storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
+VALUES (
+  'application-message-attachments',
+  'application-message-attachments',
+  false,
+  2097152,  -- 2 MB
+  ARRAY[
+    'image/jpeg',
+    'image/jpg',
+    'image/png',
+    'image/webp'
+  ]
+)
+ON CONFLICT (id) DO UPDATE
+  SET public             = EXCLUDED.public,
+      file_size_limit    = EXCLUDED.file_size_limit,
+      allowed_mime_types = EXCLUDED.allowed_mime_types;
+
+-- SELECT (다운로드·signed URL 사전 경로 확인)
+-- 인플루언서: 본인 응모건 경로({application_id}/...) 만 허용
+-- 관리자: 전체 허용
+DROP POLICY IF EXISTS "msg_attachments_influencer_select" ON storage.objects;
+CREATE POLICY "msg_attachments_influencer_select"
+  ON storage.objects FOR SELECT
+  TO authenticated
+  USING (
+    bucket_id = 'application-message-attachments'
+    AND (
+      public.is_admin()
+      OR EXISTS (
+        SELECT 1 FROM public.applications a
+         WHERE a.user_id = auth.uid()
+           -- 경로 첫 세그먼트가 application_id 와 일치 여부
+           AND (storage.foldername(name))[1] = a.id::text
+      )
+    )
+  );
+
+-- INSERT (업로드)
+-- 인플루언서: 본인 응모건 경로만 허용
+-- 관리자: 전체 허용
+DROP POLICY IF EXISTS "msg_attachments_insert" ON storage.objects;
+CREATE POLICY "msg_attachments_insert"
+  ON storage.objects FOR INSERT
+  TO authenticated
+  WITH CHECK (
+    bucket_id = 'application-message-attachments'
+    AND (
+      public.is_admin()
+      OR EXISTS (
+        SELECT 1 FROM public.applications a
+         WHERE a.user_id = auth.uid()
+           AND (storage.foldername(name))[1] = a.id::text
+      )
+    )
+  );
+
+-- UPDATE (덮어쓰기 upsert 대응)
+DROP POLICY IF EXISTS "msg_attachments_update" ON storage.objects;
+CREATE POLICY "msg_attachments_update"
+  ON storage.objects FOR UPDATE
+  TO authenticated
+  USING (
+    bucket_id = 'application-message-attachments'
+    AND (
+      public.is_admin()
+      OR EXISTS (
+        SELECT 1 FROM public.applications a
+         WHERE a.user_id = auth.uid()
+           AND (storage.foldername(name))[1] = a.id::text
+      )
+    )
+  )
+  WITH CHECK (
+    bucket_id = 'application-message-attachments'
+    AND (
+      public.is_admin()
+      OR EXISTS (
+        SELECT 1 FROM public.applications a
+         WHERE a.user_id = auth.uid()
+           AND (storage.foldername(name))[1] = a.id::text
+      )
+    )
+  );
+
+-- DELETE (회수 시 즉시 삭제 또는 cleanup 용)
+-- 인플루언서: 본인 응모건 경로만 허용 (withdraw_own_message 후 클라이언트 호출)
+-- 관리자: 전체 허용
+DROP POLICY IF EXISTS "msg_attachments_delete" ON storage.objects;
+CREATE POLICY "msg_attachments_delete"
+  ON storage.objects FOR DELETE
+  TO authenticated
+  USING (
+    bucket_id = 'application-message-attachments'
+    AND (
+      public.is_admin()
+      OR EXISTS (
+        SELECT 1 FROM public.applications a
+         WHERE a.user_id = auth.uid()
+           AND (storage.foldername(name))[1] = a.id::text
+      )
+    )
+  );
+
+
+-- ============================================================
+-- 14. RPC get_application_messages — 서버 측 마스킹 조회
+--     사양서 §9 행 1304-1305: 클라이언트 마스킹은 본문이 네트워크로 노출되어
+--     보안상 부적합. SECURITY DEFINER RPC 에서 서버 측에서 마스킹 처리.
+--
+--     마스킹 4종 케이스 (사양서 §3-5 + §9 비대칭 분기):
+--
+--     [호출자 = 인플루언서]
+--       A) hidden_by_admin_at IS NOT NULL (강제 숨김)
+--          → body=NULL, attachments='[]', mask_state='hidden_by_admin'
+--       B) self_withdrawn_at IS NOT NULL (회수)
+--          → body=NULL, attachments='[]'
+--            mask_state: self_withdrawn_by_kind='influencer' → 'self_withdrawn_influencer'
+--                        self_withdrawn_by_kind='admin'      → 'self_withdrawn_admin'
+--       C) 그 외 → body/attachments 원본, mask_state='visible'
+--
+--     [호출자 = 관리자]
+--       D) hidden_by_admin_at IS NOT NULL (강제 숨김)
+--          → body/attachments 원본 유지, mask_state='hidden_by_admin'
+--            (다른 관리자가 원본 열람 가능 — §3-5 ①)
+--       E) self_withdrawn_at IS NOT NULL AND self_withdrawn_by_kind='influencer' (인플루언서 본인 회수)
+--          → body=NULL, attachments='[]', mask_state='self_withdrawn_influencer'
+--            (관리자도 못 봄 — §3-5 본인 회수 양쪽 마스킹)
+--       F) self_withdrawn_at IS NOT NULL AND self_withdrawn_by_kind='admin' (관리자 본인 회수)
+--          → body/attachments 원본 유지, mask_state='self_withdrawn_admin'
+--            (다른 관리자에게 원본 보임 — §3-5 ② 비대칭)
+--       G) 그 외 → body/attachments 원본, mask_state='visible'
+--
+--     케이스 D vs E vs F 가 관리자 비대칭 핵심:
+--       강제 숨김(D)       → 관리자는 원본 볼 수 있음 (운영팀 내부 분쟁 대응)
+--       인플 본인 회수(E)  → 관리자도 원본 볼 수 없음 (본인 회수 존중)
+--       관리자 본인 회수(F) → 다른 관리자는 원본 볼 수 있음 (관리자 간 투명성)
+--
+-- 롤백:
+--   DROP FUNCTION IF EXISTS public.get_application_messages(uuid);
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.get_application_messages(
+  p_application_id uuid
+) RETURNS TABLE (
+  id                      uuid,
+  application_id          uuid,
+  sender_kind             text,
+  sender_name             text,
+  body                    text,        -- 마스킹 시 NULL
+  attachments             jsonb,       -- 마스킹 시 '[]'::jsonb
+  created_at              timestamptz,
+  read_by_influencer_at   timestamptz,
+  broadcast_id            uuid,
+  hidden_by_admin_at      timestamptz,
+  self_withdrawn_at       timestamptz,
+  self_withdrawn_by_kind  text,
+  mask_state              text         -- 'visible' | 'hidden_by_admin' | 'self_withdrawn_influencer' | 'self_withdrawn_admin'
+)
+LANGUAGE plpgsql STABLE SECURITY DEFINER SET search_path = ''
+AS $$
+DECLARE
+  v_caller_is_admin  boolean;
+  v_app_owner        uuid;
+BEGIN
+  -- 응모 소유자 확인
+  SELECT user_id INTO v_app_owner
+    FROM public.applications WHERE id = p_application_id;
+
+  IF v_app_owner IS NULL THEN
+    RAISE EXCEPTION '応募が見つかりません';
+  END IF;
+
+  -- 호출자 권한 판별
+  v_caller_is_admin := public.is_admin();
+
+  -- 인플루언서 본인 또는 관리자가 아니면 차단
+  IF NOT v_caller_is_admin AND v_app_owner <> auth.uid() THEN
+    RAISE EXCEPTION '権限がありません';
+  END IF;
+
+  RETURN QUERY
+  SELECT
+    m.id,
+    m.application_id,
+    m.sender_kind,
+    m.sender_name,
+    -- body 마스킹 분기
+    CASE
+      WHEN v_caller_is_admin THEN
+        -- 관리자: 인플루언서 본인 회수(케이스 E)만 마스킹
+        CASE
+          WHEN m.self_withdrawn_at IS NOT NULL AND m.self_withdrawn_by_kind = 'influencer'
+            THEN NULL  -- 케이스 E: 양쪽 마스킹 (관리자도 못 봄)
+          ELSE m.body  -- 케이스 D(강제숨김), F(관리자회수), G(visible) 모두 원본 유지
+        END
+      ELSE
+        -- 인플루언서: 강제 숨김(A) 또는 회수(B) 시 마스킹
+        CASE
+          WHEN m.hidden_by_admin_at IS NOT NULL THEN NULL  -- 케이스 A
+          WHEN m.self_withdrawn_at  IS NOT NULL THEN NULL  -- 케이스 B
+          ELSE m.body                                      -- 케이스 C
+        END
+    END AS body,
+    -- attachments 마스킹 분기 (body 와 동일 로직)
+    CASE
+      WHEN v_caller_is_admin THEN
+        CASE
+          WHEN m.self_withdrawn_at IS NOT NULL AND m.self_withdrawn_by_kind = 'influencer'
+            THEN '[]'::jsonb
+          ELSE m.attachments
+        END
+      ELSE
+        CASE
+          WHEN m.hidden_by_admin_at IS NOT NULL THEN '[]'::jsonb
+          WHEN m.self_withdrawn_at  IS NOT NULL THEN '[]'::jsonb
+          ELSE m.attachments
+        END
+    END AS attachments,
+    m.created_at,
+    m.read_by_influencer_at,
+    m.broadcast_id,
+    m.hidden_by_admin_at,
+    m.self_withdrawn_at,
+    m.self_withdrawn_by_kind,
+    -- mask_state 계산
+    CASE
+      WHEN v_caller_is_admin THEN
+        CASE
+          -- 우선순위: 인플루언서 본인 회수(E)를 D보다 먼저 판별
+          -- (혹시 hidden_by_admin_at + self_withdrawn_at 둘 다 있는 예외 케이스 대비)
+          WHEN m.self_withdrawn_at IS NOT NULL AND m.self_withdrawn_by_kind = 'influencer'
+            THEN 'self_withdrawn_influencer'  -- 케이스 E
+          WHEN m.hidden_by_admin_at IS NOT NULL
+            THEN 'hidden_by_admin'            -- 케이스 D
+          WHEN m.self_withdrawn_at IS NOT NULL AND m.self_withdrawn_by_kind = 'admin'
+            THEN 'self_withdrawn_admin'       -- 케이스 F
+          ELSE 'visible'                      -- 케이스 G
+        END
+      ELSE
+        CASE
+          WHEN m.hidden_by_admin_at IS NOT NULL
+            THEN 'hidden_by_admin'                    -- 케이스 A
+          WHEN m.self_withdrawn_at IS NOT NULL AND m.self_withdrawn_by_kind = 'influencer'
+            THEN 'self_withdrawn_influencer'           -- 케이스 B (본인 회수)
+          WHEN m.self_withdrawn_at IS NOT NULL AND m.self_withdrawn_by_kind = 'admin'
+            THEN 'self_withdrawn_admin'               -- 케이스 B (관리자 회수)
+          ELSE 'visible'                              -- 케이스 C
+        END
+    END AS mask_state
+  FROM public.application_messages m
+  WHERE m.application_id = p_application_id
+  ORDER BY m.created_at ASC;
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.get_application_messages(uuid) FROM PUBLIC, anon;
+GRANT  EXECUTE ON FUNCTION public.get_application_messages(uuid) TO authenticated;
+
+COMMENT ON FUNCTION public.get_application_messages(uuid) IS
+  '[144] 응모건 메시지 목록 조회 RPC. 서버 측 마스킹 처리 (사양서 §9). '
+  '인플루언서: 강제숨김+회수 시 body=NULL, attachments=[]. '
+  '관리자: 인플루언서 본인 회수만 양쪽 마스킹, 강제숨김·관리자회수는 원본 유지 (비대칭). '
+  'mask_state: visible|hidden_by_admin|self_withdrawn_influencer|self_withdrawn_admin. '
+  'SECURITY DEFINER + search_path 고정.';
+
+
+COMMIT;


### PR DESCRIPTION
## 변경 요약
- 응모(신청)건 단위 인플루언서 ↔ 관리자 양방향 메시지 — **PR 1 (기반 인프라 + 인플루언서 발신)**
- 마이그레이션 144: 테이블 5개 + 마스킹 조회/발송/읽음/회수 RPC(rate limit 포함) + security_invoker 집계 뷰 + Storage 버킷 + 숨김사유 7종 시드
- 인플루언서 메시지 모달(게시판형) — 텍스트+이미지 첨부(자동 압축/HEIC 변환), 25분 본인 회수, 숨김·회수 서버 마스킹 표시
- 응모이력 카드 메시지 버튼 + 미읽음 배지

## 요청 외 추가 변경
- 없음
- (분리 결정) GNB 「메시지」 메뉴·알림(message_received)은 관리자 발신이 있어야 데이터가 생기므로 **PR 2(관리자 발신)와 함께** 진행 — 사용자 결정 2026-05-20
- (보류) 약관 중대 변경 D-7 사전 통지·정책 4종 갱신은 **PR 5 운영 배포 직전** 집행 — 사용자 결정 2026-05-20

## 관련 사양서
- docs/specs/2026-05-15-application-messaging.md (구현 결과 PR 1 기록 포함)

## DB 변경
- 마이그레이션 144 — 머지 후 **개발 DB SQL Editor 적용 필요** (개발 먼저 → 검증 → 운영). 운영 적용은 PR 5 약관 통지 일정과 함께

## 검증
- reverb-supabase-expert: 마이그레이션 144 설계·작성·보안 강화
- reverb-reviewer: 정적 검토 통과 (Critical 0)
- reverb-qa-tester: **light 권장** — dev 머지 + 개발 DB 적용 후 인플 메시지 발송/회수 E2E

🤖 Generated with [Claude Code](https://claude.com/claude-code)