### PR TITLE
chore(legal): 약관 페이지 죽은 placeholder 청소 + 폴백 문구 정정

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -12,7 +12,7 @@
 // 회귀(2026-05-12 PR #182 머지 직후 발생)를 방지하기 위한 자동 reload 가드.
 // sessionStorage 차단 환경(시크릿 모드 일부, 쿠키 차단)에서는 자연스럽게 skip.
 (function(){
-  var CURRENT_BUILD = 'v1779852020';
+  var CURRENT_BUILD = 'v1779852237';
   if (CURRENT_BUILD.indexOf('__') === 0) return; // 빌드 미적용 (dev/ 직접 열기) 시 skip
   try {
     var prev = sessionStorage.getItem('reverb.adminBuild');
@@ -1729,7 +1729,7 @@ textarea.form-input{resize:vertical;min-height:80px}
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-05-27 12:20 · 0820d7c</span>
+          <span class="admin-build-text">2026-05-27 12:23 · b8631b2</span>
         </div>
       </div>
     </aside>
@@ -8290,13 +8290,8 @@ function buildLegalContent(kind) {
       <p>REVERBは、日本で活動するインフルエンサーの皆さまと、韓国の人気Kブランドをつなぐ体験型プラットフォームです。</p>
     `;
   }
-  if (kind === 'terms' || kind === 'privacy') {
-    return `
-      <p>${kind==='terms'?'利用規約':'個人情報処理方針'}の日本語版は現在準備中です。</p>
-      <p>ご質問は公式LINE（<a href="https://line.me/R/ti/p/@reverb.jp" target="_blank" rel="noopener">@reverb.jp</a>）までお問い合わせください。</p>
-      <p style="font-size:11px;color:var(--muted);margin-top:18px">施行予定日: 2026年5月1日</p>
-    `;
-  }
+  // terms·privacy 는 별도 페이지(#page-legal, openLegalPage/legal.js)로 표시.
+  // 과거 모달 placeholder 분기는 제거됨 — about(회사정보)만 모달 사용.
   return '';
 }
 

--- a/dev/js/ui.js
+++ b/dev/js/ui.js
@@ -726,13 +726,8 @@ function buildLegalContent(kind) {
       <p>REVERBは、日本で活動するインフルエンサーの皆さまと、韓国の人気Kブランドをつなぐ体験型プラットフォームです。</p>
     `;
   }
-  if (kind === 'terms' || kind === 'privacy') {
-    return `
-      <p>${kind==='terms'?'利用規約':'個人情報処理方針'}の日本語版は現在準備中です。</p>
-      <p>ご質問は公式LINE（<a href="https://line.me/R/ti/p/@reverb.jp" target="_blank" rel="noopener">@reverb.jp</a>）までお問い合わせください。</p>
-      <p style="font-size:11px;color:var(--muted);margin-top:18px">施行予定日: 2026年5月1日</p>
-    `;
-  }
+  // terms·privacy 는 별도 페이지(#page-legal, openLegalPage/legal.js)로 표시.
+  // 과거 모달 placeholder 분기는 제거됨 — about(회사정보)만 모달 사용.
   return '';
 }
 

--- a/dev/lib/legal.js
+++ b/dev/lib/legal.js
@@ -140,14 +140,13 @@ async function renderLegalPage() {
     if (lang === 'ja') {
       body.innerHTML = `
         <div style="padding:40px 16px;text-align:center;color:var(--muted);font-size:13px;line-height:1.8">
-          <div style="font-size:32px;margin-bottom:12px"><span class="material-icons-round notranslate" translate="no">translate</span></div>
-          <div style="font-weight:700;color:var(--ink);margin-bottom:6px">日本語版は現在準備中です</div>
-          <div>正式な日本語訳は施行日（2026年5月1日）までに公開予定です。</div>
-          <div style="margin-top:12px">韓国語版を確認するか、公式LINE（<a href="https://line.me/R/ti/p/@reverb.jp" target="_blank" rel="noopener" style="color:var(--pink)">@reverb.jp</a>）までお問い合わせください。</div>
-          <button class="btn btn-ghost" style="margin-top:16px" onclick="setLegalLang('ko')">韓国語版を見る</button>
+          <div style="font-size:32px;margin-bottom:12px"><span class="material-icons-round notranslate" translate="no">cloud_off</span></div>
+          <div style="font-weight:700;color:var(--ink);margin-bottom:6px">読み込みに失敗しました</div>
+          <div>通信状況をご確認のうえ、もう一度お試しください。</div>
+          <div style="margin-top:12px">問題が続く場合は公式LINE（<a href="https://line.me/R/ti/p/@reverb.jp" target="_blank" rel="noopener" style="color:var(--pink)">@reverb.jp</a>）までお問い合わせください。</div>
         </div>`;
     } else {
-      body.innerHTML = `<div style="padding:40px 16px;text-align:center;color:var(--muted)">문서를 불러올 수 없습니다.</div>`;
+      body.innerHTML = `<div style="padding:40px 16px;text-align:center;color:var(--muted)">문서를 불러올 수 없습니다. 네트워크 상태를 확인 후 다시 시도해 주세요.</div>`;
     }
   }
 }

--- a/index.html
+++ b/index.html
@@ -6572,14 +6572,13 @@ async function renderLegalPage() {
     if (lang === 'ja') {
       body.innerHTML = `
         <div style="padding:40px 16px;text-align:center;color:var(--muted);font-size:13px;line-height:1.8">
-          <div style="font-size:32px;margin-bottom:12px"><span class="material-icons-round notranslate" translate="no">translate</span></div>
-          <div style="font-weight:700;color:var(--ink);margin-bottom:6px">日本語版は現在準備中です</div>
-          <div>正式な日本語訳は施行日（2026年5月1日）までに公開予定です。</div>
-          <div style="margin-top:12px">韓国語版を確認するか、公式LINE（<a href="https://line.me/R/ti/p/@reverb.jp" target="_blank" rel="noopener" style="color:var(--pink)">@reverb.jp</a>）までお問い合わせください。</div>
-          <button class="btn btn-ghost" style="margin-top:16px" onclick="setLegalLang('ko')">韓国語版を見る</button>
+          <div style="font-size:32px;margin-bottom:12px"><span class="material-icons-round notranslate" translate="no">cloud_off</span></div>
+          <div style="font-weight:700;color:var(--ink);margin-bottom:6px">読み込みに失敗しました</div>
+          <div>通信状況をご確認のうえ、もう一度お試しください。</div>
+          <div style="margin-top:12px">問題が続く場合は公式LINE（<a href="https://line.me/R/ti/p/@reverb.jp" target="_blank" rel="noopener" style="color:var(--pink)">@reverb.jp</a>）までお問い合わせください。</div>
         </div>`;
     } else {
-      body.innerHTML = `<div style="padding:40px 16px;text-align:center;color:var(--muted)">문서를 불러올 수 없습니다.</div>`;
+      body.innerHTML = `<div style="padding:40px 16px;text-align:center;color:var(--muted)">문서를 불러올 수 없습니다. 네트워크 상태를 확인 후 다시 시도해 주세요.</div>`;
     }
   }
 }
