### PR TITLE
feat(messaging): 받은편지함 정렬·검색 + 메타 위치 + 3단 항상표시

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -12,7 +12,7 @@
 // 회귀(2026-05-12 PR #182 머지 직후 발생)를 방지하기 위한 자동 reload 가드.
 // sessionStorage 차단 환경(시크릿 모드 일부, 쿠키 차단)에서는 자연스럽게 skip.
 (function(){
-  var CURRENT_BUILD = 'v1779273407';
+  var CURRENT_BUILD = 'v1779274854';
   if (CURRENT_BUILD.indexOf('__') === 0) return; // 빌드 미적용 (dev/ 직접 열기) 시 skip
   try {
     var prev = sessionStorage.getItem('reverb.adminBuild');
@@ -1462,16 +1462,19 @@ textarea.form-input{resize:vertical;min-height:80px}
 .inbox-col-threads{border-right:1px solid var(--line)}
 .inbox-col-view{display:flex;flex-direction:column}
 .inbox-empty{padding:24px 16px;color:var(--muted);font-size:13px;text-align:center}
-/* 단계: campaigns(캠페인 전체폭) → threads(대화상대 확대) → view(대화내용 확대) */
-.inbox-3pane.stage-campaigns .inbox-col-camps{flex:1;width:auto}
-.inbox-3pane.stage-campaigns .inbox-col-threads,
-.inbox-3pane.stage-campaigns .inbox-col-view{display:none}
-.inbox-3pane.stage-threads .inbox-col-camps{width:320px;flex-shrink:0}
-.inbox-3pane.stage-threads .inbox-col-threads{flex:1;width:auto}
-.inbox-3pane.stage-threads .inbox-col-view{display:none}
-.inbox-3pane.stage-view .inbox-col-camps{width:340px;flex-shrink:0}
-.inbox-3pane.stage-view .inbox-col-threads{width:320px;flex-shrink:0}
-.inbox-3pane.stage-view .inbox-col-view{flex:1;min-width:0}
+/* 단계: 3단 모두 항상 표시, 활성 단만 flex-grow 로 넓힘 (숨김 없이 너비만 부드럽게 변화) */
+.inbox-col-camps{min-width:210px;transition:flex-grow .25s ease}
+.inbox-col-threads{min-width:220px;transition:flex-grow .25s ease}
+.inbox-col-view{min-width:320px;flex:1;min-height:0;transition:flex-grow .25s ease}
+.inbox-3pane.stage-campaigns .inbox-col-camps{flex:3}
+.inbox-3pane.stage-campaigns .inbox-col-threads{flex:1}
+.inbox-3pane.stage-campaigns .inbox-col-view{flex:1}
+.inbox-3pane.stage-threads .inbox-col-camps{flex:1}
+.inbox-3pane.stage-threads .inbox-col-threads{flex:3}
+.inbox-3pane.stage-threads .inbox-col-view{flex:1}
+.inbox-3pane.stage-view .inbox-col-camps{flex:1}
+.inbox-3pane.stage-view .inbox-col-threads{flex:1}
+.inbox-3pane.stage-view .inbox-col-view{flex:3}
 /* 좌: 캠페인 정보 카드 (좌측 정보 + 우측 미응대 배지) */
 .inbox-camp-item{display:flex;flex-direction:row;align-items:center;gap:8px;width:100%;padding:12px 14px;border:0;border-bottom:1px solid var(--line);background:none;cursor:pointer;text-align:left;color:var(--ink)}
 .inbox-camp-item:hover{background:var(--light-pink)}
@@ -1482,7 +1485,7 @@ textarea.form-input{resize:vertical;min-height:80px}
 .inbox-camp-title{font-size:13px;font-weight:600;word-break:break-word;line-height:1.4}
 .inbox-camp-sub{font-size:11px;color:var(--muted)}
 .inbox-camp-meta{display:flex;align-items:center;gap:6px;font-size:11px;color:var(--muted)}
-.inbox-camp-badge{display:inline-flex;align-items:center;justify-content:center;min-width:18px;height:18px;padding:0 5px;border-radius:9px;background:var(--pink);color:#fff;font-size:11px;font-weight:700}
+.inbox-camp-badge{display:inline-flex;align-items:center;justify-content:center;height:20px;padding:0 8px;border-radius:10px;background:var(--pink);color:#fff;font-size:11px;font-weight:700;white-space:nowrap}
 /* 중: 대화 상대 카드 (좌측 이름·이메일·미리보기 + 우측 시간↑·미응대 배지↓) */
 .inbox-thread-item{display:flex;flex-direction:row;align-items:flex-start;gap:8px;width:100%;padding:12px 14px;border:0;border-bottom:1px solid var(--line);background:none;cursor:pointer;text-align:left;color:var(--ink)}
 .inbox-thread-item:hover{background:var(--surface-dim)}
@@ -1500,13 +1503,15 @@ textarea.form-input{resize:vertical;min-height:80px}
 .inbox-thread-chip.unread{background:var(--pink);color:#fff}
 
 /* 대화 내용 영역 (받은편지함 우측 + 모달 본문 공용) */
-.adm-msg-actionbar{display:flex;gap:8px;padding:10px 14px;border-bottom:1px solid var(--line);flex-shrink:0;background:var(--surface-container-low)}
+.adm-msg-actionbar{display:flex;gap:8px;align-items:center;padding:10px 14px;border-bottom:1px solid var(--line);flex-shrink:0;background:var(--surface-container-low)}
+.adm-msg-bar-spacer{flex:1}
+.adm-msg-search{flex:0 1 220px;border:1px solid var(--line);border-radius:8px;padding:5px 10px;font-size:12px;font-family:inherit}
 .adm-msg-bar-btn{padding:5px 12px;border:1px solid var(--line);border-radius:8px;background:#fff;font-size:12px;cursor:pointer;color:var(--ink)}
 .adm-msg-bar-btn.primary{background:var(--pink);color:#fff;border-color:var(--pink)}
 .adm-msg-thread{overflow-y:auto;padding:14px;display:flex;flex-direction:column;gap:10px;min-height:0;flex:1}
-/* 메시지 — 말풍선 + 옆 메타(시간·읽음·액션). mine 은 우측 정렬, 메타는 풍선 왼쪽 */
-.msg-row{display:flex;gap:8px;align-items:flex-end;max-width:85%;align-self:flex-start}
-.msg-row.mine{flex-direction:row-reverse;align-self:flex-end}
+/* 메시지 — 말풍선 + 옆 메타(시간·읽음·액션). 메타는 풍선 바깥쪽(상대=오른쪽, mine=왼쪽) */
+.msg-row{display:flex;gap:8px;align-items:flex-end;max-width:85%;align-self:flex-start;flex-direction:row-reverse}
+.msg-row.mine{flex-direction:row;align-self:flex-end}
 .msg-bubble{background:var(--surface-dim);border-radius:12px;padding:10px 12px;min-width:0}
 .msg-row.mine .msg-bubble{background:var(--light-pink)}
 .msg-bubble .msg-sender{font-size:11px;font-weight:700;color:var(--dark-pink);margin-bottom:4px}
@@ -1625,7 +1630,7 @@ textarea.form-input{resize:vertical;min-height:80px}
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-05-20 19:36 · 89bf4a2</span>
+          <span class="admin-build-text">2026-05-20 20:00 · 6ed21ad</span>
         </div>
       </div>
     </aside>
@@ -2614,11 +2619,22 @@ textarea.form-input{resize:vertical;min-height:80px}
                 </select>
               </div>
               <div class="admin-filter-group">
+                <label>정렬</label>
+                <select class="admin-select" onchange="changeInboxSort(this.value)">
+                  <option value="recent">최근 메시지순</option>
+                  <option value="unresolved">미응대 우선</option>
+                </select>
+              </div>
+              <div class="admin-filter-group">
                 <label>미응대</label>
                 <label style="display:inline-flex;align-items:center;gap:4px;font-size:12px;cursor:pointer;height:32px">
                   <input type="checkbox" onchange="toggleInboxUnresolved(this.checked)" style="margin:0">
                   <span>미응대만</span>
                 </label>
+              </div>
+              <div class="admin-filter-group" style="margin-left:auto;flex:1;min-width:200px;max-width:300px">
+                <label>검색</label>
+                <input type="search" class="admin-filter-search" autocomplete="off" data-lpignore="true" data-1p-ignore="true" readonly onfocus="this.removeAttribute('readonly')" placeholder="인플루언서명 · 메시지 검색" oninput="searchInbox(this.value)" style="width:100%">
               </div>
             </div>
           </div>
@@ -11161,12 +11177,16 @@ let _inboxThreads = [];                 // fetchAdminMessageThreads 결과 (뷰 
 let _inboxUnreadMap = new Map();        // application_id → 본인 미열람 수
 let _inboxSelectedCampaign = null;      // 좌 패널 선택 캠페인 id
 let _inboxFilters = { unresolvedOnly: false, sinceMonths: 6 };
+let _inboxSort = 'recent';              // 'recent'(최근 메시지순) | 'unresolved'(미응대 우선)
+let _inboxSearch = '';                  // 받은편지함 검색어 (인플 이름·이메일·캠페인명·미리보기)
 
 // 메시지 모달/패널 공용 상태
 let _admMsgAppId = null;                // 현재 열린 응모건
 let _admMsgContext = 'modal';           // 'modal' | 'inbox' — 전송 후 재렌더 대상
 let _admMsgPendingFiles = [];
 let _admMsgSending = false;
+let _admMsgCurrentMsgs = [];        // 현재 열린 대화 전체 메시지 (검색 필터 원본)
+let _admMsgCurrentThreadId = null;  // 현재 렌더 중인 thread DOM id
 
 // 응모 행 메시지 버튼 셀에 표시할 본인 미열람 맵 (페인 로드 시 채움)
 let _applicantMsgUnreadMap = new Map();
@@ -11192,6 +11212,7 @@ async function loadHideReasons() {
 // ════════════════════════════════════════════════════════════════════
 async function loadMessagesInbox() {
   _inboxSelectedCampaign = null;
+  _inboxSearch = '';  // 페인 재진입 시 검색어 초기화 (정렬은 사용자 선택 유지)
   if (_admMsgContext === 'inbox') _admMsgAppId = null;
   const wrap = document.getElementById('inboxThreadView');
   if (wrap) wrap.innerHTML = '<div class="inbox-empty">대화를 선택하세요.</div>';
@@ -11250,17 +11271,21 @@ function updateInboxSidebarBadge() {
 function renderInboxCampaignList() {
   const el = document.getElementById('inboxCampaigns');
   if (!el) return;
-  // campaign_id 별 집계
+  // campaign_id 별 집계 (미응대만·검색 필터 적용된 목록 기준)
   const byCamp = new Map();
-  for (const t of _inboxThreads) {
-    if (_inboxFilters.unresolvedOnly && !t.unresolved_for_admin_team) continue;
+  for (const t of filteredInboxThreads()) {
     let g = byCamp.get(t.campaign_id);
     if (!g) { g = { campaign_id: t.campaign_id, total: 0, unresolved: 0, lastAt: t.last_message_at }; byCamp.set(t.campaign_id, g); }
     g.total += 1;
     if (t.unresolved_for_admin_team) g.unresolved += 1;
     if (t.last_message_at > g.lastAt) g.lastAt = t.last_message_at;
   }
-  const groups = Array.from(byCamp.values()).sort((a, b) => (b.lastAt || '').localeCompare(a.lastAt || ''));
+  const groups = Array.from(byCamp.values());
+  if (_inboxSort === 'unresolved') {
+    groups.sort((a, b) => (b.unresolved - a.unresolved) || (b.lastAt || '').localeCompare(a.lastAt || ''));
+  } else {
+    groups.sort((a, b) => (b.lastAt || '').localeCompare(a.lastAt || ''));
+  }
   if (!groups.length) {
     el.innerHTML = '<div class="inbox-empty">표시할 대화가 없습니다.</div>';
     return;
@@ -11269,7 +11294,7 @@ function renderInboxCampaignList() {
     const c = inboxCampaignById(g.campaign_id);
     const title = c ? (c.title || '(제목 없음)') : '(캠페인)';
     const active = g.campaign_id === _inboxSelectedCampaign ? 'active' : '';
-    const badge = g.unresolved > 0 ? `<span class="inbox-camp-badge">${g.unresolved}</span>` : '';
+    const badge = g.unresolved > 0 ? `<span class="inbox-camp-badge">미응대 ${g.unresolved}건</span>` : '';
     // 모집타입 배지(공통 헬퍼) + 캠페인 상태 배지(캠페인 전용 — 신청 상태와 라벨 다름)
     const typeBadge = (c && typeof getRecruitTypeBadgeKoSm === 'function') ? getRecruitTypeBadgeKoSm(c.recruit_type) : '';
     const statusBadge = c ? inboxCampStatusBadge(c.status) : '';
@@ -11308,9 +11333,13 @@ function renderInboxThreadList() {
     el.innerHTML = '<div class="inbox-empty">왼쪽에서 캠페인을 선택하세요.</div>';
     return;
   }
-  let list = _inboxThreads.filter(t => t.campaign_id === _inboxSelectedCampaign);
-  if (_inboxFilters.unresolvedOnly) list = list.filter(t => t.unresolved_for_admin_team);
-  list.sort((a, b) => (b.last_message_at || '').localeCompare(a.last_message_at || ''));
+  let list = filteredInboxThreads().filter(t => t.campaign_id === _inboxSelectedCampaign);
+  if (_inboxSort === 'unresolved') {
+    list.sort((a, b) => (Number(b.unresolved_for_admin_team) - Number(a.unresolved_for_admin_team))
+      || (b.last_message_at || '').localeCompare(a.last_message_at || ''));
+  } else {
+    list.sort((a, b) => (b.last_message_at || '').localeCompare(a.last_message_at || ''));
+  }
   if (!list.length) {
     el.innerHTML = '<div class="inbox-empty">대화가 없습니다.</div>';
     return;
@@ -11381,6 +11410,33 @@ function changeInboxSince(months) {
   _inboxFilters.sinceMonths = Number(months) || 6;
   refreshInboxData();
 }
+function changeInboxSort(v) {
+  _inboxSort = (v === 'unresolved') ? 'unresolved' : 'recent';
+  renderInboxCampaignList();
+  renderInboxThreadList();
+}
+// 받은편지함 검색 — 인플 이름·이메일·캠페인명·최근 메시지로 대화 목록 필터
+function searchInbox(query) {
+  _inboxSearch = (query || '').trim().toLowerCase();
+  renderInboxCampaignList();
+  renderInboxThreadList();
+}
+// 미응대만·검색어를 적용한 대화 목록 (캠페인/대화 렌더 공통)
+function filteredInboxThreads() {
+  let list = _inboxThreads;
+  if (_inboxFilters.unresolvedOnly) list = list.filter(t => t.unresolved_for_admin_team);
+  if (_inboxSearch) {
+    list = list.filter(t => {
+      const inf = (_inboxInflMap && _inboxInflMap[t.influencer_id]) || {};
+      const prev = _inboxPreviewMap.get(t.application_id);
+      const camp = inboxCampaignById(t.campaign_id);
+      const bag = [inf.name, inf.name_kana, inf.email, prev && prev.body, camp && camp.title, camp && (camp.brand_ko || camp.brand)]
+        .filter(Boolean).join(' ').toLowerCase();
+      return bag.includes(_inboxSearch);
+    });
+  }
+  return list;
+}
 
 // ════════════════════════════════════════════════════════════════════
 // 2. 메시지 모달 (응모 행 버튼 진입)
@@ -11427,6 +11483,8 @@ function adminThreadViewHtml(ctx) {
     ? `<button type="button" class="adm-msg-bar-btn" onclick="toggleHideHistory('${ctx}')">숨김 이력</button>` : '';
   return `
     <div class="adm-msg-actionbar">
+      <input type="search" class="adm-msg-search" placeholder="대화 내용 검색" oninput="searchAdminMsg(this.value)">
+      <span class="adm-msg-bar-spacer"></span>
       <button type="button" class="adm-msg-bar-btn primary" onclick="markCurrentResolved()">응대 완료</button>
       ${histBtn}
     </div>
@@ -11471,11 +11529,16 @@ async function toggleHideHistory(ctx) {
 // ════════════════════════════════════════════════════════════════════
 // 3. 스레드 렌더 (공용 — 받은편지함 우측·모달 모두)
 // ════════════════════════════════════════════════════════════════════
-function renderAdminMsgThread(threadElId, messages) {
+function renderAdminMsgThread(threadElId, messages, _isSearchResult) {
+  // 검색 결과 렌더가 아니면 전체 메시지를 보관(검색 필터 원본) + 현재 thread 추적
+  if (!_isSearchResult) {
+    _admMsgCurrentMsgs = messages || [];
+    _admMsgCurrentThreadId = threadElId;
+  }
   const thread = document.getElementById(threadElId);
   if (!thread) return;
   if (!messages || !messages.length) {
-    thread.innerHTML = '<div class="msg-empty">아직 메시지가 없습니다.</div>';
+    thread.innerHTML = `<div class="msg-empty">${_isSearchResult ? '검색 결과가 없습니다.' : '아직 메시지가 없습니다.'}</div>`;
     return;
   }
   const now = Date.now();
@@ -11554,6 +11617,16 @@ function msgCardMasked(senderLabel, timeStr, sideCls, text) {
       <div class="msg-masked-body">${esc(text)}</div>
     </div>
   </div>`;
+}
+
+// 대화창 내 메시지 검색 — 현재 열린 대화의 본문에서 매칭 (검색 결과만 표시)
+function searchAdminMsg(query) {
+  if (!_admMsgCurrentThreadId) return;
+  const q = (query || '').trim().toLowerCase();
+  const filtered = q
+    ? _admMsgCurrentMsgs.filter(m => (m.body || '').toLowerCase().includes(q))
+    : _admMsgCurrentMsgs;
+  renderAdminMsgThread(_admMsgCurrentThreadId, filtered, true);
 }
 
 async function loadAdmMsgAttachThumb(elId, path) {

--- a/dev/admin/index.html
+++ b/dev/admin/index.html
@@ -1117,11 +1117,22 @@
                 </select>
               </div>
               <div class="admin-filter-group">
+                <label>정렬</label>
+                <select class="admin-select" onchange="changeInboxSort(this.value)">
+                  <option value="recent">최근 메시지순</option>
+                  <option value="unresolved">미응대 우선</option>
+                </select>
+              </div>
+              <div class="admin-filter-group">
                 <label>미응대</label>
                 <label style="display:inline-flex;align-items:center;gap:4px;font-size:12px;cursor:pointer;height:32px">
                   <input type="checkbox" onchange="toggleInboxUnresolved(this.checked)" style="margin:0">
                   <span>미응대만</span>
                 </label>
+              </div>
+              <div class="admin-filter-group" style="margin-left:auto;flex:1;min-width:200px;max-width:300px">
+                <label>검색</label>
+                <input type="search" class="admin-filter-search" autocomplete="off" data-lpignore="true" data-1p-ignore="true" readonly onfocus="this.removeAttribute('readonly')" placeholder="인플루언서명 · 메시지 검색" oninput="searchInbox(this.value)" style="width:100%">
               </div>
             </div>
           </div>

--- a/dev/css/admin.css
+++ b/dev/css/admin.css
@@ -1057,16 +1057,19 @@
 .inbox-col-threads{border-right:1px solid var(--line)}
 .inbox-col-view{display:flex;flex-direction:column}
 .inbox-empty{padding:24px 16px;color:var(--muted);font-size:13px;text-align:center}
-/* 단계: campaigns(캠페인 전체폭) → threads(대화상대 확대) → view(대화내용 확대) */
-.inbox-3pane.stage-campaigns .inbox-col-camps{flex:1;width:auto}
-.inbox-3pane.stage-campaigns .inbox-col-threads,
-.inbox-3pane.stage-campaigns .inbox-col-view{display:none}
-.inbox-3pane.stage-threads .inbox-col-camps{width:320px;flex-shrink:0}
-.inbox-3pane.stage-threads .inbox-col-threads{flex:1;width:auto}
-.inbox-3pane.stage-threads .inbox-col-view{display:none}
-.inbox-3pane.stage-view .inbox-col-camps{width:340px;flex-shrink:0}
-.inbox-3pane.stage-view .inbox-col-threads{width:320px;flex-shrink:0}
-.inbox-3pane.stage-view .inbox-col-view{flex:1;min-width:0}
+/* 단계: 3단 모두 항상 표시, 활성 단만 flex-grow 로 넓힘 (숨김 없이 너비만 부드럽게 변화) */
+.inbox-col-camps{min-width:210px;transition:flex-grow .25s ease}
+.inbox-col-threads{min-width:220px;transition:flex-grow .25s ease}
+.inbox-col-view{min-width:320px;flex:1;min-height:0;transition:flex-grow .25s ease}
+.inbox-3pane.stage-campaigns .inbox-col-camps{flex:3}
+.inbox-3pane.stage-campaigns .inbox-col-threads{flex:1}
+.inbox-3pane.stage-campaigns .inbox-col-view{flex:1}
+.inbox-3pane.stage-threads .inbox-col-camps{flex:1}
+.inbox-3pane.stage-threads .inbox-col-threads{flex:3}
+.inbox-3pane.stage-threads .inbox-col-view{flex:1}
+.inbox-3pane.stage-view .inbox-col-camps{flex:1}
+.inbox-3pane.stage-view .inbox-col-threads{flex:1}
+.inbox-3pane.stage-view .inbox-col-view{flex:3}
 /* 좌: 캠페인 정보 카드 (좌측 정보 + 우측 미응대 배지) */
 .inbox-camp-item{display:flex;flex-direction:row;align-items:center;gap:8px;width:100%;padding:12px 14px;border:0;border-bottom:1px solid var(--line);background:none;cursor:pointer;text-align:left;color:var(--ink)}
 .inbox-camp-item:hover{background:var(--light-pink)}
@@ -1077,7 +1080,7 @@
 .inbox-camp-title{font-size:13px;font-weight:600;word-break:break-word;line-height:1.4}
 .inbox-camp-sub{font-size:11px;color:var(--muted)}
 .inbox-camp-meta{display:flex;align-items:center;gap:6px;font-size:11px;color:var(--muted)}
-.inbox-camp-badge{display:inline-flex;align-items:center;justify-content:center;min-width:18px;height:18px;padding:0 5px;border-radius:9px;background:var(--pink);color:#fff;font-size:11px;font-weight:700}
+.inbox-camp-badge{display:inline-flex;align-items:center;justify-content:center;height:20px;padding:0 8px;border-radius:10px;background:var(--pink);color:#fff;font-size:11px;font-weight:700;white-space:nowrap}
 /* 중: 대화 상대 카드 (좌측 이름·이메일·미리보기 + 우측 시간↑·미응대 배지↓) */
 .inbox-thread-item{display:flex;flex-direction:row;align-items:flex-start;gap:8px;width:100%;padding:12px 14px;border:0;border-bottom:1px solid var(--line);background:none;cursor:pointer;text-align:left;color:var(--ink)}
 .inbox-thread-item:hover{background:var(--surface-dim)}
@@ -1095,13 +1098,15 @@
 .inbox-thread-chip.unread{background:var(--pink);color:#fff}
 
 /* 대화 내용 영역 (받은편지함 우측 + 모달 본문 공용) */
-.adm-msg-actionbar{display:flex;gap:8px;padding:10px 14px;border-bottom:1px solid var(--line);flex-shrink:0;background:var(--surface-container-low)}
+.adm-msg-actionbar{display:flex;gap:8px;align-items:center;padding:10px 14px;border-bottom:1px solid var(--line);flex-shrink:0;background:var(--surface-container-low)}
+.adm-msg-bar-spacer{flex:1}
+.adm-msg-search{flex:0 1 220px;border:1px solid var(--line);border-radius:8px;padding:5px 10px;font-size:12px;font-family:inherit}
 .adm-msg-bar-btn{padding:5px 12px;border:1px solid var(--line);border-radius:8px;background:#fff;font-size:12px;cursor:pointer;color:var(--ink)}
 .adm-msg-bar-btn.primary{background:var(--pink);color:#fff;border-color:var(--pink)}
 .adm-msg-thread{overflow-y:auto;padding:14px;display:flex;flex-direction:column;gap:10px;min-height:0;flex:1}
-/* 메시지 — 말풍선 + 옆 메타(시간·읽음·액션). mine 은 우측 정렬, 메타는 풍선 왼쪽 */
-.msg-row{display:flex;gap:8px;align-items:flex-end;max-width:85%;align-self:flex-start}
-.msg-row.mine{flex-direction:row-reverse;align-self:flex-end}
+/* 메시지 — 말풍선 + 옆 메타(시간·읽음·액션). 메타는 풍선 바깥쪽(상대=오른쪽, mine=왼쪽) */
+.msg-row{display:flex;gap:8px;align-items:flex-end;max-width:85%;align-self:flex-start;flex-direction:row-reverse}
+.msg-row.mine{flex-direction:row;align-self:flex-end}
 .msg-bubble{background:var(--surface-dim);border-radius:12px;padding:10px 12px;min-width:0}
 .msg-row.mine .msg-bubble{background:var(--light-pink)}
 .msg-bubble .msg-sender{font-size:11px;font-weight:700;color:var(--dark-pink);margin-bottom:4px}

--- a/dev/js/admin-messaging.js
+++ b/dev/js/admin-messaging.js
@@ -19,12 +19,16 @@ let _inboxThreads = [];                 // fetchAdminMessageThreads 결과 (뷰 
 let _inboxUnreadMap = new Map();        // application_id → 본인 미열람 수
 let _inboxSelectedCampaign = null;      // 좌 패널 선택 캠페인 id
 let _inboxFilters = { unresolvedOnly: false, sinceMonths: 6 };
+let _inboxSort = 'recent';              // 'recent'(최근 메시지순) | 'unresolved'(미응대 우선)
+let _inboxSearch = '';                  // 받은편지함 검색어 (인플 이름·이메일·캠페인명·미리보기)
 
 // 메시지 모달/패널 공용 상태
 let _admMsgAppId = null;                // 현재 열린 응모건
 let _admMsgContext = 'modal';           // 'modal' | 'inbox' — 전송 후 재렌더 대상
 let _admMsgPendingFiles = [];
 let _admMsgSending = false;
+let _admMsgCurrentMsgs = [];        // 현재 열린 대화 전체 메시지 (검색 필터 원본)
+let _admMsgCurrentThreadId = null;  // 현재 렌더 중인 thread DOM id
 
 // 응모 행 메시지 버튼 셀에 표시할 본인 미열람 맵 (페인 로드 시 채움)
 let _applicantMsgUnreadMap = new Map();
@@ -50,6 +54,7 @@ async function loadHideReasons() {
 // ════════════════════════════════════════════════════════════════════
 async function loadMessagesInbox() {
   _inboxSelectedCampaign = null;
+  _inboxSearch = '';  // 페인 재진입 시 검색어 초기화 (정렬은 사용자 선택 유지)
   if (_admMsgContext === 'inbox') _admMsgAppId = null;
   const wrap = document.getElementById('inboxThreadView');
   if (wrap) wrap.innerHTML = '<div class="inbox-empty">대화를 선택하세요.</div>';
@@ -108,17 +113,21 @@ function updateInboxSidebarBadge() {
 function renderInboxCampaignList() {
   const el = document.getElementById('inboxCampaigns');
   if (!el) return;
-  // campaign_id 별 집계
+  // campaign_id 별 집계 (미응대만·검색 필터 적용된 목록 기준)
   const byCamp = new Map();
-  for (const t of _inboxThreads) {
-    if (_inboxFilters.unresolvedOnly && !t.unresolved_for_admin_team) continue;
+  for (const t of filteredInboxThreads()) {
     let g = byCamp.get(t.campaign_id);
     if (!g) { g = { campaign_id: t.campaign_id, total: 0, unresolved: 0, lastAt: t.last_message_at }; byCamp.set(t.campaign_id, g); }
     g.total += 1;
     if (t.unresolved_for_admin_team) g.unresolved += 1;
     if (t.last_message_at > g.lastAt) g.lastAt = t.last_message_at;
   }
-  const groups = Array.from(byCamp.values()).sort((a, b) => (b.lastAt || '').localeCompare(a.lastAt || ''));
+  const groups = Array.from(byCamp.values());
+  if (_inboxSort === 'unresolved') {
+    groups.sort((a, b) => (b.unresolved - a.unresolved) || (b.lastAt || '').localeCompare(a.lastAt || ''));
+  } else {
+    groups.sort((a, b) => (b.lastAt || '').localeCompare(a.lastAt || ''));
+  }
   if (!groups.length) {
     el.innerHTML = '<div class="inbox-empty">표시할 대화가 없습니다.</div>';
     return;
@@ -127,7 +136,7 @@ function renderInboxCampaignList() {
     const c = inboxCampaignById(g.campaign_id);
     const title = c ? (c.title || '(제목 없음)') : '(캠페인)';
     const active = g.campaign_id === _inboxSelectedCampaign ? 'active' : '';
-    const badge = g.unresolved > 0 ? `<span class="inbox-camp-badge">${g.unresolved}</span>` : '';
+    const badge = g.unresolved > 0 ? `<span class="inbox-camp-badge">미응대 ${g.unresolved}건</span>` : '';
     // 모집타입 배지(공통 헬퍼) + 캠페인 상태 배지(캠페인 전용 — 신청 상태와 라벨 다름)
     const typeBadge = (c && typeof getRecruitTypeBadgeKoSm === 'function') ? getRecruitTypeBadgeKoSm(c.recruit_type) : '';
     const statusBadge = c ? inboxCampStatusBadge(c.status) : '';
@@ -166,9 +175,13 @@ function renderInboxThreadList() {
     el.innerHTML = '<div class="inbox-empty">왼쪽에서 캠페인을 선택하세요.</div>';
     return;
   }
-  let list = _inboxThreads.filter(t => t.campaign_id === _inboxSelectedCampaign);
-  if (_inboxFilters.unresolvedOnly) list = list.filter(t => t.unresolved_for_admin_team);
-  list.sort((a, b) => (b.last_message_at || '').localeCompare(a.last_message_at || ''));
+  let list = filteredInboxThreads().filter(t => t.campaign_id === _inboxSelectedCampaign);
+  if (_inboxSort === 'unresolved') {
+    list.sort((a, b) => (Number(b.unresolved_for_admin_team) - Number(a.unresolved_for_admin_team))
+      || (b.last_message_at || '').localeCompare(a.last_message_at || ''));
+  } else {
+    list.sort((a, b) => (b.last_message_at || '').localeCompare(a.last_message_at || ''));
+  }
   if (!list.length) {
     el.innerHTML = '<div class="inbox-empty">대화가 없습니다.</div>';
     return;
@@ -239,6 +252,33 @@ function changeInboxSince(months) {
   _inboxFilters.sinceMonths = Number(months) || 6;
   refreshInboxData();
 }
+function changeInboxSort(v) {
+  _inboxSort = (v === 'unresolved') ? 'unresolved' : 'recent';
+  renderInboxCampaignList();
+  renderInboxThreadList();
+}
+// 받은편지함 검색 — 인플 이름·이메일·캠페인명·최근 메시지로 대화 목록 필터
+function searchInbox(query) {
+  _inboxSearch = (query || '').trim().toLowerCase();
+  renderInboxCampaignList();
+  renderInboxThreadList();
+}
+// 미응대만·검색어를 적용한 대화 목록 (캠페인/대화 렌더 공통)
+function filteredInboxThreads() {
+  let list = _inboxThreads;
+  if (_inboxFilters.unresolvedOnly) list = list.filter(t => t.unresolved_for_admin_team);
+  if (_inboxSearch) {
+    list = list.filter(t => {
+      const inf = (_inboxInflMap && _inboxInflMap[t.influencer_id]) || {};
+      const prev = _inboxPreviewMap.get(t.application_id);
+      const camp = inboxCampaignById(t.campaign_id);
+      const bag = [inf.name, inf.name_kana, inf.email, prev && prev.body, camp && camp.title, camp && (camp.brand_ko || camp.brand)]
+        .filter(Boolean).join(' ').toLowerCase();
+      return bag.includes(_inboxSearch);
+    });
+  }
+  return list;
+}
 
 // ════════════════════════════════════════════════════════════════════
 // 2. 메시지 모달 (응모 행 버튼 진입)
@@ -285,6 +325,8 @@ function adminThreadViewHtml(ctx) {
     ? `<button type="button" class="adm-msg-bar-btn" onclick="toggleHideHistory('${ctx}')">숨김 이력</button>` : '';
   return `
     <div class="adm-msg-actionbar">
+      <input type="search" class="adm-msg-search" placeholder="대화 내용 검색" oninput="searchAdminMsg(this.value)">
+      <span class="adm-msg-bar-spacer"></span>
       <button type="button" class="adm-msg-bar-btn primary" onclick="markCurrentResolved()">응대 완료</button>
       ${histBtn}
     </div>
@@ -329,11 +371,16 @@ async function toggleHideHistory(ctx) {
 // ════════════════════════════════════════════════════════════════════
 // 3. 스레드 렌더 (공용 — 받은편지함 우측·모달 모두)
 // ════════════════════════════════════════════════════════════════════
-function renderAdminMsgThread(threadElId, messages) {
+function renderAdminMsgThread(threadElId, messages, _isSearchResult) {
+  // 검색 결과 렌더가 아니면 전체 메시지를 보관(검색 필터 원본) + 현재 thread 추적
+  if (!_isSearchResult) {
+    _admMsgCurrentMsgs = messages || [];
+    _admMsgCurrentThreadId = threadElId;
+  }
   const thread = document.getElementById(threadElId);
   if (!thread) return;
   if (!messages || !messages.length) {
-    thread.innerHTML = '<div class="msg-empty">아직 메시지가 없습니다.</div>';
+    thread.innerHTML = `<div class="msg-empty">${_isSearchResult ? '검색 결과가 없습니다.' : '아직 메시지가 없습니다.'}</div>`;
     return;
   }
   const now = Date.now();
@@ -412,6 +459,16 @@ function msgCardMasked(senderLabel, timeStr, sideCls, text) {
       <div class="msg-masked-body">${esc(text)}</div>
     </div>
   </div>`;
+}
+
+// 대화창 내 메시지 검색 — 현재 열린 대화의 본문에서 매칭 (검색 결과만 표시)
+function searchAdminMsg(query) {
+  if (!_admMsgCurrentThreadId) return;
+  const q = (query || '').trim().toLowerCase();
+  const filtered = q
+    ? _admMsgCurrentMsgs.filter(m => (m.body || '').toLowerCase().includes(q))
+    : _admMsgCurrentMsgs;
+  renderAdminMsgThread(_admMsgCurrentThreadId, filtered, true);
 }
 
 async function loadAdmMsgAttachThumb(elId, path) {


### PR DESCRIPTION
## 변경 요약
- 메시지 메타(시간·읽음·숨김버튼) 풍선 안쪽으로
- 3단 항상 표시(숨김 제거), 활성 단만 너비 확대
- 캠페인 배지 「미응대 N건」 텍스트
- 정렬: 최근 메시지순 / 미응대 우선
- 대화창 내 메시지 검색 + 받은편지함 검색(인플·메시지)
- 헤더 UI 정렬(기간/정렬/미응대만/검색)

## DB 변경
- 없음

## Test plan
- [ ] 메타 위치(풍선 안쪽), 3단 항상 표시 + 너비 전환
- [ ] 캠페인 배지 「미응대 N건」, 정렬 2종
- [ ] 대화창 검색(본문), 받은편지함 검색(인플·캠페인·미리보기)
- [ ] 재진입 시 검색어 초기화

[via reviewer]

🤖 Generated with [Claude Code](https://claude.com/claude-code)