### PR TITLE
style(admin): 운영 현황 미니카드 크기를 브랜드 카드와 통일

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -12,7 +12,7 @@
 // 회귀(2026-05-12 PR #182 머지 직후 발생)를 방지하기 위한 자동 reload 가드.
 // sessionStorage 차단 환경(시크릿 모드 일부, 쿠키 차단)에서는 자연스럽게 skip.
 (function(){
-  var CURRENT_BUILD = 'v1779414608';
+  var CURRENT_BUILD = 'v1779421987';
   if (CURRENT_BUILD.indexOf('__') === 0) return; // 빌드 미적용 (dev/ 직접 열기) 시 skip
   try {
     var prev = sessionStorage.getItem('reverb.adminBuild');
@@ -445,8 +445,8 @@ textarea.form-input{resize:vertical;min-height:80px}
 .brand-ops-card:hover{box-shadow:0 4px 14px rgba(0,0,0,.08);transform:translateY(-1px)}
 @keyframes brandOpsPulse{0%,100%{opacity:1}50%{opacity:.45}}
 /* 브랜드 상세 — 캠페인 미니카드 그리드 */
-.brand-ops-mini-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(280px,1fr));gap:10px}
-.brand-ops-mini-card{background:#fff;border:1px solid var(--line);border-radius:10px;padding:10px}
+.brand-ops-mini-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(320px,1fr));gap:14px}
+.brand-ops-mini-card{background:#fff;border:1px solid var(--line);border-radius:12px;padding:14px}
 .brand-ops-app summary::-webkit-details-marker{display:none}
 /* 다중 선택 드롭다운 */
 .admin-filter-group{display:flex;flex-direction:column;gap:2px}
@@ -1729,7 +1729,7 @@ textarea.form-input{resize:vertical;min-height:80px}
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-05-22 10:50 · 6c37f3f</span>
+          <span class="admin-build-text">2026-05-22 12:53 · 58176d4</span>
         </div>
       </div>
     </aside>

--- a/dev/css/admin.css
+++ b/dev/css/admin.css
@@ -20,8 +20,8 @@
 .brand-ops-card:hover{box-shadow:0 4px 14px rgba(0,0,0,.08);transform:translateY(-1px)}
 @keyframes brandOpsPulse{0%,100%{opacity:1}50%{opacity:.45}}
 /* 브랜드 상세 — 캠페인 미니카드 그리드 */
-.brand-ops-mini-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(280px,1fr));gap:10px}
-.brand-ops-mini-card{background:#fff;border:1px solid var(--line);border-radius:10px;padding:10px}
+.brand-ops-mini-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(320px,1fr));gap:14px}
+.brand-ops-mini-card{background:#fff;border:1px solid var(--line);border-radius:12px;padding:14px}
 .brand-ops-app summary::-webkit-details-marker{display:none}
 /* 다중 선택 드롭다운 */
 .admin-filter-group{display:flex;flex-direction:column;gap:2px}


### PR DESCRIPTION
## 변경 요약
- 운영 현황 상세 캠페인 미니카드 그리드·카드 크기를 목록 브랜드 카드와 동일하게 맞춤 (minmax 320px, gap/padding 14px, radius 12px)

## 요청 외 추가 변경
- 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)