### PR TITLE
style(mypage): 응모이력 카드 상태·결과물 배지 하단 가로 정렬

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -12,7 +12,7 @@
 // 회귀(2026-05-12 PR #182 머지 직후 발생)를 방지하기 위한 자동 reload 가드.
 // sessionStorage 차단 환경(시크릿 모드 일부, 쿠키 차단)에서는 자연스럽게 skip.
 (function(){
-  var CURRENT_BUILD = 'v1779377989';
+  var CURRENT_BUILD = 'v1779379959';
   if (CURRENT_BUILD.indexOf('__') === 0) return; // 빌드 미적용 (dev/ 직접 열기) 시 skip
   try {
     var prev = sessionStorage.getItem('reverb.adminBuild');
@@ -1706,7 +1706,7 @@ textarea.form-input{resize:vertical;min-height:80px}
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-05-22 00:39 · d680e97</span>
+          <span class="admin-build-text">2026-05-22 01:12 · 7b2a616</span>
         </div>
       </div>
     </aside>

--- a/admin/index.html
+++ b/admin/index.html
@@ -12,7 +12,7 @@
 // 회귀(2026-05-12 PR #182 머지 직후 발생)를 방지하기 위한 자동 reload 가드.
 // sessionStorage 차단 환경(시크릿 모드 일부, 쿠키 차단)에서는 자연스럽게 skip.
 (function(){
-  var CURRENT_BUILD = 'v1779379959';
+  var CURRENT_BUILD = 'v1779380326';
   if (CURRENT_BUILD.indexOf('__') === 0) return; // 빌드 미적용 (dev/ 직접 열기) 시 skip
   try {
     var prev = sessionStorage.getItem('reverb.adminBuild');
@@ -1706,7 +1706,7 @@ textarea.form-input{resize:vertical;min-height:80px}
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-05-22 01:12 · 7b2a616</span>
+          <span class="admin-build-text">2026-05-22 01:18 · d2f4799</span>
         </div>
       </div>
     </aside>

--- a/dev/js/mypage.js
+++ b/dev/js/mypage.js
@@ -214,7 +214,7 @@ async function renderMyApplyList() {
     // Stage 6: 결과물 상태 배지 — 당첨(approved) 신청 행 카드 하단에 「{종류} {상태}」 라벨로 노출.
     // 단순 「승인」만으론 영수증 승인/결과물 승인 구분이 안 되므로 종류 prefix를 붙임.
     // monitor 캠페인은 영수증·리뷰 캡쳐 두 단계가 별도 진행 → 라벨도 두 줄로 표시.
-    let delivBadgeLine = '';
+    let delivItemsHtml = '';
     if (a.status === 'approved') {
       const ds = (_myDelivsByApp[a.id] || []);
       // kind별로 가장 최신 1건만 추출 (재제출 시 더 최근 행 우선)
@@ -236,11 +236,10 @@ async function renderMyApplyList() {
         else if (d.status === 'rejected') { bg = '#FFE4E4'; color = '#C33'; }
         items.push(`<span style="display:inline-block;background:${bg};color:${color};font-size:11px;font-weight:700;padding:2px 8px;border-radius:3px">${esc(kindLabel)} ${esc(statusLabel)}</span>`);
       }
-      if (items.length) {
-        // 결과물 종류별 상태 라벨 — 카드 본문 맨 아래 가로 한 줄(왼쪽 정렬, 넘치면 줄바꿈)
-        delivBadgeLine = `<div class="apply-item-deliv" style="display:flex;flex-wrap:wrap;gap:6px;margin-top:6px">${items.join('')}</div>`;
-      }
+      delivItemsHtml = items.join('');
     }
+    // 응모 상태 배지(당첨/심사중 등) + 결과물 상태 배지를 카드 본문 맨 아래 가로 한 줄로 모음
+    const badgeRow = `<div class="apply-item-badges" style="display:flex;flex-wrap:wrap;gap:6px;align-items:center;margin-top:6px">${getStatusBadge(a.status)}${delivItemsHtml}</div>`;
     const cautionLine = a.caution_agreed_at
       ? `<div class="apply-item-caution" style="font-size:11px;color:var(--green);margin-top:2px;display:inline-flex;align-items:center;gap:3px;flex-wrap:wrap"><span class="material-icons-round notranslate" translate="no" style="font-size:13px">check_circle</span>${t('appHistory.cautionAgreed')} ${formatDate(a.caution_agreed_at)}${cautionCompareButton(a, camp)}</div>`
       : '';
@@ -251,11 +250,11 @@ async function renderMyApplyList() {
       <div class="apply-thumb">${thumb}</div>
       <div class="apply-item-info">
         ${camp.recruit_type ? `<div style="font-size:10px;font-weight:700;color:var(--pink);margin-bottom:2px">${esc(getRecruitTypeLabelJa(camp.recruit_type))}</div>` : ''}
-        <div class="apply-item-name" style="display:flex;align-items:center;gap:6px;flex-wrap:wrap"><span class="apply-item-name-status">${getStatusBadge(a.status)}</span><span style="overflow:hidden;text-overflow:ellipsis;white-space:nowrap;min-width:0;flex:1">${esc(camp.title||a.campaign_id)}</span></div>
+        <div class="apply-item-name" style="display:flex;align-items:center;gap:6px"><span style="overflow:hidden;text-overflow:ellipsis;white-space:nowrap;min-width:0;flex:1">${esc(camp.title||a.campaign_id)}</span></div>
         <div class="apply-item-meta">${esc(camp.brand||'')} · ${t('appHistory.applyDate')} ${formatDate(a.created_at)}</div>
         ${cautionLine}
         ${cancelledLine}
-        ${delivBadgeLine}
+        ${badgeRow}
       </div>
       <div class="apply-item-status" style="display:flex;flex-direction:column;align-items:flex-end;gap:4px"><div class="apply-item-actions" style="display:flex;align-items:center;gap:2px">${msgBtn}${menuHtml}</div></div>
     </div>`;

--- a/dev/js/mypage.js
+++ b/dev/js/mypage.js
@@ -237,8 +237,8 @@ async function renderMyApplyList() {
         items.push(`<span style="display:inline-block;background:${bg};color:${color};font-size:11px;font-weight:700;padding:2px 8px;border-radius:3px">${esc(kindLabel)} ${esc(statusLabel)}</span>`);
       }
       if (items.length) {
-        // 영수증 제출 / 리뷰 캡쳐 등 종류별 라벨이 둘 이상이면 세로로 쌓이도록 column 배치
-        delivBadgeLine = `<div class="apply-item-deliv" style="display:flex;flex-direction:column;gap:4px;align-items:flex-end">${items.join('')}</div>`;
+        // 결과물 종류별 상태 라벨 — 카드 본문 맨 아래 가로 한 줄(왼쪽 정렬, 넘치면 줄바꿈)
+        delivBadgeLine = `<div class="apply-item-deliv" style="display:flex;flex-wrap:wrap;gap:6px;margin-top:6px">${items.join('')}</div>`;
       }
     }
     const cautionLine = a.caution_agreed_at
@@ -255,8 +255,9 @@ async function renderMyApplyList() {
         <div class="apply-item-meta">${esc(camp.brand||'')} · ${t('appHistory.applyDate')} ${formatDate(a.created_at)}</div>
         ${cautionLine}
         ${cancelledLine}
+        ${delivBadgeLine}
       </div>
-      <div class="apply-item-status" style="display:flex;flex-direction:column;align-items:flex-end;gap:4px">${delivBadgeLine}<div class="apply-item-actions" style="display:flex;align-items:center;gap:2px">${msgBtn}${menuHtml}</div></div>
+      <div class="apply-item-status" style="display:flex;flex-direction:column;align-items:flex-end;gap:4px"><div class="apply-item-actions" style="display:flex;align-items:center;gap:2px">${msgBtn}${menuHtml}</div></div>
     </div>`;
   }).join('');
 }

--- a/index.html
+++ b/index.html
@@ -9701,8 +9701,8 @@ async function renderMyApplyList() {
         items.push(`<span style="display:inline-block;background:${bg};color:${color};font-size:11px;font-weight:700;padding:2px 8px;border-radius:3px">${esc(kindLabel)} ${esc(statusLabel)}</span>`);
       }
       if (items.length) {
-        // 영수증 제출 / 리뷰 캡쳐 등 종류별 라벨이 둘 이상이면 세로로 쌓이도록 column 배치
-        delivBadgeLine = `<div class="apply-item-deliv" style="display:flex;flex-direction:column;gap:4px;align-items:flex-end">${items.join('')}</div>`;
+        // 결과물 종류별 상태 라벨 — 카드 본문 맨 아래 가로 한 줄(왼쪽 정렬, 넘치면 줄바꿈)
+        delivBadgeLine = `<div class="apply-item-deliv" style="display:flex;flex-wrap:wrap;gap:6px;margin-top:6px">${items.join('')}</div>`;
       }
     }
     const cautionLine = a.caution_agreed_at
@@ -9719,8 +9719,9 @@ async function renderMyApplyList() {
         <div class="apply-item-meta">${esc(camp.brand||'')} · ${t('appHistory.applyDate')} ${formatDate(a.created_at)}</div>
         ${cautionLine}
         ${cancelledLine}
+        ${delivBadgeLine}
       </div>
-      <div class="apply-item-status" style="display:flex;flex-direction:column;align-items:flex-end;gap:4px">${delivBadgeLine}<div class="apply-item-actions" style="display:flex;align-items:center;gap:2px">${msgBtn}${menuHtml}</div></div>
+      <div class="apply-item-status" style="display:flex;flex-direction:column;align-items:flex-end;gap:4px"><div class="apply-item-actions" style="display:flex;align-items:center;gap:2px">${msgBtn}${menuHtml}</div></div>
     </div>`;
   }).join('');
 }

--- a/index.html
+++ b/index.html
@@ -9678,7 +9678,7 @@ async function renderMyApplyList() {
     // Stage 6: 결과물 상태 배지 — 당첨(approved) 신청 행 카드 하단에 「{종류} {상태}」 라벨로 노출.
     // 단순 「승인」만으론 영수증 승인/결과물 승인 구분이 안 되므로 종류 prefix를 붙임.
     // monitor 캠페인은 영수증·리뷰 캡쳐 두 단계가 별도 진행 → 라벨도 두 줄로 표시.
-    let delivBadgeLine = '';
+    let delivItemsHtml = '';
     if (a.status === 'approved') {
       const ds = (_myDelivsByApp[a.id] || []);
       // kind별로 가장 최신 1건만 추출 (재제출 시 더 최근 행 우선)
@@ -9700,11 +9700,10 @@ async function renderMyApplyList() {
         else if (d.status === 'rejected') { bg = '#FFE4E4'; color = '#C33'; }
         items.push(`<span style="display:inline-block;background:${bg};color:${color};font-size:11px;font-weight:700;padding:2px 8px;border-radius:3px">${esc(kindLabel)} ${esc(statusLabel)}</span>`);
       }
-      if (items.length) {
-        // 결과물 종류별 상태 라벨 — 카드 본문 맨 아래 가로 한 줄(왼쪽 정렬, 넘치면 줄바꿈)
-        delivBadgeLine = `<div class="apply-item-deliv" style="display:flex;flex-wrap:wrap;gap:6px;margin-top:6px">${items.join('')}</div>`;
-      }
+      delivItemsHtml = items.join('');
     }
+    // 응모 상태 배지(당첨/심사중 등) + 결과물 상태 배지를 카드 본문 맨 아래 가로 한 줄로 모음
+    const badgeRow = `<div class="apply-item-badges" style="display:flex;flex-wrap:wrap;gap:6px;align-items:center;margin-top:6px">${getStatusBadge(a.status)}${delivItemsHtml}</div>`;
     const cautionLine = a.caution_agreed_at
       ? `<div class="apply-item-caution" style="font-size:11px;color:var(--green);margin-top:2px;display:inline-flex;align-items:center;gap:3px;flex-wrap:wrap"><span class="material-icons-round notranslate" translate="no" style="font-size:13px">check_circle</span>${t('appHistory.cautionAgreed')} ${formatDate(a.caution_agreed_at)}${cautionCompareButton(a, camp)}</div>`
       : '';
@@ -9715,11 +9714,11 @@ async function renderMyApplyList() {
       <div class="apply-thumb">${thumb}</div>
       <div class="apply-item-info">
         ${camp.recruit_type ? `<div style="font-size:10px;font-weight:700;color:var(--pink);margin-bottom:2px">${esc(getRecruitTypeLabelJa(camp.recruit_type))}</div>` : ''}
-        <div class="apply-item-name" style="display:flex;align-items:center;gap:6px;flex-wrap:wrap"><span class="apply-item-name-status">${getStatusBadge(a.status)}</span><span style="overflow:hidden;text-overflow:ellipsis;white-space:nowrap;min-width:0;flex:1">${esc(camp.title||a.campaign_id)}</span></div>
+        <div class="apply-item-name" style="display:flex;align-items:center;gap:6px"><span style="overflow:hidden;text-overflow:ellipsis;white-space:nowrap;min-width:0;flex:1">${esc(camp.title||a.campaign_id)}</span></div>
         <div class="apply-item-meta">${esc(camp.brand||'')} · ${t('appHistory.applyDate')} ${formatDate(a.created_at)}</div>
         ${cautionLine}
         ${cancelledLine}
-        ${delivBadgeLine}
+        ${badgeRow}
       </div>
       <div class="apply-item-status" style="display:flex;flex-direction:column;align-items:flex-end;gap:4px"><div class="apply-item-actions" style="display:flex;align-items:center;gap:2px">${msgBtn}${menuHtml}</div></div>
     </div>`;


### PR DESCRIPTION
## 변경 요약
인플루언서 응모이력 카드의 배지 배치 개선 (사용자 요청).
- 결과물 상태 배지(영수증 제출·리뷰 캡쳐·게시물 URL)를 카드 우측 세로 → 카드 본문 맨 아래 가로 한 줄로 이동
- 응모 상태 배지(당첨·심사중·낙첨·취소)도 제목 옆 → 카드 하단으로 이동
- 두 배지를 하단 한 줄(`badgeRow`)로 통합, 제목은 상태 배지 없이 전체폭 사용

## 요청 외 추가 변경
- 없음

## 관련 사양서
- 없음 (단순 배치 조정)

## 검증
- reverb-reviewer 통과(GO) — getStatusBadge 중복 호출·delivBadgeLine 잔존·esc 점검
- 로컬 Playwright 시뮬레이션: 당첨+영수증 비승인+리뷰 캡쳐 검수중이 카드 하단 가로 한 줄 표시 확인
- DB/RLS 변경 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)