### PR TITLE
feat(messaging): 메시지 입력 포커스 시 FAQ 게이트 숨김

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -12,7 +12,7 @@
 // 회귀(2026-05-12 PR #182 머지 직후 발생)를 방지하기 위한 자동 reload 가드.
 // sessionStorage 차단 환경(시크릿 모드 일부, 쿠키 차단)에서는 자연스럽게 skip.
 (function(){
-  var CURRENT_BUILD = 'v1779413531';
+  var CURRENT_BUILD = 'v1779414020';
   if (CURRENT_BUILD.indexOf('__') === 0) return; // 빌드 미적용 (dev/ 직접 열기) 시 skip
   try {
     var prev = sessionStorage.getItem('reverb.adminBuild');
@@ -1729,7 +1729,7 @@ textarea.form-input{resize:vertical;min-height:80px}
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-05-22 10:32 · 1f5b519</span>
+          <span class="admin-build-text">2026-05-22 10:40 · a259ad7</span>
         </div>
       </div>
     </aside>

--- a/dev/index.html
+++ b/dev/index.html
@@ -281,7 +281,7 @@ window._supabaseLoaded = false;
         <span class="material-icons-round notranslate" translate="no">image</span>
         <input id="msgModalAttachInput" type="file" accept="image/*" multiple style="display:none" onchange="onMsgAttachSelected(this)">
       </label>
-      <textarea id="msgModalInput" class="msg-input" rows="2" oninput="onMsgInputChanged()"></textarea>
+      <textarea id="msgModalInput" class="msg-input" rows="2" oninput="onMsgInputChanged()" onfocus="onMsgInputFocus()" onblur="onMsgInputBlur()"></textarea>
       <button id="msgModalSendBtn" class="msg-send-btn" onclick="sendMessageFromModal()" aria-label="send">
         <span class="material-icons-round notranslate" translate="no">send</span>
       </button>

--- a/dev/js/messaging.js
+++ b/dev/js/messaging.js
@@ -534,6 +534,9 @@ async function setupFaqGate(app, camp) {
   }
   // 진입 시 입력어 없이 단계 기반 제안 1차 노출
   _faqRenderSuggest(_faqFindCandidates(''));
+  // 노드 로드 중 빠른 포커스→블러로 게이트가 숨겨졌고 지금 입력란에 포커스가 없으면 복원
+  //   (포커스가 아직 입력란에 있으면 onMsgInputBlur 가 나중에 복원).
+  if (gate && document.activeElement !== $('msgModalInput')) gate.style.display = '';
 }
 
 // 입력 textarea 변경 → 디바운스 후 제안 갱신 (HTML oninput 에서 호출)
@@ -545,6 +548,18 @@ function onMsgInputChanged() {
     const txt = (inputEl?.value || '').trim();
     _faqRenderSuggest(_faqFindCandidates(txt));
   }, FAQ_SUGGEST_DEBOUNCE_MS);
+}
+
+// 입력란 포커스(입력 중) — 입력란 위 FAQ 게이트(추천 카드 + 「よくある質問」 버튼)를 숨겨
+//   입력 공간을 확보한다. 페이지 전환(2026-05-22) 후 키보드 감지 대신 포커스 이벤트로 처리(사용자 요청).
+//   입력란에서 벗어나면(blur) 복원하되, _faqLoaded 후에만 복원해 setupFaqGate 완료 전 빈 게이트 깜빡임을 막는다.
+function onMsgInputFocus() {
+  const gate = $('msgFaqGate');
+  if (gate) gate.style.display = 'none';
+}
+function onMsgInputBlur() {
+  const gate = $('msgFaqGate');
+  if (gate && _faqLoaded) gate.style.display = '';
 }
 
 // 유사 후보 선별 (§2 결정 2) — 단계 일치로 후보를 깔고, 입력어가 질문 제목에 포함되면 가중치 상향

--- a/index.html
+++ b/index.html
@@ -927,7 +927,7 @@ textarea.form-input{resize:vertical;min-height:80px}
         <span class="material-icons-round notranslate" translate="no">image</span>
         <input id="msgModalAttachInput" type="file" accept="image/*" multiple style="display:none" onchange="onMsgAttachSelected(this)">
       </label>
-      <textarea id="msgModalInput" class="msg-input" rows="2" oninput="onMsgInputChanged()"></textarea>
+      <textarea id="msgModalInput" class="msg-input" rows="2" oninput="onMsgInputChanged()" onfocus="onMsgInputFocus()" onblur="onMsgInputBlur()"></textarea>
       <button id="msgModalSendBtn" class="msg-send-btn" onclick="sendMessageFromModal()" aria-label="send">
         <span class="material-icons-round notranslate" translate="no">send</span>
       </button>
@@ -10980,6 +10980,9 @@ async function setupFaqGate(app, camp) {
   }
   // 진입 시 입력어 없이 단계 기반 제안 1차 노출
   _faqRenderSuggest(_faqFindCandidates(''));
+  // 노드 로드 중 빠른 포커스→블러로 게이트가 숨겨졌고 지금 입력란에 포커스가 없으면 복원
+  //   (포커스가 아직 입력란에 있으면 onMsgInputBlur 가 나중에 복원).
+  if (gate && document.activeElement !== $('msgModalInput')) gate.style.display = '';
 }
 
 // 입력 textarea 변경 → 디바운스 후 제안 갱신 (HTML oninput 에서 호출)
@@ -10991,6 +10994,18 @@ function onMsgInputChanged() {
     const txt = (inputEl?.value || '').trim();
     _faqRenderSuggest(_faqFindCandidates(txt));
   }, FAQ_SUGGEST_DEBOUNCE_MS);
+}
+
+// 입력란 포커스(입력 중) — 입력란 위 FAQ 게이트(추천 카드 + 「よくある質問」 버튼)를 숨겨
+//   입력 공간을 확보한다. 페이지 전환(2026-05-22) 후 키보드 감지 대신 포커스 이벤트로 처리(사용자 요청).
+//   입력란에서 벗어나면(blur) 복원하되, _faqLoaded 후에만 복원해 setupFaqGate 완료 전 빈 게이트 깜빡임을 막는다.
+function onMsgInputFocus() {
+  const gate = $('msgFaqGate');
+  if (gate) gate.style.display = 'none';
+}
+function onMsgInputBlur() {
+  const gate = $('msgFaqGate');
+  if (gate && _faqLoaded) gate.style.display = '';
 }
 
 // 유사 후보 선별 (§2 결정 2) — 단계 일치로 후보를 깔고, 입력어가 질문 제목에 포함되면 가중치 상향


### PR DESCRIPTION
## 변경 요약
- 메시지 입력란에 포커스(입력 중)하면 입력란 위 FAQ 게이트(추천 카드 + 「よくある質問」 버튼)를 숨겨 입력 공간 확보, 입력란에서 벗어나면(blur) 복원.
- 모달→페이지 전환 시 제거됐던 게이트 숨김 동작을, 페이지에 맞게 포커스 이벤트 기반으로 재구현.
- 노드 로딩 중 빠른 포커스→블러로 게이트가 영구 숨김되는 경우를 `setupFaqGate` 의 포커스 인지 복원으로 방지.

## 요청 외 추가 변경
- 없음

## 검증
- reverb-reviewer GO (Warning: 로드 중 영구 숨김 → setupFaqGate 복원 보강 완료)
- ⚠️ dev 머지 후 아이폰 실기기 확인: 입력란 탭 시 추천/「자주 묻는 질문」 영역이 사라지고, 입력란 벗어나면 다시 나타나는지 (qa light)

🤖 Generated with [Claude Code](https://claude.com/claude-code)