### PR TITLE
fix(mypage): 햄버거 미입력 배지 모든 계정 표시 (#252 후속)

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -12,7 +12,7 @@
 // 회귀(2026-05-12 PR #182 머지 직후 발생)를 방지하기 위한 자동 reload 가드.
 // sessionStorage 차단 환경(시크릿 모드 일부, 쿠키 차단)에서는 자연스럽게 skip.
 (function(){
-  var CURRENT_BUILD = 'v1779377257';
+  var CURRENT_BUILD = 'v1779377989';
   if (CURRENT_BUILD.indexOf('__') === 0) return; // 빌드 미적용 (dev/ 직접 열기) 시 skip
   try {
     var prev = sessionStorage.getItem('reverb.adminBuild');
@@ -1706,7 +1706,7 @@ textarea.form-input{resize:vertical;min-height:80px}
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-05-22 00:27 · f2ea1af</span>
+          <span class="admin-build-text">2026-05-22 00:39 · d680e97</span>
         </div>
       </div>
     </aside>

--- a/dev/js/notifications.js
+++ b/dev/js/notifications.js
@@ -52,9 +52,9 @@ function renderNavMenu() {
       <span class="nav-label">${esc(t('tab.mypage'))}</span>
       <span class="material-icons-round notranslate nav-accordion-arrow" translate="no" id="navMypageArrow">${_navMypageOpen ? 'expand_less' : 'expand_more'}</span>
     </button>`;
-    // 未登録 배지 계산 (mypage.js computeProfileBadges 공용).
-    // 관리자 계정은 인플루언서 프로필이 비어 전 항목 미등록으로 떠 노이즈가 되므로 배지 생략.
-    const b = (!isAdmin && typeof computeProfileBadges === 'function')
+    // 未登録 배지 계산 (mypage.js computeProfileBadges 공용). 마이페이지 랜딩 화면과 동일하게
+    // 모든 계정에서 미입력 항목에 배지 표시 (관리자도 인플루언서로 활동 시 입력 필요).
+    const b = (typeof computeProfileBadges === 'function')
       ? computeProfileBadges(typeof currentUserProfile !== 'undefined' ? currentUserProfile : {})
       : {hasName:true, hasSns:true, hasAddress:true, hasPaypal:true};
     const subs = [

--- a/index.html
+++ b/index.html
@@ -9169,9 +9169,9 @@ function renderNavMenu() {
       <span class="nav-label">${esc(t('tab.mypage'))}</span>
       <span class="material-icons-round notranslate nav-accordion-arrow" translate="no" id="navMypageArrow">${_navMypageOpen ? 'expand_less' : 'expand_more'}</span>
     </button>`;
-    // 未登録 배지 계산 (mypage.js computeProfileBadges 공용).
-    // 관리자 계정은 인플루언서 프로필이 비어 전 항목 미등록으로 떠 노이즈가 되므로 배지 생략.
-    const b = (!isAdmin && typeof computeProfileBadges === 'function')
+    // 未登録 배지 계산 (mypage.js computeProfileBadges 공용). 마이페이지 랜딩 화면과 동일하게
+    // 모든 계정에서 미입력 항목에 배지 표시 (관리자도 인플루언서로 활동 시 입력 필요).
+    const b = (typeof computeProfileBadges === 'function')
       ? computeProfileBadges(typeof currentUserProfile !== 'undefined' ? currentUserProfile : {})
       : {hasName:true, hasSns:true, hasAddress:true, hasPaypal:true};
     const subs = [


### PR DESCRIPTION
## 변경 요약
- 햄버거 메뉴 미입력(未登録) 배지의 `!isAdmin` 가드 제거 — 마이페이지 랜딩 화면처럼 모든 계정(관리자 포함)에서 미입력 항목에 배지 표시
- 관리자 계정으로 인플루언서 화면을 볼 때도 기본정보/SNS/배송지/PayPal 미입력 시 배지가 뜨도록 복원

## 요청 외 추가 변경
- 없음

## 관련 사양서
- 없음 (문서는 이미 "미입력 배지 표시"로 기술됨 — 가드가 오히려 불일치였음)

## 검증
- reverb-reviewer 통과(GO)
- 로컬 시뮬레이션: 관리자 4개 배지, 일반 인플 미입력 3개 배지 정상 표시
- DB/RLS 변경 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)