### PR TITLE
fix(email): admin digest influencer name/SNS join key (auth_id → id)

### DIFF
--- a/supabase/functions/notify-admin-daily-digest/index.ts
+++ b/supabase/functions/notify-admin-daily-digest/index.ts
@@ -342,7 +342,7 @@ interface CampaignRow {
   recruit_type: string | null;
 }
 interface InfluencerRow {
-  auth_id: string;
+  id: string;
   name: string | null;
   name_kanji: string | null;
   name_kana: string | null;
@@ -467,7 +467,7 @@ function renderCancelledSection(args: {
     const rows = grouped.get(cid)!;
     const cancelRowsHtml = rows.map((r) => {
       const infl = args.influencerMap.get(r.user_id) || {
-        auth_id: r.user_id, name: null, name_kanji: null, name_kana: null,
+        id: r.user_id, name: null, name_kanji: null, name_kana: null,
         primary_sns: null, ig: null, tiktok: null, x: null, youtube: null,
       };
       const reasonLabel = r.cancel_reason_code
@@ -599,7 +599,7 @@ function renderSubmittedSection(args: {
       const d = args.deliverableMap.get(ev.deliverable_id) || null;
       const infl = d ? args.influencerMap.get(d.user_id) : null;
       const fallbackInfl = {
-        auth_id: d?.user_id || "", name: null, name_kanji: null, name_kana: null,
+        id: d?.user_id || "", name: null, name_kanji: null, name_kana: null,
         primary_sns: null, ig: null, tiktok: null, x: null, youtube: null,
       };
       const i = infl || fallbackInfl;
@@ -681,7 +681,7 @@ function renderReprocessedSection(args: {
     const reprocessRowsHtml = items.map((it) => {
       const infl = it.user_id ? args.influencerMap.get(it.user_id) : null;
       const fallbackInfl = {
-        auth_id: it.user_id || "", name: null, name_kanji: null, name_kana: null,
+        id: it.user_id || "", name: null, name_kanji: null, name_kana: null,
         primary_sns: null, ig: null, tiktok: null, x: null, youtube: null,
       };
       const i = infl || fallbackInfl;
@@ -950,12 +950,12 @@ Deno.serve(async (req: Request) => {
     if (userIds.size > 0) {
       const { data: infls, error } = await sb
         .from("influencers")
-        .select("auth_id, name, name_kanji, name_kana, primary_sns, ig, tiktok, x, youtube")
-        .in("auth_id", [...userIds]);
+        .select("id, name, name_kanji, name_kana, primary_sns, ig, tiktok, x, youtube")
+        .in("id", [...userIds]);
       if (error) {
         console.warn("[notify-admin-daily] influencer lookup failed", error);
       } else {
-        (infls || []).forEach((i: InfluencerRow) => influencerMap.set(i.auth_id, i));
+        (infls || []).forEach((i: InfluencerRow) => influencerMap.set(i.id, i));
       }
     }
 

--- a/supabase/functions/notify-application-cancelled-daily/index.ts
+++ b/supabase/functions/notify-application-cancelled-daily/index.ts
@@ -137,7 +137,7 @@ interface CampaignRow {
 }
 
 interface InfluencerRow {
-  auth_id: string;
+  id: string;
   name: string | null;
   name_kanji: string | null;
   name_kana: string | null;
@@ -411,13 +411,13 @@ Deno.serve(async (req: Request) => {
   if (userIds.length > 0) {
     const { data: infls, error: infErr } = await sb
       .from("influencers")
-      .select("auth_id, name, name_kanji, name_kana")
-      .in("auth_id", userIds);
+      .select("id, name, name_kanji, name_kana")
+      .in("id", userIds);
     if (infErr) {
       console.warn("[notify-cancel-daily] influencer lookup failed", infErr);
     } else {
       (infls || []).forEach((row: InfluencerRow) => {
-        influencerMap.set(row.auth_id, row);
+        influencerMap.set(row.id, row);
       });
     }
   }
@@ -488,7 +488,7 @@ Deno.serve(async (req: Request) => {
   const renderCard = (r: CancelledRow): string => {
     const camp = campaignMap.get(r.campaign_id) || null;
     const infl = influencerMap.get(r.user_id) || {
-      auth_id: r.user_id,
+      id: r.user_id,
       name: null,
       name_kanji: null,
       name_kana: null,

--- a/supabase/functions/notify-application-received-admin-daily/index.ts
+++ b/supabase/functions/notify-application-received-admin-daily/index.ts
@@ -197,7 +197,7 @@ interface CampRow {
   recruit_type: string | null;
 }
 interface InflRow {
-  auth_id: string;
+  id: string;
   name: string | null;
   name_kanji: string | null;
   name_kana: string | null;
@@ -276,9 +276,9 @@ Deno.serve(async (req: Request) => {
   const inflMap = new Map<string, InflRow>();
   if (userIds.length > 0) {
     const { data: infls } = await sb.from("influencers")
-      .select("auth_id, name, name_kanji, name_kana, primary_sns, ig, tiktok, x, youtube")
-      .in("auth_id", userIds);
-    (infls || []).forEach((i: InflRow) => inflMap.set(i.auth_id, i));
+      .select("id, name, name_kanji, name_kana, primary_sns, ig, tiktok, x, youtube")
+      .in("id", userIds);
+    (infls || []).forEach((i: InflRow) => inflMap.set(i.id, i));
   }
 
   const emailMap = new Map<string, string>();


### PR DESCRIPTION
## 변경 요약
- 관리자 일일 통합 다이제스트 메일에서 인플루언서 이름(한자/가나)·SNS가 전부 「-」로만 나오고 이메일만 표시되던 버그 수정
- 원인: `influencers` 조회 키로 존재하지 않는 컬럼 `auth_id`를 사용 (테이블 PK `id` = auth.users.id). 조회 0건 → 이름·SNS 공란, 이메일만 별도 경로로 생존
- 3개 Edge Function의 조회 키를 `id`로 교정 (가동 중 notify-admin-daily-digest + cron 해제된 미사용 2종 — 회귀 방지)
- 올바른 패턴은 notify-deliverable-decision(`.eq("id", user_id)`)이 이미 사용 중

## 요청 외 추가 변경
- 없음

## 관련 사양서
- 없음 (버그 수정)

## 배포 메모
- dev에는 운영 보류 중인 응모건 메시지 PR 1·2가 있어 cherry-pick 핫픽스로 분리
- 머지 후 운영 Edge Function 재배포 필요 (`supabase functions deploy notify-admin-daily-digest --project-ref twofagomeizrtkwlhsuv`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)