### PR TITLE
fix(cancel): deadlock recovery + clearer not-found message (prod)

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -12,7 +12,7 @@
 // 회귀(2026-05-12 PR #182 머지 직후 발생)를 방지하기 위한 자동 reload 가드.
 // sessionStorage 차단 환경(시크릿 모드 일부, 쿠키 차단)에서는 자연스럽게 skip.
 (function(){
-  var CURRENT_BUILD = 'v1779246908';
+  var CURRENT_BUILD = 'v1779333349';
   if (CURRENT_BUILD.indexOf('__') === 0) return; // 빌드 미적용 (dev/ 직접 열기) 시 skip
   try {
     var prev = sessionStorage.getItem('reverb.adminBuild');
@@ -1522,7 +1522,7 @@ textarea.form-input{resize:vertical;min-height:80px}
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-05-20 12:15 · a71b423</span>
+          <span class="admin-build-text">2026-05-21 12:15 · a66a9c9</span>
         </div>
       </div>
     </aside>

--- a/dev/js/mypage.js
+++ b/dev/js/mypage.js
@@ -558,45 +558,12 @@ async function openCancelModalFor(appId) {
   const campNameEl = $('cancelPageCampaign');
   if (campNameEl) campNameEl.textContent = camp.title || app.campaign_id || '';
   const isSimple = phase === 'recruit';
-  const warnBox   = $('cancelPageWarning');
-  const reasonBox = $('cancelPageReason');
-  const noteBox   = $('cancelPageNoteWrap');
-  const ackBox    = $('cancelPageAckWrap');
-  const simpleBody = $('cancelPageSimpleBody');
-  if (warnBox)   warnBox.style.display   = isSimple ? 'none' : 'block';
-  if (reasonBox) reasonBox.style.display = isSimple ? 'none' : 'block';
-  if (noteBox)   noteBox.style.display   = isSimple ? 'none' : 'block';
-  if (ackBox)    ackBox.style.display    = isSimple ? 'none' : 'block';
-  if (simpleBody) simpleBody.style.display = isSimple ? 'block' : 'none';
-  // 경고 카피
-  const warnTextEl = $('cancelPageWarningText');
-  if (warnTextEl && !isSimple) {
-    const key = `appHistory.cancel.warning${phase.charAt(0).toUpperCase()}${phase.slice(1)}`;
-    warnTextEl.textContent = t(key);
-  }
-  // 사유 셀렉트: 카탈로그 캐시
-  if (!isSimple) {
-    if (!_cancelReasonsCache) _cancelReasonsCache = await fetchCancelReasons();
-    const sel = $('cancelPageReasonSelect');
-    if (sel) {
-      const lang = (typeof getLang === 'function') ? getLang() : 'ja';
-      const pickLabel = (r) => (lang === 'ko' ? (r.name_ko || r.name_ja) : (r.name_ja || r.name_ko));
-      const placeholder = `<option value="">${esc(t('appHistory.cancel.reasonSelect'))}</option>`;
-      const opts = _cancelReasonsCache.map(r => `<option value="${esc(r.code)}">${esc(pickLabel(r))}</option>`).join('');
-      sel.innerHTML = placeholder + opts;
-      sel.value = '';
-      // 카테고리 선택 시 textarea placeholder 를 카테고리별 가이드로 갱신.
-      // 사용자가 어떤 내용을 입력해야 하는지 안내.
-      sel.onchange = () => _syncCancelNotePlaceholder(sel.value);
-    }
-    const note = $('cancelPageNote');
-    if (note) {
-      note.value = '';
-      // 초기 placeholder: 기본 가이드 (카테고리 미선택 상태)
-      note.placeholder = t('appHistory.cancel.notePlaceholderDefault');
-    }
-    const ack = $('cancelPageAck');
-    if (ack) ack.checked = false;
+  // 단계별 화면 분기 — recruit 는 간단 취소, 그 외는 사유 입력 모드.
+  // 두 모드 전환 로직은 데드락 자동 복구에서도 재사용하도록 헬퍼로 분리.
+  if (isSimple) {
+    _showCancelSimpleMode();
+  } else {
+    await _revealCancelReasonFields(phase);
   }
   // phase + appId hidden
   const phaseEl = $('cancelPagePhase');
@@ -616,6 +583,54 @@ async function openCancelModalFor(appId) {
   // #appShell 이 position:fixed + overflow:hidden 이라 iOS Safari 의 자동
   // 스크롤이 .page.active 내부 컨테이너에서 작동하지 않으므로 직접 처리.
   _attachCancelPageFocusScroll();
+}
+
+// 간단 취소 모드 — 사유/동의/경고 박스 숨김, 간단 안내만 표시 (recruit 단계)
+function _showCancelSimpleMode() {
+  const boxes = ['cancelPageWarning','cancelPageReason','cancelPageNoteWrap','cancelPageAckWrap']
+    .map(id => $(id));
+  boxes.forEach(b => { if (b) b.style.display = 'none'; });
+  const simpleBody = $('cancelPageSimpleBody');
+  if (simpleBody) simpleBody.style.display = 'block';
+}
+
+// 사유 입력 모드로 전환 — 박스 표시 + 경고 카피 + 사유 카탈로그 로드 + 입력 초기화.
+// 진입 시(비-recruit)와 데드락 자동 복구(서버가 사유를 요구)에서 공통 호출.
+async function _revealCancelReasonFields(phase) {
+  const boxes = ['cancelPageWarning','cancelPageReason','cancelPageNoteWrap','cancelPageAckWrap']
+    .map(id => $(id));
+  boxes.forEach(b => { if (b) b.style.display = 'block'; });
+  const simpleBody = $('cancelPageSimpleBody');
+  if (simpleBody) simpleBody.style.display = 'none';
+  // 경고 카피 — 단계별 문구, recruit/미상이면 일반 문구(warningOther)
+  const warnTextEl = $('cancelPageWarningText');
+  if (warnTextEl) {
+    const valid = ['purchase','visit','post'];
+    const key = valid.includes(phase)
+      ? `appHistory.cancel.warning${phase.charAt(0).toUpperCase()}${phase.slice(1)}`
+      : 'appHistory.cancel.warningOther';
+    warnTextEl.textContent = t(key);
+  }
+  // 사유 셀렉트 카탈로그 로드 + 입력 초기화
+  if (!_cancelReasonsCache) _cancelReasonsCache = await fetchCancelReasons();
+  const sel = $('cancelPageReasonSelect');
+  if (sel) {
+    const lang = (typeof getLang === 'function') ? getLang() : 'ja';
+    const pickLabel = (r) => (lang === 'ko' ? (r.name_ko || r.name_ja) : (r.name_ja || r.name_ko));
+    const placeholder = `<option value="">${esc(t('appHistory.cancel.reasonSelect'))}</option>`;
+    const opts = _cancelReasonsCache.map(r => `<option value="${esc(r.code)}">${esc(pickLabel(r))}</option>`).join('');
+    sel.innerHTML = placeholder + opts;
+    sel.value = '';
+    // 카테고리 선택 시 textarea placeholder 를 카테고리별 가이드로 갱신
+    sel.onchange = () => _syncCancelNotePlaceholder(sel.value);
+  }
+  const note = $('cancelPageNote');
+  if (note) {
+    note.value = '';
+    note.placeholder = t('appHistory.cancel.notePlaceholderDefault');
+  }
+  const ack = $('cancelPageAck');
+  if (ack) ack.checked = false;
 }
 
 // 카테고리 코드별 textarea placeholder 동기화
@@ -701,12 +716,22 @@ async function submitCancelApplicationFromPage() {
   });
   if (submitBtn) submitBtn.disabled = false;
   if (!res.ok) {
+    // 데드락 자동 복구: 화면은 간단(recruit) 모드인데 서버가 사유·동의를 요구하면
+    // 클라이언트/서버 단계 판정이 엇갈린 것. 사유 입력란을 펼쳐 재입력받는다.
+    if (isSimple && (res.error === 'reason_required' || res.error === 'acknowledgement_required')) {
+      const phaseEl = $('cancelPagePhase');
+      if (phaseEl) phaseEl.value = 'other'; // 비-recruit 로 보정 → 재제출 시 사유 검증 경로 진입
+      await _revealCancelReasonFields('other');
+      showErr(t('appHistory.cancel.reasonNowRequired'));
+      return;
+    }
     const errKey = {
       'not_owner':                    'appHistory.cancel.errorOwner',
       'invalid_status':               'appHistory.cancel.errorStatus',
       'deliverable_already_approved': 'appHistory.cancel.errorDeliverable',
       'reason_required':              'appHistory.cancel.errorReason',
-      'acknowledgement_required':     'appHistory.cancel.errorAck'
+      'acknowledgement_required':     'appHistory.cancel.errorAck',
+      'application_not_found':        'appHistory.cancel.errorNotFound'
     }[res.error] || 'appHistory.cancel.errorGeneric';
     showErr(t(errKey));
     return;

--- a/dev/lib/i18n/ja.js
+++ b/dev/lib/i18n/ja.js
@@ -248,6 +248,8 @@ window.I18N_JA = {
       errorNoteRequired: '補足説明を入力してください',
       errorAck: '同意のチェックが必要です',
       errorGeneric: '取消に失敗しました。再度お試しください',
+      errorNotFound: '対象の応募が見つかりませんでした。画面を更新してもう一度お試しください',
+      reasonNowRequired: '現在は取消理由の入力が必要です。下記を選択・記入のうえ、もう一度お試しください',
     },
     cancelDetail: {
       title: '取消の詳細',

--- a/dev/lib/i18n/ko.js
+++ b/dev/lib/i18n/ko.js
@@ -241,6 +241,8 @@ window.I18N_KO = {
       errorNoteRequired: '추가 설명을 입력해주세요',
       errorAck: '동의 체크가 필요합니다',
       errorGeneric: '취소에 실패했습니다. 다시 시도해주세요',
+      errorNotFound: '대상 응모를 찾을 수 없습니다. 화면을 새로고침한 뒤 다시 시도해주세요',
+      reasonNowRequired: '현재는 취소 사유 입력이 필요합니다. 아래를 선택·작성한 뒤 다시 시도해주세요',
     },
     cancelDetail: {
       title: '취소 상세',

--- a/index.html
+++ b/index.html
@@ -2402,6 +2402,8 @@ window.I18N_JA = {
       errorNoteRequired: '補足説明を入力してください',
       errorAck: '同意のチェックが必要です',
       errorGeneric: '取消に失敗しました。再度お試しください',
+      errorNotFound: '対象の応募が見つかりませんでした。画面を更新してもう一度お試しください',
+      reasonNowRequired: '現在は取消理由の入力が必要です。下記を選択・記入のうえ、もう一度お試しください',
     },
     cancelDetail: {
       title: '取消の詳細',
@@ -2962,6 +2964,8 @@ window.I18N_KO = {
       errorNoteRequired: '추가 설명을 입력해주세요',
       errorAck: '동의 체크가 필요합니다',
       errorGeneric: '취소에 실패했습니다. 다시 시도해주세요',
+      errorNotFound: '대상 응모를 찾을 수 없습니다. 화면을 새로고침한 뒤 다시 시도해주세요',
+      reasonNowRequired: '현재는 취소 사유 입력이 필요합니다. 아래를 선택·작성한 뒤 다시 시도해주세요',
     },
     cancelDetail: {
       title: '취소 상세',
@@ -9090,45 +9094,12 @@ async function openCancelModalFor(appId) {
   const campNameEl = $('cancelPageCampaign');
   if (campNameEl) campNameEl.textContent = camp.title || app.campaign_id || '';
   const isSimple = phase === 'recruit';
-  const warnBox   = $('cancelPageWarning');
-  const reasonBox = $('cancelPageReason');
-  const noteBox   = $('cancelPageNoteWrap');
-  const ackBox    = $('cancelPageAckWrap');
-  const simpleBody = $('cancelPageSimpleBody');
-  if (warnBox)   warnBox.style.display   = isSimple ? 'none' : 'block';
-  if (reasonBox) reasonBox.style.display = isSimple ? 'none' : 'block';
-  if (noteBox)   noteBox.style.display   = isSimple ? 'none' : 'block';
-  if (ackBox)    ackBox.style.display    = isSimple ? 'none' : 'block';
-  if (simpleBody) simpleBody.style.display = isSimple ? 'block' : 'none';
-  // 경고 카피
-  const warnTextEl = $('cancelPageWarningText');
-  if (warnTextEl && !isSimple) {
-    const key = `appHistory.cancel.warning${phase.charAt(0).toUpperCase()}${phase.slice(1)}`;
-    warnTextEl.textContent = t(key);
-  }
-  // 사유 셀렉트: 카탈로그 캐시
-  if (!isSimple) {
-    if (!_cancelReasonsCache) _cancelReasonsCache = await fetchCancelReasons();
-    const sel = $('cancelPageReasonSelect');
-    if (sel) {
-      const lang = (typeof getLang === 'function') ? getLang() : 'ja';
-      const pickLabel = (r) => (lang === 'ko' ? (r.name_ko || r.name_ja) : (r.name_ja || r.name_ko));
-      const placeholder = `<option value="">${esc(t('appHistory.cancel.reasonSelect'))}</option>`;
-      const opts = _cancelReasonsCache.map(r => `<option value="${esc(r.code)}">${esc(pickLabel(r))}</option>`).join('');
-      sel.innerHTML = placeholder + opts;
-      sel.value = '';
-      // 카테고리 선택 시 textarea placeholder 를 카테고리별 가이드로 갱신.
-      // 사용자가 어떤 내용을 입력해야 하는지 안내.
-      sel.onchange = () => _syncCancelNotePlaceholder(sel.value);
-    }
-    const note = $('cancelPageNote');
-    if (note) {
-      note.value = '';
-      // 초기 placeholder: 기본 가이드 (카테고리 미선택 상태)
-      note.placeholder = t('appHistory.cancel.notePlaceholderDefault');
-    }
-    const ack = $('cancelPageAck');
-    if (ack) ack.checked = false;
+  // 단계별 화면 분기 — recruit 는 간단 취소, 그 외는 사유 입력 모드.
+  // 두 모드 전환 로직은 데드락 자동 복구에서도 재사용하도록 헬퍼로 분리.
+  if (isSimple) {
+    _showCancelSimpleMode();
+  } else {
+    await _revealCancelReasonFields(phase);
   }
   // phase + appId hidden
   const phaseEl = $('cancelPagePhase');
@@ -9148,6 +9119,54 @@ async function openCancelModalFor(appId) {
   // #appShell 이 position:fixed + overflow:hidden 이라 iOS Safari 의 자동
   // 스크롤이 .page.active 내부 컨테이너에서 작동하지 않으므로 직접 처리.
   _attachCancelPageFocusScroll();
+}
+
+// 간단 취소 모드 — 사유/동의/경고 박스 숨김, 간단 안내만 표시 (recruit 단계)
+function _showCancelSimpleMode() {
+  const boxes = ['cancelPageWarning','cancelPageReason','cancelPageNoteWrap','cancelPageAckWrap']
+    .map(id => $(id));
+  boxes.forEach(b => { if (b) b.style.display = 'none'; });
+  const simpleBody = $('cancelPageSimpleBody');
+  if (simpleBody) simpleBody.style.display = 'block';
+}
+
+// 사유 입력 모드로 전환 — 박스 표시 + 경고 카피 + 사유 카탈로그 로드 + 입력 초기화.
+// 진입 시(비-recruit)와 데드락 자동 복구(서버가 사유를 요구)에서 공통 호출.
+async function _revealCancelReasonFields(phase) {
+  const boxes = ['cancelPageWarning','cancelPageReason','cancelPageNoteWrap','cancelPageAckWrap']
+    .map(id => $(id));
+  boxes.forEach(b => { if (b) b.style.display = 'block'; });
+  const simpleBody = $('cancelPageSimpleBody');
+  if (simpleBody) simpleBody.style.display = 'none';
+  // 경고 카피 — 단계별 문구, recruit/미상이면 일반 문구(warningOther)
+  const warnTextEl = $('cancelPageWarningText');
+  if (warnTextEl) {
+    const valid = ['purchase','visit','post'];
+    const key = valid.includes(phase)
+      ? `appHistory.cancel.warning${phase.charAt(0).toUpperCase()}${phase.slice(1)}`
+      : 'appHistory.cancel.warningOther';
+    warnTextEl.textContent = t(key);
+  }
+  // 사유 셀렉트 카탈로그 로드 + 입력 초기화
+  if (!_cancelReasonsCache) _cancelReasonsCache = await fetchCancelReasons();
+  const sel = $('cancelPageReasonSelect');
+  if (sel) {
+    const lang = (typeof getLang === 'function') ? getLang() : 'ja';
+    const pickLabel = (r) => (lang === 'ko' ? (r.name_ko || r.name_ja) : (r.name_ja || r.name_ko));
+    const placeholder = `<option value="">${esc(t('appHistory.cancel.reasonSelect'))}</option>`;
+    const opts = _cancelReasonsCache.map(r => `<option value="${esc(r.code)}">${esc(pickLabel(r))}</option>`).join('');
+    sel.innerHTML = placeholder + opts;
+    sel.value = '';
+    // 카테고리 선택 시 textarea placeholder 를 카테고리별 가이드로 갱신
+    sel.onchange = () => _syncCancelNotePlaceholder(sel.value);
+  }
+  const note = $('cancelPageNote');
+  if (note) {
+    note.value = '';
+    note.placeholder = t('appHistory.cancel.notePlaceholderDefault');
+  }
+  const ack = $('cancelPageAck');
+  if (ack) ack.checked = false;
 }
 
 // 카테고리 코드별 textarea placeholder 동기화
@@ -9233,12 +9252,22 @@ async function submitCancelApplicationFromPage() {
   });
   if (submitBtn) submitBtn.disabled = false;
   if (!res.ok) {
+    // 데드락 자동 복구: 화면은 간단(recruit) 모드인데 서버가 사유·동의를 요구하면
+    // 클라이언트/서버 단계 판정이 엇갈린 것. 사유 입력란을 펼쳐 재입력받는다.
+    if (isSimple && (res.error === 'reason_required' || res.error === 'acknowledgement_required')) {
+      const phaseEl = $('cancelPagePhase');
+      if (phaseEl) phaseEl.value = 'other'; // 비-recruit 로 보정 → 재제출 시 사유 검증 경로 진입
+      await _revealCancelReasonFields('other');
+      showErr(t('appHistory.cancel.reasonNowRequired'));
+      return;
+    }
     const errKey = {
       'not_owner':                    'appHistory.cancel.errorOwner',
       'invalid_status':               'appHistory.cancel.errorStatus',
       'deliverable_already_approved': 'appHistory.cancel.errorDeliverable',
       'reason_required':              'appHistory.cancel.errorReason',
-      'acknowledgement_required':     'appHistory.cancel.errorAck'
+      'acknowledgement_required':     'appHistory.cancel.errorAck',
+      'application_not_found':        'appHistory.cancel.errorNotFound'
     }[res.error] || 'appHistory.cancel.errorGeneric';
     showErr(t(errKey));
     return;


### PR DESCRIPTION
## 변경 요약
- 응모 취소 데드락 자동 복구(서버가 사유 요구 시 사유란 자동 펼침) + '신청 못 찾음' 에러 메시지 명확화 + warningRecruit 키 누락 버그 수정
- 개발서버 d26caaa 와 **소스 동일**, 빌드 산출물만 main 기준 재생성

## 요청 외 추가 변경
- 없음

## 메시지 기능 누출 방지
- dev 빌드 산출물에는 운영 보류 중인 응모건 메시지 기능이 포함되어 cherry-pick 불가
- main 기준 재빌드로 처리 (검증: index.html 내 messaging 참조 0건, cancel 수정 9건)

## 관련 사양서
- docs/specs/2026-05-11-application-cancel.md §15 (dev 한정 — 원인 재평가 포함)

🤖 Generated with [Claude Code](https://claude.com/claude-code)