### PR TITLE
feat(admin): 운영 현황 카드 사유 배너 (마이그레이션 148)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,7 +152,7 @@
 - **가격체크**: `products[i].price_check` (`'higher'|'lower'|'equal'`, optional) — 마켓 등록 가격 vs 신청 금액 비교. 신청 목록 표 「가격체크」 드롭다운 컬럼 토글. 미선택이면 키 자체 없음
 - **URL 입력 자동 prefix**: `normalizeBrandUrlInput(raw)` — 스킴 없는 입력(`example.com`) 에 `https://` 자동 prefix, 위험 스킴(javascript:, data:) 차단. 견적서/오리엔시트 셀 적용
 - **엑셀 내보내기**: 페인 헤더에 엑셀 다운로드 버튼 — 신청일·신청번호·폼타입·업체/브랜드명·담당자·이메일·연락처·세금계산서 주소·예상견적·상태
-- **운영 현황 페인**: 회사(`companies`) 기반 브랜드 카드 그리드. `get_brand_ops_overview(p_company_id)` 19컬럼 + alert_level 4단계(`danger`/`warning`/`caution`/`normal`). 브랜드 상세 진입 시 `get_brand_ops_detail(p_brand_id)` jsonb 통합 반환(brand/company/applications/external_campaigns). 사양서 `docs/specs/2026-05-13-brand-ops-redesign.md`
+- **운영 현황 페인**: 회사(`companies`) 기반 브랜드 카드 그리드. `get_brand_ops_overview(p_company_id)` 22컬럼 + alert_level 4단계(`danger`/`warning`/`caution`/`normal`). 카드에 **사유 배너**(긴급/대응 필요/주의 카드 한정, 정상 카드는 미표시) — 서버가 `alert_reasons text[]`(조건 코드 배열: `recruit_low_deadline_near`/`cancel_7d_high`/`d1_imminent`/`d3_imminent`/`recruit_low`) + `soonest_deadline`/`d1_count` 를 주면 화면(`brandOpsAlertReasonLines`)이 한국어 문구로 조립(예: 「모집률 28% · 마감 5일 남음」, 「마감 하루 전 2건」, 「최근 7일 취소 5건」). 임계값은 마이그레이션 120 기준 그대로(148 은 출력 컬럼만 추가). 브랜드 상세 진입 시 `get_brand_ops_detail(p_brand_id)` jsonb 통합 반환(brand/company/applications/external_campaigns). 사양서 `docs/specs/2026-05-13-brand-ops-redesign.md`
 - **캠페인 ↔ 신청 연결/해제**: `link_campaign_to_application` / `unlink_campaign_from_application` RPC. 같은 brand_id 검증 후 채번 재발급 + `legacy_no` 콤마 누적 + `numbering_legacy_map` UPSERT. 동시성 `pg_advisory_xact_lock` 2단 잠금. 멱등성 `unchanged:true` 반환. 가드 `is_campaign_admin()` 이상
 
 ### 인플루언서 관리
@@ -204,7 +204,7 @@
 - `brand_app_daily_counter` — 일자별(JST) 채번 카운터. SECURITY DEFINER 트리거 전용
 - `companies` — 회사 마스터 (1개 회사 = N 개 brands, 4단 계층: 회사 > 브랜드 > 신청 > 캠페인). `name_ko`(NOT NULL)/`name_ja`/`name_en` + `name_normalized` UNIQUE NOT NULL(자동 정규화 트리거) + `business_no` + `address` + `homepage_url` + `contact_*` 3종 + `billing_email`/`billing_address`/`memo` + `status CHECK(active|archived)` + `total_brands` 자동 재계산. RLS SELECT `is_admin()`, CUD `is_campaign_admin()` 이상
 - `brands` — 브랜드 마스터. `name`, `name_normalized`(자동 정규화), `brand_seq` UNIQUE, `company_id` FK ON DELETE SET NULL
-- `get_brand_ops_overview(p_company_id uuid)` — 운영 현황 19컬럼 집계 RPC (`SECURITY DEFINER + SET search_path='' + is_admin()`)
+- `get_brand_ops_overview(p_company_id uuid)` — 운영 현황 22컬럼 집계 RPC (`SECURITY DEFINER + SET search_path='' + is_admin()`). 마이그레이션 148 로 `alert_reasons text[]`(alert 발생 조건 코드 배열) + `soonest_deadline date` + `d1_count bigint` 출력 추가(카드 사유 배너용). 임계값은 120 기준 유지, `flag_agg` CTE 로 임계값 1회 계산 후 alert_level/alert_reasons 가 동일 플래그 재참조
 - `get_brand_ops_detail(p_brand_id uuid)` — 브랜드 상세 jsonb 통합 RPC
 - `link_campaign_to_application` / `unlink_campaign_from_application` — 캠페인↔신청 연결/해제 RPC (`is_campaign_admin()` 이상, advisory_xact_lock 2단)
 

