### PR TITLE
refactor(admin): split over-long functions into helpers

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -12,7 +12,7 @@
 // 회귀(2026-05-12 PR #182 머지 직후 발생)를 방지하기 위한 자동 reload 가드.
 // sessionStorage 차단 환경(시크릿 모드 일부, 쿠키 차단)에서는 자연스럽게 skip.
 (function(){
-  var CURRENT_BUILD = 'v1779710450';
+  var CURRENT_BUILD = 'v1779710917';
   if (CURRENT_BUILD.indexOf('__') === 0) return; // 빌드 미적용 (dev/ 직접 열기) 시 skip
   try {
     var prev = sessionStorage.getItem('reverb.adminBuild');
@@ -1729,7 +1729,7 @@ textarea.form-input{resize:vertical;min-height:80px}
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-05-25 21:00 · 5e33ac1</span>
+          <span class="admin-build-text">2026-05-25 21:08 · 88f874e</span>
         </div>
       </div>
     </aside>
@@ -18171,7 +18171,8 @@ function renderSignupKPIs(users) {
   $('kpiWeekRange').textContent = `${fmt(weekAgo)} ~ ${fmt(now)}`;
 }
 
-function renderSignupChart(users, days) {
+// 가입 추이 시리즈 집계 (전체=월별 / 그 외=최근 days 일별) — 렌더 함수 길이 축소 목적 분리
+function _computeSignupSeries(users, days) {
   const now = new Date();
   const labels = [];
   const counts = [];
@@ -18200,6 +18201,11 @@ function renderSignupChart(users, days) {
       counts.push(count);
     }
   }
+  return { labels, counts };
+}
+
+function renderSignupChart(users, days) {
+  const { labels, counts } = _computeSignupSeries(users, days);
 
   const canvas = $('signupChart');
   if (!canvas) return;
@@ -18794,6 +18800,13 @@ async function loadAdminAccounts() {
     fetchAdminEmailSubscriptions(adminIds),
     _getAdminEmailKinds()
   ]);
+
+  _renderAdminAccountsTable(admins, subs, kinds, isSuper);
+  applyLookupMenuVisibility();
+}
+
+// 관리자 목록 테이블 렌더 (loadAdminAccounts 길이 축소 목적 분리)
+function _renderAdminAccountsTable(admins, subs, kinds, isSuper) {
   const kindLabel = code => (kinds.find(k => k.code === code) || {}).name_ko || code;
 
   const roleLabel = r => r === 'super_admin'
@@ -18831,8 +18844,6 @@ async function loadAdminAccounts() {
       ${(isSuper && a.auth_id !== currentUser?.id) ? `<button class="btn btn-ghost btn-xs" style="color:#B3261E" data-email="${esc(a.email)}" data-auth-id="${a.auth_id}" onclick="openDeleteAdminModal('${a.id}',this.dataset.authId,this.dataset.email)">삭제</button>` : ''}
     </div></td>
   </tr>`).join('') : '<tr><td colspan="6" style="text-align:center;color:var(--muted);padding:24px">데이터 없음</td></tr>';
-
-  applyLookupMenuVisibility();
 }
 
 // ──────────────────────────────────────
@@ -19883,6 +19894,11 @@ function openMiniEditorLinkPopover(aEl, contentDiv) {
   _positionMenuInViewport(pop, rect, {placement: 'below', gap: 6});
   _miniEditorLinkPopover = pop;
 
+  _bindMiniEditorLinkPopoverEvents(pop, aEl, contentDiv, href);
+}
+
+// 링크 팝오버 이벤트 바인딩 (openMiniEditorLinkPopover 길이 축소 목적 분리)
+function _bindMiniEditorLinkPopoverEvents(pop, aEl, contentDiv, href) {
   const input = pop.querySelector('.melp-url');
   const btnCopy = pop.querySelector('.melp-copy');
   const btnOpen = pop.querySelector('.melp-open');

--- a/dev/js/admin-accounts.js
+++ b/dev/js/admin-accounts.js
@@ -64,6 +64,13 @@ async function loadAdminAccounts() {
     fetchAdminEmailSubscriptions(adminIds),
     _getAdminEmailKinds()
   ]);
+
+  _renderAdminAccountsTable(admins, subs, kinds, isSuper);
+  applyLookupMenuVisibility();
+}
+
+// 관리자 목록 테이블 렌더 (loadAdminAccounts 길이 축소 목적 분리)
+function _renderAdminAccountsTable(admins, subs, kinds, isSuper) {
   const kindLabel = code => (kinds.find(k => k.code === code) || {}).name_ko || code;
 
   const roleLabel = r => r === 'super_admin'
@@ -101,8 +108,6 @@ async function loadAdminAccounts() {
       ${(isSuper && a.auth_id !== currentUser?.id) ? `<button class="btn btn-ghost btn-xs" style="color:#B3261E" data-email="${esc(a.email)}" data-auth-id="${a.auth_id}" onclick="openDeleteAdminModal('${a.id}',this.dataset.authId,this.dataset.email)">삭제</button>` : ''}
     </div></td>
   </tr>`).join('') : '<tr><td colspan="6" style="text-align:center;color:var(--muted);padding:24px">데이터 없음</td></tr>';
-
-  applyLookupMenuVisibility();
 }
 
 // ──────────────────────────────────────

--- a/dev/js/admin-dashboard.js
+++ b/dev/js/admin-dashboard.js
@@ -288,7 +288,8 @@ function renderSignupKPIs(users) {
   $('kpiWeekRange').textContent = `${fmt(weekAgo)} ~ ${fmt(now)}`;
 }
 
-function renderSignupChart(users, days) {
+// 가입 추이 시리즈 집계 (전체=월별 / 그 외=최근 days 일별) — 렌더 함수 길이 축소 목적 분리
+function _computeSignupSeries(users, days) {
   const now = new Date();
   const labels = [];
   const counts = [];
@@ -317,6 +318,11 @@ function renderSignupChart(users, days) {
       counts.push(count);
     }
   }
+  return { labels, counts };
+}
+
+function renderSignupChart(users, days) {
+  const { labels, counts } = _computeSignupSeries(users, days);
 
   const canvas = $('signupChart');
   if (!canvas) return;

--- a/dev/js/admin-lookups.js
+++ b/dev/js/admin-lookups.js
@@ -755,6 +755,11 @@ function openMiniEditorLinkPopover(aEl, contentDiv) {
   _positionMenuInViewport(pop, rect, {placement: 'below', gap: 6});
   _miniEditorLinkPopover = pop;
 
+  _bindMiniEditorLinkPopoverEvents(pop, aEl, contentDiv, href);
+}
+
+// 링크 팝오버 이벤트 바인딩 (openMiniEditorLinkPopover 길이 축소 목적 분리)
+function _bindMiniEditorLinkPopoverEvents(pop, aEl, contentDiv, href) {
   const input = pop.querySelector('.melp-url');
   const btnCopy = pop.querySelector('.melp-copy');
   const btnOpen = pop.querySelector('.melp-open');


### PR DESCRIPTION
## 변경 요약
- admin.js 분리 후속. 50줄 초과 함수를 동작 보존(순수 추출) 헬퍼로 분리.
- renderSignupChart → _computeSignupSeries + 본체 / loadAdminAccounts → _renderAdminAccountsTable + 본체 / openMiniEditorLinkPopover → _bindMiniEditorLinkPopoverEvents + 본체.
- renderCampaignBreakdown은 실측 39줄이라 대상 아님(이전 리뷰 줄수 부정확).

## 검증
- node --check / build.sh 통과, reviewer GO (전부 동작 보존·호이스팅 안전)
- _bindMiniEditorLinkPopoverEvents 66줄은 핸들러 4개 클로저 공유라 추가 분리 비권장(reviewer 동의), 118→19+66 개선

## 요청 외 추가 변경
- 없음

## 관련 사양서
- docs/refactoring/admin-js-split-plan.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)