### PR TITLE
perf(admin): 부트 경량화 — 새로고침 시 진입 화면 데이터만 로드 (PR 3 운영 핫픽스)

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -12,7 +12,7 @@
 // 회귀(2026-05-12 PR #182 머지 직후 발생)를 방지하기 위한 자동 reload 가드.
 // sessionStorage 차단 환경(시크릿 모드 일부, 쿠키 차단)에서는 자연스럽게 skip.
 (function(){
-  var CURRENT_BUILD = 'v1779673956';
+  var CURRENT_BUILD = 'v1779676662';
   if (CURRENT_BUILD.indexOf('__') === 0) return; // 빌드 미적용 (dev/ 직접 열기) 시 skip
   try {
     var prev = sessionStorage.getItem('reverb.adminBuild');
@@ -1522,7 +1522,7 @@ textarea.form-input{resize:vertical;min-height:80px}
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-05-25 10:52 · 71fec7c</span>
+          <span class="admin-build-text">2026-05-25 11:37 · 07a8b5d</span>
         </div>
       </div>
     </aside>
@@ -4718,6 +4718,18 @@ async function fetchPendingDeliverableCount() {
     if (error) throw error;
     return count || 0;
   } catch(e) { console.error('[fetchPendingDeliverableCount]', e); return 0; }
+}
+
+// 신청 관리 사이드바 배지용 — 대기(pending) 신청 개수만 가볍게 조회 (전건 fetch 대체)
+async function fetchPendingApplicationCount() {
+  if (!db) return 0;
+  try {
+    const {count, error} = await db?.from('applications')
+      .select('id', {count: 'exact', head: true})
+      .eq('status', 'pending');
+    if (error) throw error;
+    return count || 0;
+  } catch(e) { console.error('[fetchPendingApplicationCount]', e); return 0; }
 }
 
 // 관리자용: 결과물 리스트 + 캠페인/인플루언서 정보 조인
@@ -11184,6 +11196,8 @@ async function loadAdminData(preloaded) {
   renderProfileCompletion(users);
   // 배송지 분포(도도부현 Top N) — 이미 fetch한 users 재사용 (중복 쿼리 방지)
   renderAddressDistribution(users);
+  // 대시보드는 apps 전건을 KPI용으로 이미 보유 → 추가 count 쿼리 없이 인라인 계산.
+  // 그 외 경로(부트의 대시보드 외 페인)는 refreshApplySidebarBadge() 가 가벼운 count 로 갱신.
   if ($('adminApplySi')) $('adminApplySi').innerHTML = `<span class="si-icon material-icons-round notranslate" translate="no">assignment</span><span class="si-text">신청 관리</span>${pending.length>0?`<span class="admin-si-badge">${pending.length>999?'999+':pending.length}</span>`:''}`;
   refreshDelivSidebarBadge();
 
@@ -17795,6 +17809,16 @@ async function refreshDelivSidebarBadge() {
   } catch(e) { /* 무시 */ }
 }
 
+// 신청 관리 사이드바 배지 — 대기(pending) 개수 (가벼운 count 쿼리, 전건 fetch 불필요)
+async function refreshApplySidebarBadge() {
+  const el = $('adminApplySi');
+  if (!el) return;
+  try {
+    const n = await fetchPendingApplicationCount();
+    el.innerHTML = `<span class="si-icon material-icons-round notranslate" translate="no">assignment</span><span class="si-text">신청 관리</span>${n>0?`<span class="admin-si-badge">${n>999?'999+':n}</span>`:''}`;
+  } catch(e) { /* 무시 */ }
+}
+
 var delivLazy = null;
 const DELIV_PAGE_SIZE = 50;
 
@@ -20459,26 +20483,22 @@ async function init() {
     // 이미지 리스트 등록
     registerImgList('campImgData', campImgData);
 
-    // campaigns/influencers/applications 3개 병렬 fetch — 순차 대기 제거
-    var preloaded = await Promise.all([fetchCampaigns(), fetchInfluencers(), fetchApplications()]);
-    allCampaigns = preloaded[0].slice();
-
-    // 신청 뱃지 업데이트
-    var _pending = preloaded[2].filter(function(a){return a.status==='pending'});
-    if ($('adminApplySi')) $('adminApplySi').innerHTML = '<span class="si-icon material-icons-round">assignment</span><span class="si-text">신청 관리</span>' + (_pending.length>0?'<span class="admin-si-badge">'+(_pending.length>999?'999+':_pending.length)+'</span>':'');
-
-    // 결과물 관리 사이드바 배지 — 검수 대기(pending) 개수
+    // 사이드바 배지 3종 — 화면 진입을 막지 않도록 백그라운드로 갱신 (전부 가벼운 count 쿼리)
+    if (typeof refreshApplySidebarBadge === 'function') refreshApplySidebarBadge();
     if (typeof refreshDelivSidebarBadge === 'function') refreshDelivSidebarBadge();
-
-    // 광고주 신청 pending 배지 (신규 brand_applications)
     if (typeof refreshBrandAppBadge === 'function') refreshBrandAppBadge();
 
-    // URL 해시가 있으면 해당 패널로 이동
+    // PR 3 부트 경량화 — 진입 화면(hash)에 필요한 데이터만 로드
+    //  - dashboard: KPI·차트용 무거운 3종(캠페인/인플/신청 전건)을 여기서만 로드
+    //  - 그 외 페인: 각 페인 loader 가 자기 데이터를 스스로 fetch → 무거운 3종 스킵
+    //    (allCampaigns 는 shared.js 에서 []로 초기화. 캠페인 페인은 loadAdminCampaigns 가 lite 로 채움)
     var hash = location.hash.replace('#','');
     if (hash && hash !== 'dashboard') {
       await Promise.resolve(switchAdminPane(hash, null, false));
     } else {
       history.replaceState({pane:'dashboard'}, '', '#dashboard');
+      var preloaded = await Promise.all([fetchCampaigns(), fetchInfluencers(), fetchApplications()]);
+      allCampaigns = preloaded[0].slice();
       await loadAdminData(preloaded);
     }
   } catch(e) {

--- a/dev/admin/app.js
+++ b/dev/admin/app.js
@@ -75,26 +75,22 @@ async function init() {
     // 이미지 리스트 등록
     registerImgList('campImgData', campImgData);
 
-    // campaigns/influencers/applications 3개 병렬 fetch — 순차 대기 제거
-    var preloaded = await Promise.all([fetchCampaigns(), fetchInfluencers(), fetchApplications()]);
-    allCampaigns = preloaded[0].slice();
-
-    // 신청 뱃지 업데이트
-    var _pending = preloaded[2].filter(function(a){return a.status==='pending'});
-    if ($('adminApplySi')) $('adminApplySi').innerHTML = '<span class="si-icon material-icons-round">assignment</span><span class="si-text">신청 관리</span>' + (_pending.length>0?'<span class="admin-si-badge">'+(_pending.length>999?'999+':_pending.length)+'</span>':'');
-
-    // 결과물 관리 사이드바 배지 — 검수 대기(pending) 개수
+    // 사이드바 배지 3종 — 화면 진입을 막지 않도록 백그라운드로 갱신 (전부 가벼운 count 쿼리)
+    if (typeof refreshApplySidebarBadge === 'function') refreshApplySidebarBadge();
     if (typeof refreshDelivSidebarBadge === 'function') refreshDelivSidebarBadge();
-
-    // 광고주 신청 pending 배지 (신규 brand_applications)
     if (typeof refreshBrandAppBadge === 'function') refreshBrandAppBadge();
 
-    // URL 해시가 있으면 해당 패널로 이동
+    // PR 3 부트 경량화 — 진입 화면(hash)에 필요한 데이터만 로드
+    //  - dashboard: KPI·차트용 무거운 3종(캠페인/인플/신청 전건)을 여기서만 로드
+    //  - 그 외 페인: 각 페인 loader 가 자기 데이터를 스스로 fetch → 무거운 3종 스킵
+    //    (allCampaigns 는 shared.js 에서 []로 초기화. 캠페인 페인은 loadAdminCampaigns 가 lite 로 채움)
     var hash = location.hash.replace('#','');
     if (hash && hash !== 'dashboard') {
       await Promise.resolve(switchAdminPane(hash, null, false));
     } else {
       history.replaceState({pane:'dashboard'}, '', '#dashboard');
+      var preloaded = await Promise.all([fetchCampaigns(), fetchInfluencers(), fetchApplications()]);
+      allCampaigns = preloaded[0].slice();
       await loadAdminData(preloaded);
     }
   } catch(e) {

--- a/dev/js/admin.js
+++ b/dev/js/admin.js
@@ -362,6 +362,8 @@ async function loadAdminData(preloaded) {
   renderProfileCompletion(users);
   // 배송지 분포(도도부현 Top N) — 이미 fetch한 users 재사용 (중복 쿼리 방지)
   renderAddressDistribution(users);
+  // 대시보드는 apps 전건을 KPI용으로 이미 보유 → 추가 count 쿼리 없이 인라인 계산.
+  // 그 외 경로(부트의 대시보드 외 페인)는 refreshApplySidebarBadge() 가 가벼운 count 로 갱신.
   if ($('adminApplySi')) $('adminApplySi').innerHTML = `<span class="si-icon material-icons-round notranslate" translate="no">assignment</span><span class="si-text">신청 관리</span>${pending.length>0?`<span class="admin-si-badge">${pending.length>999?'999+':pending.length}</span>`:''}`;
   refreshDelivSidebarBadge();
 
@@ -6970,6 +6972,16 @@ async function refreshDelivSidebarBadge() {
   try {
     const n = await fetchPendingDeliverableCount();
     el.innerHTML = `<span class="si-icon material-icons-round notranslate" translate="no">fact_check</span><span class="si-text">결과물 관리</span>${n>0?`<span class="admin-si-badge">${n>999?'999+':n}</span>`:''}`;
+  } catch(e) { /* 무시 */ }
+}
+
+// 신청 관리 사이드바 배지 — 대기(pending) 개수 (가벼운 count 쿼리, 전건 fetch 불필요)
+async function refreshApplySidebarBadge() {
+  const el = $('adminApplySi');
+  if (!el) return;
+  try {
+    const n = await fetchPendingApplicationCount();
+    el.innerHTML = `<span class="si-icon material-icons-round notranslate" translate="no">assignment</span><span class="si-text">신청 관리</span>${n>0?`<span class="admin-si-badge">${n>999?'999+':n}</span>`:''}`;
   } catch(e) { /* 무시 */ }
 }
 

--- a/dev/lib/storage.js
+++ b/dev/lib/storage.js
@@ -506,6 +506,18 @@ async function fetchPendingDeliverableCount() {
   } catch(e) { console.error('[fetchPendingDeliverableCount]', e); return 0; }
 }
 
+// 신청 관리 사이드바 배지용 — 대기(pending) 신청 개수만 가볍게 조회 (전건 fetch 대체)
+async function fetchPendingApplicationCount() {
+  if (!db) return 0;
+  try {
+    const {count, error} = await db?.from('applications')
+      .select('id', {count: 'exact', head: true})
+      .eq('status', 'pending');
+    if (error) throw error;
+    return count || 0;
+  } catch(e) { console.error('[fetchPendingApplicationCount]', e); return 0; }
+}
+
 // 관리자용: 결과물 리스트 + 캠페인/인플루언서 정보 조인
 async function fetchDeliverables(filters) {
   if (!db) return [];

--- a/docs/specs/2026-05-22-admin-campaign-list-perf.md
+++ b/docs/specs/2026-05-22-admin-campaign-list-perf.md
@@ -92,13 +92,43 @@
 
 ## 구현 결과
 
-**구현일:** (개발 세션이 채울 것)
-**관련 커밋:** (개발 세션이 채울 것)
+**구현일:** PR 1 = 2026-05-22, PR 2 = 2026-05-25
+**관련 PR:**
+- 개발(dev): PR 1 #266 (feature/campaign-list-perf), PR 2 #268 (feature/campaign-list-diet)
+- 운영(main): PR 1 #267 (hotfix/campaign-perf-prod), PR 2 #269 (hotfix/campaign-diet-prod) — dev 통째 머지 대신 소스만 재적용 후 재빌드(보류 기능 분리). 2026-05-25 양쪽 운영 반영 확인 (www.globalreverb.com)
+- 운영 검증: PR 1 qa light 7/7 PASS, PR 2 qa light 7/7 PASS (편집 폼 무거운 필드·엑셀 내보내기 회귀 없음)
 
 ### 초안 대비 변경 사항
 - 추가된 것:
-- 빠진 것:
+  - `fetchCampaignsForAdminList()` — ADMIN_LIST_COLUMNS 컬럼셋(23개)으로 SELECT, autoOpenCampaigns/autoCloseCampaigns 포함
+  - `fetchApplicationsCountLite()` — campaign_id + status 2컬럼만 SELECT
+  - `ADMIN_LIST_COLUMNS` 상수 — storage.js 최상단 선언, 목록에서 참조하는 컬럼 전수 분석 후 확정
+- 빠진 것: 없음 (사양서 전체 반영)
 - 달라진 것:
+  - `fetchCampaignsForAdminList` 에서 autoOpenCampaigns/autoCloseCampaigns 호출 포함 (사양서 주석 "전환은 fetchCampaigns 경로에서만"에서 변경 — reviewer 경고 2 해소)
+  - `changeCampStatus` 의 `allCampaigns = await fetchCampaigns()` 이중 조회 제거 (reviewer 경고 1 해소)
+  - `renderCampaigns(allCampaigns)` dead code 제거 (admin 빌드에 campaign.js 미포함)
 
 ### 구현 중 기술 결정 사항
--
+- `allCampaigns` 사용처 전수 분석: buildCampRow, changeCampStatus, moveCampOrder, loadCampApplicants, renderCautionHistoryModal, 엑셀 내보내기 4종 — 무거운 컬럼(participation_steps/caution_items/ng_items/리치텍스트)을 참조하는 곳이 없음을 확인 → 설계 분기 (가) 적용
+- autoOpenCampaigns/autoCloseCampaigns 는 status/recruit_start/deadline 만 참조하므로 라이트 컬럼셋에서도 정상 작동 확인
+- 마이그레이션 없음 (DB 구조 변경 없이 클라이언트 SELECT 컬럼 조정만)
+
+---
+
+## PR 3 — 부트(첫 로드) 경량화
+
+**배경:** 운영서버 실측 결과, 새로고침 시 진입 화면과 무관하게 부트(`dev/admin/app.js`)가 무거운 3종(campaigns `select *` 1.7초 / influencers 약1,700명 1.7초 / applications 약3,000건 3페이지 3.9초)을 전건 조회해 ~4.6초 블로킹. 캠페인 페인은 이를 버리고 lite 재조회(이중). 합계 체감 ~7초.
+
+**핵심 발견:** 부트의 무거운 3종은 사실상 대시보드 전용. 다른 페인은 각자 loader 가 자기 데이터를 fetch. 부트 공통 필요 최소 = 사이드바 배지 3종(전부 head count).
+
+**변경:**
+- `dev/lib/storage.js`: `fetchPendingApplicationCount()` 신설 — applications status=pending head count (기존 fetchPendingDeliverableCount/fetchBrandAppPendingCount 패턴).
+- `dev/js/admin.js`: `refreshApplySidebarBadge()` 신설 — 신청 배지를 가벼운 count 로 갱신. `loadAdminData` 인라인 배지는 유지(대시보드는 apps 전건 보유 → 추가 쿼리 회피).
+- `dev/admin/app.js` 부트: 배지 3종을 백그라운드(await 없이) 발사 + hash 분기 — `dashboard` 면 그 안에서만 무거운 3종 Promise.all + allCampaigns 채움 + loadAdminData, 그 외 페인은 `switchAdminPane(hash)` 만(무거운 3종 스킵).
+
+**효과:** 캠페인(및 대시보드 외) 페인 새로고침 시 인플 전건·무거운 campaigns/applications 조회 제거 + 이중 조회 해소.
+
+**결정/검증:** 배지는 백그라운드 처리(체감 우선), 신청 배지 count 통일. DB 변경 없음. reviewer GO(Warning: db?.from 통일 반영). qa full 권장(전 페인 새로고침 영향).
+
+**관련 PR:** (개발/운영 — 배포 후 채움)

--- a/index.html
+++ b/index.html
@@ -3876,6 +3876,18 @@ async function fetchPendingDeliverableCount() {
   } catch(e) { console.error('[fetchPendingDeliverableCount]', e); return 0; }
 }
 
+// 신청 관리 사이드바 배지용 — 대기(pending) 신청 개수만 가볍게 조회 (전건 fetch 대체)
+async function fetchPendingApplicationCount() {
+  if (!db) return 0;
+  try {
+    const {count, error} = await db?.from('applications')
+      .select('id', {count: 'exact', head: true})
+      .eq('status', 'pending');
+    if (error) throw error;
+    return count || 0;
+  } catch(e) { console.error('[fetchPendingApplicationCount]', e); return 0; }
+}
+
 // 관리자용: 결과물 리스트 + 캠페인/인플루언서 정보 조인
 async function fetchDeliverables(filters) {
   if (!db) return [];


### PR DESCRIPTION
## 변경 요약
새로고침 시 부트가 진입 화면과 무관하게 무거운 3종(캠페인/인플 1,700명/신청 3,000건)을 전건 조회해 ~4.6초 블로킹하던 문제 해소. **dev PR #271과 동일 소스**를 main에 재적용(보류 기능 분리, git apply --3way clean).

- 대시보드일 때만 무거운 3종 로드, 그 외 페인은 각자 fetch
- 사이드바 배지 백그라운드 + 신청 배지 가벼운 개수 세기

DB/RLS/마이그레이션 없음. main 재빌드(PR3 포함, PR1·2 유지, 보류 기능 누출 0).

## 검증
- dev PR #271: reviewer GO + qa full 10/10 PASS (전 페인 새로고침·배지 정확성, 콘솔 에러 0)

## 관련 사양서
- docs/specs/2026-05-22-admin-campaign-list-perf.md (PR 3 섹션)

🤖 Generated with [Claude Code](https://claude.com/claude-code)