### PR TITLE
perf(admin): 캠페인 관리 검색 깜빡임·지연 제거 (운영 핫픽스)

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -12,7 +12,7 @@
 // 회귀(2026-05-12 PR #182 머지 직후 발생)를 방지하기 위한 자동 reload 가드.
 // sessionStorage 차단 환경(시크릿 모드 일부, 쿠키 차단)에서는 자연스럽게 skip.
 (function(){
-  var CURRENT_BUILD = 'v1779333349';
+  var CURRENT_BUILD = 'v1779433331';
   if (CURRENT_BUILD.indexOf('__') === 0) return; // 빌드 미적용 (dev/ 직접 열기) 시 skip
   try {
     var prev = sessionStorage.getItem('reverb.adminBuild');
@@ -1522,7 +1522,7 @@ textarea.form-input{resize:vertical;min-height:80px}
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-05-21 12:15 · a66a9c9</span>
+          <span class="admin-build-text">2026-05-22 16:02 · 00ab4a1</span>
         </div>
       </div>
     </aside>
@@ -1638,7 +1638,7 @@ textarea.form-input{resize:vertical;min-height:80px}
                 <label>검색</label>
                 <div style="position:relative">
                   <span class="material-icons-round" style="position:absolute;left:8px;top:50%;transform:translateY(-50%);font-size:16px;color:var(--muted)">search</span>
-                  <input type="search" id="adminCampSearch" class="admin-filter-search" autocomplete="off" data-lpignore="true" data-1p-ignore="true" readonly onfocus="this.removeAttribute('readonly')" placeholder="캠페인명 · 브랜드 · 캠페인번호 검색" oninput="filterAdminCampaigns()">
+                  <input type="search" id="adminCampSearch" class="admin-filter-search" autocomplete="off" data-lpignore="true" data-1p-ignore="true" readonly onfocus="this.removeAttribute('readonly')" placeholder="캠페인명 · 브랜드 · 캠페인번호 검색" oninput="debouncedFilterAdminCampaigns()">
                 </div>
               </div>
             </div>
@@ -6225,6 +6225,15 @@ new MutationObserver(() => {
 function esc(s) {
   if (!s) return '';
   return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;').replace(/'/g,'&#39;');
+}
+
+// 입력 지연 처리 (연타 시 마지막 호출만 실행) — 검색창 등 고빈도 입력에 사용
+function debounce(fn, wait = 300) {
+  let timer = null;
+  return function(...args) {
+    if (timer) clearTimeout(timer);
+    timer = setTimeout(() => { timer = null; fn.apply(this, args); }, wait);
+  };
 }
 
 // 필수 필드 경고 표시/해제
@@ -11209,6 +11218,8 @@ var adminCampSortDir = '';
 // ════════════════════════════════════════════════════════════════════
 
 function filterAdminCampaigns() { loadAdminCampaigns(true); }
+// 검색창 전용 — 글자 연타 시 마지막 입력만 반영(0.3초). 드롭다운 필터는 즉시 호출 유지.
+const debouncedFilterAdminCampaigns = debounce(filterAdminCampaigns, 300);
 
 function resetCampSort() {
   adminCampSortKey = '';
@@ -11581,6 +11592,15 @@ function applyImageCropsToList(imgList, cropsMap) {
 var campsLazy = null;
 const CAMPS_PAGE_SIZE = 50;
 
+// 캠페인 목록의 신청 카운트(승인/대기)용 신청 데이터 캐시.
+// 검색/필터/정렬(useCache=true)에서는 재사용해 호주 서버 전건 재조회를 막는다.
+// 페인 재진입·실데이터 갱신(useCache=false) 시에만 새로 fetch (allCampaigns 와 동일한 갱신 정책).
+// ⚠️ 이 캐시는 useCache=falsy(인자 없는 호출) 경로로만 갱신된다.
+//    신청 승인/반려 후 캠페인 페인으로 돌아오면 switchAdminPane('campaigns') → loaders.campaigns()
+//    가 loadAdminCampaigns 를 인자 없이 호출하므로 자동 갱신된다.
+//    loadAdminCampaigns(true) 직접 호출은 캐시를 갱신하지 않으니, 신청 상태가 바뀐 직후 경로에서는 쓰지 말 것.
+var _campListApps = null;
+
 // 캠페인 다중 선택 — 현재 필터/정렬 적용된 캠페인 리스트 캐시
 // loadAdminCampaigns 가 매 호출마다 갱신. toggleCampSelectAll·updateCampSelectionUI 에서 참조
 var _currentFilteredCamps = [];
@@ -11633,7 +11653,8 @@ async function loadAdminCampaigns(useCache) {
 
   updateFilterResetBtn('btnCampFilterReset', ['campTypeMulti','campStatusMulti'], 'adminCampSearch');
 
-  const allApps = await fetchApplications();
+  // useCache(검색/필터/정렬)면 캐시 재사용 → 네트워크 0회. 캐시가 비어있으면 1회만 조회.
+  const allApps = (useCache && _campListApps) ? _campListApps : (_campListApps = await fetchApplications());
 
   // 정렬
   const appCount = id => allApps.filter(a=>a.campaign_id===id).length;
@@ -11786,8 +11807,10 @@ async function loadAdminCampaigns(useCache) {
     // 순서변경 모드: 전체 DOM 필요 (↑↓ 위치 인덱스 기반). lazy 비활성.
     if (campsLazy) { campsLazy.destroy(); campsLazy = null; }
     campsBody.innerHTML = camps.length ? camps.map((c, i) => buildCampRow(c, i, camps.length)).join('') : emptyHtml;
+  } else if (campsLazy) {
+    // 인스턴스 재생성 없이 행만 교체 (sentinel 정리·스크롤 복귀는 reset 내부 처리)
+    campsLazy.reset(camps);
   } else {
-    if (campsLazy) campsLazy.destroy();
     campsLazy = mountLazyList({
       tbody: campsBody,
       scrollRoot: campsBody.closest('.admin-table-wrap'),

--- a/dev/admin/index.html
+++ b/dev/admin/index.html
@@ -243,7 +243,7 @@
                 <label>검색</label>
                 <div style="position:relative">
                   <span class="material-icons-round" style="position:absolute;left:8px;top:50%;transform:translateY(-50%);font-size:16px;color:var(--muted)">search</span>
-                  <input type="search" id="adminCampSearch" class="admin-filter-search" autocomplete="off" data-lpignore="true" data-1p-ignore="true" readonly onfocus="this.removeAttribute('readonly')" placeholder="캠페인명 · 브랜드 · 캠페인번호 검색" oninput="filterAdminCampaigns()">
+                  <input type="search" id="adminCampSearch" class="admin-filter-search" autocomplete="off" data-lpignore="true" data-1p-ignore="true" readonly onfocus="this.removeAttribute('readonly')" placeholder="캠페인명 · 브랜드 · 캠페인번호 검색" oninput="debouncedFilterAdminCampaigns()">
                 </div>
               </div>
             </div>

--- a/dev/js/admin.js
+++ b/dev/js/admin.js
@@ -451,6 +451,8 @@ var adminCampSortDir = '';
 // ════════════════════════════════════════════════════════════════════
 
 function filterAdminCampaigns() { loadAdminCampaigns(true); }
+// 검색창 전용 — 글자 연타 시 마지막 입력만 반영(0.3초). 드롭다운 필터는 즉시 호출 유지.
+const debouncedFilterAdminCampaigns = debounce(filterAdminCampaigns, 300);
 
 function resetCampSort() {
   adminCampSortKey = '';
@@ -823,6 +825,15 @@ function applyImageCropsToList(imgList, cropsMap) {
 var campsLazy = null;
 const CAMPS_PAGE_SIZE = 50;
 
+// 캠페인 목록의 신청 카운트(승인/대기)용 신청 데이터 캐시.
+// 검색/필터/정렬(useCache=true)에서는 재사용해 호주 서버 전건 재조회를 막는다.
+// 페인 재진입·실데이터 갱신(useCache=false) 시에만 새로 fetch (allCampaigns 와 동일한 갱신 정책).
+// ⚠️ 이 캐시는 useCache=falsy(인자 없는 호출) 경로로만 갱신된다.
+//    신청 승인/반려 후 캠페인 페인으로 돌아오면 switchAdminPane('campaigns') → loaders.campaigns()
+//    가 loadAdminCampaigns 를 인자 없이 호출하므로 자동 갱신된다.
+//    loadAdminCampaigns(true) 직접 호출은 캐시를 갱신하지 않으니, 신청 상태가 바뀐 직후 경로에서는 쓰지 말 것.
+var _campListApps = null;
+
 // 캠페인 다중 선택 — 현재 필터/정렬 적용된 캠페인 리스트 캐시
 // loadAdminCampaigns 가 매 호출마다 갱신. toggleCampSelectAll·updateCampSelectionUI 에서 참조
 var _currentFilteredCamps = [];
@@ -875,7 +886,8 @@ async function loadAdminCampaigns(useCache) {
 
   updateFilterResetBtn('btnCampFilterReset', ['campTypeMulti','campStatusMulti'], 'adminCampSearch');
 
-  const allApps = await fetchApplications();
+  // useCache(검색/필터/정렬)면 캐시 재사용 → 네트워크 0회. 캐시가 비어있으면 1회만 조회.
+  const allApps = (useCache && _campListApps) ? _campListApps : (_campListApps = await fetchApplications());
 
   // 정렬
   const appCount = id => allApps.filter(a=>a.campaign_id===id).length;
@@ -1028,8 +1040,10 @@ async function loadAdminCampaigns(useCache) {
     // 순서변경 모드: 전체 DOM 필요 (↑↓ 위치 인덱스 기반). lazy 비활성.
     if (campsLazy) { campsLazy.destroy(); campsLazy = null; }
     campsBody.innerHTML = camps.length ? camps.map((c, i) => buildCampRow(c, i, camps.length)).join('') : emptyHtml;
+  } else if (campsLazy) {
+    // 인스턴스 재생성 없이 행만 교체 (sentinel 정리·스크롤 복귀는 reset 내부 처리)
+    campsLazy.reset(camps);
   } else {
-    if (campsLazy) campsLazy.destroy();
     campsLazy = mountLazyList({
       tbody: campsBody,
       scrollRoot: campsBody.closest('.admin-table-wrap'),

--- a/dev/js/ui.js
+++ b/dev/js/ui.js
@@ -16,6 +16,15 @@ function esc(s) {
   return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;').replace(/'/g,'&#39;');
 }
 
+// 입력 지연 처리 (연타 시 마지막 호출만 실행) — 검색창 등 고빈도 입력에 사용
+function debounce(fn, wait = 300) {
+  let timer = null;
+  return function(...args) {
+    if (timer) clearTimeout(timer);
+    timer = setTimeout(() => { timer = null; fn.apply(this, args); }, wait);
+  };
+}
+
 // 필수 필드 경고 표시/해제
 function markRequired(id, msg) {
   const el = $(id);

--- a/docs/specs/2026-05-22-admin-campaign-list-perf.md
+++ b/docs/specs/2026-05-22-admin-campaign-list-perf.md
@@ -1,0 +1,104 @@
+# 관리자 캠페인 관리 화면 속도 개선 (코드 최적화, 서버 이관 없이)
+
+**작성일:** 2026-05-22
+**작성 세션:** 고문(메인) 세션 — 진단·기획·검증 담당
+**구현 세션:** 개발 세션 (별도 worktree, 시퀀셜)
+**관련 에이전트:** reverb-planner(계획 수립 완료)
+
+> 운영서버(Supabase)가 호주 시드니, 사용자는 한/일에서 접속 → 네트워크 왕복 지연(latency)이 큼.
+> 당장 서버 이관(호주→일본)은 불가하므로 **코드에서만** 개선한다.
+
+---
+
+## 1. 증상
+
+- 관리자 캠페인 관리 화면(`#adminPane-campaigns`)에서 **검색어를 입력하면 목록이 깜빡거리며, 결과가 나오기까지 한참 걸린다.**
+- 화면 진입 자체도 느리다.
+
+## 2. 진단 (코드 추적으로 확정)
+
+| # | 위치 | 문제 |
+|---|---|---|
+| 1 | `dev/admin/index.html:243` | 검색 input 이 `oninput="filterAdminCampaigns()"` — 매 글자마다 즉시 호출, 입력 지연(debounce) 없음 |
+| 2 | `dev/js/admin.js:887` | **(최대 병목)** `const allApps = await fetchApplications();` — `loadAdminCampaigns(useCache)` 의 useCache 분기 밖이라 검색/필터/정렬 때마다 **항상** 신청 전건을 호주 서버에서 재조회. 검색어 6글자 = 신청 전건 6회 재조회 |
+| 3 | `dev/lib/storage.js:363` | `fetchApplications` 캐시 계층 없음. `select('*')` + `fetchAllPaged`(1000건씩 반복) |
+| 4 | `storage.js:37`, `:363` | `fetchCampaigns`·`fetchApplications` 모두 `select('*')` — 목록 렌더(`buildCampRow`)에 안 쓰는 무거운 jsonb 스냅샷(participation_steps/caution_items/ng_items)·rich text 본문까지 전부 전송 |
+| 5 | `dev/js/admin.js:840` | 캠페인 페인 진입 시 `loadAdminCampaigns()`(무인자)가 `fetchCampaigns()` 전건 재조회 |
+
+**깜빡임 메커니즘**: 매 글자마다 `await fetchApplications()`(호주 왕복)가 끝난 뒤에야 목록을 비우고 다시 그림 → 네트워크 대기 동안 멈췄다가 갱신.
+
+### 보강 사실 (planner 확인)
+- `fetchApplications()` 는 12군데 호출. 무인자 전건 호출: `admin.js:335`(부트), `:887`(검색마다), `:4112`(대시보드), `:8555`(진행현황), `admin/app.js:79`(부트), `admin-brand-ops.js` 2곳.
+- `mountLazyList` 에 `reset(newRows)` 이미 구현됨(`dev/js/ui.js`) — 내부에서 `scrollTop=0` + sentinel 재마운트 수행. destroy→재생성과 기능 동일, 객체·observer 재할당 비용만 절감.
+- `allCampaigns` 는 admin.js 전용 전역(인플루언서 앱 무관). 단 `fetchCampaigns` **함수 자체**는 인플루언서 앱·관리자 양쪽 공유.
+
+## 3. 확정된 결정 (사용자 승인 완료, 2026-05-22)
+
+| 항목 | 결정 |
+|---|---|
+| 개선 범위 | 즉효 3종 + 데이터 다이어트 |
+| 다이어트 방식 | **목록 전용 조회 함수 신설** (기존 `fetchCampaigns`/`fetchApplications` 보존 → 인플루언서 앱·타 화면 영향 0, DB 변경 없음) |
+| 지연 범위 | **검색창만 0.3초 지연**, 타입/상태 드롭다운은 즉시 |
+| 신청 카운트 캐시 갱신 | **캠페인 페인 재진입 시 갱신**(기존 `allCampaigns` 캐시와 동일 정책). 검색/필터/정렬은 캐시 재사용(네트워크 0회) |
+
+## 4. PR 분할 (admin.js 핫스팟 → worktree 병렬 금지, 한 세션 시퀀셜)
+
+### PR 1 — 즉효 3종 (A + B + C). DB 변경 없음.
+가장 안전하고 효과 큼. 이것만으로 깜빡임·지연 대부분 해소.
+
+**A. 검색/필터/정렬 시 applications 재조회 제거**
+- 대상: `dev/js/admin.js` `loadAdminCampaigns`(840~), `887행`.
+- 캠페인 목록용 신청 데이터를 모듈 전역(예: `_campListApps`)에 캐시.
+  - `useCache=false`(페인 진입·실데이터 갱신)일 때만 `fetchApplications()` 호출 후 `_campListApps`에 저장.
+  - `useCache=true`(검색/필터/정렬)일 때는 `_campListApps` 재사용, 네트워크 0회.
+  - 형태 예: `const allApps = useCache ? _campListApps : (_campListApps = await fetchApplications());`
+- 검증: 검색 입력 시 네트워크 탭에 applications 요청 0건, 페인 재진입 시 1건.
+
+**B. 검색 입력 debounce (~300ms)**
+- 대상: `dev/admin/index.html:243` `oninput`.
+- `oninput="debouncedFilterAdminCampaigns()"` 로 교체 + admin.js 에 `const debouncedFilterAdminCampaigns = debounce(filterAdminCampaigns, 300)`.
+- debounce 헬퍼가 `dev/js/ui.js` 에 없으면 거기 추가(공통 유틸 규칙).
+- 타입/상태 드롭다운(`syncMultiFilter` 의 `() => filterAdminCampaigns()`)은 **즉시 호출 유지**(검색 input 만 debounce).
+
+**C. 목록 재렌더 `reset()` 활용 (destroy/재생성 제거)**
+- 대상: `dev/js/admin.js:1041~1049`.
+- 검색/필터/정렬(`useCache=true`) + 순서변경 모드 아님일 때: `campsLazy` 살아있으면 `campsLazy.reset(camps)` 로 행만 교체. 인스턴스 없을 때(첫 진입)만 `mountLazyList` 생성. 순서변경 모드 진입/이탈은 기존대로 destroy.
+- `_currentFilteredCamps` / `updateCampSelectionUI` 동기화는 reset 경로에서도 동일 호출 유지(현재 1051~1054 setTimeout 유지).
+- 검증: 검색 시 체크박스 선택·전체선택 indeterminate 정상, 50건 초과 스크롤 추가 로드(sentinel) 정상.
+
+### PR 2 — 데이터 다이어트 (D). PR 1 검증·배포 후.
+- 대상: `dev/lib/storage.js`.
+- **목록 전용 함수 신설**:
+  - `fetchCampaignsForAdminList()` — 목록 표시·정렬·검색에 필요한 컬럼만 select. 후보 컬럼: `id, title, brand, brand_ko, product, product_ko, campaign_no, recruit_type, status, slots, view_count, created_at, updated_at, order_index, img1~img8, image_url, image_crops, emoji, recruit_start, deadline`. (구현 시 `buildCampRow`·정렬·검색에서 실제 참조하는 컬럼을 grep 으로 전수 확인 후 확정)
+  - `fetchApplicationsCountLite()` — `campaign_id, status` 만 select (캠페인별 승인/대기 카운트 전용).
+- 기존 `fetchCampaigns`/`fetchApplications` 는 손대지 않음.
+- `loadAdminCampaigns` 가 위 두 신설 함수를 쓰도록 교체. **단 `allCampaigns` 를 다른 관리자 화면이 무거운 컬럼까지 기대하며 공유하는지** 반드시 확인(공유하면 별도 캐시 변수 분리 필요).
+- DB 변경 없음(마이그레이션 불필요).
+
+## 5. 에이전트 호출 지점
+
+- **reverb-supabase-expert**: PR 2 에서 `storage.js` 쿼리 변경 → 권장(행 단위 보안 정책·페이로드 영향 점검). (집계 뷰/원격 함수 옵션은 미채택이라 마이그레이션 없음)
+- **reverb-reviewer**: PR 1·2 각 커밋 직전 필수(stale 참조·LazyList reset 회귀).
+- **reverb-qa-tester**: 캠페인 관리는 관리자 핵심 플로우 → PR 1 운영 배포 전 Light(S5+S6) E2E(검색·필터·정렬·순서변경·선택·진행현황 카운트 일치).
+
+## 6. 빌드
+- 수정 파일(`admin.js`/`ui.js`/`storage.js`/`admin/index.html`) 모두 기존 등록 → `build.sh` 신규 등록 불필요. 수정 후 `cd dev && bash build.sh` 의무.
+
+## 7. 배포
+- PR 1: feature → dev PR → reviewer GO + 빌드 후 dev 머지(Claude 진행 가능). 개발서버 검증 후 운영(dev→main)은 사용자 확인.
+- PR 2: PR 1 운영 배포·검증 후 착수.
+
+---
+
+## 구현 결과
+
+**구현일:** (개발 세션이 채울 것)
+**관련 커밋:** (개발 세션이 채울 것)
+
+### 초안 대비 변경 사항
+- 추가된 것:
+- 빠진 것:
+- 달라진 것:
+
+### 구현 중 기술 결정 사항
+-

--- a/index.html
+++ b/index.html
@@ -5537,6 +5537,15 @@ function esc(s) {
   return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;').replace(/'/g,'&#39;');
 }
 
+// 입력 지연 처리 (연타 시 마지막 호출만 실행) — 검색창 등 고빈도 입력에 사용
+function debounce(fn, wait = 300) {
+  let timer = null;
+  return function(...args) {
+    if (timer) clearTimeout(timer);
+    timer = setTimeout(() => { timer = null; fn.apply(this, args); }, wait);
+  };
+}
+
 // 필수 필드 경고 표시/해제
 function markRequired(id, msg) {
   const el = $(id);


### PR DESCRIPTION
## 변경 요약
캠페인 관리 화면에서 검색어 한 글자마다 호주 서버에서 신청 전건을 재조회하던 문제를 코드 최적화로 해소. **dev PR #266과 동일한 소스 변경**을 main 위에 재적용(dev의 미배포 기능을 끌고 오지 않기 위해 통째 머지 대신 분리).

- 신청 재조회 제거(`_campListApps` 캐시) → 검색/필터/정렬 시 네트워크 0회
- 검색 입력 debounce 0.3초 (드롭다운은 즉시)
- 목록 다시 그리기 `reset()` 재사용

DB/RLS/마이그레이션 변경 없음. main 기준 재빌드(보류 기능 누출 0 확인).

## 검증
- dev PR #266: reviewer GO + qa light 7/7 PASS
- 본 핫픽스: main 재빌드 후 빌드 산출물에 messaging/faq 마커 0건 확인

## 관련 사양서
- docs/specs/2026-05-22-admin-campaign-list-perf.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)