### PR TITLE
feat(messaging): 인플루언서 관리자 미응답 안내 배너

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -12,7 +12,7 @@
 // 회귀(2026-05-12 PR #182 머지 직후 발생)를 방지하기 위한 자동 reload 가드.
 // sessionStorage 차단 환경(시크릿 모드 일부, 쿠키 차단)에서는 자연스럽게 skip.
 (function(){
-  var CURRENT_BUILD = 'v1779274854';
+  var CURRENT_BUILD = 'v1779275088';
   if (CURRENT_BUILD.indexOf('__') === 0) return; // 빌드 미적용 (dev/ 직접 열기) 시 skip
   try {
     var prev = sessionStorage.getItem('reverb.adminBuild');
@@ -1630,7 +1630,7 @@ textarea.form-input{resize:vertical;min-height:80px}
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-05-20 20:00 · 6ed21ad</span>
+          <span class="admin-build-text">2026-05-20 20:04 · 9527342</span>
         </div>
       </div>
     </aside>

--- a/dev/css/mypage.css
+++ b/dev/css/mypage.css
@@ -89,6 +89,7 @@
 .msg-attachments{display:flex;flex-wrap:wrap;gap:6px;margin-top:8px}
 .msg-attach-thumb{width:72px;height:72px;border-radius:8px;overflow:hidden;background:var(--surface-dim);display:flex;align-items:center;justify-content:center;cursor:pointer;color:var(--muted)}
 .msg-attach-thumb img{width:100%;height:100%;object-fit:cover}
+.msg-pending-notice{flex-shrink:0;padding:10px 14px;background:#FFF6E5;color:#8A6D3B;font-size:12px;line-height:1.5;border-top:1px solid var(--outline);text-align:center}
 .msg-modal-input-area{flex-shrink:0;border-top:1px solid var(--outline);padding:10px 12px;background:var(--surface,#fff)}
 .msg-attach-preview{display:flex;flex-wrap:wrap;gap:6px}
 .msg-attach-preview:not(:empty){margin-bottom:8px}

--- a/dev/index.html
+++ b/dev/index.html
@@ -257,6 +257,7 @@ window._supabaseLoaded = false;
       </button>
     </div>
     <div id="msgModalThread" class="msg-modal-thread"></div>
+    <div id="msgPendingNotice" class="msg-pending-notice" style="display:none"></div>
     <div class="msg-modal-input-area">
       <div id="msgModalAttachPreview" class="msg-attach-preview"></div>
       <div class="msg-input-row">

--- a/dev/js/messaging.js
+++ b/dev/js/messaging.js
@@ -61,6 +61,7 @@ function closeMessageModal() {
 function renderMessageThread(messages) {
   const thread = $('msgModalThread');
   if (!thread) return;
+  updateMsgPendingNotice(messages);  // 관리자 미응답 안내 토글
   if (!messages || !messages.length) {
     thread.innerHTML = `<div class="msg-empty">${esc(t('messaging.emptyThread'))}</div>`;
     return;
@@ -116,6 +117,21 @@ function renderMessageThread(messages) {
   }).join('');
   // 최신 메시지로 스크롤
   thread.scrollTop = thread.scrollHeight;
+}
+
+// 관리자 미응답 안내 배너 — 마지막 살아있는 메시지가 인플루언서 발신이면 표시,
+//   관리자가 답하면(마지막이 admin) 자동으로 사라짐
+function updateMsgPendingNotice(messages) {
+  const notice = $('msgPendingNotice');
+  if (!notice) return;
+  const visible = (messages || []).filter(m => !m.mask_state || m.mask_state === 'visible');
+  const last = visible[visible.length - 1];
+  if (last && last.sender_kind === 'influencer') {
+    notice.textContent = t('messaging.pendingNotice');
+    notice.style.display = '';
+  } else {
+    notice.style.display = 'none';
+  }
 }
 
 // 첨부 썸네일 signed URL 비동기 로드 (5분 시한)

--- a/dev/lib/i18n/ja.js
+++ b/dev/lib/i18n/ja.js
@@ -589,5 +589,6 @@ window.I18N_JA = {
     unreadBadge: '未読',
     navMenu: 'メッセージ',
     notifTitle: '運営からのメッセージ',
+    pendingNotice: '運営が順次確認のうえ、ご返信いたします。お返事までお時間をいただく場合がございます。',
   },
 };

--- a/dev/lib/i18n/ko.js
+++ b/dev/lib/i18n/ko.js
@@ -569,5 +569,6 @@ window.I18N_KO = {
     unreadBadge: '미읽음',
     navMenu: '메시지',
     notifTitle: '운영팀 메시지',
+    pendingNotice: '운영팀이 순차적으로 확인 후 회신드립니다. 답변까지 시간이 걸릴 수 있습니다.',
   },
 };

--- a/index.html
+++ b/index.html
@@ -596,6 +596,7 @@ textarea.form-input{resize:vertical;min-height:80px}
 .msg-attachments{display:flex;flex-wrap:wrap;gap:6px;margin-top:8px}
 .msg-attach-thumb{width:72px;height:72px;border-radius:8px;overflow:hidden;background:var(--surface-dim);display:flex;align-items:center;justify-content:center;cursor:pointer;color:var(--muted)}
 .msg-attach-thumb img{width:100%;height:100%;object-fit:cover}
+.msg-pending-notice{flex-shrink:0;padding:10px 14px;background:#FFF6E5;color:#8A6D3B;font-size:12px;line-height:1.5;border-top:1px solid var(--outline);text-align:center}
 .msg-modal-input-area{flex-shrink:0;border-top:1px solid var(--outline);padding:10px 12px;background:var(--surface,#fff)}
 .msg-attach-preview{display:flex;flex-wrap:wrap;gap:6px}
 .msg-attach-preview:not(:empty){margin-bottom:8px}
@@ -834,6 +835,7 @@ textarea.form-input{resize:vertical;min-height:80px}
       </button>
     </div>
     <div id="msgModalThread" class="msg-modal-thread"></div>
+    <div id="msgPendingNotice" class="msg-pending-notice" style="display:none"></div>
     <div class="msg-modal-input-area">
       <div id="msgModalAttachPreview" class="msg-attach-preview"></div>
       <div class="msg-input-row">
@@ -2828,6 +2830,7 @@ window.I18N_JA = {
     unreadBadge: '未読',
     navMenu: 'メッセージ',
     notifTitle: '運営からのメッセージ',
+    pendingNotice: '運営が順次確認のうえ、ご返信いたします。お返事までお時間をいただく場合がございます。',
   },
 };
 
@@ -3402,6 +3405,7 @@ window.I18N_KO = {
     unreadBadge: '미읽음',
     navMenu: '메시지',
     notifTitle: '운영팀 메시지',
+    pendingNotice: '운영팀이 순차적으로 확인 후 회신드립니다. 답변까지 시간이 걸릴 수 있습니다.',
   },
 };
 
@@ -9852,6 +9856,7 @@ function closeMessageModal() {
 function renderMessageThread(messages) {
   const thread = $('msgModalThread');
   if (!thread) return;
+  updateMsgPendingNotice(messages);  // 관리자 미응답 안내 토글
   if (!messages || !messages.length) {
     thread.innerHTML = `<div class="msg-empty">${esc(t('messaging.emptyThread'))}</div>`;
     return;
@@ -9907,6 +9912,21 @@ function renderMessageThread(messages) {
   }).join('');
   // 최신 메시지로 스크롤
   thread.scrollTop = thread.scrollHeight;
+}
+
+// 관리자 미응답 안내 배너 — 마지막 살아있는 메시지가 인플루언서 발신이면 표시,
+//   관리자가 답하면(마지막이 admin) 자동으로 사라짐
+function updateMsgPendingNotice(messages) {
+  const notice = $('msgPendingNotice');
+  if (!notice) return;
+  const visible = (messages || []).filter(m => !m.mask_state || m.mask_state === 'visible');
+  const last = visible[visible.length - 1];
+  if (last && last.sender_kind === 'influencer') {
+    notice.textContent = t('messaging.pendingNotice');
+    notice.style.display = '';
+  } else {
+    notice.style.display = 'none';
+  }
 }
 
 // 첨부 썸네일 signed URL 비동기 로드 (5분 시한)


### PR DESCRIPTION
## 변경 요약
- 인플루언서가 메시지를 보내고 관리자가 아직 답하지 않은 상태이면 「운영팀이 순차적으로 확인 후 회신드립니다. 답변까지 시간이 걸릴 수 있습니다.」 안내 배너 표시
- 관리자가 답하면 자동으로 사라짐
- 구체 일수 없는 일반 안내 (사용자 결정)

## DB 변경
- 없음

## Test plan
- [ ] 인플이 메시지 발송 후 입력창 위 안내 배너 표시
- [ ] 관리자 답장 후 인플이 다시 열면 배너 사라짐
- [ ] 빈 대화/마스킹 메시지에서 배너 미표시

[via reviewer]

🤖 Generated with [Claude Code](https://claude.com/claude-code)