### PR TITLE
feat(messaging): 관리자 발신 + 받은편지함 + GNB 메뉴 + 알림 (PR 2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -214,14 +214,14 @@
 - `admin_notice_reads` — 관리자별 읽음 기록. `(admin_id, notice_id, read_at)` UNIQUE. `upsert_admin_notice_read` RPC. 미읽음 카운트 = published - reads(by admin)
 - `influencer_flags` — 인플루언서 관리자 마킹 이력. `influencer_id`, `action`(verify/violation/blacklist/clear), `reasons text[]` (blacklist_reason ∪ violation_reason lookup), `memo`, `evidence_paths text[]`, `updated_at/by/by_name`. 위반 행만 UPDATE RLS
 
-### 응모건 메시지 (인플루언서 ↔ 관리자, PR 1 — 개발 검증 중, 마이그레이션 144)
-> 응모(신청)건 단위 양방향 메시지. PR 1 은 인플루언서 발신 + 모달 + 응모이력 진입. 관리자 발신 UI·GNB 메뉴·알림(`message_received`)은 PR 2. 사양서 `docs/specs/2026-05-15-application-messaging.md`. 약관 중대 변경(D-7 사전 통지)은 PR 5 운영 배포 직전 집행(현재 보류).
+### 응모건 메시지 (인플루언서 ↔ 관리자, PR 1·2 — 개발 검증 중, 마이그레이션 144·145)
+> 응모(신청)건 단위 양방향 메시지. PR 1: 인플루언서 발신 + 모달 + 응모이력 진입. PR 2(마이그레이션 145): 관리자 발신(받은편지함 3단 페인 `#adminPane-messages` + 응모행 「메시지」 버튼 3개 페인 + 메시지 모달) + 강제 숨김/복구 + 수동 응대 완료 + 인플 GNB 「メッセージ」 메뉴 + 알림 `message_received`. 관리자 로직은 `dev/js/admin-messaging.js` 분리. 사양서 `docs/specs/2026-05-15-application-messaging.md`. 일괄 발송(PR 3)·메일 지연 큐(PR 4)·LINE 안내+약관 D-7(PR 5)은 미구현. 운영 배포는 PR 5 약관 통지와 함께(현재 보류).
 - `application_messages` — 메시지 본문. `application_id` FK CASCADE, `sender_kind`(influencer|admin), `sender_id/name`, `body`, `attachments jsonb`(`[{path,name,size,mime}]`), `read_by_influencer_at`, 강제숨김 4컬럼(`hidden_by_admin_at/_id/_reason_code/_memo`), 본인회수(`self_withdrawn_at`/`_by_kind`), 메일큐(`email_send_at`/`email_sent_at`/`email_skip_reason`), `broadcast_id` FK. RLS SELECT 본인 응모건 또는 `is_admin()`, INSERT/UPDATE 는 RPC 만 (sender_kind 변조 차단)
 - `application_message_admin_reads` — 관리자 개인별 읽음. `(message_id, admin_auth_id)` PK
 - `application_message_resolutions` — 응모건 응대 완료. `application_id` PK, `resolution_method`(auto_replied|manual)
 - `application_message_broadcasts` — 일괄 발송 그룹 (테이블만 PR 1, bulk/withdraw RPC 는 PR 3)
 - `application_message_hide_history` — 숨김/회수 audit (append-only, SELECT super_admin)
-- 뷰 `application_message_summary`(`security_invoker=true` — 인플 본인 행만 RLS 상속) + RPC: `get_application_messages`(호출자 역할별 4종 마스킹), `send_application_message`(rate limit 100/h + 자동 응대/reopen + 메일큐 계산), `mark_application_messages_read`, `withdraw_own_message`(25분 한도 + rate limit 50/h + 첨부 클라 삭제), `application_message_admin_unread_counts`(is_admin 가드). 모두 SECURITY DEFINER + `search_path=''`
+- 뷰 `application_message_summary`(`security_invoker=true` — 인플 본인 행만 RLS 상속, 관리자는 전체. 컬럼: message_count·unread_for_influencer·unresolved_for_admin_team·last_message_at) + RPC: `get_application_messages`(호출자 역할별 4종 마스킹), `send_application_message`(rate limit 100/h + 자동 응대/reopen + **관리자 발신 시 message_received 알림 INSERT** — 145), `mark_application_messages_read`, `withdraw_own_message`(25분 한도 + rate limit 50/h + 첨부 클라 삭제), `application_message_admin_unread_counts`(is_admin 가드). PR 2 신규(145): `mark_application_resolved`(is_admin — 수동 응대 완료), `hide_application_message`(is_campaign_admin — 강제 숨김 + hide_history INSERT), `unhide_application_message`(is_super_admin — 복구, 사유 메모 필수). 모두 SECURITY DEFINER + `search_path=''`
 - lookup `message_hide_reason` 7종 시드 + Storage 버킷 `application-message-attachments`(비공개, 응모건 폴더 기반 정책). 첨부는 클라 압축(`dev/lib/image-compress.js`, HEIC→JPEG/2048px) 후 업로드
 
 ### 메일·기준 데이터·알림
@@ -229,7 +229,7 @@
 - `participation_sets` — 참여방법 번들. `name_ko`/`ja`, `recruit_types[]`, `steps jsonb`, `sort_order`, `active`. `campaigns.participation_steps jsonb` + `participation_set_id` FK ON DELETE SET NULL 로 스냅샷·원본 참조
 - `caution_sets` — 주의사항 번들. items 구조 `{text_ko, text_ja, link_url?, link_label_ko?, link_label_ja?, text_after_ko?, text_after_ja?}`. `campaigns.caution_items jsonb` + `caution_set_id` FK ON DELETE SET NULL. RLS SELECT 관리자 (인플은 campaigns 스냅샷 경유)
 - `ng_sets` — NG 사항 번들. items 구조 `{html_ko, html_ja}` (DOMPurify, inline 서식만). `campaigns.ng_set_id` + `ng_items jsonb` 스냅샷. RLS SELECT `is_admin()`, CUD `is_campaign_admin()` 이상. 신청자 동의 시점 스냅샷 없음 (NG는 표시용 가이드라인)
-- `notifications` — 인플루언서 알림. `kind`(deliverable_rejected/deliverable_changed/deliverable_approved), `ref_table`/`ref_id`, `read_at`. deliverables.status 전이 트리거로 자동 생성, 재제출 시 미읽음 알림 자동 dismiss
+- `notifications` — 인플루언서 알림. `kind`(deliverable_rejected/deliverable_changed/deliverable_approved/application_cancelled/message_received), `ref_table`/`ref_id`, `title`, `body`, `read_at`. deliverables.status 전이 트리거로 자동 생성(deliverable_*), 재제출 시 미읽음 알림 자동 dismiss. `message_received`(마이그레이션 145)는 관리자가 응모건 메시지에 답장 시 send RPC 가 INSERT(ref_table='applications', 미읽음 중복 방지). 알림 모달에서 `message_received` 클릭 시 메시지 모달 직접 오픈(kind 로 분기 — application_cancelled 와 ref_table 공유하므로 kind 한정 필수)
 - `admin_daily_digest_runs` — 관리자 통합 다이제스트 발송 로그. `digest_date` UNIQUE(중복 호출 차단 + INSERT 선행 mutex) + `status CHECK(sent|skipped_no_data|failed)` + `sections_summary jsonb`(`{received, cancelled, submitted, reprocessed}`) + `recipients_count` + `error_message` + `run_at`. RLS SELECT `is_admin()`, INSERT 는 service_role 만 우회
 - `influencer_daily_digest_runs` / `application_received_admin_digest_runs` — 메일 파이프라인 운영 로그. `digest_date` UNIQUE
 - `deadline_reminder_email_sent` — 영수증/결과물 D-5·D-1 임박 메일 재발송 차단. UNIQUE 4-tuple `(influencer_id, campaign_id, kind, d_minus)`

--- a/admin/index.html
+++ b/admin/index.html
@@ -12,7 +12,7 @@
 // 회귀(2026-05-12 PR #182 머지 직후 발생)를 방지하기 위한 자동 reload 가드.
 // sessionStorage 차단 환경(시크릿 모드 일부, 쿠키 차단)에서는 자연스럽게 skip.
 (function(){
-  var CURRENT_BUILD = 'v1779266420';
+  var CURRENT_BUILD = 'v1779269973';
   if (CURRENT_BUILD.indexOf('__') === 0) return; // 빌드 미적용 (dev/ 직접 열기) 시 skip
   try {
     var prev = sessionStorage.getItem('reverb.adminBuild');
@@ -1452,6 +1452,83 @@ textarea.form-input{resize:vertical;min-height:80px}
 .visibility-toggle.is-mini .visibility-toggle-knob{width:14px;height:14px;top:2px;left:2px}
 .visibility-toggle.is-mini.is-on .visibility-toggle-knob{transform:translateX(16px)}
 
+/* ════════════════════════════════════════════════════════════
+   응모건 메시지 (PR 2) — 받은편지함 3단 + 메시지 카드/모달
+   ════════════════════════════════════════════════════════════ */
+/* 받은편지함 3단 패널 */
+.inbox-3pane{display:flex;gap:0;flex:1;min-height:0;height:calc(100vh - 130px);border:1px solid var(--line);border-radius:12px;overflow:hidden;background:#fff}
+.inbox-col{overflow-y:auto;min-height:0}
+.inbox-col-camps{width:240px;flex-shrink:0;border-right:1px solid var(--line);background:var(--surface-container-low)}
+.inbox-col-threads{width:300px;flex-shrink:0;border-right:1px solid var(--line)}
+.inbox-col-view{flex:1;min-width:0;display:flex;flex-direction:column}
+.inbox-empty{padding:24px 16px;color:var(--muted);font-size:13px;text-align:center}
+/* 좌: 캠페인 항목 */
+.inbox-camp-item{display:flex;align-items:center;justify-content:space-between;gap:8px;width:100%;padding:12px 14px;border:0;border-bottom:1px solid var(--line);background:none;cursor:pointer;text-align:left;font-size:13px;color:var(--ink)}
+.inbox-camp-item:hover{background:var(--light-pink)}
+.inbox-camp-item.active{background:var(--light-pink);font-weight:600}
+.inbox-camp-title{flex:1;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.inbox-camp-meta{display:flex;align-items:center;gap:6px;font-size:11px;color:var(--muted);flex-shrink:0}
+.inbox-camp-badge{display:inline-flex;align-items:center;justify-content:center;min-width:18px;height:18px;padding:0 5px;border-radius:9px;background:var(--pink);color:#fff;font-size:11px;font-weight:700}
+/* 중: 대화 상대 항목 */
+.inbox-thread-item{display:flex;align-items:center;justify-content:space-between;gap:8px;width:100%;padding:12px 14px;border:0;border-bottom:1px solid var(--line);background:none;cursor:pointer;text-align:left;font-size:13px;color:var(--ink)}
+.inbox-thread-item:hover{background:var(--surface-dim)}
+.inbox-thread-item.active{background:var(--light-pink);font-weight:600}
+.inbox-thread-name{flex:1;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.inbox-thread-meta{display:flex;align-items:center;gap:6px;flex-shrink:0}
+.inbox-thread-time{font-size:10px;color:var(--muted)}
+.inbox-thread-chip{display:inline-flex;align-items:center;padding:1px 6px;border-radius:8px;font-size:10px;font-weight:600}
+.inbox-thread-chip.unresolved{background:var(--gold-l);color:var(--gold)}
+.inbox-thread-chip.unread{background:var(--pink);color:#fff}
+.inbox-filter-chk{font-size:13px;color:var(--ink);display:inline-flex;align-items:center;gap:4px;cursor:pointer}
+
+/* 대화 내용 영역 (받은편지함 우측 + 모달 본문 공용) */
+.adm-msg-actionbar{display:flex;gap:8px;padding:10px 14px;border-bottom:1px solid var(--line);flex-shrink:0;background:var(--surface-container-low)}
+.adm-msg-bar-btn{padding:5px 12px;border:1px solid var(--line);border-radius:8px;background:#fff;font-size:12px;cursor:pointer;color:var(--ink)}
+.adm-msg-bar-btn.primary{background:var(--pink);color:#fff;border-color:var(--pink)}
+.adm-msg-thread{overflow-y:auto;padding:14px;display:flex;flex-direction:column;gap:10px;min-height:0;flex:1}
+/* 메시지 카드 */
+.msg-card{max-width:78%;align-self:flex-start;background:var(--surface-dim);border-radius:12px;padding:10px 12px}
+.msg-card.mine{align-self:flex-end;background:var(--light-pink)}
+.msg-card-head{display:flex;align-items:center;gap:8px;margin-bottom:4px;flex-wrap:wrap}
+.msg-card-head .msg-sender{font-size:11px;font-weight:700;color:var(--dark-pink)}
+.msg-card-head .msg-time{font-size:10px;color:var(--muted)}
+.msg-card-body{font-size:13px;line-height:1.6;color:var(--ink);word-break:break-word}
+.msg-card-masked{opacity:.7}
+.msg-masked-body{font-size:12px;color:var(--muted);font-style:italic}
+.msg-attachments{display:flex;flex-wrap:wrap;gap:6px;margin-top:8px}
+.msg-attach-thumb{width:64px;height:64px;border-radius:8px;overflow:hidden;background:var(--surface-container);display:flex;align-items:center;justify-content:center;cursor:pointer;color:var(--muted)}
+.msg-attach-thumb img{width:100%;height:100%;object-fit:cover}
+.adm-msg-status{font-size:10px;font-weight:600;padding:1px 6px;border-radius:6px}
+.adm-msg-status.hidden{background:var(--red-l);color:var(--red)}
+.adm-msg-status.withdrawn{background:var(--surface-dim);color:var(--muted)}
+.adm-msg-act{font-size:10px;padding:2px 8px;border-radius:6px;border:1px solid var(--line);background:#fff;cursor:pointer;color:var(--ink)}
+.adm-msg-act.hide{color:var(--red);border-color:var(--red)}
+.adm-msg-act.unhide{color:var(--green);border-color:var(--green)}
+/* composer */
+.adm-msg-composer{border-top:1px solid var(--line);padding:10px 14px;flex-shrink:0;background:#fff}
+.adm-msg-composer-row{display:flex;align-items:flex-end;gap:8px}
+.adm-msg-input{flex:1;resize:none;border:1px solid var(--line);border-radius:10px;padding:8px 10px;font-size:14px;font-family:inherit}
+.adm-msg-attach-btn{display:inline-flex;align-items:center;justify-content:center;width:38px;height:38px;border-radius:10px;border:1px solid var(--line);cursor:pointer;color:var(--muted);flex-shrink:0}
+.adm-msg-send{flex-shrink:0}
+.adm-msg-attach-preview{display:flex;flex-wrap:wrap;gap:6px;margin-bottom:8px}
+.msg-attach-pending{position:relative;width:56px;height:56px;border-radius:8px;overflow:hidden}
+.msg-attach-pending img{width:100%;height:100%;object-fit:cover}
+.msg-attach-remove{position:absolute;top:2px;right:2px;width:18px;height:18px;border-radius:50%;border:0;background:rgba(0,0,0,.55);color:#fff;display:flex;align-items:center;justify-content:center;cursor:pointer}
+.msg-attach-remove .material-icons-round{font-size:13px}
+.msg-empty{padding:24px;text-align:center;color:var(--muted);font-size:13px}
+/* 모달 본문은 thread 가 높이를 채우도록 */
+#admMsgModalBody .adm-msg-thread{max-height:60vh}
+/* 숨김 이력 패널 */
+.adm-msg-hide-history{padding:12px 14px;border-top:1px dashed var(--line);background:var(--surface-container-low);font-size:12px;max-height:200px;overflow-y:auto}
+.adm-hide-hist-title{font-weight:700;color:var(--ink);margin-bottom:6px}
+.adm-hide-hist-row{padding:4px 0;color:var(--muted);border-bottom:1px solid var(--line)}
+.adm-hide-hist-empty{color:var(--muted);font-style:italic}
+/* 응모 행 메시지 버튼 */
+.applicant-msg-btn{display:inline-flex;align-items:center;gap:4px;padding:3px 8px;border:1px solid var(--line);border-radius:8px;background:#fff;cursor:pointer;font-size:11px;color:var(--ink);position:relative}
+.applicant-msg-btn:hover{background:var(--light-pink);border-color:var(--pink)}
+.applicant-msg-btn .material-icons-round{font-size:14px;color:var(--pink)}
+.applicant-msg-badge{display:inline-flex;align-items:center;justify-content:center;min-width:16px;height:16px;padding:0 4px;border-radius:8px;background:var(--pink);color:#fff;font-size:10px;font-weight:700;margin-left:2px}
+
 </style>
 </head>
 <body style="background:#F8F5F8">
@@ -1498,6 +1575,7 @@ textarea.form-input{resize:vertical;min-height:80px}
         <div class="admin-si" data-pane="campaigns" onclick="navAdminPaneReload('campaigns')"><span class="si-icon material-icons-round">campaign</span><span class="si-text">캠페인 관리</span></div>
         <div class="admin-si" data-pane="applications" id="adminApplySi" onclick="navAdminPaneReload('applications')"><span class="si-icon material-icons-round">assignment</span><span class="si-text">신청 관리</span></div>
         <div class="admin-si" data-pane="deliverables" id="adminDelivSi" onclick="navAdminPaneReload('deliverables')"><span class="si-icon material-icons-round">fact_check</span><span class="si-text">결과물 관리</span></div>
+        <div class="admin-si" data-pane="messages" id="adminMessagesSi" onclick="navAdminPaneReload('messages')"><span class="si-icon material-icons-round">forum</span><span class="si-text">메시지</span><span id="navMsgBadge" class="admin-si-badge" style="display:none">0</span></div>
         <div class="admin-si-lbl">브랜드 서베이</div>
         <div class="admin-si" data-pane="brand-dashboard" id="adminBrandDashSi" onclick="navAdminPaneReload('brand-dashboard')"><span class="si-icon material-icons-round">insights</span><span class="si-text">현황 대시보드</span></div>
         <div class="admin-si" data-pane="brands" id="adminBrandsSi" onclick="navAdminPaneReload('brands')"><span class="si-icon material-icons-round">business</span><span class="si-text">브랜드 관리</span></div>
@@ -1522,7 +1600,7 @@ textarea.form-input{resize:vertical;min-height:80px}
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-05-20 17:40 · aed9cd9</span>
+          <span class="admin-build-text">2026-05-20 18:39 · 9827ccb</span>
         </div>
       </div>
     </aside>
@@ -2494,6 +2572,27 @@ textarea.form-input{resize:vertical;min-height:80px}
         </div>
 
         <!-- BRAND DASHBOARD (광고주 서베이 현황) PANE -->
+        <!-- 메시지 받은편지함 (3단: 캠페인 / 대화 상대 / 대화 내용) -->
+        <div id="adminPane-messages" class="admin-pane">
+          <div class="admin-sticky-header">
+            <h2 class="admin-pane-title">메시지</h2>
+            <div class="admin-filters">
+              <label class="inbox-filter-chk"><input type="checkbox" onchange="toggleInboxUnresolved(this.checked)"> 미응대만</label>
+              <select class="admin-select" onchange="changeInboxSince(this.value)">
+                <option value="6">최근 6개월</option>
+                <option value="3">최근 3개월</option>
+                <option value="12">최근 1년</option>
+                <option value="120">전체</option>
+              </select>
+            </div>
+          </div>
+          <div class="inbox-3pane">
+            <div class="inbox-col inbox-col-camps" id="inboxCampaigns"></div>
+            <div class="inbox-col inbox-col-threads" id="inboxThreads"></div>
+            <div class="inbox-col inbox-col-view" id="inboxThreadView"></div>
+          </div>
+        </div>
+
         <div id="adminPane-brand-dashboard" class="admin-pane">
           <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:16px;gap:12px;flex-wrap:wrap">
             <div>
@@ -3751,6 +3850,46 @@ textarea.form-input{resize:vertical;min-height:80px}
   </div>
 </div>
 
+<!-- 응모건 메시지 모달 (응모 행 「메시지」 버튼 진입) -->
+<div class="modal-overlay" id="admMsgModal" style="z-index:640">
+  <div class="modal" style="max-width:720px;width:96vw;border-radius:16px;margin:auto;max-height:86vh;display:flex;flex-direction:column">
+    <div class="modal-header" style="padding:16px 20px 12px;border-bottom:1px solid var(--line);display:flex;align-items:center;justify-content:space-between">
+      <div style="font-size:14px;font-weight:700;color:var(--ink)" id="admMsgModalTitle">메시지</div>
+      <button class="btn btn-ghost btn-xs" onclick="closeAdminMessageModal()" style="padding:4px 10px">✕</button>
+    </div>
+    <div class="modal-body" id="admMsgModalBody" style="padding:0;overflow:hidden;flex:1;display:flex;flex-direction:column"></div>
+  </div>
+</div>
+
+<!-- 강제 숨김 사유 모달 -->
+<div class="modal-overlay" id="admHideModal" style="z-index:650">
+  <div class="modal" style="max-width:440px;border-radius:18px;margin:auto;display:flex;flex-direction:column">
+    <div class="modal-header" style="padding:16px 20px 12px;border-bottom:1px solid var(--line);display:flex;align-items:center;justify-content:space-between">
+      <div style="font-size:14px;font-weight:700;color:var(--ink)">메시지 숨김</div>
+      <button class="btn btn-ghost btn-xs" onclick="closeHideModal()" style="padding:4px 10px">✕</button>
+    </div>
+    <div class="modal-body" style="padding:16px 20px;display:flex;flex-direction:column;gap:12px">
+      <label style="font-size:13px;color:var(--muted)">숨김 사유
+        <select id="admHideReasonSelect" class="admin-select" style="width:100%;margin-top:6px"></select>
+      </label>
+      <label style="font-size:13px;color:var(--muted)">메모 (선택)
+        <textarea id="admHideMemo" rows="3" style="width:100%;margin-top:6px;font-size:14px" placeholder="추가 설명 (선택)"></textarea>
+      </label>
+    </div>
+    <div class="modal-footer" style="padding:14px 20px;border-top:1px solid var(--line);display:flex;gap:8px;justify-content:flex-end">
+      <button class="btn btn-ghost" onclick="closeHideModal()">취소</button>
+      <button class="btn btn-primary" onclick="confirmHideMessage()">숨김</button>
+    </div>
+  </div>
+</div>
+
+<!-- 메시지 첨부 라이트박스 -->
+<div class="modal-overlay" id="admMsgLightbox" style="z-index:660" onclick="closeAdmMsgLightbox()">
+  <div style="margin:auto;max-width:92vw;max-height:88vh;display:flex;align-items:center;justify-content:center">
+    <img id="admMsgLightboxImg" src="" alt="" style="max-width:92vw;max-height:88vh;border-radius:8px">
+  </div>
+</div>
+
 
 <script>
 // ══════════════════════════════════════
@@ -4193,6 +4332,9 @@ const PANE_REFRESHERS = {
   'campaigns': async () => {
     // 관리자 캠페인 목록 갱신 — `loadCampaigns`(인플루언서 함수) 오참조 버그 수정
     if (typeof loadAdminCampaigns === 'function') await loadAdminCampaigns();
+  },
+  'messages': async () => {
+    if (typeof refreshInboxData === 'function') await refreshInboxData();
   }
 };
 async function refreshPane(paneId) {
@@ -6293,6 +6435,98 @@ async function fetchInfluencerUnreadMessageThreads() {
     .gt('unread_for_influencer', 0)
     .order('last_message_at', { ascending: false });
   if (error) { console.warn('[fetchInfluencerUnreadMessageThreads]', error); return []; }
+  return data || [];
+}
+
+// ════════════════════════════════════════════════════════════════════
+// 응모건 메시지 — 관리자 발신/숨김/응대 (PR 2)
+//   마이그레이션 145. 관리자 받은편지함·강제 숨김/복구·응대 완료.
+// ════════════════════════════════════════════════════════════════════
+
+// 응모건 수동 응대 완료 마킹 (모든 관리자 — 사양서 §3-4). RPC mark_application_resolved.
+async function markApplicationResolved(applicationId) {
+  if (!db || !applicationId) return;
+  await retryWithRefresh(async () => {
+    const {error} = await db.rpc('mark_application_resolved', { p_application_id: applicationId });
+    if (error) throw error;
+  });
+}
+
+// 메시지 강제 숨김 (campaign_admin 이상). reasonCode 는 lookup_values(kind='message_hide_reason').code.
+async function hideApplicationMessage(messageId, reasonCode, reasonMemo = null) {
+  if (!db || !messageId) throw new Error('잘못된 호출');
+  await retryWithRefresh(async () => {
+    const {error} = await db.rpc('hide_application_message', {
+      p_message_id: messageId,
+      p_reason_code: reasonCode,
+      p_reason_memo: reasonMemo || null,
+    });
+    if (error) throw error;
+  });
+}
+
+// 강제 숨김 복구 (super_admin 한정). reasonMemo 필수.
+async function unhideApplicationMessage(messageId, reasonMemo) {
+  if (!db || !messageId) throw new Error('잘못된 호출');
+  await retryWithRefresh(async () => {
+    const {error} = await db.rpc('unhide_application_message', {
+      p_message_id: messageId,
+      p_reason_memo: reasonMemo,
+    });
+    if (error) throw error;
+  });
+}
+
+// 관리자 본인 미열람 메시지 수 (응모건별). RPC application_message_admin_unread_counts.
+// 반환: Map<application_id, unread_count> (응모행 배지·받은편지함 개인 강조용)
+async function fetchAdminMessageUnreadCounts() {
+  if (!db) return new Map();
+  const {data, error} = await db.rpc('application_message_admin_unread_counts', { p_admin_auth_id: null });
+  if (error) { console.warn('[fetchAdminMessageUnreadCounts]', error); return new Map(); }
+  const map = new Map();
+  (data || []).forEach(r => map.set(r.application_id, Number(r.unread_count) || 0));
+  return map;
+}
+
+// 관리자 받은편지함 대화 목록 — application_message_summary 뷰 조회.
+//   security_invoker=true 라 관리자 호출 시 전체 응모건 RLS 통과.
+//   message_count>0 (메시지 있는 건만) + last_message_at 최근순. 1000행 cap 대응 pagination.
+//   opts: { sinceMonths(기본 6), campaignId(선택) }
+async function fetchAdminMessageThreads(opts = {}) {
+  if (!db) return [];
+  const sinceMonths = opts.sinceMonths || 6;
+  const sinceIso = new Date(Date.now() - sinceMonths * 30 * 24 * 60 * 60 * 1000).toISOString();
+  const cols = 'application_id, influencer_id, campaign_id, message_count, unread_for_influencer, unresolved_for_admin_team, last_message_at';
+  const rows = [];
+  let from = 0;
+  const PAGE = 1000;
+  while (true) {
+    let q = db?.from('application_message_summary')
+      .select(cols)
+      .gt('message_count', 0)
+      .gte('last_message_at', sinceIso)
+      .order('last_message_at', { ascending: false })
+      .range(from, from + PAGE - 1);
+    if (opts.campaignId) q = q.eq('campaign_id', opts.campaignId);
+    const {data, error} = await q;
+    if (error) { console.warn('[fetchAdminMessageThreads]', error); break; }
+    rows.push(...(data || []));
+    if (!data || data.length < PAGE) break;
+    from += PAGE;
+  }
+  return rows;
+}
+
+// 응모건 단위 숨김/복구 이력 (super_admin — append-only audit). 메시지 모달 하단 패널용.
+//   hide_history 는 message_id 만 가지므로 application_messages inner join 으로 응모건 필터.
+//   RLS SELECT 는 super_admin 한정 (144) — 매니저 호출 시 빈 배열.
+async function fetchApplicationHideHistory(applicationId) {
+  if (!db || !applicationId) return [];
+  const {data, error} = await db.from('application_message_hide_history')
+    .select('id, message_id, action, by_user_kind, by_name, reason_code, reason_memo, at, application_messages!inner(application_id)')
+    .eq('application_messages.application_id', applicationId)
+    .order('at', { ascending: false });
+  if (error) { console.warn('[fetchApplicationHideHistory]', error); return []; }
   return data || [];
 }
 
@@ -10845,6 +11079,548 @@ async function confirmPaidAtEdit(anyChildEl) {
 
 
 // ════════════════════════════════════════════════════════════════════
+// admin-messaging.js — 관리자 응모건 메시지 (PR 2)
+//   사양서 docs/specs/2026-05-15-application-messaging.md §5-3, §5-4, §3-4, §3-5
+//   - 받은편지함 3단 패널 (좌: 캠페인 / 중: 대화 상대 / 우: 대화 내용)
+//   - 응모 행 「메시지」 버튼 → 메시지 모달 (신청관리·캠페인별 신청자·결과물 관리 공용)
+//   - 답장 / 강제 숨김(campaign_admin+) / 복구(super_admin) / 수동 응대 완료(모든 관리자)
+//   DB: storage.js (fetchApplicationMessages / sendApplicationMessage / markApplicationMessagesRead /
+//        withdrawOwnMessage / markApplicationResolved / hideApplicationMessage /
+//        unhideApplicationMessage / fetchAdminMessageThreads / fetchAdminMessageUnreadCounts /
+//        fetchApplicationHideHistory / uploadMessageAttachment / getMessageAttachmentSignedUrl)
+//   admin.js 핫스팟 회피용 분리 파일 (admin-brand.js 패턴). UI 텍스트는 한국어.
+// ════════════════════════════════════════════════════════════════════
+
+const ADM_MSG_WITHDRAW_LIMIT_MS = 25 * 60 * 1000;  // 본인(관리자) 회수 25분 (§3-5 ②)
+const ADM_MSG_MAX_ATTACH = 5;                       // 메시지당 첨부 최대 5장 (§3-2)
+
+// 받은편지함 상태
+let _inboxThreads = [];                 // fetchAdminMessageThreads 결과 (뷰 행)
+let _inboxUnreadMap = new Map();        // application_id → 본인 미열람 수
+let _inboxSelectedCampaign = null;      // 좌 패널 선택 캠페인 id
+let _inboxFilters = { unresolvedOnly: false, sinceMonths: 6 };
+
+// 메시지 모달/패널 공용 상태
+let _admMsgAppId = null;                // 현재 열린 응모건
+let _admMsgContext = 'modal';           // 'modal' | 'inbox' — 전송 후 재렌더 대상
+let _admMsgPendingFiles = [];
+let _admMsgSending = false;
+
+// 응모 행 메시지 버튼 셀에 표시할 본인 미열람 맵 (페인 로드 시 채움)
+let _applicantMsgUnreadMap = new Map();
+
+// 받은편지함 인플루언서 이름 맵 (influencer_id → 행). refreshInboxData 에서 채움
+let _inboxInflMap = {};
+
+// 현재 super_admin 여부 (admin.js 의 currentAdminInfo 기준)
+function admMsgIsSuper() {
+  return (typeof currentAdminInfo !== 'undefined' && currentAdminInfo?.role === 'super_admin');
+}
+
+// 숨김 사유 카테고리 (message_hide_reason — fetchLookups 가 active 만 반환·캐시)
+async function loadHideReasons() {
+  try { return await fetchLookups('message_hide_reason'); }
+  catch (e) { console.warn('[loadHideReasons]', e); return []; }
+}
+
+// ════════════════════════════════════════════════════════════════════
+// 1. 받은편지함 3단 패널 (#adminPane-messages)
+// ════════════════════════════════════════════════════════════════════
+async function loadMessagesInbox() {
+  const wrap = document.getElementById('inboxThreadView');
+  if (wrap) wrap.innerHTML = '<div class="inbox-empty">대화를 선택하세요.</div>';
+  await refreshInboxData();
+}
+
+// 뷰 + 본인 미열람 맵을 다시 조회하고 좌/중 패널 재렌더
+async function refreshInboxData() {
+  try {
+    const [threads, unreadMap] = await Promise.all([
+      fetchAdminMessageThreads({ sinceMonths: _inboxFilters.sinceMonths }),
+      fetchAdminMessageUnreadCounts(),
+    ]);
+    _inboxThreads = threads || [];
+    _inboxUnreadMap = unreadMap || new Map();
+    // 인플루언서 이름 보강 (id 목록 → fetchInfluencersByIds 맵)
+    const ids = [...new Set(_inboxThreads.map(t => t.influencer_id).filter(Boolean))];
+    _inboxInflMap = ids.length ? (await fetchInfluencersByIds(ids)) : {};
+  } catch (e) {
+    console.error('[refreshInboxData]', e);
+    _inboxThreads = []; _inboxUnreadMap = new Map(); _inboxInflMap = {};
+  }
+  renderInboxCampaignList();
+  renderInboxThreadList();
+  updateInboxSidebarBadge();
+}
+
+// 사이드바 「메시지」 미응대 배지 = 우리 팀 미응대 응모건 수 (그룹 공통)
+function updateInboxSidebarBadge() {
+  const badge = document.getElementById('navMsgBadge');
+  if (!badge) return;
+  const n = _inboxThreads.filter(t => t.unresolved_for_admin_team).length;
+  if (n > 0) { badge.textContent = n > 99 ? '99+' : String(n); badge.style.display = ''; }
+  else { badge.style.display = 'none'; }
+}
+
+// 좌: 캠페인 목록 (메시지 있는 응모건을 campaign_id 로 그룹 + 미응대 합계)
+function renderInboxCampaignList() {
+  const el = document.getElementById('inboxCampaigns');
+  if (!el) return;
+  // campaign_id 별 집계
+  const byCamp = new Map();
+  for (const t of _inboxThreads) {
+    if (_inboxFilters.unresolvedOnly && !t.unresolved_for_admin_team) continue;
+    let g = byCamp.get(t.campaign_id);
+    if (!g) { g = { campaign_id: t.campaign_id, total: 0, unresolved: 0, lastAt: t.last_message_at }; byCamp.set(t.campaign_id, g); }
+    g.total += 1;
+    if (t.unresolved_for_admin_team) g.unresolved += 1;
+    if (t.last_message_at > g.lastAt) g.lastAt = t.last_message_at;
+  }
+  const groups = Array.from(byCamp.values()).sort((a, b) => (b.lastAt || '').localeCompare(a.lastAt || ''));
+  if (!groups.length) {
+    el.innerHTML = '<div class="inbox-empty">표시할 대화가 없습니다.</div>';
+    return;
+  }
+  el.innerHTML = groups.map(g => {
+    const camp = campaignTitleById(g.campaign_id);
+    const active = g.campaign_id === _inboxSelectedCampaign ? 'active' : '';
+    const badge = g.unresolved > 0 ? `<span class="inbox-camp-badge">${g.unresolved}</span>` : '';
+    return `<button type="button" class="inbox-camp-item ${active}" onclick="selectInboxCampaign('${esc(g.campaign_id)}')">
+      <span class="inbox-camp-title">${esc(camp)}</span>
+      <span class="inbox-camp-meta">${g.total}건${badge}</span>
+    </button>`;
+  }).join('');
+}
+
+function selectInboxCampaign(campaignId) {
+  _inboxSelectedCampaign = campaignId;
+  renderInboxCampaignList();
+  renderInboxThreadList();
+}
+
+// 중: 선택 캠페인의 대화 상대(인플루언서) 목록
+function renderInboxThreadList() {
+  const el = document.getElementById('inboxThreads');
+  if (!el) return;
+  if (!_inboxSelectedCampaign) {
+    el.innerHTML = '<div class="inbox-empty">왼쪽에서 캠페인을 선택하세요.</div>';
+    return;
+  }
+  let list = _inboxThreads.filter(t => t.campaign_id === _inboxSelectedCampaign);
+  if (_inboxFilters.unresolvedOnly) list = list.filter(t => t.unresolved_for_admin_team);
+  list.sort((a, b) => (b.last_message_at || '').localeCompare(a.last_message_at || ''));
+  if (!list.length) {
+    el.innerHTML = '<div class="inbox-empty">대화가 없습니다.</div>';
+    return;
+  }
+  el.innerHTML = list.map(t => {
+    const name = influencerNameById(t.influencer_id);
+    const unread = _inboxUnreadMap.get(t.application_id) || 0;
+    const active = t.application_id === _admMsgAppId ? 'active' : '';
+    const unresolved = t.unresolved_for_admin_team
+      ? '<span class="inbox-thread-chip unresolved">미응대</span>' : '';
+    const unreadChip = unread > 0
+      ? `<span class="inbox-thread-chip unread">${unread > 99 ? '99+' : unread}</span>` : '';
+    return `<button type="button" class="inbox-thread-item ${active}" onclick="openInboxThread('${esc(t.application_id)}')">
+      <span class="inbox-thread-name">${esc(name)}</span>
+      <span class="inbox-thread-meta">${unresolved}${unreadChip}<span class="inbox-thread-time">${esc(formatDate(t.last_message_at))}</span></span>
+    </button>`;
+  }).join('');
+}
+
+// 우: 선택 응모건 대화 내용 (인라인 패널)
+async function openInboxThread(applicationId) {
+  _admMsgAppId = applicationId;
+  _admMsgContext = 'inbox';
+  _admMsgPendingFiles = [];
+  renderInboxThreadList();  // active 표시 갱신
+  const view = document.getElementById('inboxThreadView');
+  if (view) view.innerHTML = '<div class="inbox-empty">불러오는 중…</div>';
+  try {
+    const msgs = await fetchApplicationMessages(applicationId);
+    if (view) view.innerHTML = adminThreadViewHtml('inbox');
+    renderAdminMsgThread('inboxMsgThread', msgs);
+    await markApplicationMessagesRead(applicationId);
+    // 본인 미열람 맵 갱신 후 중 패널 재렌더
+    _inboxUnreadMap = await fetchAdminMessageUnreadCounts();
+    renderInboxThreadList();
+  } catch (e) {
+    console.error('[openInboxThread]', e);
+    if (view) view.innerHTML = '<div class="inbox-empty">메시지를 불러오지 못했습니다.</div>';
+  }
+}
+
+// 받은편지함 필터 토글
+function toggleInboxUnresolved(checked) {
+  _inboxFilters.unresolvedOnly = !!checked;
+  renderInboxCampaignList();
+  renderInboxThreadList();
+}
+function changeInboxSince(months) {
+  _inboxFilters.sinceMonths = Number(months) || 6;
+  refreshInboxData();
+}
+
+// ════════════════════════════════════════════════════════════════════
+// 2. 메시지 모달 (응모 행 버튼 진입)
+// ════════════════════════════════════════════════════════════════════
+async function openAdminMessageModal(applicationId, campaignId) {
+  if (!applicationId) return;
+  _admMsgAppId = applicationId;
+  _admMsgContext = 'modal';
+  _admMsgPendingFiles = [];
+  const m = document.getElementById('admMsgModal');
+  if (!m) return;
+  const titleEl = document.getElementById('admMsgModalTitle');
+  if (titleEl) titleEl.textContent = `${campaignTitleById(campaignId)} — 메시지`;
+  const body = document.getElementById('admMsgModalBody');
+  if (body) body.innerHTML = adminThreadViewHtml('modal');
+  openModal('admMsgModal');
+  const thread = document.getElementById('admMsgThread');
+  if (thread) thread.innerHTML = '<div class="msg-empty">불러오는 중…</div>';
+  try {
+    const msgs = await fetchApplicationMessages(applicationId);
+    renderAdminMsgThread('admMsgThread', msgs);
+    await markApplicationMessagesRead(applicationId);
+    _applicantMsgUnreadMap.set(applicationId, 0);
+    updateApplicantMsgBadge(applicationId);
+  } catch (e) {
+    console.error('[openAdminMessageModal]', e);
+    if (thread) thread.innerHTML = '<div class="msg-empty">메시지를 불러오지 못했습니다.</div>';
+  }
+}
+
+function closeAdminMessageModal() {
+  closeModal('admMsgModal');
+  _admMsgPendingFiles = [];
+  if (_admMsgContext === 'modal') _admMsgAppId = null;
+}
+
+// 대화 내용 컨테이너 HTML (받은편지함 우측 / 모달 본문 공용)
+//   ctx: 'inbox' | 'modal' — thread/composer DOM id 접두사 결정
+function adminThreadViewHtml(ctx) {
+  const threadId = ctx === 'inbox' ? 'inboxMsgThread' : 'admMsgThread';
+  const composerId = ctx === 'inbox' ? 'inboxComposer' : 'admComposer';
+  const histId = ctx === 'inbox' ? 'inboxHideHist' : 'admHideHist';
+  const histBtn = admMsgIsSuper()
+    ? `<button type="button" class="adm-msg-bar-btn" onclick="toggleHideHistory('${ctx}')">숨김 이력</button>` : '';
+  return `
+    <div class="adm-msg-actionbar">
+      <button type="button" class="adm-msg-bar-btn primary" onclick="markCurrentResolved()">응대 완료</button>
+      ${histBtn}
+    </div>
+    <div class="adm-msg-thread" id="${threadId}"></div>
+    <div class="adm-msg-hide-history" id="${histId}" style="display:none"></div>
+    <div class="adm-msg-composer" id="${composerId}">
+      <div class="adm-msg-attach-preview" id="${composerId}Preview"></div>
+      <div class="adm-msg-composer-row">
+        <label class="adm-msg-attach-btn" title="이미지 첨부">
+          <span class="material-icons-round notranslate" translate="no">image</span>
+          <input type="file" accept="image/*" multiple style="display:none" onchange="onAdmMsgAttachSelected(this)">
+        </label>
+        <textarea class="adm-msg-input" id="${composerId}Input" rows="2" placeholder="답장 입력…"></textarea>
+        <button type="button" class="btn btn-primary adm-msg-send" onclick="sendAdminMessage()">전송</button>
+      </div>
+    </div>`;
+}
+
+// 숨김 이력 패널 토글 (super_admin) — 응모건 단위 audit
+async function toggleHideHistory(ctx) {
+  const histId = ctx === 'inbox' ? 'inboxHideHist' : 'admHideHist';
+  const el = document.getElementById(histId);
+  if (!el || !_admMsgAppId) return;
+  if (el.style.display !== 'none') { el.style.display = 'none'; return; }
+  el.style.display = '';
+  el.innerHTML = '<div class="msg-empty">불러오는 중…</div>';
+  try {
+    const rows = await fetchApplicationHideHistory(_admMsgAppId);
+    if (!rows.length) { el.innerHTML = '<div class="adm-hide-hist-empty">숨김/복구 이력이 없습니다.</div>'; return; }
+    el.innerHTML = '<div class="adm-hide-hist-title">숨김/복구 이력</div>' + rows.map(r => {
+      const act = r.action === 'hide' ? '숨김' : '복구';
+      const reason = r.reason_code ? ` · ${esc(r.reason_code)}` : '';
+      const memo = r.reason_memo ? ` · ${esc(r.reason_memo)}` : '';
+      return `<div class="adm-hide-hist-row"><b>${act}</b> ${esc(r.by_name || '')} · ${esc(formatDate(r.at))}${reason}${memo}</div>`;
+    }).join('');
+  } catch (e) {
+    console.error('[toggleHideHistory]', e);
+    el.innerHTML = '<div class="adm-hide-hist-empty">이력을 불러오지 못했습니다.</div>';
+  }
+}
+
+// ════════════════════════════════════════════════════════════════════
+// 3. 스레드 렌더 (공용 — 받은편지함 우측·모달 모두)
+// ════════════════════════════════════════════════════════════════════
+function renderAdminMsgThread(threadElId, messages) {
+  const thread = document.getElementById(threadElId);
+  if (!thread) return;
+  if (!messages || !messages.length) {
+    thread.innerHTML = '<div class="msg-empty">아직 메시지가 없습니다.</div>';
+    return;
+  }
+  const now = Date.now();
+  const isSuper = admMsgIsSuper();
+  thread.innerHTML = messages.map(msg => {
+    const fromAdmin = msg.sender_kind === 'admin';
+    const senderLabel = fromAdmin ? `운영팀 (${esc(msg.sender_name || '')})` : esc(msg.sender_name || '인플루언서');
+    const timeStr = formatDate(msg.created_at);
+    const sideCls = fromAdmin ? 'mine' : '';
+
+    // 인플루언서 본인 회수 → 관리자도 못 봄 (placeholder)
+    if (msg.mask_state === 'self_withdrawn_influencer') {
+      return msgCardMasked(senderLabel, timeStr, sideCls, '인플루언서가 회수한 메시지입니다.');
+    }
+
+    const bodyHtml = esc(msg.body || '').replace(/\n/g, '<br>');
+    const atts = Array.isArray(msg.attachments) ? msg.attachments : [];
+    let attachHtml = '';
+    if (atts.length) {
+      attachHtml = `<div class="msg-attachments">${atts.map((a, i) => {
+        const elId = `admatt-${msg.id}-${i}`;
+        loadAdmMsgAttachThumb(elId, a.path);
+        return `<div class="msg-attach-thumb" id="${elId}" onclick="openAdmMsgLightbox('${esc(a.path)}')"><span class="material-icons-round notranslate" translate="no">image</span></div>`;
+      }).join('')}</div>`;
+    }
+
+    // 상태 뱃지 + 액션 버튼
+    let statusBadge = '';
+    let actions = '';
+    if (msg.mask_state === 'hidden_by_admin') {
+      statusBadge = '<span class="adm-msg-status hidden">숨김 처리됨</span>';
+      if (isSuper) actions += `<button type="button" class="adm-msg-act unhide" onclick="promptUnhideMessage('${esc(msg.id)}')">복구</button>`;
+    } else if (msg.mask_state === 'self_withdrawn_admin') {
+      statusBadge = '<span class="adm-msg-status withdrawn">회수됨</span>';
+    } else {
+      // visible
+      if (fromAdmin) {
+        // 운영팀 발신 + 25분 이내 → 회수 (회수는 withdraw_own_message RPC 가 본인 검증)
+        const elapsed = now - new Date(msg.created_at).getTime();
+        if (elapsed < ADM_MSG_WITHDRAW_LIMIT_MS) {
+          const pathsJson = esc(JSON.stringify(atts.map(a => a.path)));
+          actions += `<button type="button" class="adm-msg-act withdraw" onclick='confirmAdmWithdraw("${esc(msg.id)}", ${pathsJson})'>회수</button>`;
+        }
+      } else {
+        // 인플루언서 메시지 → campaign_admin+ 강제 숨김 (RPC 가 권한 가드)
+        actions += `<button type="button" class="adm-msg-act hide" onclick="promptHideMessage('${esc(msg.id)}')">숨김</button>`;
+      }
+    }
+
+    return `<div class="msg-card ${sideCls}">
+      <div class="msg-card-head"><span class="msg-sender">${senderLabel}</span><span class="msg-time">${esc(timeStr)}</span>${statusBadge}${actions}</div>
+      <div class="msg-card-body">${bodyHtml}</div>
+      ${attachHtml}
+    </div>`;
+  }).join('');
+  thread.scrollTop = thread.scrollHeight;
+}
+
+function msgCardMasked(senderLabel, timeStr, sideCls, text) {
+  return `<div class="msg-card msg-card-masked ${sideCls}">
+    <div class="msg-card-head"><span class="msg-sender">${senderLabel}</span><span class="msg-time">${esc(timeStr)}</span></div>
+    <div class="msg-masked-body">${esc(text)}</div>
+  </div>`;
+}
+
+async function loadAdmMsgAttachThumb(elId, path) {
+  try {
+    const url = await getMessageAttachmentSignedUrl(path);
+    const el = document.getElementById(elId);
+    if (el && url) el.innerHTML = `<img src="${esc(url)}" loading="lazy" decoding="async" alt="">`;
+  } catch (e) { /* 아이콘 유지 */ }
+}
+
+// ── 라이트박스 ──
+async function openAdmMsgLightbox(path) {
+  const lb = document.getElementById('admMsgLightbox');
+  const img = document.getElementById('admMsgLightboxImg');
+  if (!lb || !img) return;
+  img.src = '';
+  openModal('admMsgLightbox');
+  try {
+    const url = await getMessageAttachmentSignedUrl(path);
+    if (url) img.src = url; else { closeAdmMsgLightbox(); toast('이미지를 불러오지 못했습니다.'); }
+  } catch (e) { closeAdmMsgLightbox(); toast('이미지를 불러오지 못했습니다.'); }
+}
+function closeAdmMsgLightbox() {
+  closeModal('admMsgLightbox');
+  const img = document.getElementById('admMsgLightboxImg');
+  if (img) img.src = '';
+}
+
+// ════════════════════════════════════════════════════════════════════
+// 4. 첨부 선택/전송
+// ════════════════════════════════════════════════════════════════════
+function curComposerId() { return _admMsgContext === 'inbox' ? 'inboxComposer' : 'admComposer'; }
+
+function onAdmMsgAttachSelected(input) {
+  const files = Array.from(input.files || []);
+  input.value = '';
+  for (const f of files) {
+    if (_admMsgPendingFiles.length >= ADM_MSG_MAX_ATTACH) { toast(`첨부는 최대 ${ADM_MSG_MAX_ATTACH}장까지 가능합니다.`); break; }
+    _admMsgPendingFiles.push(f);
+  }
+  renderAdmMsgAttachPreview();
+}
+function removeAdmMsgAttach(idx) { _admMsgPendingFiles.splice(idx, 1); renderAdmMsgAttachPreview(); }
+function renderAdmMsgAttachPreview() {
+  const wrap = document.getElementById(curComposerId() + 'Preview');
+  if (!wrap) return;
+  if (!_admMsgPendingFiles.length) { wrap.innerHTML = ''; return; }
+  wrap.innerHTML = _admMsgPendingFiles.map((f, i) => {
+    const url = URL.createObjectURL(f);
+    return `<div class="msg-attach-pending"><img src="${url}" alt=""><button type="button" class="msg-attach-remove" onclick="removeAdmMsgAttach(${i})" aria-label="삭제"><span class="material-icons-round notranslate" translate="no">close</span></button></div>`;
+  }).join('');
+}
+
+async function sendAdminMessage() {
+  if (_admMsgSending || !_admMsgAppId) return;
+  const inputEl = document.getElementById(curComposerId() + 'Input');
+  const body = (inputEl?.value || '').trim();
+  if (!body && !_admMsgPendingFiles.length) { toast('메시지를 입력하세요.'); return; }
+  _admMsgSending = true;
+  try {
+    const attachments = [];
+    for (const f of _admMsgPendingFiles) {
+      try { attachments.push(await uploadMessageAttachment(f, _admMsgAppId)); }
+      catch (e) {
+        console.error('[sendAdminMessage] 첨부', e);
+        toast(e?.message === 'too_large' ? '이미지 용량이 큽니다.' : '첨부 업로드에 실패했습니다.');
+        _admMsgSending = false; return;
+      }
+    }
+    await sendApplicationMessage(_admMsgAppId, body, attachments);
+    if (inputEl) inputEl.value = '';
+    _admMsgPendingFiles = [];
+    renderAdmMsgAttachPreview();
+    const msgs = await fetchApplicationMessages(_admMsgAppId);
+    renderAdminMsgThread(_admMsgContext === 'inbox' ? 'inboxMsgThread' : 'admMsgThread', msgs);
+    // 관리자 답장 = 자동 응대 완료 → 받은편지함 집계 갱신
+    if (_admMsgContext === 'inbox') await refreshInboxData();
+    else updateInboxSidebarBadge();
+  } catch (e) {
+    console.error('[sendAdminMessage]', e);
+    toast(e?.code === 'P0001' && e?.message ? e.message : '전송에 실패했습니다.');
+  } finally {
+    _admMsgSending = false;
+  }
+}
+
+// ── 본인(관리자) 회수 ──
+async function confirmAdmWithdraw(messageId, attachmentPaths) {
+  if (!confirm('이 메시지를 회수하시겠습니까?')) return;
+  try {
+    await withdrawOwnMessage(messageId, attachmentPaths || []);
+    const msgs = await fetchApplicationMessages(_admMsgAppId);
+    renderAdminMsgThread(_admMsgContext === 'inbox' ? 'inboxMsgThread' : 'admMsgThread', msgs);
+  } catch (e) {
+    console.error('[confirmAdmWithdraw]', e);
+    toast(e?.code === 'P0001' && e?.message ? e.message : '회수에 실패했습니다.');
+  }
+}
+
+// ════════════════════════════════════════════════════════════════════
+// 5. 강제 숨김 / 복구
+// ════════════════════════════════════════════════════════════════════
+let _hideTargetMsgId = null;
+async function promptHideMessage(messageId) {
+  _hideTargetMsgId = messageId;
+  const reasons = await loadHideReasons();
+  const sel = document.getElementById('admHideReasonSelect');
+  if (sel) sel.innerHTML = reasons.map(r => `<option value="${esc(r.code)}">${esc(r.name_ko)}</option>`).join('');
+  const memo = document.getElementById('admHideMemo');
+  if (memo) memo.value = '';
+  openModal('admHideModal');
+}
+function closeHideModal() {
+  closeModal('admHideModal');
+  _hideTargetMsgId = null;
+}
+async function confirmHideMessage() {
+  if (!_hideTargetMsgId) return;
+  const code = document.getElementById('admHideReasonSelect')?.value;
+  const memo = document.getElementById('admHideMemo')?.value || '';
+  if (!code) { toast('숨김 사유를 선택하세요.'); return; }
+  try {
+    await hideApplicationMessage(_hideTargetMsgId, code, memo);
+    closeHideModal();
+    const msgs = await fetchApplicationMessages(_admMsgAppId);
+    renderAdminMsgThread(_admMsgContext === 'inbox' ? 'inboxMsgThread' : 'admMsgThread', msgs);
+    toast('메시지를 숨김 처리했습니다.');
+  } catch (e) {
+    console.error('[confirmHideMessage]', e);
+    toast(e?.code === 'P0001' && e?.message ? e.message : '숨김 처리에 실패했습니다.');
+  }
+}
+
+async function promptUnhideMessage(messageId) {
+  const memo = prompt('복구 사유를 입력하세요 (필수):');
+  if (memo === null) return;
+  if (!memo.trim()) { toast('복구 사유는 필수입니다.'); return; }
+  try {
+    await unhideApplicationMessage(messageId, memo.trim());
+    const msgs = await fetchApplicationMessages(_admMsgAppId);
+    renderAdminMsgThread(_admMsgContext === 'inbox' ? 'inboxMsgThread' : 'admMsgThread', msgs);
+    toast('메시지를 복구했습니다.');
+  } catch (e) {
+    console.error('[promptUnhideMessage]', e);
+    toast(e?.code === 'P0001' && e?.message ? e.message : '복구에 실패했습니다.');
+  }
+}
+
+// ── 수동 응대 완료 ──
+async function markCurrentResolved() {
+  if (!_admMsgAppId) return;
+  try {
+    await markApplicationResolved(_admMsgAppId);
+    toast('응대 완료로 표시했습니다.');
+    if (_admMsgContext === 'inbox') await refreshInboxData();
+    else updateInboxSidebarBadge();
+  } catch (e) {
+    console.error('[markCurrentResolved]', e);
+    toast(e?.code === 'P0001' && e?.message ? e.message : '처리에 실패했습니다.');
+  }
+}
+
+// ════════════════════════════════════════════════════════════════════
+// 6. 응모 행 「메시지」 버튼 셀 (신청관리·캠페인별 신청자·결과물 관리 공용)
+// ════════════════════════════════════════════════════════════════════
+// 페인 로드 시 미열람 맵을 채워두고 호출 (renderApplicantMsgBtn 가 이 맵 참조)
+async function loadApplicantMsgUnread() {
+  _applicantMsgUnreadMap = await fetchAdminMessageUnreadCounts();
+}
+
+// 응모 행에 넣을 메시지 버튼 HTML (app: {id, campaign_id})
+function renderApplicantMsgBtn(app) {
+  if (!app || !app.id) return '';
+  const unread = _applicantMsgUnreadMap.get(app.id) || 0;
+  const badge = unread > 0 ? `<span class="applicant-msg-badge">${unread > 99 ? '99+' : unread}</span>` : '';
+  return `<button type="button" class="applicant-msg-btn" title="메시지" data-msgbtn="${esc(app.id)}"
+    onclick="openAdminMessageModal('${esc(app.id)}','${esc(app.campaign_id || '')}')">
+    <span class="material-icons-round notranslate" translate="no">forum</span><span>메시지</span>${badge}</button>`;
+}
+
+// 모달 열어 읽음 처리 후 특정 응모 행 배지 갱신 (DOM 직접 — 행 전체 재렌더 회피)
+function updateApplicantMsgBadge(applicationId) {
+  document.querySelectorAll(`[data-msgbtn="${applicationId}"]`).forEach(el => {
+    const b = el.querySelector('.applicant-msg-badge');
+    if (b) b.remove();
+  });
+}
+
+// ── 헬퍼: 캠페인명 / 인플 이름 ──
+function campaignTitleById(id) {
+  if (!id) return '(캠페인)';
+  const list = (typeof allCampaigns !== 'undefined' && Array.isArray(allCampaigns)) ? allCampaigns : [];
+  const c = list.find(x => x.id === id);
+  return c ? (c.title || '(제목 없음)') : '(캠페인)';
+}
+function influencerNameById(id) {
+  if (!id) return '(인플루언서)';
+  const inf = _inboxInflMap && _inboxInflMap[id];
+  if (!inf) return '(인플루언서)';
+  return inf.name || inf.name_kana || inf.email || '(이름 없음)';
+}
+
+// ════════════════════════════════════════════════════════════════════
 // REVERB ADMIN — dev/js/admin.js
 // ════════════════════════════════════════════════════════════════════
 //
@@ -11042,7 +11818,8 @@ function switchAdminPane(pane, el, pushHistory) {
     'brand-applications': loadBrandApplications,
     'brand-dashboard': loadBrandDashboard,
     'brands': loadBrandsPane,
-    'admin-notices': loadAdminNotices
+    'admin-notices': loadAdminNotices,
+    'messages': loadMessagesInbox
   };
   // 브라우저 히스토리 기록 (뒤로가기 지원)
   if (pushHistory !== false) {
@@ -13881,6 +14658,7 @@ const CAMP_APPLICANTS_PAGE_SIZE = 50;
 async function loadCampApplicants() {
   const filter = $('campAppFilterStatus')?.value || '';
   const searchQ = ($('campAppSearch')?.value || '').trim().toLowerCase();
+  await loadApplicantMsgUnread();  // 응모건 메시지 본인 미열람 배지 맵
   let apps = await fetchApplications({campaign_id: currentCampApplicantId});
   const total = apps.length;
   const allApproved = apps.filter(a => a.status === 'approved').length;
@@ -13949,6 +14727,7 @@ async function loadCampApplicants() {
     <td>
       <div style="font-weight:600;color:var(--pink);cursor:pointer" onclick="openInfluencerModal('${_u.id||''}')">${esc(a.user_name)||'—'}${adminBadge(a.user_email)}${influencerStatusBadges(_u)}</div>
       <div style="font-size:11px;color:var(--muted)">${esc(a.user_email)||''}</div>${_u.line_id?`<div style="font-size:11px;color:var(--muted)">LINE: ${esc(_u.line_id)}</div>`:''}
+      <div style="margin-top:4px">${renderApplicantMsgBtn(a)}</div>
     </td>
     <td>${snsCell('instagram', _u.ig || a.ig_id || a.user_ig)}<div style="font-size:11px;color:var(--muted)">${igF}명</div></td>
     <td>${snsCell('x', _u.x)}<div style="font-size:11px;color:var(--muted)">${xF}명</div></td>
@@ -14947,6 +15726,8 @@ async function renderAppCampList() {
     const [cs, as, us] = await Promise.all([fetchCampaigns(), fetchApplications(), fetchInfluencers()]);
     _appListCache = { camps: cs, allAppsRaw: as, users: us };
   }
+  // 응모건 메시지 본인 미열람 배지 맵 (응모 행 메시지 버튼용)
+  await loadApplicantMsgUnread();
   let camps = _appListCache.camps.slice();
   const allAppsRaw = _appListCache.allAppsRaw;
   let apps = allAppsRaw.slice();
@@ -15080,6 +15861,7 @@ async function renderAppCampList() {
       <td>
         <div style="font-weight:600;color:var(--pink);cursor:pointer" onclick="openInfluencerModal('${u.id||''}')">${esc(a.user_name)||'—'}${influencerStatusBadges(u)}</div>
         <div style="font-size:11px;color:var(--muted)">${esc(a.user_email)||''}</div>${u.line_id?`<div style="font-size:11px;color:var(--muted)">LINE: ${esc(u.line_id)}</div>`:''}
+        <div style="margin-top:4px">${renderApplicantMsgBtn(a)}</div>
       </td>
       <td>${msgCell(a.message, a)}</td>
       <td style="font-size:12px;color:var(--muted);white-space:nowrap">${formatDate(a.created_at)}</td>
@@ -17810,6 +18592,7 @@ async function renderDeliverablesList() {
   const tbody = $('delivTableBody');
   if (!tbody) return;
   tbody.innerHTML = '<tr><td colspan="7" style="text-align:center;color:var(--muted);padding:24px"><span class="spinner" style="width:20px;height:20px;border-width:2px;border-color:rgba(200,120,163,.2);border-top-color:var(--pink)"></span></td></tr>';
+  await loadApplicantMsgUnread();  // 응모건 메시지 본인 미열람 배지 맵
 
   // 캠페인 리스트 로드 + 모집타입↔캠페인 캐스케이드
   const campsForFilter = await fetchCampaigns().catch(() => []);
@@ -18010,7 +18793,7 @@ function renderDelivAppRow(g) {
   return `<tr data-app-id="${esc(g.application_id)}" style="${rowStyle}">
     <td>${rtBadge}</td>
     <td>${campNoBadge}<div>${esc(camp.title || '—')}</div><div style="font-size:10px;color:var(--muted)">${esc(camp.brand || '')}</div></td>
-    <td><div style="font-weight:600;color:var(--pink);cursor:pointer" onclick="openInfluencerModal('${esc(inf.id||'')}')">${infName}${(typeof influencerStatusBadges === 'function') ? influencerStatusBadges(inf) : ''}</div>${infSub ? `<div style="font-size:10px;color:var(--muted)">${infSub}</div>` : ''}</td>
+    <td><div style="font-weight:600;color:var(--pink);cursor:pointer" onclick="openInfluencerModal('${esc(inf.id||'')}')">${infName}${(typeof influencerStatusBadges === 'function') ? influencerStatusBadges(inf) : ''}</div>${infSub ? `<div style="font-size:10px;color:var(--muted)">${infSub}</div>` : ''}<div style="margin-top:4px">${renderApplicantMsgBtn({id: g.application_id, campaign_id: (camp && camp.id) || ''})}</div></td>
     <td>${receiptCell}</td>
     <td>${resultCell}</td>
     <td>${submittedCell}</td>

--- a/dev/admin/index.html
+++ b/dev/admin/index.html
@@ -103,6 +103,7 @@
         <div class="admin-si" data-pane="campaigns" onclick="navAdminPaneReload('campaigns')"><span class="si-icon material-icons-round">campaign</span><span class="si-text">캠페인 관리</span></div>
         <div class="admin-si" data-pane="applications" id="adminApplySi" onclick="navAdminPaneReload('applications')"><span class="si-icon material-icons-round">assignment</span><span class="si-text">신청 관리</span></div>
         <div class="admin-si" data-pane="deliverables" id="adminDelivSi" onclick="navAdminPaneReload('deliverables')"><span class="si-icon material-icons-round">fact_check</span><span class="si-text">결과물 관리</span></div>
+        <div class="admin-si" data-pane="messages" id="adminMessagesSi" onclick="navAdminPaneReload('messages')"><span class="si-icon material-icons-round">forum</span><span class="si-text">메시지</span><span id="navMsgBadge" class="admin-si-badge" style="display:none">0</span></div>
         <div class="admin-si-lbl">브랜드 서베이</div>
         <div class="admin-si" data-pane="brand-dashboard" id="adminBrandDashSi" onclick="navAdminPaneReload('brand-dashboard')"><span class="si-icon material-icons-round">insights</span><span class="si-text">현황 대시보드</span></div>
         <div class="admin-si" data-pane="brands" id="adminBrandsSi" onclick="navAdminPaneReload('brands')"><span class="si-icon material-icons-round">business</span><span class="si-text">브랜드 관리</span></div>
@@ -1099,6 +1100,27 @@
         </div>
 
         <!-- BRAND DASHBOARD (광고주 서베이 현황) PANE -->
+        <!-- 메시지 받은편지함 (3단: 캠페인 / 대화 상대 / 대화 내용) -->
+        <div id="adminPane-messages" class="admin-pane">
+          <div class="admin-sticky-header">
+            <h2 class="admin-pane-title">메시지</h2>
+            <div class="admin-filters">
+              <label class="inbox-filter-chk"><input type="checkbox" onchange="toggleInboxUnresolved(this.checked)"> 미응대만</label>
+              <select class="admin-select" onchange="changeInboxSince(this.value)">
+                <option value="6">최근 6개월</option>
+                <option value="3">최근 3개월</option>
+                <option value="12">최근 1년</option>
+                <option value="120">전체</option>
+              </select>
+            </div>
+          </div>
+          <div class="inbox-3pane">
+            <div class="inbox-col inbox-col-camps" id="inboxCampaigns"></div>
+            <div class="inbox-col inbox-col-threads" id="inboxThreads"></div>
+            <div class="inbox-col inbox-col-view" id="inboxThreadView"></div>
+          </div>
+        </div>
+
         <div id="adminPane-brand-dashboard" class="admin-pane">
           <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:16px;gap:12px;flex-wrap:wrap">
             <div>
@@ -2355,6 +2377,46 @@
         <button class="btn btn-primary" style="min-width:100px" onclick="resolveConfirmModal(true)">확인</button>
       </div>
     </div>
+  </div>
+</div>
+
+<!-- 응모건 메시지 모달 (응모 행 「메시지」 버튼 진입) -->
+<div class="modal-overlay" id="admMsgModal" style="z-index:640">
+  <div class="modal" style="max-width:720px;width:96vw;border-radius:16px;margin:auto;max-height:86vh;display:flex;flex-direction:column">
+    <div class="modal-header" style="padding:16px 20px 12px;border-bottom:1px solid var(--line);display:flex;align-items:center;justify-content:space-between">
+      <div style="font-size:14px;font-weight:700;color:var(--ink)" id="admMsgModalTitle">메시지</div>
+      <button class="btn btn-ghost btn-xs" onclick="closeAdminMessageModal()" style="padding:4px 10px">✕</button>
+    </div>
+    <div class="modal-body" id="admMsgModalBody" style="padding:0;overflow:hidden;flex:1;display:flex;flex-direction:column"></div>
+  </div>
+</div>
+
+<!-- 강제 숨김 사유 모달 -->
+<div class="modal-overlay" id="admHideModal" style="z-index:650">
+  <div class="modal" style="max-width:440px;border-radius:18px;margin:auto;display:flex;flex-direction:column">
+    <div class="modal-header" style="padding:16px 20px 12px;border-bottom:1px solid var(--line);display:flex;align-items:center;justify-content:space-between">
+      <div style="font-size:14px;font-weight:700;color:var(--ink)">메시지 숨김</div>
+      <button class="btn btn-ghost btn-xs" onclick="closeHideModal()" style="padding:4px 10px">✕</button>
+    </div>
+    <div class="modal-body" style="padding:16px 20px;display:flex;flex-direction:column;gap:12px">
+      <label style="font-size:13px;color:var(--muted)">숨김 사유
+        <select id="admHideReasonSelect" class="admin-select" style="width:100%;margin-top:6px"></select>
+      </label>
+      <label style="font-size:13px;color:var(--muted)">메모 (선택)
+        <textarea id="admHideMemo" rows="3" style="width:100%;margin-top:6px;font-size:14px" placeholder="추가 설명 (선택)"></textarea>
+      </label>
+    </div>
+    <div class="modal-footer" style="padding:14px 20px;border-top:1px solid var(--line);display:flex;gap:8px;justify-content:flex-end">
+      <button class="btn btn-ghost" onclick="closeHideModal()">취소</button>
+      <button class="btn btn-primary" onclick="confirmHideMessage()">숨김</button>
+    </div>
+  </div>
+</div>
+
+<!-- 메시지 첨부 라이트박스 -->
+<div class="modal-overlay" id="admMsgLightbox" style="z-index:660" onclick="closeAdmMsgLightbox()">
+  <div style="margin:auto;max-width:92vw;max-height:88vh;display:flex;align-items:center;justify-content:center">
+    <img id="admMsgLightboxImg" src="" alt="" style="max-width:92vw;max-height:88vh;border-radius:8px">
   </div>
 </div>
 

--- a/dev/build.sh
+++ b/dev/build.sh
@@ -75,7 +75,7 @@ PYTHON_SCRIPT
 mkdir -p ../admin
 
 ADMIN_CSS_FILES=("css/base.css" "css/components.css" "css/admin.css")
-ADMIN_JS_FILES=("lib/supabase.js" "lib/shared.js" "lib/storage.js" "js/ui.js" "js/admin-brand.js" "js/admin.js" "admin/app.js")
+ADMIN_JS_FILES=("lib/supabase.js" "lib/shared.js" "lib/storage.js" "js/ui.js" "js/admin-brand.js" "js/admin-messaging.js" "js/admin.js" "admin/app.js")
 
 : > "$BUILD_TMP/admin.css"
 for f in "${ADMIN_CSS_FILES[@]}"; do

--- a/dev/css/admin.css
+++ b/dev/css/admin.css
@@ -1046,3 +1046,80 @@
 .visibility-toggle.is-mini{width:34px;height:18px;border-radius:9px;margin-left:6px;vertical-align:middle}
 .visibility-toggle.is-mini .visibility-toggle-knob{width:14px;height:14px;top:2px;left:2px}
 .visibility-toggle.is-mini.is-on .visibility-toggle-knob{transform:translateX(16px)}
+
+/* ════════════════════════════════════════════════════════════
+   응모건 메시지 (PR 2) — 받은편지함 3단 + 메시지 카드/모달
+   ════════════════════════════════════════════════════════════ */
+/* 받은편지함 3단 패널 */
+.inbox-3pane{display:flex;gap:0;flex:1;min-height:0;height:calc(100vh - 130px);border:1px solid var(--line);border-radius:12px;overflow:hidden;background:#fff}
+.inbox-col{overflow-y:auto;min-height:0}
+.inbox-col-camps{width:240px;flex-shrink:0;border-right:1px solid var(--line);background:var(--surface-container-low)}
+.inbox-col-threads{width:300px;flex-shrink:0;border-right:1px solid var(--line)}
+.inbox-col-view{flex:1;min-width:0;display:flex;flex-direction:column}
+.inbox-empty{padding:24px 16px;color:var(--muted);font-size:13px;text-align:center}
+/* 좌: 캠페인 항목 */
+.inbox-camp-item{display:flex;align-items:center;justify-content:space-between;gap:8px;width:100%;padding:12px 14px;border:0;border-bottom:1px solid var(--line);background:none;cursor:pointer;text-align:left;font-size:13px;color:var(--ink)}
+.inbox-camp-item:hover{background:var(--light-pink)}
+.inbox-camp-item.active{background:var(--light-pink);font-weight:600}
+.inbox-camp-title{flex:1;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.inbox-camp-meta{display:flex;align-items:center;gap:6px;font-size:11px;color:var(--muted);flex-shrink:0}
+.inbox-camp-badge{display:inline-flex;align-items:center;justify-content:center;min-width:18px;height:18px;padding:0 5px;border-radius:9px;background:var(--pink);color:#fff;font-size:11px;font-weight:700}
+/* 중: 대화 상대 항목 */
+.inbox-thread-item{display:flex;align-items:center;justify-content:space-between;gap:8px;width:100%;padding:12px 14px;border:0;border-bottom:1px solid var(--line);background:none;cursor:pointer;text-align:left;font-size:13px;color:var(--ink)}
+.inbox-thread-item:hover{background:var(--surface-dim)}
+.inbox-thread-item.active{background:var(--light-pink);font-weight:600}
+.inbox-thread-name{flex:1;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.inbox-thread-meta{display:flex;align-items:center;gap:6px;flex-shrink:0}
+.inbox-thread-time{font-size:10px;color:var(--muted)}
+.inbox-thread-chip{display:inline-flex;align-items:center;padding:1px 6px;border-radius:8px;font-size:10px;font-weight:600}
+.inbox-thread-chip.unresolved{background:var(--gold-l);color:var(--gold)}
+.inbox-thread-chip.unread{background:var(--pink);color:#fff}
+.inbox-filter-chk{font-size:13px;color:var(--ink);display:inline-flex;align-items:center;gap:4px;cursor:pointer}
+
+/* 대화 내용 영역 (받은편지함 우측 + 모달 본문 공용) */
+.adm-msg-actionbar{display:flex;gap:8px;padding:10px 14px;border-bottom:1px solid var(--line);flex-shrink:0;background:var(--surface-container-low)}
+.adm-msg-bar-btn{padding:5px 12px;border:1px solid var(--line);border-radius:8px;background:#fff;font-size:12px;cursor:pointer;color:var(--ink)}
+.adm-msg-bar-btn.primary{background:var(--pink);color:#fff;border-color:var(--pink)}
+.adm-msg-thread{overflow-y:auto;padding:14px;display:flex;flex-direction:column;gap:10px;min-height:0;flex:1}
+/* 메시지 카드 */
+.msg-card{max-width:78%;align-self:flex-start;background:var(--surface-dim);border-radius:12px;padding:10px 12px}
+.msg-card.mine{align-self:flex-end;background:var(--light-pink)}
+.msg-card-head{display:flex;align-items:center;gap:8px;margin-bottom:4px;flex-wrap:wrap}
+.msg-card-head .msg-sender{font-size:11px;font-weight:700;color:var(--dark-pink)}
+.msg-card-head .msg-time{font-size:10px;color:var(--muted)}
+.msg-card-body{font-size:13px;line-height:1.6;color:var(--ink);word-break:break-word}
+.msg-card-masked{opacity:.7}
+.msg-masked-body{font-size:12px;color:var(--muted);font-style:italic}
+.msg-attachments{display:flex;flex-wrap:wrap;gap:6px;margin-top:8px}
+.msg-attach-thumb{width:64px;height:64px;border-radius:8px;overflow:hidden;background:var(--surface-container);display:flex;align-items:center;justify-content:center;cursor:pointer;color:var(--muted)}
+.msg-attach-thumb img{width:100%;height:100%;object-fit:cover}
+.adm-msg-status{font-size:10px;font-weight:600;padding:1px 6px;border-radius:6px}
+.adm-msg-status.hidden{background:var(--red-l);color:var(--red)}
+.adm-msg-status.withdrawn{background:var(--surface-dim);color:var(--muted)}
+.adm-msg-act{font-size:10px;padding:2px 8px;border-radius:6px;border:1px solid var(--line);background:#fff;cursor:pointer;color:var(--ink)}
+.adm-msg-act.hide{color:var(--red);border-color:var(--red)}
+.adm-msg-act.unhide{color:var(--green);border-color:var(--green)}
+/* composer */
+.adm-msg-composer{border-top:1px solid var(--line);padding:10px 14px;flex-shrink:0;background:#fff}
+.adm-msg-composer-row{display:flex;align-items:flex-end;gap:8px}
+.adm-msg-input{flex:1;resize:none;border:1px solid var(--line);border-radius:10px;padding:8px 10px;font-size:14px;font-family:inherit}
+.adm-msg-attach-btn{display:inline-flex;align-items:center;justify-content:center;width:38px;height:38px;border-radius:10px;border:1px solid var(--line);cursor:pointer;color:var(--muted);flex-shrink:0}
+.adm-msg-send{flex-shrink:0}
+.adm-msg-attach-preview{display:flex;flex-wrap:wrap;gap:6px;margin-bottom:8px}
+.msg-attach-pending{position:relative;width:56px;height:56px;border-radius:8px;overflow:hidden}
+.msg-attach-pending img{width:100%;height:100%;object-fit:cover}
+.msg-attach-remove{position:absolute;top:2px;right:2px;width:18px;height:18px;border-radius:50%;border:0;background:rgba(0,0,0,.55);color:#fff;display:flex;align-items:center;justify-content:center;cursor:pointer}
+.msg-attach-remove .material-icons-round{font-size:13px}
+.msg-empty{padding:24px;text-align:center;color:var(--muted);font-size:13px}
+/* 모달 본문은 thread 가 높이를 채우도록 */
+#admMsgModalBody .adm-msg-thread{max-height:60vh}
+/* 숨김 이력 패널 */
+.adm-msg-hide-history{padding:12px 14px;border-top:1px dashed var(--line);background:var(--surface-container-low);font-size:12px;max-height:200px;overflow-y:auto}
+.adm-hide-hist-title{font-weight:700;color:var(--ink);margin-bottom:6px}
+.adm-hide-hist-row{padding:4px 0;color:var(--muted);border-bottom:1px solid var(--line)}
+.adm-hide-hist-empty{color:var(--muted);font-style:italic}
+/* 응모 행 메시지 버튼 */
+.applicant-msg-btn{display:inline-flex;align-items:center;gap:4px;padding:3px 8px;border:1px solid var(--line);border-radius:8px;background:#fff;cursor:pointer;font-size:11px;color:var(--ink);position:relative}
+.applicant-msg-btn:hover{background:var(--light-pink);border-color:var(--pink)}
+.applicant-msg-btn .material-icons-round{font-size:14px;color:var(--pink)}
+.applicant-msg-badge{display:inline-flex;align-items:center;justify-content:center;min-width:16px;height:16px;padding:0 4px;border-radius:8px;background:var(--pink);color:#fff;font-size:10px;font-weight:700;margin-left:2px}

--- a/dev/js/admin-messaging.js
+++ b/dev/js/admin-messaging.js
@@ -1,0 +1,541 @@
+// ════════════════════════════════════════════════════════════════════
+// admin-messaging.js — 관리자 응모건 메시지 (PR 2)
+//   사양서 docs/specs/2026-05-15-application-messaging.md §5-3, §5-4, §3-4, §3-5
+//   - 받은편지함 3단 패널 (좌: 캠페인 / 중: 대화 상대 / 우: 대화 내용)
+//   - 응모 행 「메시지」 버튼 → 메시지 모달 (신청관리·캠페인별 신청자·결과물 관리 공용)
+//   - 답장 / 강제 숨김(campaign_admin+) / 복구(super_admin) / 수동 응대 완료(모든 관리자)
+//   DB: storage.js (fetchApplicationMessages / sendApplicationMessage / markApplicationMessagesRead /
+//        withdrawOwnMessage / markApplicationResolved / hideApplicationMessage /
+//        unhideApplicationMessage / fetchAdminMessageThreads / fetchAdminMessageUnreadCounts /
+//        fetchApplicationHideHistory / uploadMessageAttachment / getMessageAttachmentSignedUrl)
+//   admin.js 핫스팟 회피용 분리 파일 (admin-brand.js 패턴). UI 텍스트는 한국어.
+// ════════════════════════════════════════════════════════════════════
+
+const ADM_MSG_WITHDRAW_LIMIT_MS = 25 * 60 * 1000;  // 본인(관리자) 회수 25분 (§3-5 ②)
+const ADM_MSG_MAX_ATTACH = 5;                       // 메시지당 첨부 최대 5장 (§3-2)
+
+// 받은편지함 상태
+let _inboxThreads = [];                 // fetchAdminMessageThreads 결과 (뷰 행)
+let _inboxUnreadMap = new Map();        // application_id → 본인 미열람 수
+let _inboxSelectedCampaign = null;      // 좌 패널 선택 캠페인 id
+let _inboxFilters = { unresolvedOnly: false, sinceMonths: 6 };
+
+// 메시지 모달/패널 공용 상태
+let _admMsgAppId = null;                // 현재 열린 응모건
+let _admMsgContext = 'modal';           // 'modal' | 'inbox' — 전송 후 재렌더 대상
+let _admMsgPendingFiles = [];
+let _admMsgSending = false;
+
+// 응모 행 메시지 버튼 셀에 표시할 본인 미열람 맵 (페인 로드 시 채움)
+let _applicantMsgUnreadMap = new Map();
+
+// 받은편지함 인플루언서 이름 맵 (influencer_id → 행). refreshInboxData 에서 채움
+let _inboxInflMap = {};
+
+// 현재 super_admin 여부 (admin.js 의 currentAdminInfo 기준)
+function admMsgIsSuper() {
+  return (typeof currentAdminInfo !== 'undefined' && currentAdminInfo?.role === 'super_admin');
+}
+
+// 숨김 사유 카테고리 (message_hide_reason — fetchLookups 가 active 만 반환·캐시)
+async function loadHideReasons() {
+  try { return await fetchLookups('message_hide_reason'); }
+  catch (e) { console.warn('[loadHideReasons]', e); return []; }
+}
+
+// ════════════════════════════════════════════════════════════════════
+// 1. 받은편지함 3단 패널 (#adminPane-messages)
+// ════════════════════════════════════════════════════════════════════
+async function loadMessagesInbox() {
+  const wrap = document.getElementById('inboxThreadView');
+  if (wrap) wrap.innerHTML = '<div class="inbox-empty">대화를 선택하세요.</div>';
+  await refreshInboxData();
+}
+
+// 뷰 + 본인 미열람 맵을 다시 조회하고 좌/중 패널 재렌더
+async function refreshInboxData() {
+  try {
+    const [threads, unreadMap] = await Promise.all([
+      fetchAdminMessageThreads({ sinceMonths: _inboxFilters.sinceMonths }),
+      fetchAdminMessageUnreadCounts(),
+    ]);
+    _inboxThreads = threads || [];
+    _inboxUnreadMap = unreadMap || new Map();
+    // 인플루언서 이름 보강 (id 목록 → fetchInfluencersByIds 맵)
+    const ids = [...new Set(_inboxThreads.map(t => t.influencer_id).filter(Boolean))];
+    _inboxInflMap = ids.length ? (await fetchInfluencersByIds(ids)) : {};
+  } catch (e) {
+    console.error('[refreshInboxData]', e);
+    _inboxThreads = []; _inboxUnreadMap = new Map(); _inboxInflMap = {};
+  }
+  renderInboxCampaignList();
+  renderInboxThreadList();
+  updateInboxSidebarBadge();
+}
+
+// 사이드바 「메시지」 미응대 배지 = 우리 팀 미응대 응모건 수 (그룹 공통)
+function updateInboxSidebarBadge() {
+  const badge = document.getElementById('navMsgBadge');
+  if (!badge) return;
+  const n = _inboxThreads.filter(t => t.unresolved_for_admin_team).length;
+  if (n > 0) { badge.textContent = n > 99 ? '99+' : String(n); badge.style.display = ''; }
+  else { badge.style.display = 'none'; }
+}
+
+// 좌: 캠페인 목록 (메시지 있는 응모건을 campaign_id 로 그룹 + 미응대 합계)
+function renderInboxCampaignList() {
+  const el = document.getElementById('inboxCampaigns');
+  if (!el) return;
+  // campaign_id 별 집계
+  const byCamp = new Map();
+  for (const t of _inboxThreads) {
+    if (_inboxFilters.unresolvedOnly && !t.unresolved_for_admin_team) continue;
+    let g = byCamp.get(t.campaign_id);
+    if (!g) { g = { campaign_id: t.campaign_id, total: 0, unresolved: 0, lastAt: t.last_message_at }; byCamp.set(t.campaign_id, g); }
+    g.total += 1;
+    if (t.unresolved_for_admin_team) g.unresolved += 1;
+    if (t.last_message_at > g.lastAt) g.lastAt = t.last_message_at;
+  }
+  const groups = Array.from(byCamp.values()).sort((a, b) => (b.lastAt || '').localeCompare(a.lastAt || ''));
+  if (!groups.length) {
+    el.innerHTML = '<div class="inbox-empty">표시할 대화가 없습니다.</div>';
+    return;
+  }
+  el.innerHTML = groups.map(g => {
+    const camp = campaignTitleById(g.campaign_id);
+    const active = g.campaign_id === _inboxSelectedCampaign ? 'active' : '';
+    const badge = g.unresolved > 0 ? `<span class="inbox-camp-badge">${g.unresolved}</span>` : '';
+    return `<button type="button" class="inbox-camp-item ${active}" onclick="selectInboxCampaign('${esc(g.campaign_id)}')">
+      <span class="inbox-camp-title">${esc(camp)}</span>
+      <span class="inbox-camp-meta">${g.total}건${badge}</span>
+    </button>`;
+  }).join('');
+}
+
+function selectInboxCampaign(campaignId) {
+  _inboxSelectedCampaign = campaignId;
+  renderInboxCampaignList();
+  renderInboxThreadList();
+}
+
+// 중: 선택 캠페인의 대화 상대(인플루언서) 목록
+function renderInboxThreadList() {
+  const el = document.getElementById('inboxThreads');
+  if (!el) return;
+  if (!_inboxSelectedCampaign) {
+    el.innerHTML = '<div class="inbox-empty">왼쪽에서 캠페인을 선택하세요.</div>';
+    return;
+  }
+  let list = _inboxThreads.filter(t => t.campaign_id === _inboxSelectedCampaign);
+  if (_inboxFilters.unresolvedOnly) list = list.filter(t => t.unresolved_for_admin_team);
+  list.sort((a, b) => (b.last_message_at || '').localeCompare(a.last_message_at || ''));
+  if (!list.length) {
+    el.innerHTML = '<div class="inbox-empty">대화가 없습니다.</div>';
+    return;
+  }
+  el.innerHTML = list.map(t => {
+    const name = influencerNameById(t.influencer_id);
+    const unread = _inboxUnreadMap.get(t.application_id) || 0;
+    const active = t.application_id === _admMsgAppId ? 'active' : '';
+    const unresolved = t.unresolved_for_admin_team
+      ? '<span class="inbox-thread-chip unresolved">미응대</span>' : '';
+    const unreadChip = unread > 0
+      ? `<span class="inbox-thread-chip unread">${unread > 99 ? '99+' : unread}</span>` : '';
+    return `<button type="button" class="inbox-thread-item ${active}" onclick="openInboxThread('${esc(t.application_id)}')">
+      <span class="inbox-thread-name">${esc(name)}</span>
+      <span class="inbox-thread-meta">${unresolved}${unreadChip}<span class="inbox-thread-time">${esc(formatDate(t.last_message_at))}</span></span>
+    </button>`;
+  }).join('');
+}
+
+// 우: 선택 응모건 대화 내용 (인라인 패널)
+async function openInboxThread(applicationId) {
+  _admMsgAppId = applicationId;
+  _admMsgContext = 'inbox';
+  _admMsgPendingFiles = [];
+  renderInboxThreadList();  // active 표시 갱신
+  const view = document.getElementById('inboxThreadView');
+  if (view) view.innerHTML = '<div class="inbox-empty">불러오는 중…</div>';
+  try {
+    const msgs = await fetchApplicationMessages(applicationId);
+    if (view) view.innerHTML = adminThreadViewHtml('inbox');
+    renderAdminMsgThread('inboxMsgThread', msgs);
+    await markApplicationMessagesRead(applicationId);
+    // 본인 미열람 맵 갱신 후 중 패널 재렌더
+    _inboxUnreadMap = await fetchAdminMessageUnreadCounts();
+    renderInboxThreadList();
+  } catch (e) {
+    console.error('[openInboxThread]', e);
+    if (view) view.innerHTML = '<div class="inbox-empty">메시지를 불러오지 못했습니다.</div>';
+  }
+}
+
+// 받은편지함 필터 토글
+function toggleInboxUnresolved(checked) {
+  _inboxFilters.unresolvedOnly = !!checked;
+  renderInboxCampaignList();
+  renderInboxThreadList();
+}
+function changeInboxSince(months) {
+  _inboxFilters.sinceMonths = Number(months) || 6;
+  refreshInboxData();
+}
+
+// ════════════════════════════════════════════════════════════════════
+// 2. 메시지 모달 (응모 행 버튼 진입)
+// ════════════════════════════════════════════════════════════════════
+async function openAdminMessageModal(applicationId, campaignId) {
+  if (!applicationId) return;
+  _admMsgAppId = applicationId;
+  _admMsgContext = 'modal';
+  _admMsgPendingFiles = [];
+  const m = document.getElementById('admMsgModal');
+  if (!m) return;
+  const titleEl = document.getElementById('admMsgModalTitle');
+  if (titleEl) titleEl.textContent = `${campaignTitleById(campaignId)} — 메시지`;
+  const body = document.getElementById('admMsgModalBody');
+  if (body) body.innerHTML = adminThreadViewHtml('modal');
+  openModal('admMsgModal');
+  const thread = document.getElementById('admMsgThread');
+  if (thread) thread.innerHTML = '<div class="msg-empty">불러오는 중…</div>';
+  try {
+    const msgs = await fetchApplicationMessages(applicationId);
+    renderAdminMsgThread('admMsgThread', msgs);
+    await markApplicationMessagesRead(applicationId);
+    _applicantMsgUnreadMap.set(applicationId, 0);
+    updateApplicantMsgBadge(applicationId);
+  } catch (e) {
+    console.error('[openAdminMessageModal]', e);
+    if (thread) thread.innerHTML = '<div class="msg-empty">메시지를 불러오지 못했습니다.</div>';
+  }
+}
+
+function closeAdminMessageModal() {
+  closeModal('admMsgModal');
+  _admMsgPendingFiles = [];
+  if (_admMsgContext === 'modal') _admMsgAppId = null;
+}
+
+// 대화 내용 컨테이너 HTML (받은편지함 우측 / 모달 본문 공용)
+//   ctx: 'inbox' | 'modal' — thread/composer DOM id 접두사 결정
+function adminThreadViewHtml(ctx) {
+  const threadId = ctx === 'inbox' ? 'inboxMsgThread' : 'admMsgThread';
+  const composerId = ctx === 'inbox' ? 'inboxComposer' : 'admComposer';
+  const histId = ctx === 'inbox' ? 'inboxHideHist' : 'admHideHist';
+  const histBtn = admMsgIsSuper()
+    ? `<button type="button" class="adm-msg-bar-btn" onclick="toggleHideHistory('${ctx}')">숨김 이력</button>` : '';
+  return `
+    <div class="adm-msg-actionbar">
+      <button type="button" class="adm-msg-bar-btn primary" onclick="markCurrentResolved()">응대 완료</button>
+      ${histBtn}
+    </div>
+    <div class="adm-msg-thread" id="${threadId}"></div>
+    <div class="adm-msg-hide-history" id="${histId}" style="display:none"></div>
+    <div class="adm-msg-composer" id="${composerId}">
+      <div class="adm-msg-attach-preview" id="${composerId}Preview"></div>
+      <div class="adm-msg-composer-row">
+        <label class="adm-msg-attach-btn" title="이미지 첨부">
+          <span class="material-icons-round notranslate" translate="no">image</span>
+          <input type="file" accept="image/*" multiple style="display:none" onchange="onAdmMsgAttachSelected(this)">
+        </label>
+        <textarea class="adm-msg-input" id="${composerId}Input" rows="2" placeholder="답장 입력…"></textarea>
+        <button type="button" class="btn btn-primary adm-msg-send" onclick="sendAdminMessage()">전송</button>
+      </div>
+    </div>`;
+}
+
+// 숨김 이력 패널 토글 (super_admin) — 응모건 단위 audit
+async function toggleHideHistory(ctx) {
+  const histId = ctx === 'inbox' ? 'inboxHideHist' : 'admHideHist';
+  const el = document.getElementById(histId);
+  if (!el || !_admMsgAppId) return;
+  if (el.style.display !== 'none') { el.style.display = 'none'; return; }
+  el.style.display = '';
+  el.innerHTML = '<div class="msg-empty">불러오는 중…</div>';
+  try {
+    const rows = await fetchApplicationHideHistory(_admMsgAppId);
+    if (!rows.length) { el.innerHTML = '<div class="adm-hide-hist-empty">숨김/복구 이력이 없습니다.</div>'; return; }
+    el.innerHTML = '<div class="adm-hide-hist-title">숨김/복구 이력</div>' + rows.map(r => {
+      const act = r.action === 'hide' ? '숨김' : '복구';
+      const reason = r.reason_code ? ` · ${esc(r.reason_code)}` : '';
+      const memo = r.reason_memo ? ` · ${esc(r.reason_memo)}` : '';
+      return `<div class="adm-hide-hist-row"><b>${act}</b> ${esc(r.by_name || '')} · ${esc(formatDate(r.at))}${reason}${memo}</div>`;
+    }).join('');
+  } catch (e) {
+    console.error('[toggleHideHistory]', e);
+    el.innerHTML = '<div class="adm-hide-hist-empty">이력을 불러오지 못했습니다.</div>';
+  }
+}
+
+// ════════════════════════════════════════════════════════════════════
+// 3. 스레드 렌더 (공용 — 받은편지함 우측·모달 모두)
+// ════════════════════════════════════════════════════════════════════
+function renderAdminMsgThread(threadElId, messages) {
+  const thread = document.getElementById(threadElId);
+  if (!thread) return;
+  if (!messages || !messages.length) {
+    thread.innerHTML = '<div class="msg-empty">아직 메시지가 없습니다.</div>';
+    return;
+  }
+  const now = Date.now();
+  const isSuper = admMsgIsSuper();
+  thread.innerHTML = messages.map(msg => {
+    const fromAdmin = msg.sender_kind === 'admin';
+    const senderLabel = fromAdmin ? `운영팀 (${esc(msg.sender_name || '')})` : esc(msg.sender_name || '인플루언서');
+    const timeStr = formatDate(msg.created_at);
+    const sideCls = fromAdmin ? 'mine' : '';
+
+    // 인플루언서 본인 회수 → 관리자도 못 봄 (placeholder)
+    if (msg.mask_state === 'self_withdrawn_influencer') {
+      return msgCardMasked(senderLabel, timeStr, sideCls, '인플루언서가 회수한 메시지입니다.');
+    }
+
+    const bodyHtml = esc(msg.body || '').replace(/\n/g, '<br>');
+    const atts = Array.isArray(msg.attachments) ? msg.attachments : [];
+    let attachHtml = '';
+    if (atts.length) {
+      attachHtml = `<div class="msg-attachments">${atts.map((a, i) => {
+        const elId = `admatt-${msg.id}-${i}`;
+        loadAdmMsgAttachThumb(elId, a.path);
+        return `<div class="msg-attach-thumb" id="${elId}" onclick="openAdmMsgLightbox('${esc(a.path)}')"><span class="material-icons-round notranslate" translate="no">image</span></div>`;
+      }).join('')}</div>`;
+    }
+
+    // 상태 뱃지 + 액션 버튼
+    let statusBadge = '';
+    let actions = '';
+    if (msg.mask_state === 'hidden_by_admin') {
+      statusBadge = '<span class="adm-msg-status hidden">숨김 처리됨</span>';
+      if (isSuper) actions += `<button type="button" class="adm-msg-act unhide" onclick="promptUnhideMessage('${esc(msg.id)}')">복구</button>`;
+    } else if (msg.mask_state === 'self_withdrawn_admin') {
+      statusBadge = '<span class="adm-msg-status withdrawn">회수됨</span>';
+    } else {
+      // visible
+      if (fromAdmin) {
+        // 운영팀 발신 + 25분 이내 → 회수 (회수는 withdraw_own_message RPC 가 본인 검증)
+        const elapsed = now - new Date(msg.created_at).getTime();
+        if (elapsed < ADM_MSG_WITHDRAW_LIMIT_MS) {
+          const pathsJson = esc(JSON.stringify(atts.map(a => a.path)));
+          actions += `<button type="button" class="adm-msg-act withdraw" onclick='confirmAdmWithdraw("${esc(msg.id)}", ${pathsJson})'>회수</button>`;
+        }
+      } else {
+        // 인플루언서 메시지 → campaign_admin+ 강제 숨김 (RPC 가 권한 가드)
+        actions += `<button type="button" class="adm-msg-act hide" onclick="promptHideMessage('${esc(msg.id)}')">숨김</button>`;
+      }
+    }
+
+    return `<div class="msg-card ${sideCls}">
+      <div class="msg-card-head"><span class="msg-sender">${senderLabel}</span><span class="msg-time">${esc(timeStr)}</span>${statusBadge}${actions}</div>
+      <div class="msg-card-body">${bodyHtml}</div>
+      ${attachHtml}
+    </div>`;
+  }).join('');
+  thread.scrollTop = thread.scrollHeight;
+}
+
+function msgCardMasked(senderLabel, timeStr, sideCls, text) {
+  return `<div class="msg-card msg-card-masked ${sideCls}">
+    <div class="msg-card-head"><span class="msg-sender">${senderLabel}</span><span class="msg-time">${esc(timeStr)}</span></div>
+    <div class="msg-masked-body">${esc(text)}</div>
+  </div>`;
+}
+
+async function loadAdmMsgAttachThumb(elId, path) {
+  try {
+    const url = await getMessageAttachmentSignedUrl(path);
+    const el = document.getElementById(elId);
+    if (el && url) el.innerHTML = `<img src="${esc(url)}" loading="lazy" decoding="async" alt="">`;
+  } catch (e) { /* 아이콘 유지 */ }
+}
+
+// ── 라이트박스 ──
+async function openAdmMsgLightbox(path) {
+  const lb = document.getElementById('admMsgLightbox');
+  const img = document.getElementById('admMsgLightboxImg');
+  if (!lb || !img) return;
+  img.src = '';
+  openModal('admMsgLightbox');
+  try {
+    const url = await getMessageAttachmentSignedUrl(path);
+    if (url) img.src = url; else { closeAdmMsgLightbox(); toast('이미지를 불러오지 못했습니다.'); }
+  } catch (e) { closeAdmMsgLightbox(); toast('이미지를 불러오지 못했습니다.'); }
+}
+function closeAdmMsgLightbox() {
+  closeModal('admMsgLightbox');
+  const img = document.getElementById('admMsgLightboxImg');
+  if (img) img.src = '';
+}
+
+// ════════════════════════════════════════════════════════════════════
+// 4. 첨부 선택/전송
+// ════════════════════════════════════════════════════════════════════
+function curComposerId() { return _admMsgContext === 'inbox' ? 'inboxComposer' : 'admComposer'; }
+
+function onAdmMsgAttachSelected(input) {
+  const files = Array.from(input.files || []);
+  input.value = '';
+  for (const f of files) {
+    if (_admMsgPendingFiles.length >= ADM_MSG_MAX_ATTACH) { toast(`첨부는 최대 ${ADM_MSG_MAX_ATTACH}장까지 가능합니다.`); break; }
+    _admMsgPendingFiles.push(f);
+  }
+  renderAdmMsgAttachPreview();
+}
+function removeAdmMsgAttach(idx) { _admMsgPendingFiles.splice(idx, 1); renderAdmMsgAttachPreview(); }
+function renderAdmMsgAttachPreview() {
+  const wrap = document.getElementById(curComposerId() + 'Preview');
+  if (!wrap) return;
+  if (!_admMsgPendingFiles.length) { wrap.innerHTML = ''; return; }
+  wrap.innerHTML = _admMsgPendingFiles.map((f, i) => {
+    const url = URL.createObjectURL(f);
+    return `<div class="msg-attach-pending"><img src="${url}" alt=""><button type="button" class="msg-attach-remove" onclick="removeAdmMsgAttach(${i})" aria-label="삭제"><span class="material-icons-round notranslate" translate="no">close</span></button></div>`;
+  }).join('');
+}
+
+async function sendAdminMessage() {
+  if (_admMsgSending || !_admMsgAppId) return;
+  const inputEl = document.getElementById(curComposerId() + 'Input');
+  const body = (inputEl?.value || '').trim();
+  if (!body && !_admMsgPendingFiles.length) { toast('메시지를 입력하세요.'); return; }
+  _admMsgSending = true;
+  try {
+    const attachments = [];
+    for (const f of _admMsgPendingFiles) {
+      try { attachments.push(await uploadMessageAttachment(f, _admMsgAppId)); }
+      catch (e) {
+        console.error('[sendAdminMessage] 첨부', e);
+        toast(e?.message === 'too_large' ? '이미지 용량이 큽니다.' : '첨부 업로드에 실패했습니다.');
+        _admMsgSending = false; return;
+      }
+    }
+    await sendApplicationMessage(_admMsgAppId, body, attachments);
+    if (inputEl) inputEl.value = '';
+    _admMsgPendingFiles = [];
+    renderAdmMsgAttachPreview();
+    const msgs = await fetchApplicationMessages(_admMsgAppId);
+    renderAdminMsgThread(_admMsgContext === 'inbox' ? 'inboxMsgThread' : 'admMsgThread', msgs);
+    // 관리자 답장 = 자동 응대 완료 → 받은편지함 집계 갱신
+    if (_admMsgContext === 'inbox') await refreshInboxData();
+    else updateInboxSidebarBadge();
+  } catch (e) {
+    console.error('[sendAdminMessage]', e);
+    toast(e?.code === 'P0001' && e?.message ? e.message : '전송에 실패했습니다.');
+  } finally {
+    _admMsgSending = false;
+  }
+}
+
+// ── 본인(관리자) 회수 ──
+async function confirmAdmWithdraw(messageId, attachmentPaths) {
+  if (!confirm('이 메시지를 회수하시겠습니까?')) return;
+  try {
+    await withdrawOwnMessage(messageId, attachmentPaths || []);
+    const msgs = await fetchApplicationMessages(_admMsgAppId);
+    renderAdminMsgThread(_admMsgContext === 'inbox' ? 'inboxMsgThread' : 'admMsgThread', msgs);
+  } catch (e) {
+    console.error('[confirmAdmWithdraw]', e);
+    toast(e?.code === 'P0001' && e?.message ? e.message : '회수에 실패했습니다.');
+  }
+}
+
+// ════════════════════════════════════════════════════════════════════
+// 5. 강제 숨김 / 복구
+// ════════════════════════════════════════════════════════════════════
+let _hideTargetMsgId = null;
+async function promptHideMessage(messageId) {
+  _hideTargetMsgId = messageId;
+  const reasons = await loadHideReasons();
+  const sel = document.getElementById('admHideReasonSelect');
+  if (sel) sel.innerHTML = reasons.map(r => `<option value="${esc(r.code)}">${esc(r.name_ko)}</option>`).join('');
+  const memo = document.getElementById('admHideMemo');
+  if (memo) memo.value = '';
+  openModal('admHideModal');
+}
+function closeHideModal() {
+  closeModal('admHideModal');
+  _hideTargetMsgId = null;
+}
+async function confirmHideMessage() {
+  if (!_hideTargetMsgId) return;
+  const code = document.getElementById('admHideReasonSelect')?.value;
+  const memo = document.getElementById('admHideMemo')?.value || '';
+  if (!code) { toast('숨김 사유를 선택하세요.'); return; }
+  try {
+    await hideApplicationMessage(_hideTargetMsgId, code, memo);
+    closeHideModal();
+    const msgs = await fetchApplicationMessages(_admMsgAppId);
+    renderAdminMsgThread(_admMsgContext === 'inbox' ? 'inboxMsgThread' : 'admMsgThread', msgs);
+    toast('메시지를 숨김 처리했습니다.');
+  } catch (e) {
+    console.error('[confirmHideMessage]', e);
+    toast(e?.code === 'P0001' && e?.message ? e.message : '숨김 처리에 실패했습니다.');
+  }
+}
+
+async function promptUnhideMessage(messageId) {
+  const memo = prompt('복구 사유를 입력하세요 (필수):');
+  if (memo === null) return;
+  if (!memo.trim()) { toast('복구 사유는 필수입니다.'); return; }
+  try {
+    await unhideApplicationMessage(messageId, memo.trim());
+    const msgs = await fetchApplicationMessages(_admMsgAppId);
+    renderAdminMsgThread(_admMsgContext === 'inbox' ? 'inboxMsgThread' : 'admMsgThread', msgs);
+    toast('메시지를 복구했습니다.');
+  } catch (e) {
+    console.error('[promptUnhideMessage]', e);
+    toast(e?.code === 'P0001' && e?.message ? e.message : '복구에 실패했습니다.');
+  }
+}
+
+// ── 수동 응대 완료 ──
+async function markCurrentResolved() {
+  if (!_admMsgAppId) return;
+  try {
+    await markApplicationResolved(_admMsgAppId);
+    toast('응대 완료로 표시했습니다.');
+    if (_admMsgContext === 'inbox') await refreshInboxData();
+    else updateInboxSidebarBadge();
+  } catch (e) {
+    console.error('[markCurrentResolved]', e);
+    toast(e?.code === 'P0001' && e?.message ? e.message : '처리에 실패했습니다.');
+  }
+}
+
+// ════════════════════════════════════════════════════════════════════
+// 6. 응모 행 「메시지」 버튼 셀 (신청관리·캠페인별 신청자·결과물 관리 공용)
+// ════════════════════════════════════════════════════════════════════
+// 페인 로드 시 미열람 맵을 채워두고 호출 (renderApplicantMsgBtn 가 이 맵 참조)
+async function loadApplicantMsgUnread() {
+  _applicantMsgUnreadMap = await fetchAdminMessageUnreadCounts();
+}
+
+// 응모 행에 넣을 메시지 버튼 HTML (app: {id, campaign_id})
+function renderApplicantMsgBtn(app) {
+  if (!app || !app.id) return '';
+  const unread = _applicantMsgUnreadMap.get(app.id) || 0;
+  const badge = unread > 0 ? `<span class="applicant-msg-badge">${unread > 99 ? '99+' : unread}</span>` : '';
+  return `<button type="button" class="applicant-msg-btn" title="메시지" data-msgbtn="${esc(app.id)}"
+    onclick="openAdminMessageModal('${esc(app.id)}','${esc(app.campaign_id || '')}')">
+    <span class="material-icons-round notranslate" translate="no">forum</span><span>메시지</span>${badge}</button>`;
+}
+
+// 모달 열어 읽음 처리 후 특정 응모 행 배지 갱신 (DOM 직접 — 행 전체 재렌더 회피)
+function updateApplicantMsgBadge(applicationId) {
+  document.querySelectorAll(`[data-msgbtn="${applicationId}"]`).forEach(el => {
+    const b = el.querySelector('.applicant-msg-badge');
+    if (b) b.remove();
+  });
+}
+
+// ── 헬퍼: 캠페인명 / 인플 이름 ──
+function campaignTitleById(id) {
+  if (!id) return '(캠페인)';
+  const list = (typeof allCampaigns !== 'undefined' && Array.isArray(allCampaigns)) ? allCampaigns : [];
+  const c = list.find(x => x.id === id);
+  return c ? (c.title || '(제목 없음)') : '(캠페인)';
+}
+function influencerNameById(id) {
+  if (!id) return '(인플루언서)';
+  const inf = _inboxInflMap && _inboxInflMap[id];
+  if (!inf) return '(인플루언서)';
+  return inf.name || inf.name_kana || inf.email || '(이름 없음)';
+}

--- a/dev/js/admin.js
+++ b/dev/js/admin.js
@@ -196,7 +196,8 @@ function switchAdminPane(pane, el, pushHistory) {
     'brand-applications': loadBrandApplications,
     'brand-dashboard': loadBrandDashboard,
     'brands': loadBrandsPane,
-    'admin-notices': loadAdminNotices
+    'admin-notices': loadAdminNotices,
+    'messages': loadMessagesInbox
   };
   // 브라우저 히스토리 기록 (뒤로가기 지원)
   if (pushHistory !== false) {
@@ -3035,6 +3036,7 @@ const CAMP_APPLICANTS_PAGE_SIZE = 50;
 async function loadCampApplicants() {
   const filter = $('campAppFilterStatus')?.value || '';
   const searchQ = ($('campAppSearch')?.value || '').trim().toLowerCase();
+  await loadApplicantMsgUnread();  // 응모건 메시지 본인 미열람 배지 맵
   let apps = await fetchApplications({campaign_id: currentCampApplicantId});
   const total = apps.length;
   const allApproved = apps.filter(a => a.status === 'approved').length;
@@ -3103,6 +3105,7 @@ async function loadCampApplicants() {
     <td>
       <div style="font-weight:600;color:var(--pink);cursor:pointer" onclick="openInfluencerModal('${_u.id||''}')">${esc(a.user_name)||'—'}${adminBadge(a.user_email)}${influencerStatusBadges(_u)}</div>
       <div style="font-size:11px;color:var(--muted)">${esc(a.user_email)||''}</div>${_u.line_id?`<div style="font-size:11px;color:var(--muted)">LINE: ${esc(_u.line_id)}</div>`:''}
+      <div style="margin-top:4px">${renderApplicantMsgBtn(a)}</div>
     </td>
     <td>${snsCell('instagram', _u.ig || a.ig_id || a.user_ig)}<div style="font-size:11px;color:var(--muted)">${igF}명</div></td>
     <td>${snsCell('x', _u.x)}<div style="font-size:11px;color:var(--muted)">${xF}명</div></td>
@@ -4101,6 +4104,8 @@ async function renderAppCampList() {
     const [cs, as, us] = await Promise.all([fetchCampaigns(), fetchApplications(), fetchInfluencers()]);
     _appListCache = { camps: cs, allAppsRaw: as, users: us };
   }
+  // 응모건 메시지 본인 미열람 배지 맵 (응모 행 메시지 버튼용)
+  await loadApplicantMsgUnread();
   let camps = _appListCache.camps.slice();
   const allAppsRaw = _appListCache.allAppsRaw;
   let apps = allAppsRaw.slice();
@@ -4234,6 +4239,7 @@ async function renderAppCampList() {
       <td>
         <div style="font-weight:600;color:var(--pink);cursor:pointer" onclick="openInfluencerModal('${u.id||''}')">${esc(a.user_name)||'—'}${influencerStatusBadges(u)}</div>
         <div style="font-size:11px;color:var(--muted)">${esc(a.user_email)||''}</div>${u.line_id?`<div style="font-size:11px;color:var(--muted)">LINE: ${esc(u.line_id)}</div>`:''}
+        <div style="margin-top:4px">${renderApplicantMsgBtn(a)}</div>
       </td>
       <td>${msgCell(a.message, a)}</td>
       <td style="font-size:12px;color:var(--muted);white-space:nowrap">${formatDate(a.created_at)}</td>
@@ -6964,6 +6970,7 @@ async function renderDeliverablesList() {
   const tbody = $('delivTableBody');
   if (!tbody) return;
   tbody.innerHTML = '<tr><td colspan="7" style="text-align:center;color:var(--muted);padding:24px"><span class="spinner" style="width:20px;height:20px;border-width:2px;border-color:rgba(200,120,163,.2);border-top-color:var(--pink)"></span></td></tr>';
+  await loadApplicantMsgUnread();  // 응모건 메시지 본인 미열람 배지 맵
 
   // 캠페인 리스트 로드 + 모집타입↔캠페인 캐스케이드
   const campsForFilter = await fetchCampaigns().catch(() => []);
@@ -7164,7 +7171,7 @@ function renderDelivAppRow(g) {
   return `<tr data-app-id="${esc(g.application_id)}" style="${rowStyle}">
     <td>${rtBadge}</td>
     <td>${campNoBadge}<div>${esc(camp.title || '—')}</div><div style="font-size:10px;color:var(--muted)">${esc(camp.brand || '')}</div></td>
-    <td><div style="font-weight:600;color:var(--pink);cursor:pointer" onclick="openInfluencerModal('${esc(inf.id||'')}')">${infName}${(typeof influencerStatusBadges === 'function') ? influencerStatusBadges(inf) : ''}</div>${infSub ? `<div style="font-size:10px;color:var(--muted)">${infSub}</div>` : ''}</td>
+    <td><div style="font-weight:600;color:var(--pink);cursor:pointer" onclick="openInfluencerModal('${esc(inf.id||'')}')">${infName}${(typeof influencerStatusBadges === 'function') ? influencerStatusBadges(inf) : ''}</div>${infSub ? `<div style="font-size:10px;color:var(--muted)">${infSub}</div>` : ''}<div style="margin-top:4px">${renderApplicantMsgBtn({id: g.application_id, campaign_id: (camp && camp.id) || ''})}</div></td>
     <td>${receiptCell}</td>
     <td>${resultCell}</td>
     <td>${submittedCell}</td>

--- a/dev/js/mypage.js
+++ b/dev/js/mypage.js
@@ -273,6 +273,8 @@ async function refreshMyMsgUnread() {
     _myMsgUnreadByApp = {};
     threads.forEach(th => { _myMsgUnreadByApp[th.application_id] = th.unread_for_influencer; });
   } catch(e) { /* 무시 */ }
+  // GNB 「メッセージ」 미읽음 배지 갱신 (햄버거 메뉴)
+  if (typeof updateNavMsgBadge === 'function') updateNavMsgBadge();
   // 응모이력 화면이 떠 있을 때만 재렌더 (배지 갱신)
   if ($('myApplicationsList') && typeof renderMyApplyList === 'function') {
     try { await renderMyApplyList(); } catch(e) { /* 무시 */ }

--- a/dev/js/notifications.js
+++ b/dev/js/notifications.js
@@ -11,6 +11,10 @@ function openNavPanel() {
   if (!p) return;
   renderNavMenu();
   p.setAttribute('aria-hidden', 'false');
+  // 메시지 미읽음 최신화 (응모이력 미방문 상태로 햄버거 열어도 배지 정확)
+  if (currentUser && typeof refreshMyMsgUnread === 'function') {
+    refreshMyMsgUnread().then(() => updateNavMsgBadge()).catch(() => {});
+  }
 }
 function closeNavPanel() {
   const p = $('navPanel');
@@ -49,6 +53,13 @@ function renderNavMenu() {
       </button>
     `).join('');
     html += divider;
+    // 메시지 — 응모이력으로 이동 (응모건 카드 메시지 버튼에서 대화 진입). 미읽음 배지 별도
+    html += `<button class="nav-item" data-nav="messages" onclick="navigate('mypage');openMypageSub('applications');closeNavPanel()">
+      <span class="material-icons-round notranslate nav-icon" translate="no">forum</span>
+      <span class="nav-label">${esc(t('messaging.navMenu'))}</span>
+      <span class="notif-badge hidden" data-role="nav-msg-badge"></span>
+    </button>`;
+    html += divider;
     // 관리자/일반 모두 알림 메뉴 노출 (본인 알림만 받음)
     html += navItemHtml({nav:'notif', icon:'notifications', label: t('menu.notifications'), onclick:"closeNavPanel();openNotifModal()", badge:true});
     html += divider;
@@ -62,6 +73,17 @@ function renderNavMenu() {
   }
   menu.innerHTML = html;
   refreshNotifBadge();
+  updateNavMsgBadge();
+}
+
+// 메시지 미읽음 배지 (GNB 「メッセージ」 항목) — _myMsgUnreadByApp(mypage.js) 합계
+function updateNavMsgBadge() {
+  const map = (typeof _myMsgUnreadByApp === 'object' && _myMsgUnreadByApp) ? _myMsgUnreadByApp : {};
+  const total = Object.values(map).reduce((s, n) => s + (Number(n) || 0), 0);
+  document.querySelectorAll('[data-role="nav-msg-badge"]').forEach(b => {
+    if (total > 0) { b.textContent = total > 9 ? '9+' : String(total); b.classList.remove('hidden'); }
+    else b.classList.add('hidden');
+  });
 }
 
 function navItemHtml(it) {
@@ -191,7 +213,7 @@ function renderNotifModal(items) {
   const hasUnread = items.some(n => !n.read_at);
   if (markBtn) markBtn.disabled = !hasUnread;
   body.innerHTML = items.map(n => {
-    const iconMap = {deliverable_rejected:{icon:'error_outline',color:'#C33'}, deliverable_changed:{icon:'change_circle',color:'#B8741A'}, deliverable_approved:{icon:'check_circle',color:'#2D7A3E'}};
+    const iconMap = {deliverable_rejected:{icon:'error_outline',color:'#C33'}, deliverable_changed:{icon:'change_circle',color:'#B8741A'}, deliverable_approved:{icon:'check_circle',color:'#2D7A3E'}, message_received:{icon:'forum',color:'#C878A3'}};
     const ic = iconMap[n.kind] || {icon:'notifications', color:'#6B7280'};
     const unread = !n.read_at ? 'unread' : '';
     const rt = _notifRecruitTypeMap[n.ref_id];
@@ -199,7 +221,7 @@ function renderNotifModal(items) {
     const rtBadge = rtLabel
       ? `<div style="font-size:10px;font-weight:700;color:var(--pink);margin-bottom:2px">${esc(rtLabel)}</div>`
       : '';
-    return `<div class="notif-item ${unread}" onclick="onNotifItemClick('${esc(n.id)}','${esc(n.ref_table||'')}','${esc(n.ref_id||'')}')">
+    return `<div class="notif-item ${unread}" onclick="onNotifItemClick('${esc(n.id)}','${esc(n.kind||'')}','${esc(n.ref_table||'')}','${esc(n.ref_id||'')}')">
       <div class="notif-item-icon" style="background:${ic.color}"><span class="material-icons-round notranslate" translate="no" style="font-size:20px;color:#fff">${ic.icon}</span></div>
       <div class="notif-item-body">
         ${rtBadge}
@@ -211,9 +233,16 @@ function renderNotifModal(items) {
   }).join('');
 }
 
-async function onNotifItemClick(id, refTable, refId) {
+async function onNotifItemClick(id, kind, refTable, refId) {
   await markNotificationRead(id);
   closeNotifModal();
+  // 메시지 알림 → 응모건 메시지 모달 직접 오픈 (사양서 §5-5)
+  //   주의: application_cancelled 알림도 ref_table='applications' 이므로 kind 로 한정 (회귀 방지)
+  if (kind === 'message_received' && refId && currentUser) {
+    if (typeof openMessageModal === 'function') openMessageModal(refId);
+    refreshNotifBadge();
+    return;
+  }
   // deliverable 참조가 있으면 활동관리 이동
   if (refTable === 'deliverables' && refId && currentUser) {
     try {

--- a/dev/lib/i18n/ja.js
+++ b/dev/lib/i18n/ja.js
@@ -587,5 +587,7 @@ window.I18N_JA = {
     sendFailed: '送信に失敗しました',
     btnLabel: 'メッセージ',
     unreadBadge: '未読',
+    navMenu: 'メッセージ',
+    notifTitle: '運営からのメッセージ',
   },
 };

--- a/dev/lib/i18n/ko.js
+++ b/dev/lib/i18n/ko.js
@@ -567,5 +567,7 @@ window.I18N_KO = {
     sendFailed: '전송에 실패했습니다',
     btnLabel: '메시지',
     unreadBadge: '미읽음',
+    navMenu: '메시지',
+    notifTitle: '운영팀 메시지',
   },
 };

--- a/dev/lib/shared.js
+++ b/dev/lib/shared.js
@@ -392,6 +392,9 @@ const PANE_REFRESHERS = {
   'campaigns': async () => {
     // 관리자 캠페인 목록 갱신 — `loadCampaigns`(인플루언서 함수) 오참조 버그 수정
     if (typeof loadAdminCampaigns === 'function') await loadAdminCampaigns();
+  },
+  'messages': async () => {
+    if (typeof refreshInboxData === 'function') await refreshInboxData();
   }
 };
 async function refreshPane(paneId) {

--- a/dev/lib/storage.js
+++ b/dev/lib/storage.js
@@ -2082,3 +2082,95 @@ async function fetchInfluencerUnreadMessageThreads() {
   return data || [];
 }
 
+// ════════════════════════════════════════════════════════════════════
+// 응모건 메시지 — 관리자 발신/숨김/응대 (PR 2)
+//   마이그레이션 145. 관리자 받은편지함·강제 숨김/복구·응대 완료.
+// ════════════════════════════════════════════════════════════════════
+
+// 응모건 수동 응대 완료 마킹 (모든 관리자 — 사양서 §3-4). RPC mark_application_resolved.
+async function markApplicationResolved(applicationId) {
+  if (!db || !applicationId) return;
+  await retryWithRefresh(async () => {
+    const {error} = await db.rpc('mark_application_resolved', { p_application_id: applicationId });
+    if (error) throw error;
+  });
+}
+
+// 메시지 강제 숨김 (campaign_admin 이상). reasonCode 는 lookup_values(kind='message_hide_reason').code.
+async function hideApplicationMessage(messageId, reasonCode, reasonMemo = null) {
+  if (!db || !messageId) throw new Error('잘못된 호출');
+  await retryWithRefresh(async () => {
+    const {error} = await db.rpc('hide_application_message', {
+      p_message_id: messageId,
+      p_reason_code: reasonCode,
+      p_reason_memo: reasonMemo || null,
+    });
+    if (error) throw error;
+  });
+}
+
+// 강제 숨김 복구 (super_admin 한정). reasonMemo 필수.
+async function unhideApplicationMessage(messageId, reasonMemo) {
+  if (!db || !messageId) throw new Error('잘못된 호출');
+  await retryWithRefresh(async () => {
+    const {error} = await db.rpc('unhide_application_message', {
+      p_message_id: messageId,
+      p_reason_memo: reasonMemo,
+    });
+    if (error) throw error;
+  });
+}
+
+// 관리자 본인 미열람 메시지 수 (응모건별). RPC application_message_admin_unread_counts.
+// 반환: Map<application_id, unread_count> (응모행 배지·받은편지함 개인 강조용)
+async function fetchAdminMessageUnreadCounts() {
+  if (!db) return new Map();
+  const {data, error} = await db.rpc('application_message_admin_unread_counts', { p_admin_auth_id: null });
+  if (error) { console.warn('[fetchAdminMessageUnreadCounts]', error); return new Map(); }
+  const map = new Map();
+  (data || []).forEach(r => map.set(r.application_id, Number(r.unread_count) || 0));
+  return map;
+}
+
+// 관리자 받은편지함 대화 목록 — application_message_summary 뷰 조회.
+//   security_invoker=true 라 관리자 호출 시 전체 응모건 RLS 통과.
+//   message_count>0 (메시지 있는 건만) + last_message_at 최근순. 1000행 cap 대응 pagination.
+//   opts: { sinceMonths(기본 6), campaignId(선택) }
+async function fetchAdminMessageThreads(opts = {}) {
+  if (!db) return [];
+  const sinceMonths = opts.sinceMonths || 6;
+  const sinceIso = new Date(Date.now() - sinceMonths * 30 * 24 * 60 * 60 * 1000).toISOString();
+  const cols = 'application_id, influencer_id, campaign_id, message_count, unread_for_influencer, unresolved_for_admin_team, last_message_at';
+  const rows = [];
+  let from = 0;
+  const PAGE = 1000;
+  while (true) {
+    let q = db?.from('application_message_summary')
+      .select(cols)
+      .gt('message_count', 0)
+      .gte('last_message_at', sinceIso)
+      .order('last_message_at', { ascending: false })
+      .range(from, from + PAGE - 1);
+    if (opts.campaignId) q = q.eq('campaign_id', opts.campaignId);
+    const {data, error} = await q;
+    if (error) { console.warn('[fetchAdminMessageThreads]', error); break; }
+    rows.push(...(data || []));
+    if (!data || data.length < PAGE) break;
+    from += PAGE;
+  }
+  return rows;
+}
+
+// 응모건 단위 숨김/복구 이력 (super_admin — append-only audit). 메시지 모달 하단 패널용.
+//   hide_history 는 message_id 만 가지므로 application_messages inner join 으로 응모건 필터.
+//   RLS SELECT 는 super_admin 한정 (144) — 매니저 호출 시 빈 배열.
+async function fetchApplicationHideHistory(applicationId) {
+  if (!db || !applicationId) return [];
+  const {data, error} = await db.from('application_message_hide_history')
+    .select('id, message_id, action, by_user_kind, by_name, reason_code, reason_memo, at, application_messages!inner(application_id)')
+    .eq('application_messages.application_id', applicationId)
+    .order('at', { ascending: false });
+  if (error) { console.warn('[fetchApplicationHideHistory]', error); return []; }
+  return data || [];
+}
+

--- a/docs/FEATURE_SPEC.md
+++ b/docs/FEATURE_SPEC.md
@@ -151,13 +151,14 @@
 | INF-080 | 햄버거 메뉴    | 홈 / キャンペーン / マイページ / 通知(미읽음 배지 9+) / ログアウト (우측 슬라이드 패널, 인증 페이지에선 숨김) |
 | INF-081 | 바텀탭 (deprecated) | 2026-04 햄버거 메뉴로 대체. 키보드 간섭 제거 목적                          |
 
-### 2.10 응모건 메시지 (인플루언서 ↔ 관리자, PR 1 — 개발 검증 중)
-- 응모이력 카드의 「メッセージ」 버튼(미읽음 배지) → 게시판형 풀스크린 모달 (`#msgModal`, `dev/js/messaging.js`)
-- 발송: 텍스트 + 이미지 첨부 (클라이언트 자동 압축 2048px·HEIC→JPEG 변환, 메시지당 최대 5장). 본인 메시지 25분 내 회수 (회수 시 첨부 즉시 삭제)
-- 숨김·회수 메시지는 본문/첨부 가림(placeholder) — 서버 `get_application_messages` RPC 가 호출자 역할별 4종 마스킹
+### 2.10 응모건 메시지 (인플루언서 ↔ 관리자, PR 1·2 — 개발 검증 중)
+- **인플루언서(PR 1):** 응모이력 카드의 「メッセージ」 버튼(미읽음 배지) → 게시판형 풀스크린 모달 (`#msgModal`, `dev/js/messaging.js`). 발송: 텍스트 + 이미지 첨부(클라 자동 압축 2048px·HEIC→JPEG, 최대 5장). 본인 25분 내 회수(첨부 즉시 삭제). 숨김·회수 메시지 본문/첨부 가림(placeholder)
+- **인플루언서 GNB·알림(PR 2):** 햄버거 메뉴에 「メッセージ」 항목 + 전체 미읽음 배지(`_myMsgUnreadByApp` 합계). 관리자 답장 시 앱 내 알림 `message_received` → 알림 모달 클릭 시 메시지 모달 직접 오픈(kind 로 분기 — application_cancelled 와 ref_table 공유)
+- **관리자(PR 2, `dev/js/admin-messaging.js`):** 사이드바 「메시지」 → 받은편지함 **3단 패널**(좌 캠페인 / 중 대화 상대 / 우 대화 내용). 응모 행(신청관리·캠페인별 신청자·결과물 관리 3개 페인) 인플 셀에 「메시지」 버튼 + 본인 미열람 배지. 메시지 모달에서 답장·이미지 첨부·25분 회수. 「응대 완료」 수동 마킹(모든 관리자). 인플 메시지 강제 숨김(campaign_admin+, 사유 카테고리+메모) / 복구(super_admin, 사유 필수) / 숨김 이력 패널(super_admin)
+- 숨김·회수 마스킹은 서버 `get_application_messages` RPC 가 호출자 역할별 4종 분기(관리자는 숨김 원본 + mask_state 표시)
 - 첨부는 비공개 버킷 `application-message-attachments` + 5분 시한 signed URL
-- DB: 마이그레이션 144 — 테이블 5개(`application_messages` 외) + 마스킹/발송(rate limit 100/h)/읽음/회수(25분, rate limit 50/h) RPC + `security_invoker` 집계 뷰 + 숨김사유 7종 시드
-- **PR 2 예정**: 관리자 발신 UI, GNB 「메시지」 메뉴, 알림(`message_received`), 강제 숨김. **약관 중대 변경(D-7 사전 통지)은 PR 5 운영 배포 직전 집행** (현재 보류)
+- DB: 마이그레이션 144(테이블 5개 + 마스킹/발송/읽음/회수 RPC + 집계 뷰 + 숨김사유 7종) + 145(notifications.kind 확장 + send RPC 알림 INSERT + mark_application_resolved/hide_application_message/unhide_application_message)
+- **미구현**: 일괄 발송(PR 3)·메일 지연 큐(PR 4)·LINE 안내+약관 D-7 사전 통지(PR 5). 운영 배포는 PR 5 약관 통지와 함께(현재 보류)
 - 사양서: `docs/specs/2026-05-15-application-messaging.md`
 
 ---

--- a/docs/specs/2026-05-15-application-messaging.md
+++ b/docs/specs/2026-05-15-application-messaging.md
@@ -1352,5 +1352,26 @@ PRIVACY_ja §5 同等行 (동일 컬럼 구조).
 - Rate limit: send 100/시간, withdraw 50/시간 (함수 내 최근 1시간 count 가드).
 - 인플 메시지 로직은 `dev/js/messaging.js` 신규 파일로 분리(인플 코드 비대화 방지).
 
-### PR 2~5
-(미진행)
+### PR 2 — 관리자 발신 + GNB 메뉴 + 인플 알림 (2026-05-20)
+
+**구현일:** 2026-05-20
+**관련 브랜치/커밋:** `feature/application-messaging-pr2` (dev PR 예정)
+**마이그레이션:** 145 (`145_application_messages_pr2.sql`)
+
+#### 초안 대비 변경 사항
+- **추가된 것:**
+  - 받은편지함을 **3단 패널**(좌: 캠페인 / 중: 대화 상대 / 우: 대화 내용)로 구현 (사용자 결정 — 사양서 §5-4의 단일 받은편지함보다 확장. 관리자 PC 전체폭 활용)
+  - 응모 행 「메시지」 버튼은 **별도 컬럼 대신 인플루언서 셀 안**에 삽입(3개 페인 표 헤더 변경 없이 일관 적용). 공통 헬퍼 `renderApplicantMsgBtn(app)`
+  - 숨김 이력은 **응모건 단위 조회**(`fetchApplicationHideHistory` — hide_history ⨝ application_messages) + 메시지 모달 하단 접이식 패널(super_admin 한정)
+- **빠진 것:** 일괄 발송(BCC)·메일 지연 큐·LINE 안내는 사양대로 PR 3~5로 분리(범위 외)
+- **달라진 것:** `mark_application_resolved` 권한을 초안 추정의 campaign_admin 이상이 아닌 **is_admin()**(모든 관리자)으로 확정 — 사양서 §3-4 「모든 관리자 발신·열람·응대완료 마킹」 충실. 자동 응대(send RPC)도 is_admin 이라 수동도 동일 등급
+
+#### 구현 중 기술 결정 사항
+- **선결작업 통합(마이그레이션 145 단일 파일):** `notifications.kind` CHECK 제약 확장(message_received) + `send_application_message` 재정의(144 본문 보존 + 관리자 발신 시 알림 INSERT, 미읽음 중복 방지) + 신규 RPC 3종을 한 파일에. 144 통합 패턴과 일관
+- **알림 클릭 분기 회귀 방지:** `application_cancelled` 알림도 `ref_table='applications'` 이므로 `onNotifItemClick`에서 `kind='message_received'` 로 한정(reviewer 가 잡은 회귀). 알림 onclick 에 kind 인자 추가
+- **admin.js 핫스팟 회피:** 관리자 로직 전부 신규 `dev/js/admin-messaging.js` 분리. admin.js 변경은 페인 로더 1줄 + 응모행 버튼/미열람맵 로딩 3곳으로 최소화. build.sh ADMIN_JS_FILES 에 admin.js 앞 등록
+- **데이터 계층 재사용:** 받은편지함은 144의 `application_message_summary` 뷰(security_invoker — 관리자 전체 조회) + `application_message_admin_unread_counts`(본인 미열람) + `fetchInfluencersByIds`(이름 보강)로 구성. 145에 뷰/집계 추가 없음
+- **GNB 메시지 배지:** `_myMsgUnreadByApp`(mypage.js) 합계 → `updateNavMsgBadge()`. 햄버거 열 때 `refreshMyMsgUnread` 백그라운드 최신화
+
+### PR 3~5
+(미진행 — PR 3 일괄 발송 / PR 4 메일 지연 큐 / PR 5 LINE 안내 + 약관 D-7 + 운영 배포)

--- a/index.html
+++ b/index.html
@@ -2215,6 +2215,9 @@ const PANE_REFRESHERS = {
   'campaigns': async () => {
     // 관리자 캠페인 목록 갱신 — `loadCampaigns`(인플루언서 함수) 오참조 버그 수정
     if (typeof loadAdminCampaigns === 'function') await loadAdminCampaigns();
+  },
+  'messages': async () => {
+    if (typeof refreshInboxData === 'function') await refreshInboxData();
   }
 };
 async function refreshPane(paneId) {
@@ -2823,6 +2826,8 @@ window.I18N_JA = {
     sendFailed: '送信に失敗しました',
     btnLabel: 'メッセージ',
     unreadBadge: '未読',
+    navMenu: 'メッセージ',
+    notifTitle: '運営からのメッセージ',
   },
 };
 
@@ -3395,6 +3400,8 @@ window.I18N_KO = {
     sendFailed: '전송에 실패했습니다',
     btnLabel: '메시지',
     unreadBadge: '미읽음',
+    navMenu: '메시지',
+    notifTitle: '운영팀 메시지',
   },
 };
 
@@ -5667,6 +5674,98 @@ async function fetchInfluencerUnreadMessageThreads() {
     .gt('unread_for_influencer', 0)
     .order('last_message_at', { ascending: false });
   if (error) { console.warn('[fetchInfluencerUnreadMessageThreads]', error); return []; }
+  return data || [];
+}
+
+// ════════════════════════════════════════════════════════════════════
+// 응모건 메시지 — 관리자 발신/숨김/응대 (PR 2)
+//   마이그레이션 145. 관리자 받은편지함·강제 숨김/복구·응대 완료.
+// ════════════════════════════════════════════════════════════════════
+
+// 응모건 수동 응대 완료 마킹 (모든 관리자 — 사양서 §3-4). RPC mark_application_resolved.
+async function markApplicationResolved(applicationId) {
+  if (!db || !applicationId) return;
+  await retryWithRefresh(async () => {
+    const {error} = await db.rpc('mark_application_resolved', { p_application_id: applicationId });
+    if (error) throw error;
+  });
+}
+
+// 메시지 강제 숨김 (campaign_admin 이상). reasonCode 는 lookup_values(kind='message_hide_reason').code.
+async function hideApplicationMessage(messageId, reasonCode, reasonMemo = null) {
+  if (!db || !messageId) throw new Error('잘못된 호출');
+  await retryWithRefresh(async () => {
+    const {error} = await db.rpc('hide_application_message', {
+      p_message_id: messageId,
+      p_reason_code: reasonCode,
+      p_reason_memo: reasonMemo || null,
+    });
+    if (error) throw error;
+  });
+}
+
+// 강제 숨김 복구 (super_admin 한정). reasonMemo 필수.
+async function unhideApplicationMessage(messageId, reasonMemo) {
+  if (!db || !messageId) throw new Error('잘못된 호출');
+  await retryWithRefresh(async () => {
+    const {error} = await db.rpc('unhide_application_message', {
+      p_message_id: messageId,
+      p_reason_memo: reasonMemo,
+    });
+    if (error) throw error;
+  });
+}
+
+// 관리자 본인 미열람 메시지 수 (응모건별). RPC application_message_admin_unread_counts.
+// 반환: Map<application_id, unread_count> (응모행 배지·받은편지함 개인 강조용)
+async function fetchAdminMessageUnreadCounts() {
+  if (!db) return new Map();
+  const {data, error} = await db.rpc('application_message_admin_unread_counts', { p_admin_auth_id: null });
+  if (error) { console.warn('[fetchAdminMessageUnreadCounts]', error); return new Map(); }
+  const map = new Map();
+  (data || []).forEach(r => map.set(r.application_id, Number(r.unread_count) || 0));
+  return map;
+}
+
+// 관리자 받은편지함 대화 목록 — application_message_summary 뷰 조회.
+//   security_invoker=true 라 관리자 호출 시 전체 응모건 RLS 통과.
+//   message_count>0 (메시지 있는 건만) + last_message_at 최근순. 1000행 cap 대응 pagination.
+//   opts: { sinceMonths(기본 6), campaignId(선택) }
+async function fetchAdminMessageThreads(opts = {}) {
+  if (!db) return [];
+  const sinceMonths = opts.sinceMonths || 6;
+  const sinceIso = new Date(Date.now() - sinceMonths * 30 * 24 * 60 * 60 * 1000).toISOString();
+  const cols = 'application_id, influencer_id, campaign_id, message_count, unread_for_influencer, unresolved_for_admin_team, last_message_at';
+  const rows = [];
+  let from = 0;
+  const PAGE = 1000;
+  while (true) {
+    let q = db?.from('application_message_summary')
+      .select(cols)
+      .gt('message_count', 0)
+      .gte('last_message_at', sinceIso)
+      .order('last_message_at', { ascending: false })
+      .range(from, from + PAGE - 1);
+    if (opts.campaignId) q = q.eq('campaign_id', opts.campaignId);
+    const {data, error} = await q;
+    if (error) { console.warn('[fetchAdminMessageThreads]', error); break; }
+    rows.push(...(data || []));
+    if (!data || data.length < PAGE) break;
+    from += PAGE;
+  }
+  return rows;
+}
+
+// 응모건 단위 숨김/복구 이력 (super_admin — append-only audit). 메시지 모달 하단 패널용.
+//   hide_history 는 message_id 만 가지므로 application_messages inner join 으로 응모건 필터.
+//   RLS SELECT 는 super_admin 한정 (144) — 매니저 호출 시 빈 배열.
+async function fetchApplicationHideHistory(applicationId) {
+  if (!db || !applicationId) return [];
+  const {data, error} = await db.from('application_message_hide_history')
+    .select('id, message_id, action, by_user_kind, by_name, reason_code, reason_memo, at, application_messages!inner(application_id)')
+    .eq('application_messages.application_id', applicationId)
+    .order('at', { ascending: false });
+  if (error) { console.warn('[fetchApplicationHideHistory]', error); return []; }
   return data || [];
 }
 
@@ -8596,6 +8695,10 @@ function openNavPanel() {
   if (!p) return;
   renderNavMenu();
   p.setAttribute('aria-hidden', 'false');
+  // 메시지 미읽음 최신화 (응모이력 미방문 상태로 햄버거 열어도 배지 정확)
+  if (currentUser && typeof refreshMyMsgUnread === 'function') {
+    refreshMyMsgUnread().then(() => updateNavMsgBadge()).catch(() => {});
+  }
 }
 function closeNavPanel() {
   const p = $('navPanel');
@@ -8634,6 +8737,13 @@ function renderNavMenu() {
       </button>
     `).join('');
     html += divider;
+    // 메시지 — 응모이력으로 이동 (응모건 카드 메시지 버튼에서 대화 진입). 미읽음 배지 별도
+    html += `<button class="nav-item" data-nav="messages" onclick="navigate('mypage');openMypageSub('applications');closeNavPanel()">
+      <span class="material-icons-round notranslate nav-icon" translate="no">forum</span>
+      <span class="nav-label">${esc(t('messaging.navMenu'))}</span>
+      <span class="notif-badge hidden" data-role="nav-msg-badge"></span>
+    </button>`;
+    html += divider;
     // 관리자/일반 모두 알림 메뉴 노출 (본인 알림만 받음)
     html += navItemHtml({nav:'notif', icon:'notifications', label: t('menu.notifications'), onclick:"closeNavPanel();openNotifModal()", badge:true});
     html += divider;
@@ -8647,6 +8757,17 @@ function renderNavMenu() {
   }
   menu.innerHTML = html;
   refreshNotifBadge();
+  updateNavMsgBadge();
+}
+
+// 메시지 미읽음 배지 (GNB 「メッセージ」 항목) — _myMsgUnreadByApp(mypage.js) 합계
+function updateNavMsgBadge() {
+  const map = (typeof _myMsgUnreadByApp === 'object' && _myMsgUnreadByApp) ? _myMsgUnreadByApp : {};
+  const total = Object.values(map).reduce((s, n) => s + (Number(n) || 0), 0);
+  document.querySelectorAll('[data-role="nav-msg-badge"]').forEach(b => {
+    if (total > 0) { b.textContent = total > 9 ? '9+' : String(total); b.classList.remove('hidden'); }
+    else b.classList.add('hidden');
+  });
 }
 
 function navItemHtml(it) {
@@ -8776,7 +8897,7 @@ function renderNotifModal(items) {
   const hasUnread = items.some(n => !n.read_at);
   if (markBtn) markBtn.disabled = !hasUnread;
   body.innerHTML = items.map(n => {
-    const iconMap = {deliverable_rejected:{icon:'error_outline',color:'#C33'}, deliverable_changed:{icon:'change_circle',color:'#B8741A'}, deliverable_approved:{icon:'check_circle',color:'#2D7A3E'}};
+    const iconMap = {deliverable_rejected:{icon:'error_outline',color:'#C33'}, deliverable_changed:{icon:'change_circle',color:'#B8741A'}, deliverable_approved:{icon:'check_circle',color:'#2D7A3E'}, message_received:{icon:'forum',color:'#C878A3'}};
     const ic = iconMap[n.kind] || {icon:'notifications', color:'#6B7280'};
     const unread = !n.read_at ? 'unread' : '';
     const rt = _notifRecruitTypeMap[n.ref_id];
@@ -8784,7 +8905,7 @@ function renderNotifModal(items) {
     const rtBadge = rtLabel
       ? `<div style="font-size:10px;font-weight:700;color:var(--pink);margin-bottom:2px">${esc(rtLabel)}</div>`
       : '';
-    return `<div class="notif-item ${unread}" onclick="onNotifItemClick('${esc(n.id)}','${esc(n.ref_table||'')}','${esc(n.ref_id||'')}')">
+    return `<div class="notif-item ${unread}" onclick="onNotifItemClick('${esc(n.id)}','${esc(n.kind||'')}','${esc(n.ref_table||'')}','${esc(n.ref_id||'')}')">
       <div class="notif-item-icon" style="background:${ic.color}"><span class="material-icons-round notranslate" translate="no" style="font-size:20px;color:#fff">${ic.icon}</span></div>
       <div class="notif-item-body">
         ${rtBadge}
@@ -8796,9 +8917,16 @@ function renderNotifModal(items) {
   }).join('');
 }
 
-async function onNotifItemClick(id, refTable, refId) {
+async function onNotifItemClick(id, kind, refTable, refId) {
   await markNotificationRead(id);
   closeNotifModal();
+  // 메시지 알림 → 응모건 메시지 모달 직접 오픈 (사양서 §5-5)
+  //   주의: application_cancelled 알림도 ref_table='applications' 이므로 kind 로 한정 (회귀 방지)
+  if (kind === 'message_received' && refId && currentUser) {
+    if (typeof openMessageModal === 'function') openMessageModal(refId);
+    refreshNotifBadge();
+    return;
+  }
   // deliverable 참조가 있으면 활동관리 이동
   if (refTable === 'deliverables' && refId && currentUser) {
     try {
@@ -9115,6 +9243,8 @@ async function refreshMyMsgUnread() {
     _myMsgUnreadByApp = {};
     threads.forEach(th => { _myMsgUnreadByApp[th.application_id] = th.unread_for_influencer; });
   } catch(e) { /* 무시 */ }
+  // GNB 「メッセージ」 미읽음 배지 갱신 (햄버거 메뉴)
+  if (typeof updateNavMsgBadge === 'function') updateNavMsgBadge();
   // 응모이력 화면이 떠 있을 때만 재렌더 (배지 갱신)
   if ($('myApplicationsList') && typeof renderMyApplyList === 'function') {
     try { await renderMyApplyList(); } catch(e) { /* 무시 */ }

--- a/supabase/migrations/145_application_messages_pr2.sql
+++ b/supabase/migrations/145_application_messages_pr2.sql
@@ -1,0 +1,514 @@
+-- ============================================================
+-- 145_application_messages_pr2.sql
+-- 2026-05-20
+--
+-- 목적:
+--   응모건 메시지 PR 2 DB 추가 — 알림·숨김·수동 응대 완료
+--
+-- 사양서:
+--   docs/specs/2026-05-15-application-messaging.md §3-5, §4-3, §5-5
+--   docs/specs/2026-05-20-HANDOFF-messaging-pr2.md §2
+--
+-- 전제 조건:
+--   마이그레이션 144 (application_messages 5개 테이블 + RPC 4개) 적용 완료
+--   패치 2026-05-20-msg-42702-hotfix.sql 적용 완료
+--
+-- 변경 내용:
+--   (1) notifications.kind CHECK 제약 — message_received 추가 (기존 5종 + 신규 1종)
+--   (2) send_application_message 재정의 — 관리자 발신 시 인플루언서 알림 INSERT 추가
+--   (3) mark_application_resolved 신규 — 수동 응대 완료 (모든 관리자 is_admin)
+--   (4) hide_application_message 신규 — 강제 숨김 (campaign_admin 이상)
+--   (5) unhide_application_message 신규 — 복구 (super_admin 한정)
+--
+-- 신규 테이블·RLS·컬럼 변경:
+--   없음 — 5개 테이블은 144에서 완성, 함수만 추가·재정의
+--
+-- 롤백:
+--   BEGIN;
+--   -- (5) unhide RPC 제거
+--   DROP FUNCTION IF EXISTS public.unhide_application_message(uuid, text);
+--   -- (4) hide RPC 제거
+--   DROP FUNCTION IF EXISTS public.hide_application_message(uuid, text, text);
+--   -- (3) mark_application_resolved RPC 제거
+--   DROP FUNCTION IF EXISTS public.mark_application_resolved(uuid);
+--   -- (2) send_application_message 를 핫픽스 버전으로 복원
+--   --     (핫픽스 파일 supabase/patches/2026-05-20-msg-42702-hotfix.sql 재실행)
+--   -- (1) notifications kind CHECK 제약 롤백
+--   ALTER TABLE public.notifications DROP CONSTRAINT IF EXISTS notifications_kind_check;
+--   ALTER TABLE public.notifications ADD CONSTRAINT notifications_kind_check CHECK (kind IN (
+--     'deliverable_rejected',
+--     'deliverable_changed',
+--     'deliverable_approved',
+--     'application_cancelled'
+--   ));
+--   COMMENT ON COLUMN public.notifications.kind IS
+--     '알림 종류. deliverable_* 3종(037)·application_cancelled(105). 관리자 알림은 admin_notices 테이블 별도.';
+--   COMMIT;
+-- ============================================================
+
+BEGIN;
+
+
+-- ============================================================
+-- (1) notifications.kind CHECK 제약 확장 — message_received 추가
+--
+-- 현행 종류 (105까지 누적):
+--   deliverable_rejected, deliverable_changed, deliverable_approved (037)
+--   application_cancelled (105)
+-- PR 2 신규:
+--   message_received — 관리자가 인플루언서 응모건에 답장 시 발생
+-- ============================================================
+ALTER TABLE public.notifications
+  DROP CONSTRAINT IF EXISTS notifications_kind_check;
+
+ALTER TABLE public.notifications
+  ADD CONSTRAINT notifications_kind_check CHECK (kind IN (
+    'deliverable_rejected',
+    'deliverable_changed',
+    'deliverable_approved',
+    'application_cancelled',
+    'message_received'
+  ));
+
+COMMENT ON COLUMN public.notifications.kind IS
+  '알림 종류. '
+  'deliverable_* 3종(037)·application_cancelled(105)·message_received(145). '
+  '관리자 알림은 admin_notices 테이블 별도. '
+  '인플루언서 화면 알림 모달: dev/js/notifications.js renderNotification().';
+
+
+-- ============================================================
+-- (2) send_application_message 재정의
+--
+-- 핫픽스(2026-05-20-msg-42702-hotfix.sql)에서 #variable_conflict use_column 추가 및
+-- nested DECLARE 평탄화가 적용된 버전을 그대로 베이스로 사용.
+--
+-- PR 2 추가 내용:
+--   관리자(admin)가 메시지를 발송한 경우,
+--   해당 응모를 소유한 인플루언서에게 notifications 행 INSERT (kind='message_received').
+--   인플루언서가 발신한 경우는 알림 INSERT 안 함 (관리자에겐 사이드바 미읽음 배지로 처리).
+--
+-- 보존된 내용 (핫픽스 포함):
+--   - sender_kind 자동 판별 (관리자 먼저 검사)
+--   - Rate limit 100건/시간
+--   - 응모 종료 90일 경과 차단 (인플루언서만, nested DECLARE 평탄화 버전 유지)
+--   - 자동 응대 처리 (결정 J):
+--       인플루언서 → resolutions DELETE (reopen)
+--       관리자     → resolutions UPSERT (auto_replied)
+--   - SECURITY DEFINER + SET search_path=''
+--   - #variable_conflict use_column 지시어 없음 (RETURNS uuid 단일 스칼라라 불필요)
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.send_application_message(
+  p_application_id uuid,
+  p_body           text,
+  p_attachments    jsonb DEFAULT '[]'::jsonb
+) RETURNS uuid  -- new message id
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = ''
+AS $$
+DECLARE
+  v_sender_kind text;
+  v_sender_name text;
+  v_app_owner   uuid;
+  v_app_status  text;
+  v_msg_id      uuid;
+  v_rate_count  bigint;
+  v_ended_at    timestamptz;  -- 응모 종료 시각 (90일 차단 판별용)
+  v_camp_title  text;         -- [PR 2 추가] 알림 title 생성용 캠페인명
+BEGIN
+  -- 응모 소유자 확인
+  SELECT user_id, status INTO v_app_owner, v_app_status
+    FROM public.applications WHERE id = p_application_id;
+
+  IF v_app_owner IS NULL THEN
+    RAISE EXCEPTION '応募が見つかりません';
+  END IF;
+
+  -- sender_kind 판별 (관리자 먼저 검사 — 관리자가 본인 응모도 있을 수 있음)
+  IF public.is_admin() THEN
+    v_sender_kind := 'admin';
+    SELECT name INTO v_sender_name FROM public.admins WHERE auth_id = auth.uid();
+  ELSIF v_app_owner = auth.uid() THEN
+    v_sender_kind := 'influencer';
+    SELECT name INTO v_sender_name FROM public.influencers WHERE id = auth.uid();
+  ELSE
+    RAISE EXCEPTION '権限がありません';
+  END IF;
+
+  -- 본문/첨부 빈값 검증
+  IF (p_body IS NULL OR btrim(p_body) = '') AND (p_attachments IS NULL OR p_attachments = '[]'::jsonb) THEN
+    RAISE EXCEPTION 'メッセージ本文または添付が必要です';
+  END IF;
+
+  -- Rate limit: 사용자별 100건/시간 (사양서 §9 행 1310)
+  SELECT count(*) INTO v_rate_count
+    FROM public.application_messages
+   WHERE sender_id = auth.uid()
+     AND created_at > now() - interval '1 hour';
+
+  IF v_rate_count >= 100 THEN
+    RAISE EXCEPTION 'メッセージの送信上限（1時間に100件）に達しました。しばらく経ってからお試しください';
+  END IF;
+
+  -- 응모 종료 90일 경과 차단 (사양서 §3-3)
+  -- 관리자는 90일 경과 후에도 발송 허용 (사후 안내 필요 케이스 대응)
+  -- nested DECLARE 제거 — 함수 상단 v_ended_at 사용 (핫픽스에서 평탄화)
+  IF NOT public.is_admin() THEN
+    SELECT CASE
+      WHEN a.cancelled_at IS NOT NULL THEN a.cancelled_at
+      WHEN a.status = 'rejected'      THEN a.reviewed_at
+      WHEN a.status = 'approved' AND NOT EXISTS (
+        SELECT 1 FROM public.deliverables d
+         WHERE d.application_id = p_application_id
+           AND d.status <> 'approved'
+      ) AND EXISTS (
+        SELECT 1 FROM public.deliverables d
+         WHERE d.application_id = p_application_id
+      ) THEN (
+        SELECT max(d.reviewed_at) FROM public.deliverables d
+         WHERE d.application_id = p_application_id
+      )
+      ELSE NULL
+    END
+    INTO v_ended_at
+    FROM public.applications a
+    WHERE a.id = p_application_id;
+
+    IF v_ended_at IS NOT NULL AND v_ended_at < now() - interval '90 days' THEN
+      RAISE EXCEPTION '応募終了から90日経過しました。閲覧のみ可能です';
+    END IF;
+  END IF;
+
+  INSERT INTO public.application_messages (
+    application_id, sender_kind, sender_id, sender_name, body, attachments
+  ) VALUES (
+    p_application_id,
+    v_sender_kind,
+    auth.uid(),
+    COALESCE(v_sender_name, '(이름미상)'),
+    COALESCE(p_body, ''),
+    COALESCE(p_attachments, '[]'::jsonb)
+  )
+  RETURNING id INTO v_msg_id;
+
+  -- 자동 응대 처리 (결정 J, 사양서 §3-4 + §4-1-3):
+  --   인플루언서 새 메시지 → application_message_resolutions 행 자동 DELETE (reopen)
+  --   관리자 답장 → application_message_resolutions 자동 UPSERT (auto_replied)
+  IF v_sender_kind = 'influencer' THEN
+    DELETE FROM public.application_message_resolutions
+     WHERE application_id = p_application_id;
+  ELSE  -- v_sender_kind = 'admin'
+    INSERT INTO public.application_message_resolutions (
+      application_id,
+      resolved_at,
+      resolved_by,
+      resolved_by_name,
+      resolved_after_message_at,
+      resolution_method
+    ) VALUES (
+      p_application_id,
+      now(),
+      auth.uid(),
+      COALESCE(v_sender_name, '(이름미상)'),
+      COALESCE(
+        (SELECT max(created_at)
+           FROM public.application_messages
+          WHERE application_id = p_application_id
+            AND sender_kind = 'influencer'
+            AND hidden_by_admin_at IS NULL
+            AND self_withdrawn_at IS NULL),
+        now()  -- 인플루언서 메시지 없을 때 (관리자가 먼저 시작한 케이스) now() 폴백
+      ),
+      'auto_replied'
+    )
+    ON CONFLICT (application_id) DO UPDATE
+      SET resolved_at               = EXCLUDED.resolved_at,
+          resolved_by               = EXCLUDED.resolved_by,
+          resolved_by_name          = EXCLUDED.resolved_by_name,
+          resolved_after_message_at = EXCLUDED.resolved_after_message_at,
+          resolution_method         = 'auto_replied';
+  END IF;
+
+  -- ----------------------------------------------------------------
+  -- [PR 2 추가] 관리자 발신 시 인플루언서에게 알림 INSERT
+  --
+  -- 조건: v_sender_kind = 'admin' (인플루언서 발신은 알림 불필요 — 관리자는 사이드바 배지)
+  -- 중복 방지: 같은 응모건에 대한 기존 미읽음 message_received 알림이 있으면
+  --            INSERT 하지 않음 (이미 읽지 않은 알림이 누적되지 않도록).
+  --            → 인플루언서가 열어서 읽어야 dismiss 되고, 다음 메시지가 또 알림 생성.
+  --
+  -- notifications 컬럼 구조 (037 기준):
+  --   id, user_id, kind, ref_table, ref_id, title, body, read_at, created_at
+  -- ----------------------------------------------------------------
+  IF v_sender_kind = 'admin' THEN
+    -- 캠페인명 조회 (알림 title 생성용)
+    SELECT c.title INTO v_camp_title
+      FROM public.applications a
+      JOIN public.campaigns c ON c.id = a.campaign_id
+     WHERE a.id = p_application_id;
+
+    -- 같은 응모건에 미읽음 message_received 알림이 없을 때만 INSERT
+    IF NOT EXISTS (
+      SELECT 1 FROM public.notifications
+       WHERE user_id   = v_app_owner
+         AND kind      = 'message_received'
+         AND ref_table = 'applications'
+         AND ref_id    = p_application_id
+         AND read_at   IS NULL
+    ) THEN
+      INSERT INTO public.notifications (
+        user_id, kind, ref_table, ref_id, title, body
+      ) VALUES (
+        v_app_owner,
+        'message_received',
+        'applications',
+        p_application_id,
+        COALESCE(v_camp_title, '') || ' — 運営からメッセージが届きました',
+        COALESCE(v_sender_name, '(이름미상)') || 'よりメッセージが送信されました'
+      );
+    END IF;
+  END IF;
+
+  RETURN v_msg_id;
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.send_application_message(uuid, text, jsonb) FROM PUBLIC, anon;
+GRANT  EXECUTE ON FUNCTION public.send_application_message(uuid, text, jsonb) TO authenticated;
+
+COMMENT ON FUNCTION public.send_application_message(uuid, text, jsonb) IS
+  '[144][hotfix-42702][145] 메시지 발송 원격 호출 함수. 인플루언서·관리자 공용, sender_kind 자동 판별. '
+  'Rate limit: 사용자별 100건/시간 (사양서 §9). '
+  '관리자 답장 시 resolutions 자동 UPSERT + 인플루언서 알림(message_received) INSERT. '
+  '인플루언서 발신은 알림 없음 (관리자는 사이드바 미읽음 배지로 처리). '
+  '미읽음 message_received 알림이 이미 있으면 중복 INSERT 안 함. '
+  '인플루언서는 응모 종료 90일 초과 시 발송 차단. SECURITY DEFINER + search_path 고정.';
+
+
+-- ============================================================
+-- (3) mark_application_resolved — 수동 응대 완료
+--
+-- 사양서 §4-1-3 (결정 J), §3-4, HANDOFF §2-3
+-- is_admin() 가드 — 응대 완료 마킹은 모든 관리자 가능
+--   (사양서 §3-4: super_admin·campaign_admin·campaign_manager 모두 발신·열람·응대완료 마킹).
+--   자동 응대(send RPC)도 is_admin() 이라 수동도 동일 등급으로 통일.
+-- application_message_resolutions 에 UPSERT (resolution_method='manual').
+-- 가장 최근 인플루언서 메시지 시각을 resolved_after_message_at 에 기록.
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.mark_application_resolved(
+  p_application_id uuid
+) RETURNS void
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = ''
+AS $$
+DECLARE
+  v_admin_name              text;
+  v_last_influencer_msg_at  timestamptz;
+BEGIN
+  IF NOT public.is_admin() THEN
+    RAISE EXCEPTION '권한이 없습니다 (관리자 전용)'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  -- 응모 존재 여부 확인
+  IF NOT EXISTS (SELECT 1 FROM public.applications WHERE id = p_application_id) THEN
+    RAISE EXCEPTION '응모를 찾을 수 없습니다';
+  END IF;
+
+  SELECT name INTO v_admin_name FROM public.admins WHERE auth_id = auth.uid();
+
+  -- 마지막 인플루언서 메시지 시각 (살아있는 것 기준)
+  SELECT max(created_at) INTO v_last_influencer_msg_at
+    FROM public.application_messages
+   WHERE application_id = p_application_id
+     AND sender_kind        = 'influencer'
+     AND hidden_by_admin_at IS NULL
+     AND self_withdrawn_at  IS NULL;
+
+  INSERT INTO public.application_message_resolutions (
+    application_id,
+    resolved_at,
+    resolved_by,
+    resolved_by_name,
+    resolved_after_message_at,
+    resolution_method
+  ) VALUES (
+    p_application_id,
+    now(),
+    auth.uid(),
+    COALESCE(v_admin_name, '(이름미상)'),
+    COALESCE(v_last_influencer_msg_at, now()),
+    'manual'
+  )
+  ON CONFLICT (application_id) DO UPDATE
+    SET resolved_at               = EXCLUDED.resolved_at,
+        resolved_by               = EXCLUDED.resolved_by,
+        resolved_by_name          = EXCLUDED.resolved_by_name,
+        resolved_after_message_at = EXCLUDED.resolved_after_message_at,
+        resolution_method         = 'manual';
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.mark_application_resolved(uuid) FROM PUBLIC, anon;
+GRANT  EXECUTE ON FUNCTION public.mark_application_resolved(uuid) TO authenticated;
+
+COMMENT ON FUNCTION public.mark_application_resolved(uuid) IS
+  '[145] 응모건 수동 응대 완료 원격 호출 함수. is_admin() 가드 (모든 관리자 — 사양서 §3-4). '
+  'application_message_resolutions UPSERT (resolution_method=manual). '
+  '살아있는 마지막 인플루언서 메시지 시각 → resolved_after_message_at. '
+  '인플루언서 메시지 없으면 now() 폴백. SECURITY DEFINER + search_path 고정.';
+
+
+-- ============================================================
+-- (4) hide_application_message — 강제 숨김
+--
+-- 사양서 §3-5 ① (HANDOFF §2-3)
+-- campaign_admin 이상 가드.
+-- application_messages.hidden_by_admin_at/_id/_reason_code/_memo UPDATE.
+-- application_message_hide_history INSERT (action='hide').
+-- 발송 대기 중인 이메일(email_send_at 도래 전)도 자동 취소.
+--
+-- hide_history 컬럼 구조 (144 기준):
+--   id, message_id, action, by_user_kind, by_user_id, by_name, reason_code, reason_memo, at
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.hide_application_message(
+  p_message_id  uuid,
+  p_reason_code text,
+  p_reason_memo text DEFAULT NULL
+) RETURNS void
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = ''
+AS $$
+DECLARE
+  v_admin_name text;
+BEGIN
+  IF NOT public.is_campaign_admin() THEN
+    RAISE EXCEPTION '권한이 없습니다 (campaign_admin 이상 필요)'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  -- 사유 카테고리 유효성 검증
+  IF NOT EXISTS (
+    SELECT 1 FROM public.lookup_values
+     WHERE kind = 'message_hide_reason'
+       AND code = p_reason_code
+       AND active = true
+  ) THEN
+    RAISE EXCEPTION '유효하지 않은 사유 카테고리입니다: %', p_reason_code;
+  END IF;
+
+  SELECT name INTO v_admin_name FROM public.admins WHERE auth_id = auth.uid();
+
+  -- 메시지 숨김 처리
+  -- 이미 숨김 처리된 경우 UPDATE 0 → FOUND=false → 예외
+  UPDATE public.application_messages
+     SET hidden_by_admin_at = now(),
+         hidden_by_admin_id = auth.uid(),
+         hidden_reason_code = p_reason_code,
+         hidden_reason_memo = p_reason_memo
+   WHERE id = p_message_id
+     AND hidden_by_admin_at IS NULL;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION '메시지를 찾을 수 없거나 이미 숨김 처리되었습니다';
+  END IF;
+
+  -- 감사 이력 기록
+  INSERT INTO public.application_message_hide_history (
+    message_id, action, by_user_kind, by_user_id, by_name, reason_code, reason_memo
+  ) VALUES (
+    p_message_id,
+    'hide',
+    'admin',
+    auth.uid(),
+    COALESCE(v_admin_name, '(이름미상)'),
+    p_reason_code,
+    p_reason_memo
+  );
+
+  -- 발송 대기 이메일 자동 취소 (email_send_at 도래 전인 경우)
+  UPDATE public.application_messages
+     SET email_skip_reason = 'cancelled'
+   WHERE id = p_message_id
+     AND email_send_at IS NOT NULL
+     AND email_send_at > now()
+     AND email_sent_at IS NULL;
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.hide_application_message(uuid, text, text) FROM PUBLIC, anon;
+GRANT  EXECUTE ON FUNCTION public.hide_application_message(uuid, text, text) TO authenticated;
+
+COMMENT ON FUNCTION public.hide_application_message(uuid, text, text) IS
+  '[145] 메시지 강제 숨김 원격 호출 함수. campaign_admin 이상 가드. '
+  'application_messages hidden_by_admin_* 4컬럼 UPDATE + hide_history INSERT(action=hide). '
+  '이미 숨김 상태면 예외. 발송 대기 이메일 자동 취소. '
+  'SECURITY DEFINER + search_path 고정. 조회는 get_application_messages RPC 비대칭 마스킹 참고.';
+
+
+-- ============================================================
+-- (5) unhide_application_message — 강제 숨김 복구
+--
+-- 사양서 §3-5 ① 복구 절차 (HANDOFF §2-3)
+-- super_admin 한정 가드 (campaign_admin 은 hide 만 가능).
+-- p_reason_memo 필수 (복구 사유 미기재 시 차단).
+-- hidden_by_admin_* 4컬럼 NULL 복원.
+-- application_message_hide_history INSERT (action='unhide').
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.unhide_application_message(
+  p_message_id  uuid,
+  p_reason_memo text
+) RETURNS void
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = ''
+AS $$
+DECLARE
+  v_admin_name text;
+BEGIN
+  IF NOT public.is_super_admin() THEN
+    RAISE EXCEPTION '권한이 없습니다 (super_admin 한정)'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  -- 복구 사유 메모 필수
+  IF p_reason_memo IS NULL OR btrim(p_reason_memo) = '' THEN
+    RAISE EXCEPTION '복구 사유 메모는 필수입니다';
+  END IF;
+
+  SELECT name INTO v_admin_name FROM public.admins WHERE auth_id = auth.uid();
+
+  -- 숨김 상태인 메시지만 복원
+  UPDATE public.application_messages
+     SET hidden_by_admin_at = NULL,
+         hidden_by_admin_id = NULL,
+         hidden_reason_code = NULL,
+         hidden_reason_memo = NULL
+   WHERE id = p_message_id
+     AND hidden_by_admin_at IS NOT NULL;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION '메시지를 찾을 수 없거나 숨김 상태가 아닙니다';
+  END IF;
+
+  -- 감사 이력 기록
+  INSERT INTO public.application_message_hide_history (
+    message_id, action, by_user_kind, by_user_id, by_name, reason_code, reason_memo
+  ) VALUES (
+    p_message_id,
+    'unhide',
+    'admin',
+    auth.uid(),
+    COALESCE(v_admin_name, '(이름미상)'),
+    NULL,         -- unhide 는 사유 카테고리 없음
+    p_reason_memo
+  );
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.unhide_application_message(uuid, text) FROM PUBLIC, anon;
+GRANT  EXECUTE ON FUNCTION public.unhide_application_message(uuid, text) TO authenticated;
+
+COMMENT ON FUNCTION public.unhide_application_message(uuid, text) IS
+  '[145] 메시지 강제 숨김 복구 원격 호출 함수. super_admin 한정. '
+  'p_reason_memo 필수 (빈값 시 예외). '
+  'hidden_by_admin_* 4컬럼 NULL 복원 + hide_history INSERT(action=unhide). '
+  '숨김 상태가 아닌 메시지 호출 시 예외. SECURITY DEFINER + search_path 고정.';
+
+
+COMMIT;


### PR DESCRIPTION
## 변경 요약
- 응모건 메시지 PR 2 — 관리자가 응모건에 답장·발신, 인플루언서 앱 내 알림, GNB 「メッセージ」 메뉴
- 관리자 받은편지함 3단 패널(캠페인 / 대화 상대 / 대화 내용) + 응모행 「메시지」 버튼(3개 페인) + 강제 숨김/복구/응대완료
- 마이그레이션 145: notifications.kind 확장(message_received) + send RPC 알림 INSERT + mark_application_resolved/hide/unhide

## 요청 외 추가 변경
- 없음 (PR 1 인수인계 문서 범위 내)

## DB 적용 필요 (개발서버 먼저)
- `supabase/migrations/145_application_messages_pr2.sql` — 개발 DB SQL Editor 적용 + 신규 함수 4종 스모크 호출 후 검증
- 운영 DB·main 머지는 'PR 5 — LINE 안내 + 약관 D-7 사전 통지'와 함께 (현재 보류)

## Test plan
- [ ] 마이그레이션 145 개발 DB 적용 + 함수 스모크 호출 (send 알림 INSERT / mark_resolved / hide / unhide)
- [ ] 관리자 받은편지함 3단 진입 → 캠페인 선택 → 대화 선택 → 답장 발송
- [ ] 응모행 메시지 버튼(신청관리·캠페인별 신청자·결과물 관리) → 모달 → 본인 미열람 배지
- [ ] 인플 메시지 강제 숨김(campaign_admin) / 복구(super_admin) / 숨김 이력
- [ ] 인플 GNB 「メッセージ」 메뉴 + 미읽음 배지 + 관리자 답장 시 알림 message_received
- [ ] 알림 모달에서 message_received 클릭 → 메시지 모달 (취소 알림 클릭은 응모이력 — 회귀 없음 확인)

## 관련 사양서
- docs/specs/2026-05-15-application-messaging.md (구현 결과 — PR 2 섹션)
- docs/specs/2026-05-20-HANDOFF-messaging-pr2.md

[via planner / supabase-expert / reviewer]

🤖 Generated with [Claude Code](https://claude.com/claude-code)