### PR TITLE
fix(messaging): complete chat-area JS (f8298fe 보완)

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -12,7 +12,7 @@
 // 회귀(2026-05-12 PR #182 머지 직후 발생)를 방지하기 위한 자동 reload 가드.
 // sessionStorage 차단 환경(시크릿 모드 일부, 쿠키 차단)에서는 자연스럽게 skip.
 (function(){
-  var CURRENT_BUILD = 'v1779859831';
+  var CURRENT_BUILD = 'v1779860226';
   if (CURRENT_BUILD.indexOf('__') === 0) return; // 빌드 미적용 (dev/ 직접 열기) 시 skip
   try {
     var prev = sessionStorage.getItem('reverb.adminBuild');
@@ -1729,7 +1729,7 @@ textarea.form-input{resize:vertical;min-height:80px}
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-05-27 14:30 · efaae2c</span>
+          <span class="admin-build-text">2026-05-27 14:37 · f8298fe</span>
         </div>
       </div>
     </aside>

--- a/dev/js/messaging.js
+++ b/dev/js/messaging.js
@@ -108,6 +108,8 @@ async function openMessagesPage(applicationId, from, pushHistory) {
     inputEl.style.height = ''; // 1줄로 리셋
     if (!inputEl._autosizeBound) {
       // 카톡식 1줄 시작 + 입력 따라 자동 확장(최대 120px). 대화 영역 확보 (2026-05-27)
+      // 전제: #msgModalInput DOM 은 페이지 생명주기 동안 재사용(cleanupMessagesPage 가 제거 안 함).
+      //       향후 cleanup 이 입력창을 재생성하면 _autosizeBound 가 stale 이 되므로 그때 플래그 재설계 필요.
       inputEl.addEventListener('input', () => {
         inputEl.style.height = 'auto';
         inputEl.style.height = Math.min(inputEl.scrollHeight, 120) + 'px';

--- a/index.html
+++ b/index.html
@@ -10622,6 +10622,8 @@ async function openMessagesPage(applicationId, from, pushHistory) {
     inputEl.style.height = ''; // 1줄로 리셋
     if (!inputEl._autosizeBound) {
       // 카톡식 1줄 시작 + 입력 따라 자동 확장(최대 120px). 대화 영역 확보 (2026-05-27)
+      // 전제: #msgModalInput DOM 은 페이지 생명주기 동안 재사용(cleanupMessagesPage 가 제거 안 함).
+      //       향후 cleanup 이 입력창을 재생성하면 _autosizeBound 가 stale 이 되므로 그때 플래그 재설계 필요.
       inputEl.addEventListener('input', () => {
         inputEl.style.height = 'auto';
         inputEl.style.height = Math.min(inputEl.scrollHeight, 120) + 'px';


### PR DESCRIPTION
## 변경 요약
- f8298fe 가 인라인 미응답 안내 HTML 제거 + 1줄 입력창 CSS 만 커밋하고 `dev/js/messaging.js` 를 미커밋으로 남겨 개발서버 메시지 화면이 정합성 깨진 상태였음 (제거된 #msgPendingNotice 를 채우려는 updateMsgPendingNotice 잔존, autogrow 미동작)
- 운영팀 미응답 안내를 renderMessageThread 안 인라인(.msg-pending-inline)으로 이동, updateMsgPendingNotice 폐기
- 입력창 autogrow(1줄→최대 120px) _autosizeBound 1회 바인딩, 진입/전송 후 1줄 리셋
- 루트 index.html / admin/index.html 재빌드

## 요청 외 추가 변경
- 없음

## 관련 사양서
- 없음 (메시지 기능 UI 미세 개선, docs/specs/2026-05-15-application-messaging.md 범위 내)

[via reviewer] GO — Critical 0 / Warning 2(선택적, rows=1 의도적 유지)
qa-tester: skip (UI 미세 개선, 운영 미배포 메시지 본체)

🤖 Generated with [Claude Code](https://claude.com/claude-code)