--- a/admin/index.html
+++ b/admin/index.html
@@ -12,7 +12,7 @@
 // 회귀(2026-05-12 PR #182 머지 직후 발생)를 방지하기 위한 자동 reload 가드.
 // sessionStorage 차단 환경(시크릿 모드 일부, 쿠키 차단)에서는 자연스럽게 skip.
 (function(){
-  var CURRENT_BUILD = 'v1779402897';
+  var CURRENT_BUILD = 'v1779406781';
   if (CURRENT_BUILD.indexOf('__') === 0) return; // 빌드 미적용 (dev/ 직접 열기) 시 skip
   try {
     var prev = sessionStorage.getItem('reverb.adminBuild');
@@ -1729,7 +1729,7 @@ textarea.form-input{resize:vertical;min-height:80px}
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-05-22 07:34 · 02c7018</span>
+          <span class="admin-build-text">2026-05-22 08:39 · 2dcf5b7</span>
         </div>
       </div>
     </aside>
@@ -12352,7 +12352,7 @@ async function saveBrandAssign() {
 // ════════════════════════════════════════════════════════════════════
 // SECTION: BRAND OPS — 운영 현황 페인 (브랜드 운영 재설계 PR 3)
 //   브랜드별 진행 상황을 카드 그리드로. alert_level 4단계로 경고 강조.
-//   데이터: get_brand_ops_overview RPC (마이그레이션 120, 19컬럼).
+//   데이터: get_brand_ops_overview RPC (마이그레이션 148, 22컬럼 — alert_reasons 사유 배너).
 //   임계값 계산은 전부 서버(RPC)에서 끝나 클라이언트는 색·라벨만 매핑.
 //   PR 4 의 브랜드 상세 페인(adminPane-brand-ops-detail)으로 진입.
 // ════════════════════════════════════════════════════════════════════
@@ -12375,6 +12375,43 @@ var BRAND_OPS_ALERT = {
 };
 // 정렬 시 경고 우선순위
 var BRAND_OPS_ALERT_RANK = { danger: 0, warning: 1, caution: 2, normal: 3 };
+// 사유 배너 표시 순서 (모집 → 마감 → 취소)
+var BRAND_OPS_REASON_ORDER = ['recruit_low_deadline_near', 'recruit_low', 'd1_imminent', 'd3_imminent', 'cancel_7d_high'];
+
+// 날짜(YYYY-MM-DD)까지 남은 일수 (오늘=0, 과거=음수)
+function brandOpsDaysUntil(dateStr) {
+  if (!dateStr) return null;
+  var d = new Date(dateStr + 'T00:00:00');
+  if (isNaN(d)) return null;
+  var today = new Date(); today.setHours(0, 0, 0, 0);
+  return Math.round((d - today) / 86400000);
+}
+
+// alert_reasons 코드 배열 → 한국어 배너 문구 배열 (서버가 준 수치로 조립)
+function brandOpsAlertReasonLines(b) {
+  var reasons = (b.alert_reasons || []).slice().sort(function(a, c) {
+    return BRAND_OPS_REASON_ORDER.indexOf(a) - BRAND_OPS_REASON_ORDER.indexOf(c);
+  });
+  var rate = (b.recruit_rate != null) ? Number(b.recruit_rate).toFixed(0) : '—';
+  var lines = [];
+  reasons.forEach(function(code) {
+    if (code === 'recruit_low_deadline_near') {
+      var dleft = brandOpsDaysUntil(b.soonest_deadline);
+      var dtxt = (dleft !== null) ? (' · 마감 ' + (dleft <= 0 ? '오늘' : dleft + '일 남음')) : '';
+      lines.push('모집률 ' + rate + '%' + dtxt);
+    } else if (code === 'recruit_low') {
+      lines.push('모집률 ' + rate + '% (마감 여유)');
+    } else if (code === 'd1_imminent') {
+      lines.push('마감 하루 전 ' + (b.d1_count || 0) + '건');
+    } else if (code === 'd3_imminent') {
+      var n = (b.d3_count || 0) - (b.d1_count || 0);   // D-1 제외한 D-3 구간 건수
+      if (n > 0) lines.push('마감 3일 이내 ' + n + '건');
+    } else if (code === 'cancel_7d_high') {
+      lines.push('최근 7일 취소 ' + (b.cancel_7d || 0) + '건');
+    }
+  });
+  return lines;
+}
 
 async function loadBrandOps() {
   var grid = $('brandOpsGrid');
@@ -12466,12 +12503,13 @@ function renderBrandOpsCard(b) {
     ? '<span style="background:' + alert.bg + ';color:' + alert.color + ';font-size:10px;font-weight:700;padding:2px 8px;border-radius:10px' + (alert.pulse ? ';animation:brandOpsPulse 1.2s ease-in-out infinite' : '') + '">' + esc(alert.label) + '</span>'
     : '';
 
-  // 경고 라인 (D-3 임박 / 7일 취소)
-  var warns = [];
-  if ((b.d3_count||0) > 0) warns.push('마감 임박 ' + b.d3_count + '건');
-  if ((b.cancel_7d||0) > 0) warns.push('7일 취소 ' + b.cancel_7d + '건');
-  var warnLine = warns.length
-    ? '<div style="margin-top:6px;font-size:11px;color:' + alert.color + ';display:flex;align-items:center;gap:4px"><span class="material-icons-round notranslate" translate="no" style="font-size:14px">warning</span>' + esc(warns.join(' · ')) + '</div>'
+  // 사유 배너: alert_reasons(서버 코드 배열) → 한국어 문구. 정상 카드는 빈 배열 → 미표시
+  var reasonLines = brandOpsAlertReasonLines(b);
+  var banner = reasonLines.length
+    ? '<div style="margin-top:8px;background:' + alert.bg + ';border:1px solid ' + alert.color + '33;border-radius:6px;padding:6px 8px;display:flex;gap:6px;align-items:flex-start">'
+      + '<span class="material-icons-round notranslate" translate="no" style="font-size:14px;color:' + alert.color + ';flex-shrink:0;margin-top:1px">warning</span>'
+      + '<div style="font-size:11px;color:' + alert.color + ';line-height:1.55;font-weight:600">' + reasonLines.map(esc).join('<br>') + '</div>'
+      + '</div>'
     : '';
 
   return '<div class="brand-ops-card" style="border-left:4px solid ' + alert.color + '" onclick="openBrandOpsDetail(\'' + esc(b.brand_id) + '\')">'
@@ -12489,7 +12527,7 @@ function renderBrandOpsCard(b) {
     + '</div>'
     + brandOpsRateBar('모집률', b.recruit_rate, b.approved_total, b.slots_total)
     + brandOpsRateBar('결과물 승인률', b.deliverable_rate, b.deliverable_approved, b.deliverable_total)
-    + warnLine
+    + banner
     + '<div style="display:flex;justify-content:space-between;align-items:center;margin-top:10px;padding-top:8px;border-top:1px solid var(--line)">'
       + '<span style="font-size:10px;color:var(--muted)">최근 활동 ' + (b.last_activity_at ? fmtDate(b.last_activity_at) : '—') + '</span>'
       + '<span style="font-size:11px;color:var(--pink);font-weight:600">상세 보기 →</span>'

--- a/dev/js/admin-brand-ops.js
+++ b/dev/js/admin-brand-ops.js
@@ -1,7 +1,7 @@
 // ════════════════════════════════════════════════════════════════════
 // SECTION: BRAND OPS — 운영 현황 페인 (브랜드 운영 재설계 PR 3)
 //   브랜드별 진행 상황을 카드 그리드로. alert_level 4단계로 경고 강조.
-//   데이터: get_brand_ops_overview RPC (마이그레이션 120, 19컬럼).
+//   데이터: get_brand_ops_overview RPC (마이그레이션 148, 22컬럼 — alert_reasons 사유 배너).
 //   임계값 계산은 전부 서버(RPC)에서 끝나 클라이언트는 색·라벨만 매핑.
 //   PR 4 의 브랜드 상세 페인(adminPane-brand-ops-detail)으로 진입.
 // ════════════════════════════════════════════════════════════════════
@@ -24,6 +24,43 @@ var BRAND_OPS_ALERT = {
 };
 // 정렬 시 경고 우선순위
 var BRAND_OPS_ALERT_RANK = { danger: 0, warning: 1, caution: 2, normal: 3 };
+// 사유 배너 표시 순서 (모집 → 마감 → 취소)
+var BRAND_OPS_REASON_ORDER = ['recruit_low_deadline_near', 'recruit_low', 'd1_imminent', 'd3_imminent', 'cancel_7d_high'];
+
+// 날짜(YYYY-MM-DD)까지 남은 일수 (오늘=0, 과거=음수)
+function brandOpsDaysUntil(dateStr) {
+  if (!dateStr) return null;
+  var d = new Date(dateStr + 'T00:00:00');
+  if (isNaN(d)) return null;
+  var today = new Date(); today.setHours(0, 0, 0, 0);
+  return Math.round((d - today) / 86400000);
+}
+
+// alert_reasons 코드 배열 → 한국어 배너 문구 배열 (서버가 준 수치로 조립)
+function brandOpsAlertReasonLines(b) {
+  var reasons = (b.alert_reasons || []).slice().sort(function(a, c) {
+    return BRAND_OPS_REASON_ORDER.indexOf(a) - BRAND_OPS_REASON_ORDER.indexOf(c);
+  });
+  var rate = (b.recruit_rate != null) ? Number(b.recruit_rate).toFixed(0) : '—';
+  var lines = [];
+  reasons.forEach(function(code) {
+    if (code === 'recruit_low_deadline_near') {
+      var dleft = brandOpsDaysUntil(b.soonest_deadline);
+      var dtxt = (dleft !== null) ? (' · 마감 ' + (dleft <= 0 ? '오늘' : dleft + '일 남음')) : '';
+      lines.push('모집률 ' + rate + '%' + dtxt);
+    } else if (code === 'recruit_low') {
+      lines.push('모집률 ' + rate + '% (마감 여유)');
+    } else if (code === 'd1_imminent') {
+      lines.push('마감 하루 전 ' + (b.d1_count || 0) + '건');
+    } else if (code === 'd3_imminent') {
+      var n = (b.d3_count || 0) - (b.d1_count || 0);   // D-1 제외한 D-3 구간 건수
+      if (n > 0) lines.push('마감 3일 이내 ' + n + '건');
+    } else if (code === 'cancel_7d_high') {
+      lines.push('최근 7일 취소 ' + (b.cancel_7d || 0) + '건');
+    }
+  });
+  return lines;
+}
 
 async function loadBrandOps() {
   var grid = $('brandOpsGrid');
@@ -115,12 +152,13 @@ function renderBrandOpsCard(b) {
     ? '<span style="background:' + alert.bg + ';color:' + alert.color + ';font-size:10px;font-weight:700;padding:2px 8px;border-radius:10px' + (alert.pulse ? ';animation:brandOpsPulse 1.2s ease-in-out infinite' : '') + '">' + esc(alert.label) + '</span>'
     : '';
 
-  // 경고 라인 (D-3 임박 / 7일 취소)
-  var warns = [];
-  if ((b.d3_count||0) > 0) warns.push('마감 임박 ' + b.d3_count + '건');
-  if ((b.cancel_7d||0) > 0) warns.push('7일 취소 ' + b.cancel_7d + '건');
-  var warnLine = warns.length
-    ? '<div style="margin-top:6px;font-size:11px;color:' + alert.color + ';display:flex;align-items:center;gap:4px"><span class="material-icons-round notranslate" translate="no" style="font-size:14px">warning</span>' + esc(warns.join(' · ')) + '</div>'
+  // 사유 배너: alert_reasons(서버 코드 배열) → 한국어 문구. 정상 카드는 빈 배열 → 미표시
+  var reasonLines = brandOpsAlertReasonLines(b);
+  var banner = reasonLines.length
+    ? '<div style="margin-top:8px;background:' + alert.bg + ';border:1px solid ' + alert.color + '33;border-radius:6px;padding:6px 8px;display:flex;gap:6px;align-items:flex-start">'
+      + '<span class="material-icons-round notranslate" translate="no" style="font-size:14px;color:' + alert.color + ';flex-shrink:0;margin-top:1px">warning</span>'
+      + '<div style="font-size:11px;color:' + alert.color + ';line-height:1.55;font-weight:600">' + reasonLines.map(esc).join('<br>') + '</div>'
+      + '</div>'
     : '';
 
   return '<div class="brand-ops-card" style="border-left:4px solid ' + alert.color + '" onclick="openBrandOpsDetail(\'' + esc(b.brand_id) + '\')">'
@@ -138,7 +176,7 @@ function renderBrandOpsCard(b) {
     + '</div>'
     + brandOpsRateBar('모집률', b.recruit_rate, b.approved_total, b.slots_total)
     + brandOpsRateBar('결과물 승인률', b.deliverable_rate, b.deliverable_approved, b.deliverable_total)
-    + warnLine
+    + banner
     + '<div style="display:flex;justify-content:space-between;align-items:center;margin-top:10px;padding-top:8px;border-top:1px solid var(--line)">'
       + '<span style="font-size:10px;color:var(--muted)">최근 활동 ' + (b.last_activity_at ? fmtDate(b.last_activity_at) : '—') + '</span>'
       + '<span style="font-size:11px;color:var(--pink);font-weight:600">상세 보기 →</span>'

--- a/docs/specs/2026-05-13-brand-ops-redesign.md
+++ b/docs/specs/2026-05-13-brand-ops-redesign.md
@@ -849,3 +849,34 @@ SELECT * FROM get_brand_ops_overview() LIMIT 5;
 ### 미구현 (후속 작업)
 - 캠페인 편집 화면 「신청」 드롭다운의 link/unlink RPC 통일 (캠페인 저장 핵심 로직 변경이라 별도 PR)
 - 캠페인 미니카드 결과물 제출률 진행바 (detail RPC 확장 또는 별도 집계 필요)
+
+---
+
+## 18. 구현 결과 — 운영 현황 카드 사유 배너 (PR 5)
+
+**구현일:** 2026-05-22
+**브랜치:** feature/brand-ops-alert
+**관련 마이그레이션:** 148 (`148_brand_ops_alert_reasons.sql`)
+
+### 배경
+PR 3(운영 현황 페인)에서 카드 우측에 alert_level 배지(긴급/대응 필요/주의)만 표시하고, 경고 라인은 D-3·7일취소 두 가지만 부분 노출했다. **왜** 그 카드가 긴급/주의가 됐는지(모집률 저조·D-1 임박 등)는 화면에서 알 수 없어, 운영자가 사유를 카드만 보고 파악하도록 색 배너로 노출.
+
+### 변경 사항
+- **마이그레이션 148** — `get_brand_ops_overview` 를 DROP + CREATE 재정의 (반환 TABLE 19 → 22컬럼). 추가 컬럼:
+  - `alert_reasons text[]` — alert 발생 조건 코드 배열 (한국어 완성문구 아님). 코드 5종: `recruit_low_deadline_near`(모집률<30 & 마감7일내), `cancel_7d_high`(7일취소≥5), `d1_imminent`(D-1), `d3_imminent`(D-3이면서 D-1 아님 = `d3>d1`), `recruit_low`(모집률<50 & 마감 여유)
+  - `soonest_deadline date` — 가장 임박한 active 캠페인 deadline
+  - `d1_count bigint` — D-1 임박 active 캠페인 수
+  - **임계값은 120 기준 그대로** (alert_level 결정 규칙 불변). `flag_agg` CTE 로 임계값을 1회만 계산해 alert_level·alert_reasons 가 같은 boolean 플래그를 재참조 → 둘이 어긋날 수 없음
+- **화면(`dev/js/admin-brand-ops.js`)** — 기존 `warnLine`(warns 배열) 제거. 신규:
+  - `brandOpsAlertReasonLines(b)` — alert_reasons 코드 배열을 서버 수치(`recruit_rate`/`soonest_deadline`/`d1_count`/`d3_count`/`cancel_7d`)로 한국어 문구 조립
+  - `brandOpsDaysUntil(dateStr)` — 마감일까지 남은 일수
+  - `BRAND_OPS_REASON_ORDER` — 배너 표시 순서(모집 → 마감 → 취소)
+  - `renderBrandOpsCard()` 에서 결과물 승인률 바 아래에 색 배너 렌더 (`alert.bg` 배경 + `alert.color` 글씨/아이콘). **정상 카드는 alert_reasons 빈 배열 → 배너 미표시**
+  - 「마감 3일 이내」 건수는 `d3_count - d1_count`(D-1 제외분)로 표시해 D-1 줄과 중복 카운트 방지
+
+### 초안 대비 변경
+- PR 3 의 "클라이언트는 색·라벨만 매핑" 방침 위에 **사유 문구 조립 로직만 추가** (임계값 판정은 여전히 서버). SQL 에 한국어를 넣지 않고 코드 배열만 반환 → 문구 수정·다국어가 화면에서 가능
+
+### 구현 중 기술 결정
+- 반환 TABLE 컬럼 추가는 `CREATE OR REPLACE` 불가 → `DROP FUNCTION` 후 `CREATE` (롤백은 120 정의 재실행)
+- `b.alert_reasons` 없을 때(구버전 RPC 응답) `(b.alert_reasons || [])` 로 graceful — 배너 미표시

--- a/supabase/migrations/148_brand_ops_alert_reasons.sql
+++ b/supabase/migrations/148_brand_ops_alert_reasons.sql
@@ -1,0 +1,293 @@
+-- ════════════════════════════════════════════════════════════════════
+-- migration 148: get_brand_ops_overview 반환 컬럼 3개 추가
+-- ────────────────────────────────────────────────────────────────────
+-- 목적:
+--   운영 현황 페인(#brand-ops) 카드에 alert_level 사유(배너)를 표시하기 위해
+--   get_brand_ops_overview 가 alert_reasons, soonest_deadline, d1_count 를
+--   추가로 반환하도록 재정의.
+--
+-- 반환 TABLE 구조 변경 (19 → 22컬럼):
+--   기존 19컬럼은 순서·이름 그대로 유지.
+--   추가 컬럼 3개 (마지막에 붙임):
+--     #20  alert_reasons    text[]      -- 해당 alert 를 발생시킨 조건 코드 배열
+--     #21  soonest_deadline date        -- 가장 임박한 active 캠페인 deadline
+--     #22  d1_count         bigint      -- D-1 임박 캠페인 수
+--
+-- alert_reasons 코드 정의 (화면이 이 코드로 한국어 문구를 조립):
+--   'recruit_low_deadline_near'  모집률 < 30% AND soonest_deadline < current_date + 7일
+--   'cancel_7d_high'             7일내 취소 >= 5건
+--   'd1_imminent'                D-1 임박 active 캠페인 1개 이상
+--   'd3_imminent'                D-3 임박 active 캠페인 1개 이상 (d1 미포함)
+--   'recruit_low'                모집률 < 50% AND soonest_deadline >= current_date + 7일(또는 NULL)
+--
+-- alert_level 결정 규칙 (120 기준 그대로 유지 — 임계값 변경 금지):
+--   danger : d1>=1 OR cancel7>=5 OR (모집률<30 AND soonest_deadline < current_date+7)
+--   warning: d3>=1
+--   caution: 모집률<50 AND (soonest_deadline IS NULL OR >= current_date+7)
+--   normal : 그 외
+--
+-- 설계 방침:
+--   동일 임계값을 두 번 계산하지 않기 위해 중간 CTE flag_agg 를 추가.
+--   flag_agg 가 각 조건을 boolean 으로 미리 계산 → alert_level 과
+--   alert_reasons 를 최종 SELECT 에서 동일 값 재참조.
+--
+-- 검증 쿼리 (트랜잭션 밖 수동 실행):
+-- /*
+--   -- 전체 브랜드 22컬럼 확인 (5건)
+--   SELECT brand_name_ko, alert_level, alert_reasons, soonest_deadline, d1_count
+--   FROM public.get_brand_ops_overview()
+--   LIMIT 5;
+--
+--   -- alert_reasons 가 비어있지 않은 브랜드 목록
+--   SELECT brand_name_ko, alert_level, alert_reasons
+--   FROM public.get_brand_ops_overview()
+--   WHERE alert_reasons <> '{}'
+--   ORDER BY alert_level;
+--
+--   -- alert_level 별 건수
+--   SELECT alert_level, COUNT(*)
+--   FROM public.get_brand_ops_overview()
+--   GROUP BY alert_level ORDER BY 1;
+-- */
+--
+-- ROLLBACK (120 정의로 복원):
+--   DROP FUNCTION IF EXISTS public.get_brand_ops_overview(uuid);
+--   그 후 supabase/migrations/120_brand_ops_rpc.sql 의
+--   get_brand_ops_overview 블록(BEGIN; ~ GRANT; 사이)을 SQL Editor에서 재실행.
+-- ════════════════════════════════════════════════════════════════════
+
+BEGIN;
+
+-- 반환 TABLE 구조가 변경되므로 CREATE OR REPLACE 불가 — DROP 후 재생성
+DROP FUNCTION IF EXISTS public.get_brand_ops_overview(uuid);
+
+CREATE FUNCTION public.get_brand_ops_overview(p_company_id uuid DEFAULT NULL)
+RETURNS TABLE (
+  -- ── 기존 19컬럼 (순서·이름 불변) ──
+  brand_id              uuid,
+  brand_seq             integer,
+  brand_no              text,
+  brand_name_ko         text,
+  brand_name_ja         text,
+  company_id            uuid,
+  company_name_ko       text,
+  open_applications     bigint,
+  active_campaigns      bigint,
+  slots_total           bigint,
+  approved_total        bigint,
+  recruit_rate          numeric,
+  deliverable_total     bigint,
+  deliverable_approved  bigint,
+  deliverable_rate      numeric,
+  d3_count              bigint,
+  cancel_7d             bigint,
+  last_activity_at      timestamptz,
+  alert_level           text,
+  -- ── 신규 3컬럼 (148 추가) ──
+  alert_reasons         text[],
+  soonest_deadline      date,
+  d1_count              bigint
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+BEGIN
+  IF NOT public.is_admin() THEN
+    RAISE EXCEPTION 'forbidden' USING ERRCODE = '42501';
+  END IF;
+
+  RETURN QUERY
+  WITH
+  -- ── 1. 캠페인 집계 (120 기준 그대로) ──
+  camp_agg AS (
+    SELECT
+      c.brand_id,
+      SUM(CASE WHEN c.status IN ('active','scheduled') THEN 1 ELSE 0 END)::bigint AS active_camps,
+      SUM(CASE WHEN c.status IN ('active','scheduled','closed') THEN COALESCE(c.slots,0) ELSE 0 END)::bigint AS slots_sum,
+      SUM(CASE
+            WHEN c.status = 'active'
+             AND c.deadline IS NOT NULL
+             AND c.deadline <= (current_date + INTERVAL '3 days')::date
+            THEN 1 ELSE 0
+          END)::bigint AS d3,
+      SUM(CASE
+            WHEN c.status = 'active'
+             AND c.deadline IS NOT NULL
+             AND c.deadline <= (current_date + INTERVAL '1 days')::date
+            THEN 1 ELSE 0
+          END)::bigint AS d1,
+      MIN(CASE WHEN c.status = 'active' THEN c.deadline END) AS soonest_dl,
+      MAX(c.updated_at) AS latest_camp_update
+    FROM public.campaigns c
+    WHERE c.brand_id IS NOT NULL
+    GROUP BY c.brand_id
+  ),
+
+  -- ── 2. 신청 집계 (120 기준 그대로) ──
+  app_agg AS (
+    SELECT c.brand_id,
+           COUNT(*) FILTER (WHERE a.status = 'approved')::bigint AS approved_cnt,
+           COUNT(*) FILTER (
+             WHERE a.cancelled_at IS NOT NULL
+               AND a.cancelled_at >= (now() - INTERVAL '7 days')
+           )::bigint AS cancel7,
+           GREATEST(MAX(a.created_at), MAX(a.reviewed_at), MAX(a.cancelled_at)) AS latest_app_update
+    FROM public.applications a
+    JOIN public.campaigns c ON c.id = a.campaign_id
+    WHERE c.brand_id IS NOT NULL
+    GROUP BY c.brand_id
+  ),
+
+  -- ── 3. 결과물 집계 (120 기준 그대로) ──
+  deliv_agg AS (
+    SELECT c.brand_id,
+           COUNT(*)::bigint AS deliv_total,
+           COUNT(*) FILTER (WHERE d.status = 'approved')::bigint AS deliv_approved
+    FROM public.deliverables d
+    JOIN public.campaigns c ON c.id = d.campaign_id
+    WHERE c.brand_id IS NOT NULL
+    GROUP BY c.brand_id
+  ),
+
+  -- ── 4. 광고주 신청(brand_applications) 집계 (120 기준 그대로) ──
+  brand_app_agg AS (
+    SELECT ba.brand_id,
+           COUNT(*) FILTER (WHERE ba.status NOT IN ('done','rejected'))::bigint AS open_apps,
+           MAX(ba.updated_at) AS latest_brand_app_update
+    FROM public.brand_applications ba
+    WHERE ba.brand_id IS NOT NULL
+    GROUP BY ba.brand_id
+  ),
+
+  -- ── 5. alert 조건 플래그 사전 계산 (신규 CTE — 중복 임계값 연산 방지) ──
+  -- 동일 임계값을 alert_level 과 alert_reasons 양쪽에서 재참조.
+  -- 모집률은 NULL 안전하게 처리 (slots_sum=0 → 모집률 없음 → 해당 조건 미발동).
+  flag_agg AS (
+    SELECT
+      b_id,
+      -- danger 조건 3종
+      (d1 >= 1)                                                            AS flag_d1,
+      (cancel7 >= 5)                                                       AS flag_cancel_high,
+      (slots_sum > 0
+         AND recruit_pct < 30
+         AND soonest_dl IS NOT NULL
+         AND soonest_dl < (current_date + INTERVAL '7 days')::date)        AS flag_low_near,
+      -- warning 조건 1종 (d1 이 없을 때만 표시 대상 — level 결정은 CASE WHEN 순서가 처리)
+      (d3 >= 1)                                                            AS flag_d3,
+      -- caution 조건 1종
+      (slots_sum > 0
+         AND recruit_pct < 50
+         AND (soonest_dl IS NULL
+              OR soonest_dl >= (current_date + INTERVAL '7 days')::date))  AS flag_low,
+      -- 수치 그대로 전달 (최종 SELECT 에서 재사용)
+      d1          AS d1_val,
+      d3          AS d3_val,
+      cancel7     AS cancel7_val,
+      slots_sum   AS slots_val,
+      soonest_dl  AS soonest_dl_val,
+      recruit_pct AS recruit_pct_val
+    FROM (
+      -- 브랜드별로 집계값을 모아 모집률을 미리 계산
+      SELECT
+        b.id AS b_id,
+        COALESCE(ca.d1, 0)                                     AS d1,
+        COALESCE(ca.d3, 0)                                     AS d3,
+        COALESCE(aa.cancel7, 0)                                AS cancel7,
+        COALESCE(ca.slots_sum, 0)                              AS slots_sum,
+        ca.soonest_dl,
+        CASE
+          WHEN COALESCE(ca.slots_sum, 0) = 0 THEN NULL
+          ELSE ROUND(100.0 * COALESCE(aa.approved_cnt, 0) / ca.slots_sum, 1)
+        END AS recruit_pct
+      FROM public.brands b
+      LEFT JOIN camp_agg  ca ON ca.brand_id = b.id
+      LEFT JOIN app_agg   aa ON aa.brand_id = b.id
+      WHERE (p_company_id IS NULL OR b.company_id = p_company_id)
+    ) sub
+  )
+
+  -- ── 6. 최종 SELECT ──
+  SELECT
+    b.id                                                         AS brand_id,
+    b.brand_seq                                                  AS brand_seq,
+    b.brand_no                                                   AS brand_no,
+    b.name                                                       AS brand_name_ko,
+    b.name_ja                                                    AS brand_name_ja,
+    b.company_id                                                 AS company_id,
+    co.name_ko                                                   AS company_name_ko,
+    COALESCE(ba.open_apps,    0)::bigint                         AS open_applications,
+    COALESCE(ca.active_camps, 0)::bigint                         AS active_campaigns,
+    COALESCE(ca.slots_sum,    0)::bigint                         AS slots_total,
+    COALESCE(aa.approved_cnt, 0)::bigint                         AS approved_total,
+    fg.recruit_pct_val                                           AS recruit_rate,
+    COALESCE(da.deliv_total,    0)::bigint                       AS deliverable_total,
+    COALESCE(da.deliv_approved, 0)::bigint                       AS deliverable_approved,
+    CASE
+      WHEN COALESCE(da.deliv_total, 0) = 0 THEN NULL
+      ELSE ROUND(100.0 * COALESCE(da.deliv_approved, 0) / da.deliv_total, 1)
+    END                                                          AS deliverable_rate,
+    COALESCE(ca.d3, 0)::bigint                                   AS d3_count,
+    COALESCE(aa.cancel7, 0)::bigint                              AS cancel_7d,
+    GREATEST(
+      COALESCE(ca.latest_camp_update,      'epoch'::timestamptz),
+      COALESCE(aa.latest_app_update,       'epoch'::timestamptz),
+      COALESCE(ba.latest_brand_app_update, 'epoch'::timestamptz),
+      b.updated_at
+    )                                                            AS last_activity_at,
+    -- alert_level: fg 의 boolean 플래그 재사용 (임계값 이중 계산 없음)
+    CASE
+      WHEN fg.flag_d1          THEN 'danger'
+      WHEN fg.flag_cancel_high THEN 'danger'
+      WHEN fg.flag_low_near    THEN 'danger'
+      WHEN fg.flag_d3          THEN 'warning'
+      WHEN fg.flag_low         THEN 'caution'
+      ELSE                          'normal'
+    END                                                          AS alert_level,
+    -- alert_reasons: alert 발생 조건 코드 배열 (normal 이어도 해당 조건 코드 포함 가능)
+    -- 화면이 이 배열 + soonest_deadline/d1_count/cancel_7d 수치로 한국어 문구 조립.
+    -- 코드 간 중복 없음: d1_imminent 와 d3_imminent 는 상호 배타(d3>=d1).
+    -- 단, 여러 danger 조건이 동시에 성립할 경우 배열에 함께 포함됨.
+    ARRAY_REMOVE(
+      ARRAY[
+        CASE WHEN fg.flag_d1          THEN 'd1_imminent'            END,
+        -- d3_imminent 는 d1 이 아닌 캠페인만 (D-3 이면서 D-1 은 아닌 것이 있을 때 의미 있음)
+        -- 그러나 d3 카운트 자체는 d1 포함이므로 (d3>=d1 조건): d3>d1 인 경우에만 노출
+        -- → d3 > 0 이고 d3 > d1 이면 'D-3 구간 캠페인 있음' 의미
+        CASE WHEN fg.flag_d3 AND fg.d3_val > fg.d1_val THEN 'd3_imminent' END,
+        -- d1 만 있고 d3 초과분이 없어도 d3_imminent 를 표시하려면 아래 조건으로 교체:
+        -- CASE WHEN fg.flag_d3 THEN 'd3_imminent' END,
+        CASE WHEN fg.flag_cancel_high THEN 'cancel_7d_high'          END,
+        CASE WHEN fg.flag_low_near   THEN 'recruit_low_deadline_near' END,
+        CASE WHEN fg.flag_low        THEN 'recruit_low'              END
+      ],
+      NULL
+    )                                                            AS alert_reasons,
+    -- soonest_deadline/d1_count: 이미 camp_agg/flag_agg 에 계산됨 — 출력만 추가
+    fg.soonest_dl_val                                            AS soonest_deadline,
+    fg.d1_val::bigint                                            AS d1_count
+  FROM public.brands b
+  LEFT JOIN public.companies      co ON co.id = b.company_id
+  LEFT JOIN brand_app_agg          ba ON ba.brand_id = b.id
+  LEFT JOIN camp_agg               ca ON ca.brand_id = b.id
+  LEFT JOIN app_agg                aa ON aa.brand_id = b.id
+  LEFT JOIN deliv_agg              da ON da.brand_id = b.id
+  -- flag_agg 는 이미 brands 를 내부에서 순회했으므로 brand_id 로 조인
+  JOIN  flag_agg                   fg ON fg.b_id    = b.id
+  WHERE
+    (p_company_id IS NULL OR b.company_id = p_company_id);
+END;
+$$;
+
+COMMENT ON FUNCTION public.get_brand_ops_overview(uuid) IS
+  '[120 → 148] 운영 현황 페인용 브랜드 카드 그리드 집계. '
+  '모집률·결과물률·D-3 임박·7일 취소·alert_level. '
+  '148 추가: alert_reasons(조건 코드 배열)/soonest_deadline/d1_count. '
+  'is_admin() 가드.';
+
+REVOKE ALL ON FUNCTION public.get_brand_ops_overview(uuid) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.get_brand_ops_overview(uuid) FROM authenticated;
+REVOKE ALL ON FUNCTION public.get_brand_ops_overview(uuid) FROM anon;
+GRANT EXECUTE ON FUNCTION public.get_brand_ops_overview(uuid) TO authenticated;
+
+COMMIT;


### PR DESCRIPTION
## 변경 요약
- 운영 현황 페인(#brand-ops) 카드에 alert_level(긴급/대응 필요/주의) **사유를 색 배너**로 표시 (정상 카드 미표시)
- 마이그레이션 148: `get_brand_ops_overview` 19→22컬럼 (`alert_reasons text[]` + `soonest_deadline` + `d1_count`). 임계값은 120 기준 유지, `flag_agg` CTE 로 1회 계산
- 화면: `warnLine` 제거 → `alert_reasons` 코드 배열을 서버 수치로 한국어 문구 조립

## 요청 외 추가 변경
- 없음

## 관련 사양서
- docs/specs/2026-05-13-brand-ops-redesign.md §18 (구현 결과 — 사유 배너)

## 배포 시 필요 (DB 수동 적용)
- 개발/운영 SQL Editor 에서 `supabase/migrations/148_brand_ops_alert_reasons.sql` 실행 필요 (DROP+CREATE 함수)

🤖 Generated with [Claude Code](https://claude.com/claude-code)