@@ -7312,13 +7311,8 @@ function buildLegalContent(kind) {
       <p>REVERBは、日本で活動するインフルエンサーの皆さまと、韓国の人気Kブランドをつなぐ体験型プラットフォームです。</p>
     `;
   }
-  if (kind === 'terms' || kind === 'privacy') {
-    return `
-      <p>${kind==='terms'?'利用規約':'個人情報処理方針'}の日本語版は現在準備中です。</p>
-      <p>ご質問は公式LINE（<a href="https://line.me/R/ti/p/@reverb.jp" target="_blank" rel="noopener">@reverb.jp</a>）までお問い合わせください。</p>
-      <p style="font-size:11px;color:var(--muted);margin-top:18px">施行予定日: 2026年5月1日</p>
-    `;
-  }
+  // terms·privacy 는 별도 페이지(#page-legal, openLegalPage/legal.js)로 표시.
+  // 과거 모달 placeholder 분기는 제거됨 — about(회사정보)만 모달 사용.
   return '';
 }
 


### PR DESCRIPTION
## 변경 요약
- 약관 전문은 이미 #page-legal 페이지(legal.js)로 운영 가동 중 — 남은 죽은 코드·부정확 문구 청소
- ui.js buildLegalContent: 호출 안 되는 terms/privacy '준비 중' placeholder 제거 (about 모달은 유지)
- legal.js fetch 실패 폴백: '준비 중/시행일까지 공개 예정' → 일시적 로딩 실패(재시도 안내)로 정정

## 관련
- planner: 약관 페이지 이미 구현·운영 가동 확인
- reviewer: GO

🤖 Generated with [Claude Code](https://claude.com/claude-code)