### PR TITLE
feat(messaging): 받은편지함 카드 배지 우측 + 읽음 표시 + 말풍선 옆 메타

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -12,7 +12,7 @@
 // 회귀(2026-05-12 PR #182 머지 직후 발생)를 방지하기 위한 자동 reload 가드.
 // sessionStorage 차단 환경(시크릿 모드 일부, 쿠키 차단)에서는 자연스럽게 skip.
 (function(){
-  var CURRENT_BUILD = 'v1779272451';
+  var CURRENT_BUILD = 'v1779273407';
   if (CURRENT_BUILD.indexOf('__') === 0) return; // 빌드 미적용 (dev/ 직접 열기) 시 skip
   try {
     var prev = sessionStorage.getItem('reverb.adminBuild');
@@ -1469,29 +1469,32 @@ textarea.form-input{resize:vertical;min-height:80px}
 .inbox-3pane.stage-threads .inbox-col-camps{width:320px;flex-shrink:0}
 .inbox-3pane.stage-threads .inbox-col-threads{flex:1;width:auto}
 .inbox-3pane.stage-threads .inbox-col-view{display:none}
-.inbox-3pane.stage-view .inbox-col-camps{width:260px;flex-shrink:0}
+.inbox-3pane.stage-view .inbox-col-camps{width:340px;flex-shrink:0}
 .inbox-3pane.stage-view .inbox-col-threads{width:320px;flex-shrink:0}
 .inbox-3pane.stage-view .inbox-col-view{flex:1;min-width:0}
-/* 좌: 캠페인 정보 카드 */
-.inbox-camp-item{display:flex;flex-direction:column;align-items:stretch;gap:4px;width:100%;padding:12px 14px;border:0;border-bottom:1px solid var(--line);background:none;cursor:pointer;text-align:left;color:var(--ink)}
+/* 좌: 캠페인 정보 카드 (좌측 정보 + 우측 미응대 배지) */
+.inbox-camp-item{display:flex;flex-direction:row;align-items:center;gap:8px;width:100%;padding:12px 14px;border:0;border-bottom:1px solid var(--line);background:none;cursor:pointer;text-align:left;color:var(--ink)}
 .inbox-camp-item:hover{background:var(--light-pink)}
 .inbox-camp-item.active{background:var(--light-pink)}
+.inbox-camp-main{flex:1;min-width:0;display:flex;flex-direction:column;gap:4px}
+.inbox-camp-right{flex-shrink:0;display:flex;align-items:center}
 .inbox-camp-badges{display:flex;gap:4px;align-items:center;flex-wrap:wrap}
 .inbox-camp-title{font-size:13px;font-weight:600;word-break:break-word;line-height:1.4}
 .inbox-camp-sub{font-size:11px;color:var(--muted)}
 .inbox-camp-meta{display:flex;align-items:center;gap:6px;font-size:11px;color:var(--muted)}
 .inbox-camp-badge{display:inline-flex;align-items:center;justify-content:center;min-width:18px;height:18px;padding:0 5px;border-radius:9px;background:var(--pink);color:#fff;font-size:11px;font-weight:700}
-/* 중: 대화 상대 카드 (한자·가나 이름 + 이메일 + 미리보기 + 시간) */
-.inbox-thread-item{display:flex;flex-direction:column;align-items:stretch;gap:3px;width:100%;padding:12px 14px;border:0;border-bottom:1px solid var(--line);background:none;cursor:pointer;text-align:left;color:var(--ink)}
+/* 중: 대화 상대 카드 (좌측 이름·이메일·미리보기 + 우측 시간↑·미응대 배지↓) */
+.inbox-thread-item{display:flex;flex-direction:row;align-items:flex-start;gap:8px;width:100%;padding:12px 14px;border:0;border-bottom:1px solid var(--line);background:none;cursor:pointer;text-align:left;color:var(--ink)}
 .inbox-thread-item:hover{background:var(--surface-dim)}
 .inbox-thread-item.active{background:var(--light-pink)}
-.inbox-thread-top{display:flex;align-items:center;justify-content:space-between;gap:8px}
+.inbox-thread-main{flex:1;min-width:0;display:flex;flex-direction:column;gap:3px}
+.inbox-thread-right{flex-shrink:0;display:flex;flex-direction:column;align-items:flex-end;gap:4px}
+.inbox-thread-chips{display:flex;align-items:center;gap:4px}
 .inbox-thread-name{font-size:13px;font-weight:600;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
 .inbox-thread-kana{font-size:11px;font-weight:400;color:var(--muted);margin-left:6px}
 .inbox-thread-email{font-size:11px;color:var(--muted);overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
 .inbox-thread-preview{font-size:12px;color:var(--ink);overflow:hidden;text-overflow:ellipsis;white-space:nowrap;opacity:.8}
-.inbox-thread-meta{display:flex;align-items:center;gap:4px;flex-shrink:0}
-.inbox-thread-time{font-size:10px;color:var(--muted)}
+.inbox-thread-time{font-size:10px;color:var(--muted);white-space:nowrap}
 .inbox-thread-chip{display:inline-flex;align-items:center;padding:1px 6px;border-radius:8px;font-size:10px;font-weight:600}
 .inbox-thread-chip.unresolved{background:var(--gold-l);color:var(--gold)}
 .inbox-thread-chip.unread{background:var(--pink);color:#fff}
@@ -1501,14 +1504,21 @@ textarea.form-input{resize:vertical;min-height:80px}
 .adm-msg-bar-btn{padding:5px 12px;border:1px solid var(--line);border-radius:8px;background:#fff;font-size:12px;cursor:pointer;color:var(--ink)}
 .adm-msg-bar-btn.primary{background:var(--pink);color:#fff;border-color:var(--pink)}
 .adm-msg-thread{overflow-y:auto;padding:14px;display:flex;flex-direction:column;gap:10px;min-height:0;flex:1}
-/* 메시지 카드 */
-.msg-card{max-width:78%;align-self:flex-start;background:var(--surface-dim);border-radius:12px;padding:10px 12px}
-.msg-card.mine{align-self:flex-end;background:var(--light-pink)}
-.msg-card-head{display:flex;align-items:center;gap:8px;margin-bottom:4px;flex-wrap:wrap}
-.msg-card-head .msg-sender{font-size:11px;font-weight:700;color:var(--dark-pink)}
-.msg-card-head .msg-time{font-size:10px;color:var(--muted)}
+/* 메시지 — 말풍선 + 옆 메타(시간·읽음·액션). mine 은 우측 정렬, 메타는 풍선 왼쪽 */
+.msg-row{display:flex;gap:8px;align-items:flex-end;max-width:85%;align-self:flex-start}
+.msg-row.mine{flex-direction:row-reverse;align-self:flex-end}
+.msg-bubble{background:var(--surface-dim);border-radius:12px;padding:10px 12px;min-width:0}
+.msg-row.mine .msg-bubble{background:var(--light-pink)}
+.msg-bubble .msg-sender{font-size:11px;font-weight:700;color:var(--dark-pink);margin-bottom:4px}
 .msg-card-body{font-size:13px;line-height:1.6;color:var(--ink);word-break:break-word}
-.msg-card-masked{opacity:.7}
+.msg-meta-side{display:flex;flex-direction:column;gap:3px;flex-shrink:0;align-items:flex-end;padding-bottom:2px}
+.msg-row:not(.mine) .msg-meta-side{align-items:flex-start}
+.msg-time{font-size:10px;color:var(--muted);white-space:nowrap}
+.msg-read{font-size:10px;font-weight:600;white-space:nowrap}
+.msg-read.read{color:var(--green)}
+.msg-read.unread{color:var(--pink)}
+.msg-status-line{margin-top:6px}
+.msg-row-masked .msg-bubble{opacity:.7}
 .msg-masked-body{font-size:12px;color:var(--muted);font-style:italic}
 .msg-attachments{display:flex;flex-wrap:wrap;gap:6px;margin-top:8px}
 .msg-attach-thumb{width:64px;height:64px;border-radius:8px;overflow:hidden;background:var(--surface-container);display:flex;align-items:center;justify-content:center;cursor:pointer;color:var(--muted)}
@@ -1615,7 +1625,7 @@ textarea.form-input{resize:vertical;min-height:80px}
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-05-20 19:20 · 9e27400</span>
+          <span class="admin-build-text">2026-05-20 19:36 · 89bf4a2</span>
         </div>
       </div>
     </aside>
@@ -11268,10 +11278,13 @@ function renderInboxCampaignList() {
     const slots = (c && c.slots) ? `모집 ${c.slots}명` : '';
     const sub = [brand, slots].filter(Boolean).join(' · ');
     return `<button type="button" class="inbox-camp-item ${active}" onclick="selectInboxCampaign('${esc(g.campaign_id)}')">
-      <span class="inbox-camp-badges">${typeBadge}${statusBadge}</span>
-      <span class="inbox-camp-title">${esc(title)}</span>
-      ${sub ? `<span class="inbox-camp-sub">${sub}</span>` : ''}
-      <span class="inbox-camp-meta">대화 ${g.total}건${badge}</span>
+      <span class="inbox-camp-main">
+        <span class="inbox-camp-badges">${typeBadge}${statusBadge}</span>
+        <span class="inbox-camp-title">${esc(title)}</span>
+        ${sub ? `<span class="inbox-camp-sub">${sub}</span>` : ''}
+        <span class="inbox-camp-meta">대화 ${g.total}건</span>
+      </span>
+      <span class="inbox-camp-right">${badge}</span>
     </button>`;
   }).join('');
 }
@@ -11322,13 +11335,15 @@ function renderInboxThreadList() {
       previewHtml = `<span class="inbox-thread-preview">${esc(who + (body || '(이미지)'))}</span>`;
     }
     return `<button type="button" class="inbox-thread-item ${active}" onclick="openInboxThread('${esc(t.application_id)}')">
-      <span class="inbox-thread-top">
+      <span class="inbox-thread-main">
         <span class="inbox-thread-name">${kanji}${kana ? `<span class="inbox-thread-kana">${kana}</span>` : ''}</span>
-        <span class="inbox-thread-meta">${unresolved}${unreadChip}</span>
+        ${email ? `<span class="inbox-thread-email">${email}</span>` : ''}
+        ${previewHtml}
       </span>
-      ${email ? `<span class="inbox-thread-email">${email}</span>` : ''}
-      ${previewHtml}
-      <span class="inbox-thread-time">${esc(formatDateTime(t.last_message_at))}</span>
+      <span class="inbox-thread-right">
+        <span class="inbox-thread-time">${esc(formatDateTime(t.last_message_at))}</span>
+        <span class="inbox-thread-chips">${unresolved}${unreadChip}</span>
+      </span>
     </button>`;
   }).join('');
 }
@@ -11510,19 +11525,34 @@ function renderAdminMsgThread(threadElId, messages) {
       }
     }
 
-    return `<div class="msg-card ${sideCls}">
-      <div class="msg-card-head"><span class="msg-sender">${senderLabel}</span><span class="msg-time">${esc(timeStr)}</span>${statusBadge}${actions}</div>
-      <div class="msg-card-body">${bodyHtml}</div>
-      ${attachHtml}
+    // 읽음 표시 (관리자 발신 + 정상 메시지 — 인플루언서가 내 메시지를 읽었는지)
+    let readMark = '';
+    if (fromAdmin && msg.mask_state === 'visible') {
+      readMark = msg.read_by_influencer_at
+        ? '<span class="msg-read read">읽음</span>'
+        : '<span class="msg-read unread">안읽음</span>';
+    }
+    // 말풍선 옆 메타: 읽음 / 시간 / 액션(숨김·회수·복구) — mine 은 풍선 왼쪽, 상대는 오른쪽
+    return `<div class="msg-row ${sideCls}">
+      <div class="msg-meta-side">${readMark}<span class="msg-time">${esc(timeStr)}</span>${actions}</div>
+      <div class="msg-bubble">
+        <div class="msg-sender">${senderLabel}</div>
+        <div class="msg-card-body">${bodyHtml}</div>
+        ${attachHtml}
+        ${statusBadge ? `<div class="msg-status-line">${statusBadge}</div>` : ''}
+      </div>
     </div>`;
   }).join('');
   thread.scrollTop = thread.scrollHeight;
 }
 
 function msgCardMasked(senderLabel, timeStr, sideCls, text) {
-  return `<div class="msg-card msg-card-masked ${sideCls}">
-    <div class="msg-card-head"><span class="msg-sender">${senderLabel}</span><span class="msg-time">${esc(timeStr)}</span></div>
-    <div class="msg-masked-body">${esc(text)}</div>
+  return `<div class="msg-row msg-row-masked ${sideCls}">
+    <div class="msg-meta-side"><span class="msg-time">${esc(timeStr)}</span></div>
+    <div class="msg-bubble">
+      <div class="msg-sender">${senderLabel}</div>
+      <div class="msg-masked-body">${esc(text)}</div>
+    </div>
   </div>`;
 }
 

--- a/dev/css/admin.css
+++ b/dev/css/admin.css
@@ -1064,29 +1064,32 @@
 .inbox-3pane.stage-threads .inbox-col-camps{width:320px;flex-shrink:0}
 .inbox-3pane.stage-threads .inbox-col-threads{flex:1;width:auto}
 .inbox-3pane.stage-threads .inbox-col-view{display:none}
-.inbox-3pane.stage-view .inbox-col-camps{width:260px;flex-shrink:0}
+.inbox-3pane.stage-view .inbox-col-camps{width:340px;flex-shrink:0}
 .inbox-3pane.stage-view .inbox-col-threads{width:320px;flex-shrink:0}
 .inbox-3pane.stage-view .inbox-col-view{flex:1;min-width:0}
-/* 좌: 캠페인 정보 카드 */
-.inbox-camp-item{display:flex;flex-direction:column;align-items:stretch;gap:4px;width:100%;padding:12px 14px;border:0;border-bottom:1px solid var(--line);background:none;cursor:pointer;text-align:left;color:var(--ink)}
+/* 좌: 캠페인 정보 카드 (좌측 정보 + 우측 미응대 배지) */
+.inbox-camp-item{display:flex;flex-direction:row;align-items:center;gap:8px;width:100%;padding:12px 14px;border:0;border-bottom:1px solid var(--line);background:none;cursor:pointer;text-align:left;color:var(--ink)}
 .inbox-camp-item:hover{background:var(--light-pink)}
 .inbox-camp-item.active{background:var(--light-pink)}
+.inbox-camp-main{flex:1;min-width:0;display:flex;flex-direction:column;gap:4px}
+.inbox-camp-right{flex-shrink:0;display:flex;align-items:center}
 .inbox-camp-badges{display:flex;gap:4px;align-items:center;flex-wrap:wrap}
 .inbox-camp-title{font-size:13px;font-weight:600;word-break:break-word;line-height:1.4}
 .inbox-camp-sub{font-size:11px;color:var(--muted)}
 .inbox-camp-meta{display:flex;align-items:center;gap:6px;font-size:11px;color:var(--muted)}
 .inbox-camp-badge{display:inline-flex;align-items:center;justify-content:center;min-width:18px;height:18px;padding:0 5px;border-radius:9px;background:var(--pink);color:#fff;font-size:11px;font-weight:700}
-/* 중: 대화 상대 카드 (한자·가나 이름 + 이메일 + 미리보기 + 시간) */
-.inbox-thread-item{display:flex;flex-direction:column;align-items:stretch;gap:3px;width:100%;padding:12px 14px;border:0;border-bottom:1px solid var(--line);background:none;cursor:pointer;text-align:left;color:var(--ink)}
+/* 중: 대화 상대 카드 (좌측 이름·이메일·미리보기 + 우측 시간↑·미응대 배지↓) */
+.inbox-thread-item{display:flex;flex-direction:row;align-items:flex-start;gap:8px;width:100%;padding:12px 14px;border:0;border-bottom:1px solid var(--line);background:none;cursor:pointer;text-align:left;color:var(--ink)}
 .inbox-thread-item:hover{background:var(--surface-dim)}
 .inbox-thread-item.active{background:var(--light-pink)}
-.inbox-thread-top{display:flex;align-items:center;justify-content:space-between;gap:8px}
+.inbox-thread-main{flex:1;min-width:0;display:flex;flex-direction:column;gap:3px}
+.inbox-thread-right{flex-shrink:0;display:flex;flex-direction:column;align-items:flex-end;gap:4px}
+.inbox-thread-chips{display:flex;align-items:center;gap:4px}
 .inbox-thread-name{font-size:13px;font-weight:600;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
 .inbox-thread-kana{font-size:11px;font-weight:400;color:var(--muted);margin-left:6px}
 .inbox-thread-email{font-size:11px;color:var(--muted);overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
 .inbox-thread-preview{font-size:12px;color:var(--ink);overflow:hidden;text-overflow:ellipsis;white-space:nowrap;opacity:.8}
-.inbox-thread-meta{display:flex;align-items:center;gap:4px;flex-shrink:0}
-.inbox-thread-time{font-size:10px;color:var(--muted)}
+.inbox-thread-time{font-size:10px;color:var(--muted);white-space:nowrap}
 .inbox-thread-chip{display:inline-flex;align-items:center;padding:1px 6px;border-radius:8px;font-size:10px;font-weight:600}
 .inbox-thread-chip.unresolved{background:var(--gold-l);color:var(--gold)}
 .inbox-thread-chip.unread{background:var(--pink);color:#fff}
@@ -1096,14 +1099,21 @@
 .adm-msg-bar-btn{padding:5px 12px;border:1px solid var(--line);border-radius:8px;background:#fff;font-size:12px;cursor:pointer;color:var(--ink)}
 .adm-msg-bar-btn.primary{background:var(--pink);color:#fff;border-color:var(--pink)}
 .adm-msg-thread{overflow-y:auto;padding:14px;display:flex;flex-direction:column;gap:10px;min-height:0;flex:1}
-/* 메시지 카드 */
-.msg-card{max-width:78%;align-self:flex-start;background:var(--surface-dim);border-radius:12px;padding:10px 12px}
-.msg-card.mine{align-self:flex-end;background:var(--light-pink)}
-.msg-card-head{display:flex;align-items:center;gap:8px;margin-bottom:4px;flex-wrap:wrap}
-.msg-card-head .msg-sender{font-size:11px;font-weight:700;color:var(--dark-pink)}
-.msg-card-head .msg-time{font-size:10px;color:var(--muted)}
+/* 메시지 — 말풍선 + 옆 메타(시간·읽음·액션). mine 은 우측 정렬, 메타는 풍선 왼쪽 */
+.msg-row{display:flex;gap:8px;align-items:flex-end;max-width:85%;align-self:flex-start}
+.msg-row.mine{flex-direction:row-reverse;align-self:flex-end}
+.msg-bubble{background:var(--surface-dim);border-radius:12px;padding:10px 12px;min-width:0}
+.msg-row.mine .msg-bubble{background:var(--light-pink)}
+.msg-bubble .msg-sender{font-size:11px;font-weight:700;color:var(--dark-pink);margin-bottom:4px}
 .msg-card-body{font-size:13px;line-height:1.6;color:var(--ink);word-break:break-word}
-.msg-card-masked{opacity:.7}
+.msg-meta-side{display:flex;flex-direction:column;gap:3px;flex-shrink:0;align-items:flex-end;padding-bottom:2px}
+.msg-row:not(.mine) .msg-meta-side{align-items:flex-start}
+.msg-time{font-size:10px;color:var(--muted);white-space:nowrap}
+.msg-read{font-size:10px;font-weight:600;white-space:nowrap}
+.msg-read.read{color:var(--green)}
+.msg-read.unread{color:var(--pink)}
+.msg-status-line{margin-top:6px}
+.msg-row-masked .msg-bubble{opacity:.7}
 .msg-masked-body{font-size:12px;color:var(--muted);font-style:italic}
 .msg-attachments{display:flex;flex-wrap:wrap;gap:6px;margin-top:8px}
 .msg-attach-thumb{width:64px;height:64px;border-radius:8px;overflow:hidden;background:var(--surface-container);display:flex;align-items:center;justify-content:center;cursor:pointer;color:var(--muted)}

--- a/dev/js/admin-messaging.js
+++ b/dev/js/admin-messaging.js
@@ -136,10 +136,13 @@ function renderInboxCampaignList() {
     const slots = (c && c.slots) ? `모집 ${c.slots}명` : '';
     const sub = [brand, slots].filter(Boolean).join(' · ');
     return `<button type="button" class="inbox-camp-item ${active}" onclick="selectInboxCampaign('${esc(g.campaign_id)}')">
-      <span class="inbox-camp-badges">${typeBadge}${statusBadge}</span>
-      <span class="inbox-camp-title">${esc(title)}</span>
-      ${sub ? `<span class="inbox-camp-sub">${sub}</span>` : ''}
-      <span class="inbox-camp-meta">대화 ${g.total}건${badge}</span>
+      <span class="inbox-camp-main">
+        <span class="inbox-camp-badges">${typeBadge}${statusBadge}</span>
+        <span class="inbox-camp-title">${esc(title)}</span>
+        ${sub ? `<span class="inbox-camp-sub">${sub}</span>` : ''}
+        <span class="inbox-camp-meta">대화 ${g.total}건</span>
+      </span>
+      <span class="inbox-camp-right">${badge}</span>
     </button>`;
   }).join('');
 }
@@ -190,13 +193,15 @@ function renderInboxThreadList() {
       previewHtml = `<span class="inbox-thread-preview">${esc(who + (body || '(이미지)'))}</span>`;
     }
     return `<button type="button" class="inbox-thread-item ${active}" onclick="openInboxThread('${esc(t.application_id)}')">
-      <span class="inbox-thread-top">
+      <span class="inbox-thread-main">
         <span class="inbox-thread-name">${kanji}${kana ? `<span class="inbox-thread-kana">${kana}</span>` : ''}</span>
-        <span class="inbox-thread-meta">${unresolved}${unreadChip}</span>
+        ${email ? `<span class="inbox-thread-email">${email}</span>` : ''}
+        ${previewHtml}
       </span>
-      ${email ? `<span class="inbox-thread-email">${email}</span>` : ''}
-      ${previewHtml}
-      <span class="inbox-thread-time">${esc(formatDateTime(t.last_message_at))}</span>
+      <span class="inbox-thread-right">
+        <span class="inbox-thread-time">${esc(formatDateTime(t.last_message_at))}</span>
+        <span class="inbox-thread-chips">${unresolved}${unreadChip}</span>
+      </span>
     </button>`;
   }).join('');
 }
@@ -378,19 +383,34 @@ function renderAdminMsgThread(threadElId, messages) {
       }
     }
 
-    return `<div class="msg-card ${sideCls}">
-      <div class="msg-card-head"><span class="msg-sender">${senderLabel}</span><span class="msg-time">${esc(timeStr)}</span>${statusBadge}${actions}</div>
-      <div class="msg-card-body">${bodyHtml}</div>
-      ${attachHtml}
+    // 읽음 표시 (관리자 발신 + 정상 메시지 — 인플루언서가 내 메시지를 읽었는지)
+    let readMark = '';
+    if (fromAdmin && msg.mask_state === 'visible') {
+      readMark = msg.read_by_influencer_at
+        ? '<span class="msg-read read">읽음</span>'
+        : '<span class="msg-read unread">안읽음</span>';
+    }
+    // 말풍선 옆 메타: 읽음 / 시간 / 액션(숨김·회수·복구) — mine 은 풍선 왼쪽, 상대는 오른쪽
+    return `<div class="msg-row ${sideCls}">
+      <div class="msg-meta-side">${readMark}<span class="msg-time">${esc(timeStr)}</span>${actions}</div>
+      <div class="msg-bubble">
+        <div class="msg-sender">${senderLabel}</div>
+        <div class="msg-card-body">${bodyHtml}</div>
+        ${attachHtml}
+        ${statusBadge ? `<div class="msg-status-line">${statusBadge}</div>` : ''}
+      </div>
     </div>`;
   }).join('');
   thread.scrollTop = thread.scrollHeight;
 }
 
 function msgCardMasked(senderLabel, timeStr, sideCls, text) {
-  return `<div class="msg-card msg-card-masked ${sideCls}">
-    <div class="msg-card-head"><span class="msg-sender">${senderLabel}</span><span class="msg-time">${esc(timeStr)}</span></div>
-    <div class="msg-masked-body">${esc(text)}</div>
+  return `<div class="msg-row msg-row-masked ${sideCls}">
+    <div class="msg-meta-side"><span class="msg-time">${esc(timeStr)}</span></div>
+    <div class="msg-bubble">
+      <div class="msg-sender">${senderLabel}</div>
+      <div class="msg-masked-body">${esc(text)}</div>
+    </div>
   </div>`;
 }
 


### PR DESCRIPTION
## 변경 요약
- 캠페인 카드 미응대 배지 우측 배치
- 대화 상대 카드 우측에 최근 일시 + 미응대/미읽음 배지
- 관리자 메시지에 인플루언서 읽음/안읽음 표시
- 메시지 말풍선 옆으로 시간·숨김 버튼 이동(메신저 스타일)
- 대화 진입 시 캠페인 목록 폭 확대(340px)

## DB 변경
- 없음

## Test plan
- [ ] 캠페인 카드 배지 우측 / 대화 상대 카드 우측 시간+배지
- [ ] 관리자 메시지 읽음/안읽음 표시 (인플이 읽으면 갱신)
- [ ] 말풍선 옆 시간·숨김 버튼 정렬 (mine 우측)
- [ ] stage-view 캠페인 폭 확대

[via reviewer]

🤖 Generated with [Claude Code](https://claude.com/claude-code)