### PR TITLE
feat(messaging): 받은편지함 단계 너비 + 캠페인·인플 정보 + 시간 표시

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -12,7 +12,7 @@
 // 회귀(2026-05-12 PR #182 머지 직후 발생)를 방지하기 위한 자동 reload 가드.
 // sessionStorage 차단 환경(시크릿 모드 일부, 쿠키 차단)에서는 자연스럽게 skip.
 (function(){
-  var CURRENT_BUILD = 'v1779269973';
+  var CURRENT_BUILD = 'v1779272451';
   if (CURRENT_BUILD.indexOf('__') === 0) return; // 빌드 미적용 (dev/ 직접 열기) 시 skip
   try {
     var prev = sessionStorage.getItem('reverb.adminBuild');
@@ -1455,31 +1455,46 @@ textarea.form-input{resize:vertical;min-height:80px}
 /* ════════════════════════════════════════════════════════════
    응모건 메시지 (PR 2) — 받은편지함 3단 + 메시지 카드/모달
    ════════════════════════════════════════════════════════════ */
-/* 받은편지함 3단 패널 */
-.inbox-3pane{display:flex;gap:0;flex:1;min-height:0;height:calc(100vh - 130px);border:1px solid var(--line);border-radius:12px;overflow:hidden;background:#fff}
+/* 받은편지함 3단 패널 — 단계 진행형 너비 */
+.inbox-3pane{display:flex;gap:0;flex:1;min-height:0;height:calc(100vh - 150px);border:1px solid var(--line);border-radius:12px;overflow:hidden;background:#fff}
 .inbox-col{overflow-y:auto;min-height:0}
-.inbox-col-camps{width:240px;flex-shrink:0;border-right:1px solid var(--line);background:var(--surface-container-low)}
-.inbox-col-threads{width:300px;flex-shrink:0;border-right:1px solid var(--line)}
-.inbox-col-view{flex:1;min-width:0;display:flex;flex-direction:column}
+.inbox-col-camps{border-right:1px solid var(--line);background:var(--surface-container-low)}
+.inbox-col-threads{border-right:1px solid var(--line)}
+.inbox-col-view{display:flex;flex-direction:column}
 .inbox-empty{padding:24px 16px;color:var(--muted);font-size:13px;text-align:center}
-/* 좌: 캠페인 항목 */
-.inbox-camp-item{display:flex;align-items:center;justify-content:space-between;gap:8px;width:100%;padding:12px 14px;border:0;border-bottom:1px solid var(--line);background:none;cursor:pointer;text-align:left;font-size:13px;color:var(--ink)}
+/* 단계: campaigns(캠페인 전체폭) → threads(대화상대 확대) → view(대화내용 확대) */
+.inbox-3pane.stage-campaigns .inbox-col-camps{flex:1;width:auto}
+.inbox-3pane.stage-campaigns .inbox-col-threads,
+.inbox-3pane.stage-campaigns .inbox-col-view{display:none}
+.inbox-3pane.stage-threads .inbox-col-camps{width:320px;flex-shrink:0}
+.inbox-3pane.stage-threads .inbox-col-threads{flex:1;width:auto}
+.inbox-3pane.stage-threads .inbox-col-view{display:none}
+.inbox-3pane.stage-view .inbox-col-camps{width:260px;flex-shrink:0}
+.inbox-3pane.stage-view .inbox-col-threads{width:320px;flex-shrink:0}
+.inbox-3pane.stage-view .inbox-col-view{flex:1;min-width:0}
+/* 좌: 캠페인 정보 카드 */
+.inbox-camp-item{display:flex;flex-direction:column;align-items:stretch;gap:4px;width:100%;padding:12px 14px;border:0;border-bottom:1px solid var(--line);background:none;cursor:pointer;text-align:left;color:var(--ink)}
 .inbox-camp-item:hover{background:var(--light-pink)}
-.inbox-camp-item.active{background:var(--light-pink);font-weight:600}
-.inbox-camp-title{flex:1;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
-.inbox-camp-meta{display:flex;align-items:center;gap:6px;font-size:11px;color:var(--muted);flex-shrink:0}
+.inbox-camp-item.active{background:var(--light-pink)}
+.inbox-camp-badges{display:flex;gap:4px;align-items:center;flex-wrap:wrap}
+.inbox-camp-title{font-size:13px;font-weight:600;word-break:break-word;line-height:1.4}
+.inbox-camp-sub{font-size:11px;color:var(--muted)}
+.inbox-camp-meta{display:flex;align-items:center;gap:6px;font-size:11px;color:var(--muted)}
 .inbox-camp-badge{display:inline-flex;align-items:center;justify-content:center;min-width:18px;height:18px;padding:0 5px;border-radius:9px;background:var(--pink);color:#fff;font-size:11px;font-weight:700}
-/* 중: 대화 상대 항목 */
-.inbox-thread-item{display:flex;align-items:center;justify-content:space-between;gap:8px;width:100%;padding:12px 14px;border:0;border-bottom:1px solid var(--line);background:none;cursor:pointer;text-align:left;font-size:13px;color:var(--ink)}
+/* 중: 대화 상대 카드 (한자·가나 이름 + 이메일 + 미리보기 + 시간) */
+.inbox-thread-item{display:flex;flex-direction:column;align-items:stretch;gap:3px;width:100%;padding:12px 14px;border:0;border-bottom:1px solid var(--line);background:none;cursor:pointer;text-align:left;color:var(--ink)}
 .inbox-thread-item:hover{background:var(--surface-dim)}
-.inbox-thread-item.active{background:var(--light-pink);font-weight:600}
-.inbox-thread-name{flex:1;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
-.inbox-thread-meta{display:flex;align-items:center;gap:6px;flex-shrink:0}
+.inbox-thread-item.active{background:var(--light-pink)}
+.inbox-thread-top{display:flex;align-items:center;justify-content:space-between;gap:8px}
+.inbox-thread-name{font-size:13px;font-weight:600;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.inbox-thread-kana{font-size:11px;font-weight:400;color:var(--muted);margin-left:6px}
+.inbox-thread-email{font-size:11px;color:var(--muted);overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.inbox-thread-preview{font-size:12px;color:var(--ink);overflow:hidden;text-overflow:ellipsis;white-space:nowrap;opacity:.8}
+.inbox-thread-meta{display:flex;align-items:center;gap:4px;flex-shrink:0}
 .inbox-thread-time{font-size:10px;color:var(--muted)}
 .inbox-thread-chip{display:inline-flex;align-items:center;padding:1px 6px;border-radius:8px;font-size:10px;font-weight:600}
 .inbox-thread-chip.unresolved{background:var(--gold-l);color:var(--gold)}
 .inbox-thread-chip.unread{background:var(--pink);color:#fff}
-.inbox-filter-chk{font-size:13px;color:var(--ink);display:inline-flex;align-items:center;gap:4px;cursor:pointer}
 
 /* 대화 내용 영역 (받은편지함 우측 + 모달 본문 공용) */
 .adm-msg-actionbar{display:flex;gap:8px;padding:10px 14px;border-bottom:1px solid var(--line);flex-shrink:0;background:var(--surface-container-low)}
@@ -1600,7 +1615,7 @@ textarea.form-input{resize:vertical;min-height:80px}
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-05-20 18:39 · 9827ccb</span>
+          <span class="admin-build-text">2026-05-20 19:20 · 9e27400</span>
         </div>
       </div>
     </aside>
@@ -2575,18 +2590,29 @@ textarea.form-input{resize:vertical;min-height:80px}
         <!-- 메시지 받은편지함 (3단: 캠페인 / 대화 상대 / 대화 내용) -->
         <div id="adminPane-messages" class="admin-pane">
           <div class="admin-sticky-header">
-            <h2 class="admin-pane-title">메시지</h2>
-            <div class="admin-filters">
-              <label class="inbox-filter-chk"><input type="checkbox" onchange="toggleInboxUnresolved(this.checked)"> 미응대만</label>
-              <select class="admin-select" onchange="changeInboxSince(this.value)">
-                <option value="6">최근 6개월</option>
-                <option value="3">최근 3개월</option>
-                <option value="12">최근 1년</option>
-                <option value="120">전체</option>
-              </select>
+            <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:12px">
+              <div style="font-size:16px;font-weight:700;color:var(--ink)">메시지</div>
+            </div>
+            <div style="display:flex;align-items:flex-end;gap:12px;flex-wrap:wrap">
+              <div class="admin-filter-group">
+                <label>기간</label>
+                <select class="admin-select" onchange="changeInboxSince(this.value)">
+                  <option value="6">최근 6개월</option>
+                  <option value="3">최근 3개월</option>
+                  <option value="12">최근 1년</option>
+                  <option value="120">전체</option>
+                </select>
+              </div>
+              <div class="admin-filter-group">
+                <label>미응대</label>
+                <label style="display:inline-flex;align-items:center;gap:4px;font-size:12px;cursor:pointer;height:32px">
+                  <input type="checkbox" onchange="toggleInboxUnresolved(this.checked)" style="margin:0">
+                  <span>미응대만</span>
+                </label>
+              </div>
             </div>
           </div>
-          <div class="inbox-3pane">
+          <div class="inbox-3pane stage-campaigns">
             <div class="inbox-col inbox-col-camps" id="inboxCampaigns"></div>
             <div class="inbox-col inbox-col-threads" id="inboxThreads"></div>
             <div class="inbox-col inbox-col-view" id="inboxThreadView"></div>
@@ -6515,6 +6541,32 @@ async function fetchAdminMessageThreads(opts = {}) {
     from += PAGE;
   }
   return rows;
+}
+
+// 받은편지함 최근 메시지 미리보기 — 응모건별 마지막 「살아있는」 메시지 본문.
+//   숨김/회수 메시지는 제외(미리보기 노출 부적절). created_at 내림차순 후 클라에서 첫 행=최신.
+//   반환: Map<application_id, {body, sender_kind, created_at}>
+//   ⚠️ PostgREST 1000행 cap: 청크당 application 100개 + limit 1000. 한 청크 내
+//      메시지 밀도가 매우 높으면(application 평균 10건 초과) 뒤쪽 응모건 미리보기가
+//      누락될 수 있음. 미리보기는 보조 정보라 치명적이지 않음. 정밀도 필요 시
+//      차후 「응모건당 최신 1건」 전용 RPC 로 개선 권장.
+async function fetchMessagePreviews(applicationIds) {
+  if (!db || !applicationIds || !applicationIds.length) return new Map();
+  const map = new Map();
+  const CHUNK = 100;  // application_id 청크 (청크당 1000행 cap 내 평균 10건 커버)
+  for (let i = 0; i < applicationIds.length; i += CHUNK) {
+    const ids = applicationIds.slice(i, i + CHUNK);
+    const {data, error} = await db?.from('application_messages')
+      .select('application_id, body, sender_kind, created_at')
+      .in('application_id', ids)
+      .is('hidden_by_admin_at', null)
+      .is('self_withdrawn_at', null)
+      .order('created_at', { ascending: false })
+      .limit(1000);
+    if (error) { console.warn('[fetchMessagePreviews]', error); continue; }
+    (data || []).forEach(m => { if (!map.has(m.application_id)) map.set(m.application_id, m); });
+  }
+  return map;
 }
 
 // 응모건 단위 숨김/복구 이력 (super_admin — append-only audit). 메시지 모달 하단 패널용.
@@ -11111,6 +11163,8 @@ let _applicantMsgUnreadMap = new Map();
 
 // 받은편지함 인플루언서 이름 맵 (influencer_id → 행). refreshInboxData 에서 채움
 let _inboxInflMap = {};
+// 받은편지함 최근 메시지 미리보기 맵 (application_id → {body, sender_kind, created_at})
+let _inboxPreviewMap = new Map();
 
 // 현재 super_admin 여부 (admin.js 의 currentAdminInfo 기준)
 function admMsgIsSuper() {
@@ -11127,9 +11181,24 @@ async function loadHideReasons() {
 // 1. 받은편지함 3단 패널 (#adminPane-messages)
 // ════════════════════════════════════════════════════════════════════
 async function loadMessagesInbox() {
+  _inboxSelectedCampaign = null;
+  if (_admMsgContext === 'inbox') _admMsgAppId = null;
   const wrap = document.getElementById('inboxThreadView');
   if (wrap) wrap.innerHTML = '<div class="inbox-empty">대화를 선택하세요.</div>';
   await refreshInboxData();
+  updateInboxStage();
+}
+
+// 단계 진행형 너비 — 선택 진척에 따라 활성 단을 넓힘 (메신저 드릴다운)
+//   캠페인 미선택 → 캠페인 목록 전체폭 / 캠페인 선택 → 대화 상대 목록 확대 / 대화 선택 → 대화 내용 확대
+function updateInboxStage() {
+  const pane = document.querySelector('.inbox-3pane');
+  if (!pane) return;
+  pane.classList.remove('stage-campaigns', 'stage-threads', 'stage-view');
+  const threadOpen = _admMsgContext === 'inbox' && _admMsgAppId;
+  if (!_inboxSelectedCampaign) pane.classList.add('stage-campaigns');
+  else if (!threadOpen) pane.classList.add('stage-threads');
+  else pane.classList.add('stage-view');
 }
 
 // 뷰 + 본인 미열람 맵을 다시 조회하고 좌/중 패널 재렌더
@@ -11141,12 +11210,17 @@ async function refreshInboxData() {
     ]);
     _inboxThreads = threads || [];
     _inboxUnreadMap = unreadMap || new Map();
-    // 인플루언서 이름 보강 (id 목록 → fetchInfluencersByIds 맵)
-    const ids = [...new Set(_inboxThreads.map(t => t.influencer_id).filter(Boolean))];
-    _inboxInflMap = ids.length ? (await fetchInfluencersByIds(ids)) : {};
+    // 인플루언서 이름·최근 메시지 미리보기 보강 (병렬)
+    const inflIds = [...new Set(_inboxThreads.map(t => t.influencer_id).filter(Boolean))];
+    const appIds = [...new Set(_inboxThreads.map(t => t.application_id).filter(Boolean))];
+    const [inflMap, prevMap] = await Promise.all([
+      inflIds.length ? fetchInfluencersByIds(inflIds) : Promise.resolve({}),
+      appIds.length ? fetchMessagePreviews(appIds) : Promise.resolve(new Map()),
+    ]);
+    _inboxInflMap = inflMap; _inboxPreviewMap = prevMap;
   } catch (e) {
     console.error('[refreshInboxData]', e);
-    _inboxThreads = []; _inboxUnreadMap = new Map(); _inboxInflMap = {};
+    _inboxThreads = []; _inboxUnreadMap = new Map(); _inboxInflMap = {}; _inboxPreviewMap = new Map();
   }
   renderInboxCampaignList();
   renderInboxThreadList();
@@ -11182,20 +11256,35 @@ function renderInboxCampaignList() {
     return;
   }
   el.innerHTML = groups.map(g => {
-    const camp = campaignTitleById(g.campaign_id);
+    const c = inboxCampaignById(g.campaign_id);
+    const title = c ? (c.title || '(제목 없음)') : '(캠페인)';
     const active = g.campaign_id === _inboxSelectedCampaign ? 'active' : '';
     const badge = g.unresolved > 0 ? `<span class="inbox-camp-badge">${g.unresolved}</span>` : '';
+    // 모집타입 배지(공통 헬퍼) + 캠페인 상태 배지(캠페인 전용 — 신청 상태와 라벨 다름)
+    const typeBadge = (c && typeof getRecruitTypeBadgeKoSm === 'function') ? getRecruitTypeBadgeKoSm(c.recruit_type) : '';
+    const statusBadge = c ? inboxCampStatusBadge(c.status) : '';
+    // 브랜드 · 모집인원
+    const brand = c ? esc(c.brand_ko || c.brand || '') : '';
+    const slots = (c && c.slots) ? `모집 ${c.slots}명` : '';
+    const sub = [brand, slots].filter(Boolean).join(' · ');
     return `<button type="button" class="inbox-camp-item ${active}" onclick="selectInboxCampaign('${esc(g.campaign_id)}')">
-      <span class="inbox-camp-title">${esc(camp)}</span>
-      <span class="inbox-camp-meta">${g.total}건${badge}</span>
+      <span class="inbox-camp-badges">${typeBadge}${statusBadge}</span>
+      <span class="inbox-camp-title">${esc(title)}</span>
+      ${sub ? `<span class="inbox-camp-sub">${sub}</span>` : ''}
+      <span class="inbox-camp-meta">대화 ${g.total}건${badge}</span>
     </button>`;
   }).join('');
 }
 
 function selectInboxCampaign(campaignId) {
   _inboxSelectedCampaign = campaignId;
+  // 캠페인 전환 시 우측 대화 초기화 (단계 = 대화 상대 선택)
+  if (_admMsgContext === 'inbox') _admMsgAppId = null;
+  const view = document.getElementById('inboxThreadView');
+  if (view) view.innerHTML = '<div class="inbox-empty">대화를 선택하세요.</div>';
   renderInboxCampaignList();
   renderInboxThreadList();
+  updateInboxStage();
 }
 
 // 중: 선택 캠페인의 대화 상대(인플루언서) 목록
@@ -11214,16 +11303,32 @@ function renderInboxThreadList() {
     return;
   }
   el.innerHTML = list.map(t => {
-    const name = influencerNameById(t.influencer_id);
+    const inf = (_inboxInflMap && _inboxInflMap[t.influencer_id]) || {};
+    const kanji = esc(inf.name || '(이름 없음)');           // 한자 이름
+    const kana = inf.name_kana ? esc(inf.name_kana) : '';   // 가나 이름
+    const email = inf.email ? esc(inf.email) : '';
     const unread = _inboxUnreadMap.get(t.application_id) || 0;
     const active = t.application_id === _admMsgAppId ? 'active' : '';
     const unresolved = t.unresolved_for_admin_team
       ? '<span class="inbox-thread-chip unresolved">미응대</span>' : '';
     const unreadChip = unread > 0
       ? `<span class="inbox-thread-chip unread">${unread > 99 ? '99+' : unread}</span>` : '';
+    // 최근 메시지 미리보기 (한 줄)
+    const prev = _inboxPreviewMap.get(t.application_id);
+    let previewHtml = '';
+    if (prev) {
+      const who = prev.sender_kind === 'admin' ? '운영팀: ' : '';
+      const body = (prev.body || '').replace(/\s+/g, ' ').trim();
+      previewHtml = `<span class="inbox-thread-preview">${esc(who + (body || '(이미지)'))}</span>`;
+    }
     return `<button type="button" class="inbox-thread-item ${active}" onclick="openInboxThread('${esc(t.application_id)}')">
-      <span class="inbox-thread-name">${esc(name)}</span>
-      <span class="inbox-thread-meta">${unresolved}${unreadChip}<span class="inbox-thread-time">${esc(formatDate(t.last_message_at))}</span></span>
+      <span class="inbox-thread-top">
+        <span class="inbox-thread-name">${kanji}${kana ? `<span class="inbox-thread-kana">${kana}</span>` : ''}</span>
+        <span class="inbox-thread-meta">${unresolved}${unreadChip}</span>
+      </span>
+      ${email ? `<span class="inbox-thread-email">${email}</span>` : ''}
+      ${previewHtml}
+      <span class="inbox-thread-time">${esc(formatDateTime(t.last_message_at))}</span>
     </button>`;
   }).join('');
 }
@@ -11233,6 +11338,7 @@ async function openInboxThread(applicationId) {
   _admMsgAppId = applicationId;
   _admMsgContext = 'inbox';
   _admMsgPendingFiles = [];
+  updateInboxStage();        // 대화 내용 단(우측) 펼침
   renderInboxThreadList();  // active 표시 갱신
   const view = document.getElementById('inboxThreadView');
   if (view) view.innerHTML = '<div class="inbox-empty">불러오는 중…</div>';
@@ -11362,7 +11468,7 @@ function renderAdminMsgThread(threadElId, messages) {
   thread.innerHTML = messages.map(msg => {
     const fromAdmin = msg.sender_kind === 'admin';
     const senderLabel = fromAdmin ? `운영팀 (${esc(msg.sender_name || '')})` : esc(msg.sender_name || '인플루언서');
-    const timeStr = formatDate(msg.created_at);
+    const timeStr = formatDateTime(msg.created_at);
     const sideCls = fromAdmin ? 'mine' : '';
 
     // 인플루언서 본인 회수 → 관리자도 못 봄 (placeholder)
@@ -11606,11 +11712,22 @@ function updateApplicantMsgBadge(applicationId) {
   });
 }
 
-// ── 헬퍼: 캠페인명 / 인플 이름 ──
-function campaignTitleById(id) {
-  if (!id) return '(캠페인)';
+// 캠페인 상태 배지 (draft/scheduled/active/closed/expired — 신청 상태와 별개)
+function inboxCampStatusBadge(s) {
+  const label = {draft:'준비', scheduled:'모집예정', active:'모집중', closed:'종료', expired:'노출마감'}[s];
+  if (!label) return '';
+  const cls = {draft:'badge-gray', scheduled:'badge-blue', active:'badge-green', closed:'badge-gold', expired:'badge-gray'}[s] || 'badge-gray';
+  return `<span class="badge ${cls}" style="font-size:9px;padding:1px 6px">${label}</span>`;
+}
+
+// ── 헬퍼: 캠페인 / 인플 이름 ──
+function inboxCampaignById(id) {
+  if (!id) return null;
   const list = (typeof allCampaigns !== 'undefined' && Array.isArray(allCampaigns)) ? allCampaigns : [];
-  const c = list.find(x => x.id === id);
+  return list.find(x => x.id === id) || null;
+}
+function campaignTitleById(id) {
+  const c = inboxCampaignById(id);
   return c ? (c.title || '(제목 없음)') : '(캠페인)';
 }
 function influencerNameById(id) {

--- a/dev/admin/index.html
+++ b/dev/admin/index.html
@@ -1103,18 +1103,29 @@
         <!-- 메시지 받은편지함 (3단: 캠페인 / 대화 상대 / 대화 내용) -->
         <div id="adminPane-messages" class="admin-pane">
           <div class="admin-sticky-header">
-            <h2 class="admin-pane-title">메시지</h2>
-            <div class="admin-filters">
-              <label class="inbox-filter-chk"><input type="checkbox" onchange="toggleInboxUnresolved(this.checked)"> 미응대만</label>
-              <select class="admin-select" onchange="changeInboxSince(this.value)">
-                <option value="6">최근 6개월</option>
-                <option value="3">최근 3개월</option>
-                <option value="12">최근 1년</option>
-                <option value="120">전체</option>
-              </select>
+            <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:12px">
+              <div style="font-size:16px;font-weight:700;color:var(--ink)">메시지</div>
+            </div>
+            <div style="display:flex;align-items:flex-end;gap:12px;flex-wrap:wrap">
+              <div class="admin-filter-group">
+                <label>기간</label>
+                <select class="admin-select" onchange="changeInboxSince(this.value)">
+                  <option value="6">최근 6개월</option>
+                  <option value="3">최근 3개월</option>
+                  <option value="12">최근 1년</option>
+                  <option value="120">전체</option>
+                </select>
+              </div>
+              <div class="admin-filter-group">
+                <label>미응대</label>
+                <label style="display:inline-flex;align-items:center;gap:4px;font-size:12px;cursor:pointer;height:32px">
+                  <input type="checkbox" onchange="toggleInboxUnresolved(this.checked)" style="margin:0">
+                  <span>미응대만</span>
+                </label>
+              </div>
             </div>
           </div>
-          <div class="inbox-3pane">
+          <div class="inbox-3pane stage-campaigns">
             <div class="inbox-col inbox-col-camps" id="inboxCampaigns"></div>
             <div class="inbox-col inbox-col-threads" id="inboxThreads"></div>
             <div class="inbox-col inbox-col-view" id="inboxThreadView"></div>

--- a/dev/css/admin.css
+++ b/dev/css/admin.css
@@ -1050,31 +1050,46 @@
 /* ════════════════════════════════════════════════════════════
    응모건 메시지 (PR 2) — 받은편지함 3단 + 메시지 카드/모달
    ════════════════════════════════════════════════════════════ */
-/* 받은편지함 3단 패널 */
-.inbox-3pane{display:flex;gap:0;flex:1;min-height:0;height:calc(100vh - 130px);border:1px solid var(--line);border-radius:12px;overflow:hidden;background:#fff}
+/* 받은편지함 3단 패널 — 단계 진행형 너비 */
+.inbox-3pane{display:flex;gap:0;flex:1;min-height:0;height:calc(100vh - 150px);border:1px solid var(--line);border-radius:12px;overflow:hidden;background:#fff}
 .inbox-col{overflow-y:auto;min-height:0}
-.inbox-col-camps{width:240px;flex-shrink:0;border-right:1px solid var(--line);background:var(--surface-container-low)}
-.inbox-col-threads{width:300px;flex-shrink:0;border-right:1px solid var(--line)}
-.inbox-col-view{flex:1;min-width:0;display:flex;flex-direction:column}
+.inbox-col-camps{border-right:1px solid var(--line);background:var(--surface-container-low)}
+.inbox-col-threads{border-right:1px solid var(--line)}
+.inbox-col-view{display:flex;flex-direction:column}
 .inbox-empty{padding:24px 16px;color:var(--muted);font-size:13px;text-align:center}
-/* 좌: 캠페인 항목 */
-.inbox-camp-item{display:flex;align-items:center;justify-content:space-between;gap:8px;width:100%;padding:12px 14px;border:0;border-bottom:1px solid var(--line);background:none;cursor:pointer;text-align:left;font-size:13px;color:var(--ink)}
+/* 단계: campaigns(캠페인 전체폭) → threads(대화상대 확대) → view(대화내용 확대) */
+.inbox-3pane.stage-campaigns .inbox-col-camps{flex:1;width:auto}
+.inbox-3pane.stage-campaigns .inbox-col-threads,
+.inbox-3pane.stage-campaigns .inbox-col-view{display:none}
+.inbox-3pane.stage-threads .inbox-col-camps{width:320px;flex-shrink:0}
+.inbox-3pane.stage-threads .inbox-col-threads{flex:1;width:auto}
+.inbox-3pane.stage-threads .inbox-col-view{display:none}
+.inbox-3pane.stage-view .inbox-col-camps{width:260px;flex-shrink:0}
+.inbox-3pane.stage-view .inbox-col-threads{width:320px;flex-shrink:0}
+.inbox-3pane.stage-view .inbox-col-view{flex:1;min-width:0}
+/* 좌: 캠페인 정보 카드 */
+.inbox-camp-item{display:flex;flex-direction:column;align-items:stretch;gap:4px;width:100%;padding:12px 14px;border:0;border-bottom:1px solid var(--line);background:none;cursor:pointer;text-align:left;color:var(--ink)}
 .inbox-camp-item:hover{background:var(--light-pink)}
-.inbox-camp-item.active{background:var(--light-pink);font-weight:600}
-.inbox-camp-title{flex:1;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
-.inbox-camp-meta{display:flex;align-items:center;gap:6px;font-size:11px;color:var(--muted);flex-shrink:0}
+.inbox-camp-item.active{background:var(--light-pink)}
+.inbox-camp-badges{display:flex;gap:4px;align-items:center;flex-wrap:wrap}
+.inbox-camp-title{font-size:13px;font-weight:600;word-break:break-word;line-height:1.4}
+.inbox-camp-sub{font-size:11px;color:var(--muted)}
+.inbox-camp-meta{display:flex;align-items:center;gap:6px;font-size:11px;color:var(--muted)}
 .inbox-camp-badge{display:inline-flex;align-items:center;justify-content:center;min-width:18px;height:18px;padding:0 5px;border-radius:9px;background:var(--pink);color:#fff;font-size:11px;font-weight:700}
-/* 중: 대화 상대 항목 */
-.inbox-thread-item{display:flex;align-items:center;justify-content:space-between;gap:8px;width:100%;padding:12px 14px;border:0;border-bottom:1px solid var(--line);background:none;cursor:pointer;text-align:left;font-size:13px;color:var(--ink)}
+/* 중: 대화 상대 카드 (한자·가나 이름 + 이메일 + 미리보기 + 시간) */
+.inbox-thread-item{display:flex;flex-direction:column;align-items:stretch;gap:3px;width:100%;padding:12px 14px;border:0;border-bottom:1px solid var(--line);background:none;cursor:pointer;text-align:left;color:var(--ink)}
 .inbox-thread-item:hover{background:var(--surface-dim)}
-.inbox-thread-item.active{background:var(--light-pink);font-weight:600}
-.inbox-thread-name{flex:1;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
-.inbox-thread-meta{display:flex;align-items:center;gap:6px;flex-shrink:0}
+.inbox-thread-item.active{background:var(--light-pink)}
+.inbox-thread-top{display:flex;align-items:center;justify-content:space-between;gap:8px}
+.inbox-thread-name{font-size:13px;font-weight:600;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.inbox-thread-kana{font-size:11px;font-weight:400;color:var(--muted);margin-left:6px}
+.inbox-thread-email{font-size:11px;color:var(--muted);overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.inbox-thread-preview{font-size:12px;color:var(--ink);overflow:hidden;text-overflow:ellipsis;white-space:nowrap;opacity:.8}
+.inbox-thread-meta{display:flex;align-items:center;gap:4px;flex-shrink:0}
 .inbox-thread-time{font-size:10px;color:var(--muted)}
 .inbox-thread-chip{display:inline-flex;align-items:center;padding:1px 6px;border-radius:8px;font-size:10px;font-weight:600}
 .inbox-thread-chip.unresolved{background:var(--gold-l);color:var(--gold)}
 .inbox-thread-chip.unread{background:var(--pink);color:#fff}
-.inbox-filter-chk{font-size:13px;color:var(--ink);display:inline-flex;align-items:center;gap:4px;cursor:pointer}
 
 /* 대화 내용 영역 (받은편지함 우측 + 모달 본문 공용) */
 .adm-msg-actionbar{display:flex;gap:8px;padding:10px 14px;border-bottom:1px solid var(--line);flex-shrink:0;background:var(--surface-container-low)}

--- a/dev/js/admin-messaging.js
+++ b/dev/js/admin-messaging.js
@@ -31,6 +31,8 @@ let _applicantMsgUnreadMap = new Map();
 
 // 받은편지함 인플루언서 이름 맵 (influencer_id → 행). refreshInboxData 에서 채움
 let _inboxInflMap = {};
+// 받은편지함 최근 메시지 미리보기 맵 (application_id → {body, sender_kind, created_at})
+let _inboxPreviewMap = new Map();
 
 // 현재 super_admin 여부 (admin.js 의 currentAdminInfo 기준)
 function admMsgIsSuper() {
@@ -47,9 +49,24 @@ async function loadHideReasons() {
 // 1. 받은편지함 3단 패널 (#adminPane-messages)
 // ════════════════════════════════════════════════════════════════════
 async function loadMessagesInbox() {
+  _inboxSelectedCampaign = null;
+  if (_admMsgContext === 'inbox') _admMsgAppId = null;
   const wrap = document.getElementById('inboxThreadView');
   if (wrap) wrap.innerHTML = '<div class="inbox-empty">대화를 선택하세요.</div>';
   await refreshInboxData();
+  updateInboxStage();
+}
+
+// 단계 진행형 너비 — 선택 진척에 따라 활성 단을 넓힘 (메신저 드릴다운)
+//   캠페인 미선택 → 캠페인 목록 전체폭 / 캠페인 선택 → 대화 상대 목록 확대 / 대화 선택 → 대화 내용 확대
+function updateInboxStage() {
+  const pane = document.querySelector('.inbox-3pane');
+  if (!pane) return;
+  pane.classList.remove('stage-campaigns', 'stage-threads', 'stage-view');
+  const threadOpen = _admMsgContext === 'inbox' && _admMsgAppId;
+  if (!_inboxSelectedCampaign) pane.classList.add('stage-campaigns');
+  else if (!threadOpen) pane.classList.add('stage-threads');
+  else pane.classList.add('stage-view');
 }
 
 // 뷰 + 본인 미열람 맵을 다시 조회하고 좌/중 패널 재렌더
@@ -61,12 +78,17 @@ async function refreshInboxData() {
     ]);
     _inboxThreads = threads || [];
     _inboxUnreadMap = unreadMap || new Map();
-    // 인플루언서 이름 보강 (id 목록 → fetchInfluencersByIds 맵)
-    const ids = [...new Set(_inboxThreads.map(t => t.influencer_id).filter(Boolean))];
-    _inboxInflMap = ids.length ? (await fetchInfluencersByIds(ids)) : {};
+    // 인플루언서 이름·최근 메시지 미리보기 보강 (병렬)
+    const inflIds = [...new Set(_inboxThreads.map(t => t.influencer_id).filter(Boolean))];
+    const appIds = [...new Set(_inboxThreads.map(t => t.application_id).filter(Boolean))];
+    const [inflMap, prevMap] = await Promise.all([
+      inflIds.length ? fetchInfluencersByIds(inflIds) : Promise.resolve({}),
+      appIds.length ? fetchMessagePreviews(appIds) : Promise.resolve(new Map()),
+    ]);
+    _inboxInflMap = inflMap; _inboxPreviewMap = prevMap;
   } catch (e) {
     console.error('[refreshInboxData]', e);
-    _inboxThreads = []; _inboxUnreadMap = new Map(); _inboxInflMap = {};
+    _inboxThreads = []; _inboxUnreadMap = new Map(); _inboxInflMap = {}; _inboxPreviewMap = new Map();
   }
   renderInboxCampaignList();
   renderInboxThreadList();
@@ -102,20 +124,35 @@ function renderInboxCampaignList() {
     return;
   }
   el.innerHTML = groups.map(g => {
-    const camp = campaignTitleById(g.campaign_id);
+    const c = inboxCampaignById(g.campaign_id);
+    const title = c ? (c.title || '(제목 없음)') : '(캠페인)';
     const active = g.campaign_id === _inboxSelectedCampaign ? 'active' : '';
     const badge = g.unresolved > 0 ? `<span class="inbox-camp-badge">${g.unresolved}</span>` : '';
+    // 모집타입 배지(공통 헬퍼) + 캠페인 상태 배지(캠페인 전용 — 신청 상태와 라벨 다름)
+    const typeBadge = (c && typeof getRecruitTypeBadgeKoSm === 'function') ? getRecruitTypeBadgeKoSm(c.recruit_type) : '';
+    const statusBadge = c ? inboxCampStatusBadge(c.status) : '';
+    // 브랜드 · 모집인원
+    const brand = c ? esc(c.brand_ko || c.brand || '') : '';
+    const slots = (c && c.slots) ? `모집 ${c.slots}명` : '';
+    const sub = [brand, slots].filter(Boolean).join(' · ');
     return `<button type="button" class="inbox-camp-item ${active}" onclick="selectInboxCampaign('${esc(g.campaign_id)}')">
-      <span class="inbox-camp-title">${esc(camp)}</span>
-      <span class="inbox-camp-meta">${g.total}건${badge}</span>
+      <span class="inbox-camp-badges">${typeBadge}${statusBadge}</span>
+      <span class="inbox-camp-title">${esc(title)}</span>
+      ${sub ? `<span class="inbox-camp-sub">${sub}</span>` : ''}
+      <span class="inbox-camp-meta">대화 ${g.total}건${badge}</span>
     </button>`;
   }).join('');
 }
 
 function selectInboxCampaign(campaignId) {
   _inboxSelectedCampaign = campaignId;
+  // 캠페인 전환 시 우측 대화 초기화 (단계 = 대화 상대 선택)
+  if (_admMsgContext === 'inbox') _admMsgAppId = null;
+  const view = document.getElementById('inboxThreadView');
+  if (view) view.innerHTML = '<div class="inbox-empty">대화를 선택하세요.</div>';
   renderInboxCampaignList();
   renderInboxThreadList();
+  updateInboxStage();
 }
 
 // 중: 선택 캠페인의 대화 상대(인플루언서) 목록
@@ -134,16 +171,32 @@ function renderInboxThreadList() {
     return;
   }
   el.innerHTML = list.map(t => {
-    const name = influencerNameById(t.influencer_id);
+    const inf = (_inboxInflMap && _inboxInflMap[t.influencer_id]) || {};
+    const kanji = esc(inf.name || '(이름 없음)');           // 한자 이름
+    const kana = inf.name_kana ? esc(inf.name_kana) : '';   // 가나 이름
+    const email = inf.email ? esc(inf.email) : '';
     const unread = _inboxUnreadMap.get(t.application_id) || 0;
     const active = t.application_id === _admMsgAppId ? 'active' : '';
     const unresolved = t.unresolved_for_admin_team
       ? '<span class="inbox-thread-chip unresolved">미응대</span>' : '';
     const unreadChip = unread > 0
       ? `<span class="inbox-thread-chip unread">${unread > 99 ? '99+' : unread}</span>` : '';
+    // 최근 메시지 미리보기 (한 줄)
+    const prev = _inboxPreviewMap.get(t.application_id);
+    let previewHtml = '';
+    if (prev) {
+      const who = prev.sender_kind === 'admin' ? '운영팀: ' : '';
+      const body = (prev.body || '').replace(/\s+/g, ' ').trim();
+      previewHtml = `<span class="inbox-thread-preview">${esc(who + (body || '(이미지)'))}</span>`;
+    }
     return `<button type="button" class="inbox-thread-item ${active}" onclick="openInboxThread('${esc(t.application_id)}')">
-      <span class="inbox-thread-name">${esc(name)}</span>
-      <span class="inbox-thread-meta">${unresolved}${unreadChip}<span class="inbox-thread-time">${esc(formatDate(t.last_message_at))}</span></span>
+      <span class="inbox-thread-top">
+        <span class="inbox-thread-name">${kanji}${kana ? `<span class="inbox-thread-kana">${kana}</span>` : ''}</span>
+        <span class="inbox-thread-meta">${unresolved}${unreadChip}</span>
+      </span>
+      ${email ? `<span class="inbox-thread-email">${email}</span>` : ''}
+      ${previewHtml}
+      <span class="inbox-thread-time">${esc(formatDateTime(t.last_message_at))}</span>
     </button>`;
   }).join('');
 }
@@ -153,6 +206,7 @@ async function openInboxThread(applicationId) {
   _admMsgAppId = applicationId;
   _admMsgContext = 'inbox';
   _admMsgPendingFiles = [];
+  updateInboxStage();        // 대화 내용 단(우측) 펼침
   renderInboxThreadList();  // active 표시 갱신
   const view = document.getElementById('inboxThreadView');
   if (view) view.innerHTML = '<div class="inbox-empty">불러오는 중…</div>';
@@ -282,7 +336,7 @@ function renderAdminMsgThread(threadElId, messages) {
   thread.innerHTML = messages.map(msg => {
     const fromAdmin = msg.sender_kind === 'admin';
     const senderLabel = fromAdmin ? `운영팀 (${esc(msg.sender_name || '')})` : esc(msg.sender_name || '인플루언서');
-    const timeStr = formatDate(msg.created_at);
+    const timeStr = formatDateTime(msg.created_at);
     const sideCls = fromAdmin ? 'mine' : '';
 
     // 인플루언서 본인 회수 → 관리자도 못 봄 (placeholder)
@@ -526,11 +580,22 @@ function updateApplicantMsgBadge(applicationId) {
   });
 }
 
-// ── 헬퍼: 캠페인명 / 인플 이름 ──
-function campaignTitleById(id) {
-  if (!id) return '(캠페인)';
+// 캠페인 상태 배지 (draft/scheduled/active/closed/expired — 신청 상태와 별개)
+function inboxCampStatusBadge(s) {
+  const label = {draft:'준비', scheduled:'모집예정', active:'모집중', closed:'종료', expired:'노출마감'}[s];
+  if (!label) return '';
+  const cls = {draft:'badge-gray', scheduled:'badge-blue', active:'badge-green', closed:'badge-gold', expired:'badge-gray'}[s] || 'badge-gray';
+  return `<span class="badge ${cls}" style="font-size:9px;padding:1px 6px">${label}</span>`;
+}
+
+// ── 헬퍼: 캠페인 / 인플 이름 ──
+function inboxCampaignById(id) {
+  if (!id) return null;
   const list = (typeof allCampaigns !== 'undefined' && Array.isArray(allCampaigns)) ? allCampaigns : [];
-  const c = list.find(x => x.id === id);
+  return list.find(x => x.id === id) || null;
+}
+function campaignTitleById(id) {
+  const c = inboxCampaignById(id);
   return c ? (c.title || '(제목 없음)') : '(캠페인)';
 }
 function influencerNameById(id) {

--- a/dev/js/messaging.js
+++ b/dev/js/messaging.js
@@ -69,7 +69,7 @@ function renderMessageThread(messages) {
   thread.innerHTML = messages.map(msg => {
     const mine = msg.sender_kind === 'influencer';
     const senderLabel = mine ? t('messaging.you') : t('messaging.adminTeam');
-    const timeStr = formatDate(msg.created_at);
+    const timeStr = formatDateTime(msg.created_at);
 
     // 마스킹 상태별 placeholder (§3-5)
     if (msg.mask_state && msg.mask_state !== 'visible') {

--- a/dev/lib/storage.js
+++ b/dev/lib/storage.js
@@ -2161,6 +2161,32 @@ async function fetchAdminMessageThreads(opts = {}) {
   return rows;
 }
 
+// 받은편지함 최근 메시지 미리보기 — 응모건별 마지막 「살아있는」 메시지 본문.
+//   숨김/회수 메시지는 제외(미리보기 노출 부적절). created_at 내림차순 후 클라에서 첫 행=최신.
+//   반환: Map<application_id, {body, sender_kind, created_at}>
+//   ⚠️ PostgREST 1000행 cap: 청크당 application 100개 + limit 1000. 한 청크 내
+//      메시지 밀도가 매우 높으면(application 평균 10건 초과) 뒤쪽 응모건 미리보기가
+//      누락될 수 있음. 미리보기는 보조 정보라 치명적이지 않음. 정밀도 필요 시
+//      차후 「응모건당 최신 1건」 전용 RPC 로 개선 권장.
+async function fetchMessagePreviews(applicationIds) {
+  if (!db || !applicationIds || !applicationIds.length) return new Map();
+  const map = new Map();
+  const CHUNK = 100;  // application_id 청크 (청크당 1000행 cap 내 평균 10건 커버)
+  for (let i = 0; i < applicationIds.length; i += CHUNK) {
+    const ids = applicationIds.slice(i, i + CHUNK);
+    const {data, error} = await db?.from('application_messages')
+      .select('application_id, body, sender_kind, created_at')
+      .in('application_id', ids)
+      .is('hidden_by_admin_at', null)
+      .is('self_withdrawn_at', null)
+      .order('created_at', { ascending: false })
+      .limit(1000);
+    if (error) { console.warn('[fetchMessagePreviews]', error); continue; }
+    (data || []).forEach(m => { if (!map.has(m.application_id)) map.set(m.application_id, m); });
+  }
+  return map;
+}
+
 // 응모건 단위 숨김/복구 이력 (super_admin — append-only audit). 메시지 모달 하단 패널용.
 //   hide_history 는 message_id 만 가지므로 application_messages inner join 으로 응모건 필터.
 //   RLS SELECT 는 super_admin 한정 (144) — 매니저 호출 시 빈 배열.

--- a/index.html
+++ b/index.html
@@ -5756,6 +5756,32 @@ async function fetchAdminMessageThreads(opts = {}) {
   return rows;
 }
 
+// 받은편지함 최근 메시지 미리보기 — 응모건별 마지막 「살아있는」 메시지 본문.
+//   숨김/회수 메시지는 제외(미리보기 노출 부적절). created_at 내림차순 후 클라에서 첫 행=최신.
+//   반환: Map<application_id, {body, sender_kind, created_at}>
+//   ⚠️ PostgREST 1000행 cap: 청크당 application 100개 + limit 1000. 한 청크 내
+//      메시지 밀도가 매우 높으면(application 평균 10건 초과) 뒤쪽 응모건 미리보기가
+//      누락될 수 있음. 미리보기는 보조 정보라 치명적이지 않음. 정밀도 필요 시
+//      차후 「응모건당 최신 1건」 전용 RPC 로 개선 권장.
+async function fetchMessagePreviews(applicationIds) {
+  if (!db || !applicationIds || !applicationIds.length) return new Map();
+  const map = new Map();
+  const CHUNK = 100;  // application_id 청크 (청크당 1000행 cap 내 평균 10건 커버)
+  for (let i = 0; i < applicationIds.length; i += CHUNK) {
+    const ids = applicationIds.slice(i, i + CHUNK);
+    const {data, error} = await db?.from('application_messages')
+      .select('application_id, body, sender_kind, created_at')
+      .in('application_id', ids)
+      .is('hidden_by_admin_at', null)
+      .is('self_withdrawn_at', null)
+      .order('created_at', { ascending: false })
+      .limit(1000);
+    if (error) { console.warn('[fetchMessagePreviews]', error); continue; }
+    (data || []).forEach(m => { if (!map.has(m.application_id)) map.set(m.application_id, m); });
+  }
+  return map;
+}
+
 // 응모건 단위 숨김/복구 이력 (super_admin — append-only audit). 메시지 모달 하단 패널용.
 //   hide_history 는 message_id 만 가지므로 application_messages inner join 으로 응모건 필터.
 //   RLS SELECT 는 super_admin 한정 (144) — 매니저 호출 시 빈 배열.
@@ -9834,7 +9860,7 @@ function renderMessageThread(messages) {
   thread.innerHTML = messages.map(msg => {
     const mine = msg.sender_kind === 'influencer';
     const senderLabel = mine ? t('messaging.you') : t('messaging.adminTeam');
-    const timeStr = formatDate(msg.created_at);
+    const timeStr = formatDateTime(msg.created_at);
 
     // 마스킹 상태별 placeholder (§3-5)
     if (msg.mask_state && msg.mask_state !== 'visible') {


### PR DESCRIPTION
## 변경 요약
- 받은편지함 3단을 단계 진행형 너비로 (캠페인 목록 → 대화 상대 → 대화 내용 순으로 활성 단 확대)
- 좌측 캠페인 카드에 모집타입·상태·브랜드·모집인원 표시
- 중간 대화 상대 카드에 한자·가나 이름 + 이메일 + 최근 메시지 미리보기 + 날짜·시간
- 메시지 카드 시간 표시 날짜→날짜+시간 (관리자·인플루언서 양쪽)
- 미응대/기간 필터를 기존 관리자 필터 스타일로 통일

## 요청 외 추가 변경
- 없음

## DB 변경
- 없음 (미리보기는 기존 application_messages 클라이언트 조회)

## Test plan
- [ ] 받은편지함 진입 시 캠페인 목록 전체폭 → 캠페인 클릭 시 대화 상대 확대 → 대화 클릭 시 대화 내용 확대
- [ ] 캠페인 카드 모집타입/상태/브랜드/모집인원 정상 표시
- [ ] 대화 상대 카드 한자·가나 이름·이메일·미리보기·날짜시간 표시
- [ ] 메시지 카드에 날짜+시간 (관리자·인플 화면)
- [ ] 미응대만/기간 필터 동작

## 관련 사양서
- docs/specs/2026-05-15-application-messaging.md

[via reviewer]

🤖 Generated with [Claude Code](https://claude.com/claude-code)