### PR TITLE
feat: campaign list — server-side aggregate RPC for application counts (PR 4)

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -12,7 +12,7 @@
 // 회귀(2026-05-12 PR #182 머지 직후 발생)를 방지하기 위한 자동 reload 가드.
 // sessionStorage 차단 환경(시크릿 모드 일부, 쿠키 차단)에서는 자연스럽게 skip.
 (function(){
-  var CURRENT_BUILD = 'v1779675708';
+  var CURRENT_BUILD = 'v1779677676';
   if (CURRENT_BUILD.indexOf('__') === 0) return; // 빌드 미적용 (dev/ 직접 열기) 시 skip
   try {
     var prev = sessionStorage.getItem('reverb.adminBuild');
@@ -1729,7 +1729,7 @@ textarea.form-input{resize:vertical;min-height:80px}
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-05-25 11:21 · 17d4b4f</span>
+          <span class="admin-build-text">2026-05-25 11:54 · f7d41ab</span>
         </div>
       </div>
     </aside>
@@ -4978,19 +4978,29 @@ async function fetchCampaignsForAdminList() {
   }
 }
 
-// 관리자 캠페인 목록 전용 신청 카운트 조회 — campaign_id + status 만 select.
-// buildCampRow 의 「N건 / M명」 표시와 승인/대기 카운트에만 쓴다.
-// fetchApplications 와 달리 status 필터 없이 전건을 가져온다 (각 상태 카운트 합산 필요).
-async function fetchApplicationsCountLite() {
-  if (!db) return [];
+// 관리자 캠페인 목록 전용 신청 집계 조회 — 서버 집계 함수(get_campaign_application_counts) 호출.
+// 반환: { [campaign_id]: { total, approved, pending } } 맵.
+//   total   = 취소(cancelled) 제외한 전체 신청 수 (PR 4 확정 동작 변경)
+//   approved = 승인 수, pending = 대기 수
+// 신청 전건(약 3,000건)을 클라이언트로 전송하던 방식에서 서버 집계 1회 호출로 전환.
+// DEMO_MODE 또는 호출 실패 시 빈 맵({}) 반환 — 카운트 0으로 폴백.
+async function fetchCampaignApplicationCounts() {
+  if (!db) return {};
   try {
-    return await fetchAllPaged(() =>
-      db.from('applications')
-        .select('campaign_id,status')
-        .order('campaign_id', { ascending: true })
-    );
+    const { data, error } = await db.rpc('get_campaign_application_counts');
+    if (error) throw error;
+    // 배열을 campaign_id 키 맵으로 변환
+    return (data || []).reduce((map, row) => {
+      map[row.campaign_id] = {
+        total:    Number(row.total    || 0),
+        approved: Number(row.approved || 0),
+        pending:  Number(row.pending  || 0),
+      };
+      return map;
+    }, {});
   } catch(e) {
-    return [];
+    console.error('fetchCampaignApplicationCounts:', e);
+    return {};
   }
 }
 
@@ -14617,14 +14627,14 @@ function applyImageCropsToList(imgList, cropsMap) {
 var campsLazy = null;
 const CAMPS_PAGE_SIZE = 50;
 
-// 캠페인 목록의 신청 카운트(승인/대기)용 신청 데이터 캐시.
-// 검색/필터/정렬(useCache=true)에서는 재사용해 호주 서버 전건 재조회를 막는다.
+// 캠페인 목록의 신청 집계 캐시 — { [campaign_id]: {total, approved, pending} } 맵.
+// 검색/필터/정렬(useCache=true)에서는 재사용해 서버 재조회를 막는다.
 // 페인 재진입·실데이터 갱신(useCache=false) 시에만 새로 fetch (allCampaigns 와 동일한 갱신 정책).
 // ⚠️ 이 캐시는 useCache=falsy(인자 없는 호출) 경로로만 갱신된다.
 //    신청 승인/반려 후 캠페인 페인으로 돌아오면 switchAdminPane('campaigns') → loaders.campaigns()
 //    가 loadAdminCampaigns 를 인자 없이 호출하므로 자동 갱신된다.
 //    loadAdminCampaigns(true) 직접 호출은 캐시를 갱신하지 않으니, 신청 상태가 바뀐 직후 경로에서는 쓰지 말 것.
-var _campListApps = null;
+var _campListCounts = null;
 
 // 캠페인 다중 선택 — 현재 필터/정렬 적용된 캠페인 리스트 캐시
 // loadAdminCampaigns 가 매 호출마다 갱신. toggleCampSelectAll·updateCampSelectionUI 에서 참조
@@ -14679,12 +14689,12 @@ async function loadAdminCampaigns(useCache) {
 
   updateFilterResetBtn('btnCampFilterReset', ['campTypeMulti','campStatusMulti'], 'adminCampSearch');
 
-  // useCache(검색/필터/정렬)면 캐시 재사용 → 네트워크 0회. 캐시가 비어있으면 1회만 조회.
-  // PR 2 데이터 다이어트: campaign_id + status 만 select (buildCampRow 카운트 전용)
-  const allApps = (useCache && _campListApps) ? _campListApps : (_campListApps = await fetchApplicationsCountLite());
+  // useCache(검색/필터/정렬)면 캐시 재사용 → 서버 재조회 0회. 캐시가 비어있으면 1회만 조회.
+  // PR 4 서버 집계: 신청 전건 전송 대신 서버 집계 함수 1회 호출로 전환.
+  const counts = (useCache && _campListCounts) ? _campListCounts : (_campListCounts = await fetchCampaignApplicationCounts());
 
   // 정렬
-  const appCount = id => allApps.filter(a=>a.campaign_id===id).length;
+  const appCount = id => (counts[id]?.total || 0);
   if (adminReorderMode) {
     camps.sort((a,b) => {
       if (a.order_index!=null&&b.order_index!=null) return a.order_index-b.order_index;
@@ -14737,9 +14747,9 @@ async function loadAdminCampaigns(useCache) {
   const campsBody = $('adminCampsBody');
   if (!campsBody) return;
   const buildCampRow = (c, i, totalLen) => {
-    const campApps = allApps.filter(a=>a.campaign_id===c.id);
-    const approvedCnt = campApps.filter(a=>a.status==='approved').length;
-    const pendingCnt = campApps.filter(a=>a.status==='pending').length;
+    const cc = counts[c.id] || { total: 0, approved: 0, pending: 0 };
+    const approvedCnt = cc.approved;
+    const pendingCnt  = cc.pending;
     const pct = c.slots > 0 ? Math.round(approvedCnt/c.slots*100) : 0;
     const barColor = pct>=100?'var(--red)':pct>=60?'var(--gold)':'var(--green)';
     const imgs = [c.img1,c.img2,c.img3,c.img4,c.img5,c.img6,c.img7,c.img8,c.image_url].filter(Boolean).filter((v,idx,a)=>a.indexOf(v)===idx);
@@ -14789,8 +14799,8 @@ async function loadAdminCampaigns(useCache) {
           <div style="width:48px;height:8px;background:var(--line);border-radius:4px;overflow:hidden">
             <div style="width:${Math.min(pct,100)}%;height:100%;background:${barColor};border-radius:4px"></div>
           </div>
-          <button class="btn btn-ghost btn-xs" style="padding:2px 8px 4px;font-weight:700;color:${campApps.length>0?'var(--ink)':'var(--muted)'};border-color:var(--line)" data-camp-title="${esc(c.title)}" onclick="openCampApplicants('${c.id}',this.dataset.campTitle)">
-            ${campApps.length} / ${c.slots}명
+          <button class="btn btn-ghost btn-xs" style="padding:2px 8px 4px;font-weight:700;color:${cc.total>0?'var(--ink)':'var(--muted)'};border-color:var(--line)" data-camp-title="${esc(c.title)}" onclick="openCampApplicants('${c.id}',this.dataset.campTitle)">
+            ${cc.total} / ${c.slots}명
           </button>
           <span style="font-size:10px;font-weight:600;color:${approvedCnt>0?'var(--pink)':'var(--muted)'}">${approvedCnt}승인${pendingCnt>0?` · <span style="color:var(--gold)">${pendingCnt}대기</span>`:''}</span>
         </div>

--- a/dev/js/admin.js
+++ b/dev/js/admin.js
@@ -836,14 +836,14 @@ function applyImageCropsToList(imgList, cropsMap) {
 var campsLazy = null;
 const CAMPS_PAGE_SIZE = 50;
 
-// 캠페인 목록의 신청 카운트(승인/대기)용 신청 데이터 캐시.
-// 검색/필터/정렬(useCache=true)에서는 재사용해 호주 서버 전건 재조회를 막는다.
+// 캠페인 목록의 신청 집계 캐시 — { [campaign_id]: {total, approved, pending} } 맵.
+// 검색/필터/정렬(useCache=true)에서는 재사용해 서버 재조회를 막는다.
 // 페인 재진입·실데이터 갱신(useCache=false) 시에만 새로 fetch (allCampaigns 와 동일한 갱신 정책).
 // ⚠️ 이 캐시는 useCache=falsy(인자 없는 호출) 경로로만 갱신된다.
 //    신청 승인/반려 후 캠페인 페인으로 돌아오면 switchAdminPane('campaigns') → loaders.campaigns()
 //    가 loadAdminCampaigns 를 인자 없이 호출하므로 자동 갱신된다.
 //    loadAdminCampaigns(true) 직접 호출은 캐시를 갱신하지 않으니, 신청 상태가 바뀐 직후 경로에서는 쓰지 말 것.
-var _campListApps = null;
+var _campListCounts = null;
 
 // 캠페인 다중 선택 — 현재 필터/정렬 적용된 캠페인 리스트 캐시
 // loadAdminCampaigns 가 매 호출마다 갱신. toggleCampSelectAll·updateCampSelectionUI 에서 참조
@@ -898,12 +898,12 @@ async function loadAdminCampaigns(useCache) {
 
   updateFilterResetBtn('btnCampFilterReset', ['campTypeMulti','campStatusMulti'], 'adminCampSearch');
 
-  // useCache(검색/필터/정렬)면 캐시 재사용 → 네트워크 0회. 캐시가 비어있으면 1회만 조회.
-  // PR 2 데이터 다이어트: campaign_id + status 만 select (buildCampRow 카운트 전용)
-  const allApps = (useCache && _campListApps) ? _campListApps : (_campListApps = await fetchApplicationsCountLite());
+  // useCache(검색/필터/정렬)면 캐시 재사용 → 서버 재조회 0회. 캐시가 비어있으면 1회만 조회.
+  // PR 4 서버 집계: 신청 전건 전송 대신 서버 집계 함수 1회 호출로 전환.
+  const counts = (useCache && _campListCounts) ? _campListCounts : (_campListCounts = await fetchCampaignApplicationCounts());
 
   // 정렬
-  const appCount = id => allApps.filter(a=>a.campaign_id===id).length;
+  const appCount = id => (counts[id]?.total || 0);
   if (adminReorderMode) {
     camps.sort((a,b) => {
       if (a.order_index!=null&&b.order_index!=null) return a.order_index-b.order_index;
@@ -956,9 +956,9 @@ async function loadAdminCampaigns(useCache) {
   const campsBody = $('adminCampsBody');
   if (!campsBody) return;
   const buildCampRow = (c, i, totalLen) => {
-    const campApps = allApps.filter(a=>a.campaign_id===c.id);
-    const approvedCnt = campApps.filter(a=>a.status==='approved').length;
-    const pendingCnt = campApps.filter(a=>a.status==='pending').length;
+    const cc = counts[c.id] || { total: 0, approved: 0, pending: 0 };
+    const approvedCnt = cc.approved;
+    const pendingCnt  = cc.pending;
     const pct = c.slots > 0 ? Math.round(approvedCnt/c.slots*100) : 0;
     const barColor = pct>=100?'var(--red)':pct>=60?'var(--gold)':'var(--green)';
     const imgs = [c.img1,c.img2,c.img3,c.img4,c.img5,c.img6,c.img7,c.img8,c.image_url].filter(Boolean).filter((v,idx,a)=>a.indexOf(v)===idx);
@@ -1008,8 +1008,8 @@ async function loadAdminCampaigns(useCache) {
           <div style="width:48px;height:8px;background:var(--line);border-radius:4px;overflow:hidden">
             <div style="width:${Math.min(pct,100)}%;height:100%;background:${barColor};border-radius:4px"></div>
           </div>
-          <button class="btn btn-ghost btn-xs" style="padding:2px 8px 4px;font-weight:700;color:${campApps.length>0?'var(--ink)':'var(--muted)'};border-color:var(--line)" data-camp-title="${esc(c.title)}" onclick="openCampApplicants('${c.id}',this.dataset.campTitle)">
-            ${campApps.length} / ${c.slots}명
+          <button class="btn btn-ghost btn-xs" style="padding:2px 8px 4px;font-weight:700;color:${cc.total>0?'var(--ink)':'var(--muted)'};border-color:var(--line)" data-camp-title="${esc(c.title)}" onclick="openCampApplicants('${c.id}',this.dataset.campTitle)">
+            ${cc.total} / ${c.slots}명
           </button>
           <span style="font-size:10px;font-weight:600;color:${approvedCnt>0?'var(--pink)':'var(--muted)'}">${approvedCnt}승인${pendingCnt>0?` · <span style="color:var(--gold)">${pendingCnt}대기</span>`:''}</span>
         </div>

--- a/dev/lib/storage.js
+++ b/dev/lib/storage.js
@@ -91,19 +91,29 @@ async function fetchCampaignsForAdminList() {
   }
 }
 
-// 관리자 캠페인 목록 전용 신청 카운트 조회 — campaign_id + status 만 select.
-// buildCampRow 의 「N건 / M명」 표시와 승인/대기 카운트에만 쓴다.
-// fetchApplications 와 달리 status 필터 없이 전건을 가져온다 (각 상태 카운트 합산 필요).
-async function fetchApplicationsCountLite() {
-  if (!db) return [];
+// 관리자 캠페인 목록 전용 신청 집계 조회 — 서버 집계 함수(get_campaign_application_counts) 호출.
+// 반환: { [campaign_id]: { total, approved, pending } } 맵.
+//   total   = 취소(cancelled) 제외한 전체 신청 수 (PR 4 확정 동작 변경)
+//   approved = 승인 수, pending = 대기 수
+// 신청 전건(약 3,000건)을 클라이언트로 전송하던 방식에서 서버 집계 1회 호출로 전환.
+// DEMO_MODE 또는 호출 실패 시 빈 맵({}) 반환 — 카운트 0으로 폴백.
+async function fetchCampaignApplicationCounts() {
+  if (!db) return {};
   try {
-    return await fetchAllPaged(() =>
-      db.from('applications')
-        .select('campaign_id,status')
-        .order('campaign_id', { ascending: true })
-    );
+    const { data, error } = await db.rpc('get_campaign_application_counts');
+    if (error) throw error;
+    // 배열을 campaign_id 키 맵으로 변환
+    return (data || []).reduce((map, row) => {
+      map[row.campaign_id] = {
+        total:    Number(row.total    || 0),
+        approved: Number(row.approved || 0),
+        pending:  Number(row.pending  || 0),
+      };
+      return map;
+    }, {});
   } catch(e) {
-    return [];
+    console.error('fetchCampaignApplicationCounts:', e);
+    return {};
   }
 }
 

--- a/docs/specs/2026-05-22-admin-campaign-list-perf.md
+++ b/docs/specs/2026-05-22-admin-campaign-list-perf.md
@@ -132,3 +132,21 @@
 **결정/검증:** 배지는 백그라운드 처리(체감 우선), 신청 배지 count 통일. DB 변경 없음. reviewer GO(Warning: db?.from 통일 반영). qa full 10/10 PASS(전 페인 새로고침·배지 정확성, 콘솔 에러 0).
 
 **관련 PR:** 개발 #271 (feature/admin-boot-lite), 운영 #272 (hotfix/admin-boot-lite-prod) — 2026-05-25 양쪽 운영 반영 확인. qa Warning: `#camp-applicants` URL 직접 진입 시 스피너 무한(PR 3 이전과 동일한 기존 동작, 운영은 버튼 진입만이라 무해).
+
+---
+
+## PR 4 — 신청 카운트 데이터베이스 집계
+
+**배경:** PR 3 이후에도 캠페인 목록의 신청 카운트(총/승인/대기)는 `fetchApplicationsCountLite()` 가 applications (campaign_id, status) 를 전건(약 3,000건 3페이지 ~1.5초) 조회해 브라우저에서 셌다.
+
+**변경:**
+- 마이그레이션 151 `get_campaign_application_counts()` RPC 신설 — `TABLE(campaign_id, total, approved, pending)` 를 `GROUP BY campaign_id` 로 한 번에 집계. SECURITY DEFINER + `SET search_path=''` + `is_admin()` 가드 + PUBLIC/anon REVOKE + authenticated GRANT.
+- **`total` 은 취소(cancelled) 제외** (`COUNT(*) FILTER (WHERE status <> 'cancelled')`) — 사용자 확정 동작 변경(기존은 취소 포함이었음). approved/pending 은 기존과 동일.
+- `dev/lib/storage.js`: `fetchCampaignApplicationCounts()`(rpc → campaign_id별 집계 맵) 신설, `fetchApplicationsCountLite()` 제거.
+- `dev/js/admin.js`: `_campListApps`(행 배열) → `_campListCounts`(집계 맵). buildCampRow·정렬키·신청자 보기 버튼이 맵 조회로 전환. 캐시 정책(useCache 재사용·페인 재진입 갱신)은 유지.
+
+**효과:** 신청 전건 전송(3페이지 ~1.5초)을 캠페인 수만큼의 작은 집계 행 1회 호출로 대체.
+
+**검증:** reviewer GO(Warning: REVOKE 보완·사양서 추가 반영). 동작 변경(취소 제외)이라 qa 에서 숫자 확인.
+
+**관련 PR:** (배포 후 채움)

--- a/index.html
+++ b/index.html
@@ -3846,19 +3846,29 @@ async function fetchCampaignsForAdminList() {
   }
 }
 
-// 관리자 캠페인 목록 전용 신청 카운트 조회 — campaign_id + status 만 select.
-// buildCampRow 의 「N건 / M명」 표시와 승인/대기 카운트에만 쓴다.
-// fetchApplications 와 달리 status 필터 없이 전건을 가져온다 (각 상태 카운트 합산 필요).
-async function fetchApplicationsCountLite() {
-  if (!db) return [];
+// 관리자 캠페인 목록 전용 신청 집계 조회 — 서버 집계 함수(get_campaign_application_counts) 호출.
+// 반환: { [campaign_id]: { total, approved, pending } } 맵.
+//   total   = 취소(cancelled) 제외한 전체 신청 수 (PR 4 확정 동작 변경)
+//   approved = 승인 수, pending = 대기 수
+// 신청 전건(약 3,000건)을 클라이언트로 전송하던 방식에서 서버 집계 1회 호출로 전환.
+// DEMO_MODE 또는 호출 실패 시 빈 맵({}) 반환 — 카운트 0으로 폴백.
+async function fetchCampaignApplicationCounts() {
+  if (!db) return {};
   try {
-    return await fetchAllPaged(() =>
-      db.from('applications')
-        .select('campaign_id,status')
-        .order('campaign_id', { ascending: true })
-    );
+    const { data, error } = await db.rpc('get_campaign_application_counts');
+    if (error) throw error;
+    // 배열을 campaign_id 키 맵으로 변환
+    return (data || []).reduce((map, row) => {
+      map[row.campaign_id] = {
+        total:    Number(row.total    || 0),
+        approved: Number(row.approved || 0),
+        pending:  Number(row.pending  || 0),
+      };
+      return map;
+    }, {});
   } catch(e) {
-    return [];
+    console.error('fetchCampaignApplicationCounts:', e);
+    return {};
   }
 }
 

--- a/supabase/migrations/151_campaign_application_counts.sql
+++ b/supabase/migrations/151_campaign_application_counts.sql
@@ -1,0 +1,38 @@
+-- 마이그레이션 151: 캠페인별 신청 집계 원격 호출 함수
+-- 목적: 관리자 캠페인 목록에서 신청 전건(약 3,000건)을 클라이언트로 전송하던 방식을
+--       서버 집계로 전환. 캠페인별 {총 신청 수, 승인 수, 대기 수}를 1회 호출로 반환.
+-- 동작 변경: total = 취소(cancelled) 제외 (PR 4 사용자 확정 결정)
+--            approved/pending 은 기존과 동일.
+--
+-- 롤백: DROP FUNCTION IF EXISTS public.get_campaign_application_counts();
+
+CREATE OR REPLACE FUNCTION public.get_campaign_application_counts()
+RETURNS TABLE(
+  campaign_id uuid,
+  total       bigint,
+  approved    bigint,
+  pending     bigint
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+BEGIN
+  -- 관리자 전용 함수 — 비관리자 접근 차단
+  IF NOT public.is_admin() THEN
+    RAISE EXCEPTION '권한 없음' USING ERRCODE = '42501';
+  END IF;
+
+  RETURN QUERY
+  SELECT
+    a.campaign_id,
+    COUNT(*)                                FILTER (WHERE a.status <> 'cancelled') AS total,
+    COUNT(*) FILTER (WHERE a.status = 'approved') AS approved,
+    COUNT(*) FILTER (WHERE a.status = 'pending')  AS pending
+  FROM public.applications a
+  GROUP BY a.campaign_id;
+END;
+$$;
+
+-- authenticated 에만 실행 권한 부여 (anon 미부여)
+GRANT EXECUTE ON FUNCTION public.get_campaign_application_counts() TO authenticated;

--- a/supabase/migrations/151_campaign_application_counts.sql
+++ b/supabase/migrations/151_campaign_application_counts.sql
@@ -34,5 +34,7 @@ BEGIN
 END;
 $$;
 
--- authenticated 에만 실행 권한 부여 (anon 미부여)
+-- 기본 PUBLIC EXECUTE 회수 후 authenticated 에만 부여 (anon 미부여 — 함수 존재 노출 차단)
+REVOKE ALL ON FUNCTION public.get_campaign_application_counts() FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.get_campaign_application_counts() FROM anon;
 GRANT EXECUTE ON FUNCTION public.get_campaign_application_counts() TO authenticated;


### PR DESCRIPTION
## 변경 요약
- 관리자 캠페인 목록에서 신청 전건(약 3,000건, 3페이지)을 클라이언트로 전송하던 방식을 서버 집계 원격 호출 함수 1회 호출로 전환
- `get_campaign_application_counts()` 함수 신설 (마이그레이션 151): 캠페인별 {총 신청 수, 승인 수, 대기 수}를 서버에서 집계
- 총 신청 수(total)에서 취소(cancelled) 건 제외 — 사용자 확정 결정

## 요청 외 추가 변경
없음

## 관련 사양서
- docs/specs/2026-05-22-admin-campaign-list-perf.md (PR 4)

## 배포 전 체크
- [x] reverb-reviewer GO
- [x] 빌드 성공 (admin/index.html 갱신)
- [x] stale 참조 전수 제거 (_campListApps / fetchApplicationsCountLite / allApps 캠프목록 컨텍스트 / campApps)
- [ ] 개발 DB: 마이그레이션 151 적용 필요 (SQL Editor)
- [ ] 개발서버 검증 후 운영 배포

## 마이그레이션
`supabase/migrations/151_campaign_application_counts.sql` 을 개발 DB SQL Editor에 적용 후 검증 필요.

롤백: `DROP FUNCTION IF EXISTS public.get_campaign_application_counts();`