### PR TITLE
perf(admin): 캠페인 목록 조회 컬럼 경량화 (PR 2 운영 핫픽스)

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -12,7 +12,7 @@
 // 회귀(2026-05-12 PR #182 머지 직후 발생)를 방지하기 위한 자동 reload 가드.
 // sessionStorage 차단 환경(시크릿 모드 일부, 쿠키 차단)에서는 자연스럽게 skip.
 (function(){
-  var CURRENT_BUILD = 'v1779433331';
+  var CURRENT_BUILD = 'v1779673956';
   if (CURRENT_BUILD.indexOf('__') === 0) return; // 빌드 미적용 (dev/ 직접 열기) 시 skip
   try {
     var prev = sessionStorage.getItem('reverb.adminBuild');
@@ -1522,7 +1522,7 @@ textarea.form-input{resize:vertical;min-height:80px}
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-05-22 16:02 · 00ab4a1</span>
+          <span class="admin-build-text">2026-05-25 10:52 · 71fec7c</span>
         </div>
       </div>
     </aside>
@@ -4263,6 +4263,61 @@ async function fetchCampaigns() {
     return DEMO_CAMPAIGNS.slice();
   } catch(e) {
     return DEMO_CAMPAIGNS.slice();
+  }
+}
+
+// 관리자 캠페인 목록 전용 조회 — 목록 렌더·검색·필터·정렬에 필요한 컬럼만 select.
+// participation_steps / caution_items / ng_items / description / appeal / guide 등
+// 무거운 jsonb·리치텍스트 컬럼은 제외해 페이로드를 절약한다.
+// ※ fetchCampaigns 는 인플루언서 앱·복제·편집 등 다른 곳에서도 공유하므로 건드리지 않는다.
+// ※ autoOpenCampaigns / autoCloseCampaigns 는 status / recruit_start / deadline 만 참조하므로
+//    목록 전용 컬럼셋에서도 문제없이 실행된다. 목록 진입 시 자동 전환을 유지하기 위해 여기서도 호출.
+const ADMIN_LIST_COLUMNS = [
+  'id', 'title', 'brand', 'brand_ko', 'product', 'product_ko',
+  'campaign_no', 'legacy_no',
+  'recruit_type', 'channel', 'status',
+  'slots', 'view_count',
+  'img1', 'img2', 'img3', 'img4', 'img5', 'img6', 'img7', 'img8',
+  'image_url', 'image_crops', 'emoji',
+  'recruit_start', 'deadline',
+  'purchase_start', 'purchase_end',
+  'visit_start', 'visit_end',
+  'submission_end',
+  'order_index', 'created_at', 'updated_at',
+].join(',');
+
+async function fetchCampaignsForAdminList() {
+  if (!db) return DEMO_CAMPAIGNS.slice();
+  try {
+    const data = await fetchAllPaged(() =>
+      db.from('campaigns')
+        .select(ADMIN_LIST_COLUMNS)
+        .order('order_index', { ascending: true, nullsFirst: false })
+    );
+    if (data.length > 0) {
+      await autoOpenCampaigns(data);   // scheduled → active (recruit_start 도래)
+      await autoCloseCampaigns(data);  // active → closed (deadline 경과)
+      return data;
+    }
+    return DEMO_CAMPAIGNS.slice();
+  } catch(e) {
+    return DEMO_CAMPAIGNS.slice();
+  }
+}
+
+// 관리자 캠페인 목록 전용 신청 카운트 조회 — campaign_id + status 만 select.
+// buildCampRow 의 「N건 / M명」 표시와 승인/대기 카운트에만 쓴다.
+// fetchApplications 와 달리 status 필터 없이 전건을 가져온다 (각 상태 카운트 합산 필요).
+async function fetchApplicationsCountLite() {
+  if (!db) return [];
+  try {
+    return await fetchAllPaged(() =>
+      db.from('applications')
+        .select('campaign_id,status')
+        .order('campaign_id', { ascending: true })
+    );
+  } catch(e) {
+    return [];
   }
 }
 
@@ -11608,7 +11663,8 @@ function getCurrentFilteredCamps() { return _currentFilteredCamps; }
 
 async function loadAdminCampaigns(useCache) {
   updateCampTableHead();
-  let camps = useCache ? allCampaigns.slice() : await fetchCampaigns();
+  // PR 2 데이터 다이어트: 목록 전용 가벼운 함수 사용 (participation_steps 등 무거운 컬럼 제외)
+  let camps = useCache ? allCampaigns.slice() : await fetchCampaignsForAdminList();
   if (!useCache) allCampaigns = camps.slice();
 
   // 상태·모집타입별 건수 요약 (필터 전 전체 기준)
@@ -11654,7 +11710,8 @@ async function loadAdminCampaigns(useCache) {
   updateFilterResetBtn('btnCampFilterReset', ['campTypeMulti','campStatusMulti'], 'adminCampSearch');
 
   // useCache(검색/필터/정렬)면 캐시 재사용 → 네트워크 0회. 캐시가 비어있으면 1회만 조회.
-  const allApps = (useCache && _campListApps) ? _campListApps : (_campListApps = await fetchApplications());
+  // PR 2 데이터 다이어트: campaign_id + status 만 select (buildCampRow 카운트 전용)
+  const allApps = (useCache && _campListApps) ? _campListApps : (_campListApps = await fetchApplicationsCountLite());
 
   // 정렬
   const appCount = id => allApps.filter(a=>a.campaign_id===id).length;
@@ -13746,9 +13803,9 @@ async function changeCampStatus(campId, newStatus) {
   }
   try {
     await updateCampaign(campId, {status: newStatus});
-    allCampaigns = await fetchCampaigns();
+    // PR 2: loadAdminCampaigns 가 fetchCampaignsForAdminList 로 allCampaigns 를 갱신.
+    //        기존 fetchCampaigns() 이중 조회 제거. renderCampaigns 는 admin 빌드에 없어 dead code.
     loadAdminCampaigns();
-    if (typeof renderCampaigns === 'function') renderCampaigns(allCampaigns);
   } catch(e) {
     toast('상태 변경 오류','error');
   }

--- a/dev/js/admin.js
+++ b/dev/js/admin.js
@@ -841,7 +841,8 @@ function getCurrentFilteredCamps() { return _currentFilteredCamps; }
 
 async function loadAdminCampaigns(useCache) {
   updateCampTableHead();
-  let camps = useCache ? allCampaigns.slice() : await fetchCampaigns();
+  // PR 2 데이터 다이어트: 목록 전용 가벼운 함수 사용 (participation_steps 등 무거운 컬럼 제외)
+  let camps = useCache ? allCampaigns.slice() : await fetchCampaignsForAdminList();
   if (!useCache) allCampaigns = camps.slice();
 
   // 상태·모집타입별 건수 요약 (필터 전 전체 기준)
@@ -887,7 +888,8 @@ async function loadAdminCampaigns(useCache) {
   updateFilterResetBtn('btnCampFilterReset', ['campTypeMulti','campStatusMulti'], 'adminCampSearch');
 
   // useCache(검색/필터/정렬)면 캐시 재사용 → 네트워크 0회. 캐시가 비어있으면 1회만 조회.
-  const allApps = (useCache && _campListApps) ? _campListApps : (_campListApps = await fetchApplications());
+  // PR 2 데이터 다이어트: campaign_id + status 만 select (buildCampRow 카운트 전용)
+  const allApps = (useCache && _campListApps) ? _campListApps : (_campListApps = await fetchApplicationsCountLite());
 
   // 정렬
   const appCount = id => allApps.filter(a=>a.campaign_id===id).length;
@@ -2979,9 +2981,9 @@ async function changeCampStatus(campId, newStatus) {
   }
   try {
     await updateCampaign(campId, {status: newStatus});
-    allCampaigns = await fetchCampaigns();
+    // PR 2: loadAdminCampaigns 가 fetchCampaignsForAdminList 로 allCampaigns 를 갱신.
+    //        기존 fetchCampaigns() 이중 조회 제거. renderCampaigns 는 admin 빌드에 없어 dead code.
     loadAdminCampaigns();
-    if (typeof renderCampaigns === 'function') renderCampaigns(allCampaigns);
   } catch(e) {
     toast('상태 변경 오류','error');
   }

--- a/dev/lib/storage.js
+++ b/dev/lib/storage.js
@@ -52,6 +52,61 @@ async function fetchCampaigns() {
   }
 }
 
+// 관리자 캠페인 목록 전용 조회 — 목록 렌더·검색·필터·정렬에 필요한 컬럼만 select.
+// participation_steps / caution_items / ng_items / description / appeal / guide 등
+// 무거운 jsonb·리치텍스트 컬럼은 제외해 페이로드를 절약한다.
+// ※ fetchCampaigns 는 인플루언서 앱·복제·편집 등 다른 곳에서도 공유하므로 건드리지 않는다.
+// ※ autoOpenCampaigns / autoCloseCampaigns 는 status / recruit_start / deadline 만 참조하므로
+//    목록 전용 컬럼셋에서도 문제없이 실행된다. 목록 진입 시 자동 전환을 유지하기 위해 여기서도 호출.
+const ADMIN_LIST_COLUMNS = [
+  'id', 'title', 'brand', 'brand_ko', 'product', 'product_ko',
+  'campaign_no', 'legacy_no',
+  'recruit_type', 'channel', 'status',
+  'slots', 'view_count',
+  'img1', 'img2', 'img3', 'img4', 'img5', 'img6', 'img7', 'img8',
+  'image_url', 'image_crops', 'emoji',
+  'recruit_start', 'deadline',
+  'purchase_start', 'purchase_end',
+  'visit_start', 'visit_end',
+  'submission_end',
+  'order_index', 'created_at', 'updated_at',
+].join(',');
+
+async function fetchCampaignsForAdminList() {
+  if (!db) return DEMO_CAMPAIGNS.slice();
+  try {
+    const data = await fetchAllPaged(() =>
+      db.from('campaigns')
+        .select(ADMIN_LIST_COLUMNS)
+        .order('order_index', { ascending: true, nullsFirst: false })
+    );
+    if (data.length > 0) {
+      await autoOpenCampaigns(data);   // scheduled → active (recruit_start 도래)
+      await autoCloseCampaigns(data);  // active → closed (deadline 경과)
+      return data;
+    }
+    return DEMO_CAMPAIGNS.slice();
+  } catch(e) {
+    return DEMO_CAMPAIGNS.slice();
+  }
+}
+
+// 관리자 캠페인 목록 전용 신청 카운트 조회 — campaign_id + status 만 select.
+// buildCampRow 의 「N건 / M명」 표시와 승인/대기 카운트에만 쓴다.
+// fetchApplications 와 달리 status 필터 없이 전건을 가져온다 (각 상태 카운트 합산 필요).
+async function fetchApplicationsCountLite() {
+  if (!db) return [];
+  try {
+    return await fetchAllPaged(() =>
+      db.from('applications')
+        .select('campaign_id,status')
+        .order('campaign_id', { ascending: true })
+    );
+  } catch(e) {
+    return [];
+  }
+}
+
 // 모집 시작일 도래 캠페인 자동 활성화 (scheduled → active)
 //   recruit_start 가 오늘(JST 자정 기준) 이하이고 status='scheduled' 면 active 로 전환.
 //   deadline 이 이미 경과한 경우는 autoCloseCampaigns 가 이어서 닫음.

--- a/index.html
+++ b/index.html
@@ -3422,6 +3422,61 @@ async function fetchCampaigns() {
   }
 }
 
+// 관리자 캠페인 목록 전용 조회 — 목록 렌더·검색·필터·정렬에 필요한 컬럼만 select.
+// participation_steps / caution_items / ng_items / description / appeal / guide 등
+// 무거운 jsonb·리치텍스트 컬럼은 제외해 페이로드를 절약한다.
+// ※ fetchCampaigns 는 인플루언서 앱·복제·편집 등 다른 곳에서도 공유하므로 건드리지 않는다.
+// ※ autoOpenCampaigns / autoCloseCampaigns 는 status / recruit_start / deadline 만 참조하므로
+//    목록 전용 컬럼셋에서도 문제없이 실행된다. 목록 진입 시 자동 전환을 유지하기 위해 여기서도 호출.
+const ADMIN_LIST_COLUMNS = [
+  'id', 'title', 'brand', 'brand_ko', 'product', 'product_ko',
+  'campaign_no', 'legacy_no',
+  'recruit_type', 'channel', 'status',
+  'slots', 'view_count',
+  'img1', 'img2', 'img3', 'img4', 'img5', 'img6', 'img7', 'img8',
+  'image_url', 'image_crops', 'emoji',
+  'recruit_start', 'deadline',
+  'purchase_start', 'purchase_end',
+  'visit_start', 'visit_end',
+  'submission_end',
+  'order_index', 'created_at', 'updated_at',
+].join(',');
+
+async function fetchCampaignsForAdminList() {
+  if (!db) return DEMO_CAMPAIGNS.slice();
+  try {
+    const data = await fetchAllPaged(() =>
+      db.from('campaigns')
+        .select(ADMIN_LIST_COLUMNS)
+        .order('order_index', { ascending: true, nullsFirst: false })
+    );
+    if (data.length > 0) {
+      await autoOpenCampaigns(data);   // scheduled → active (recruit_start 도래)
+      await autoCloseCampaigns(data);  // active → closed (deadline 경과)
+      return data;
+    }
+    return DEMO_CAMPAIGNS.slice();
+  } catch(e) {
+    return DEMO_CAMPAIGNS.slice();
+  }
+}
+
+// 관리자 캠페인 목록 전용 신청 카운트 조회 — campaign_id + status 만 select.
+// buildCampRow 의 「N건 / M명」 표시와 승인/대기 카운트에만 쓴다.
+// fetchApplications 와 달리 status 필터 없이 전건을 가져온다 (각 상태 카운트 합산 필요).
+async function fetchApplicationsCountLite() {
+  if (!db) return [];
+  try {
+    return await fetchAllPaged(() =>
+      db.from('applications')
+        .select('campaign_id,status')
+        .order('campaign_id', { ascending: true })
+    );
+  } catch(e) {
+    return [];
+  }
+}
+
 // 모집 시작일 도래 캠페인 자동 활성화 (scheduled → active)
 //   recruit_start 가 오늘(JST 자정 기준) 이하이고 status='scheduled' 면 active 로 전환.
 //   deadline 이 이미 경과한 경우는 autoCloseCampaigns 가 이어서 닫음.


### PR DESCRIPTION
## 변경 요약
캠페인 목록을 목록 전용 가벼운 컬럼만 조회하도록 변경(`fetchCampaignsForAdminList`/`fetchApplicationsCountLite`)해 호주 서버 전송량을 줄임. **dev PR #268과 동일한 소스 변경**을 main에 재적용(보류 기능 분리, git apply --3way 깨끗이 적용).

- 무거운 jsonb 스냅샷(참여방법/주의사항/NG)·리치텍스트 본문 전송 제거
- 신청 카운트는 campaign_id/status 2컬럼만
- 기존 fetchCampaigns/fetchApplications 미변경 (인플루언서 앱·엑셀·편집 폼 공유)

DB/RLS/마이그레이션 변경 없음. main 재빌드(보류 기능 누출 0, PR1 코드 유지 확인).

## 검증
- dev PR #268: supabase-expert 위험 분석(안전) + reviewer GO + qa light 7/7 PASS (편집 폼/엑셀 회귀 없음)
- 본 핫픽스: main apply --3way clean + 빌드 산출물 검증(PR2 5건/PR1 2건/누출 0)

## 관련 사양서
- docs/specs/2026-05-22-admin-campaign-list-perf.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)