### PR TITLE
fix(notice): 통지 배너를 hero 위 fixed 오버레이로

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -12,7 +12,7 @@
 // 회귀(2026-05-12 PR #182 머지 직후 발생)를 방지하기 위한 자동 reload 가드.
 // sessionStorage 차단 환경(시크릿 모드 일부, 쿠키 차단)에서는 자연스럽게 skip.
 (function(){
-  var CURRENT_BUILD = 'v1779872029';
+  var CURRENT_BUILD = 'v1779872641';
   if (CURRENT_BUILD.indexOf('__') === 0) return; // 빌드 미적용 (dev/ 직접 열기) 시 skip
   try {
     var prev = sessionStorage.getItem('reverb.adminBuild');
@@ -352,9 +352,10 @@ textarea.form-input{resize:vertical;min-height:80px}
 .policy-notice-actions button{flex:1;padding:12px;border-radius:10px;font-size:14px;font-weight:700;cursor:pointer}
 .policy-notice-detail{background:#fff;border:1px solid var(--primary);color:var(--primary)}
 .policy-notice-confirm{background:var(--primary);border:1px solid var(--primary);color:#fff}
-/* 홈 상단 배너 (래퍼 #policyNoticeBannerWrap 가 표시 토글 + 홈 스크롤 컨테이너 상단 sticky 고정) */
-#policyNoticeBannerWrap{position:sticky;top:0;z-index:50;background:#E5E5E5;padding:10px 14px}
-#policyNoticeBanner{display:flex;align-items:center;gap:10px;padding:11px 14px;background:#FFF6E5;border:1px solid #F0D9A8;border-radius:12px;font-size:12.5px;line-height:1.5;color:#8A6D3B;box-shadow:0 2px 8px rgba(0,0,0,.08)}
+/* 홈 상단 배너 — GNB(.gnb height:56px) 바로 아래에 fixed 오버레이로 떠서 hero 위에 겹침(콘텐츠 안 밀림).
+   #appShell 이 transform 보유 → 자손 position:fixed 는 appShell(480px) 기준. 홈 외 페이지는 app.js navigate 에서 숨김. */
+#policyNoticeBannerWrap{position:fixed;top:56px;left:0;right:0;z-index:90;padding:10px 14px;pointer-events:none}
+#policyNoticeBanner{display:flex;align-items:center;gap:10px;padding:11px 14px;background:#FFF6E5;border:1px solid #F0D9A8;border-radius:12px;font-size:12.5px;line-height:1.5;color:#8A6D3B;box-shadow:0 4px 14px rgba(0,0,0,.18);pointer-events:auto}
 #policyNoticeBanner .pn-banner-icon{flex-shrink:0;font-size:18px;color:#C8923A}
 #policyNoticeBanner .pn-banner-text{flex:1}
 #policyNoticeBanner .pn-banner-detail{flex-shrink:0;background:none;border:none;color:#2563EB;font-weight:700;font-size:12px;cursor:pointer;text-decoration:underline;padding:0;white-space:nowrap}
@@ -1749,7 +1750,7 @@ textarea.form-input{resize:vertical;min-height:80px}
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-05-27 17:53 · 9bd4e13</span>
+          <span class="admin-build-text">2026-05-27 18:04 · 01e2eca</span>
         </div>
       </div>
     </aside>
@@ -4983,11 +4984,14 @@ function openPolicyNoticeLegal() {
   if (typeof openLegalPage === 'function') openLegalPage('privacy');
 }
 
-// 홈 상단 배너 — 홈 진입 시(navigate 'home') 호출. 닫기는 이번 방문만 숨김(부활).
+// 홈 상단 배너 — fixed 오버레이라 홈에서만 노출. 닫기는 이번 방문만 숨김(부활).
+//   홈 여부를 함수 자체에서 판정 → 로그인 직후·초기 로드 등 navigate 미경유 호출에서도 타 페이지 노출 방지.
 function renderPolicyNoticeBanner() {
   const wrap = document.getElementById('policyNoticeBannerWrap');
   if (!wrap) return;
-  const show = currentUser && !currentUser._isAdmin && _policyNoticeActive() && !_policyBannerDismissed;
+  const h = location.hash;
+  const isHome = (h === '' || h === '#' || h === '#home');
+  const show = isHome && currentUser && !currentUser._isAdmin && _policyNoticeActive() && !_policyBannerDismissed;
   if (!show) { wrap.style.display = 'none'; return; }
   const textEl = document.getElementById('policyNoticeBannerText');
   if (textEl) textEl.textContent = t('policyNotice.banner');

--- a/dev/css/components.css
+++ b/dev/css/components.css
@@ -243,9 +243,10 @@ textarea.form-input{resize:vertical;min-height:80px}
 .policy-notice-actions button{flex:1;padding:12px;border-radius:10px;font-size:14px;font-weight:700;cursor:pointer}
 .policy-notice-detail{background:#fff;border:1px solid var(--primary);color:var(--primary)}
 .policy-notice-confirm{background:var(--primary);border:1px solid var(--primary);color:#fff}
-/* 홈 상단 배너 (래퍼 #policyNoticeBannerWrap 가 표시 토글 + 홈 스크롤 컨테이너 상단 sticky 고정) */
-#policyNoticeBannerWrap{position:sticky;top:0;z-index:50;background:#E5E5E5;padding:10px 14px}
-#policyNoticeBanner{display:flex;align-items:center;gap:10px;padding:11px 14px;background:#FFF6E5;border:1px solid #F0D9A8;border-radius:12px;font-size:12.5px;line-height:1.5;color:#8A6D3B;box-shadow:0 2px 8px rgba(0,0,0,.08)}
+/* 홈 상단 배너 — GNB(.gnb height:56px) 바로 아래에 fixed 오버레이로 떠서 hero 위에 겹침(콘텐츠 안 밀림).
+   #appShell 이 transform 보유 → 자손 position:fixed 는 appShell(480px) 기준. 홈 외 페이지는 app.js navigate 에서 숨김. */
+#policyNoticeBannerWrap{position:fixed;top:56px;left:0;right:0;z-index:90;padding:10px 14px;pointer-events:none}
+#policyNoticeBanner{display:flex;align-items:center;gap:10px;padding:11px 14px;background:#FFF6E5;border:1px solid #F0D9A8;border-radius:12px;font-size:12.5px;line-height:1.5;color:#8A6D3B;box-shadow:0 4px 14px rgba(0,0,0,.18);pointer-events:auto}
 #policyNoticeBanner .pn-banner-icon{flex-shrink:0;font-size:18px;color:#C8923A}
 #policyNoticeBanner .pn-banner-text{flex:1}
 #policyNoticeBanner .pn-banner-detail{flex-shrink:0;background:none;border:none;color:#2563EB;font-weight:700;font-size:12px;cursor:pointer;text-decoration:underline;padding:0;white-space:nowrap}

--- a/dev/js/app.js
+++ b/dev/js/app.js
@@ -89,6 +89,7 @@ function navigate(page, pushHistory) {
   if (typeof updateFloatingAuthCta === 'function') updateFloatingAuthCta(pageName);
 
   if (pageName === 'home') { loadCampaigns(); if (typeof renderPolicyNoticeBanner === 'function') renderPolicyNoticeBanner(); }
+  else { const _pnb = document.getElementById('policyNoticeBannerWrap'); if (_pnb) _pnb.style.display = 'none'; }  // 배너는 fixed 오버레이 → 홈 외 페이지에선 숨김
   if (pageName === 'campaigns') loadCampaignsPage();
   if (pageName === 'mypage') {
     if (!currentUser) { navigate('login'); return; }

--- a/dev/lib/shared.js
+++ b/dev/lib/shared.js
@@ -574,11 +574,14 @@ function openPolicyNoticeLegal() {
   if (typeof openLegalPage === 'function') openLegalPage('privacy');
 }
 
-// 홈 상단 배너 — 홈 진입 시(navigate 'home') 호출. 닫기는 이번 방문만 숨김(부활).
+// 홈 상단 배너 — fixed 오버레이라 홈에서만 노출. 닫기는 이번 방문만 숨김(부활).
+//   홈 여부를 함수 자체에서 판정 → 로그인 직후·초기 로드 등 navigate 미경유 호출에서도 타 페이지 노출 방지.
 function renderPolicyNoticeBanner() {
   const wrap = document.getElementById('policyNoticeBannerWrap');
   if (!wrap) return;
-  const show = currentUser && !currentUser._isAdmin && _policyNoticeActive() && !_policyBannerDismissed;
+  const h = location.hash;
+  const isHome = (h === '' || h === '#' || h === '#home');
+  const show = isHome && currentUser && !currentUser._isAdmin && _policyNoticeActive() && !_policyBannerDismissed;
   if (!show) { wrap.style.display = 'none'; return; }
   const textEl = document.getElementById('policyNoticeBannerText');
   if (textEl) textEl.textContent = t('policyNotice.banner');

--- a/index.html
+++ b/index.html
@@ -331,9 +331,10 @@ textarea.form-input{resize:vertical;min-height:80px}
 .policy-notice-actions button{flex:1;padding:12px;border-radius:10px;font-size:14px;font-weight:700;cursor:pointer}
 .policy-notice-detail{background:#fff;border:1px solid var(--primary);color:var(--primary)}
 .policy-notice-confirm{background:var(--primary);border:1px solid var(--primary);color:#fff}
-/* 홈 상단 배너 (래퍼 #policyNoticeBannerWrap 가 표시 토글 + 홈 스크롤 컨테이너 상단 sticky 고정) */
-#policyNoticeBannerWrap{position:sticky;top:0;z-index:50;background:#E5E5E5;padding:10px 14px}
-#policyNoticeBanner{display:flex;align-items:center;gap:10px;padding:11px 14px;background:#FFF6E5;border:1px solid #F0D9A8;border-radius:12px;font-size:12.5px;line-height:1.5;color:#8A6D3B;box-shadow:0 2px 8px rgba(0,0,0,.08)}
+/* 홈 상단 배너 — GNB(.gnb height:56px) 바로 아래에 fixed 오버레이로 떠서 hero 위에 겹침(콘텐츠 안 밀림).
+   #appShell 이 transform 보유 → 자손 position:fixed 는 appShell(480px) 기준. 홈 외 페이지는 app.js navigate 에서 숨김. */
+#policyNoticeBannerWrap{position:fixed;top:56px;left:0;right:0;z-index:90;padding:10px 14px;pointer-events:none}
+#policyNoticeBanner{display:flex;align-items:center;gap:10px;padding:11px 14px;background:#FFF6E5;border:1px solid #F0D9A8;border-radius:12px;font-size:12.5px;line-height:1.5;color:#8A6D3B;box-shadow:0 4px 14px rgba(0,0,0,.18);pointer-events:auto}
 #policyNoticeBanner .pn-banner-icon{flex-shrink:0;font-size:18px;color:#C8923A}
 #policyNoticeBanner .pn-banner-text{flex:1}
 #policyNoticeBanner .pn-banner-detail{flex-shrink:0;background:none;border:none;color:#2563EB;font-weight:700;font-size:12px;cursor:pointer;text-decoration:underline;padding:0;white-space:nowrap}
@@ -2438,11 +2439,14 @@ function openPolicyNoticeLegal() {
   if (typeof openLegalPage === 'function') openLegalPage('privacy');
 }
 
-// 홈 상단 배너 — 홈 진입 시(navigate 'home') 호출. 닫기는 이번 방문만 숨김(부활).
+// 홈 상단 배너 — fixed 오버레이라 홈에서만 노출. 닫기는 이번 방문만 숨김(부활).
+//   홈 여부를 함수 자체에서 판정 → 로그인 직후·초기 로드 등 navigate 미경유 호출에서도 타 페이지 노출 방지.
 function renderPolicyNoticeBanner() {
   const wrap = document.getElementById('policyNoticeBannerWrap');
   if (!wrap) return;
-  const show = currentUser && !currentUser._isAdmin && _policyNoticeActive() && !_policyBannerDismissed;
+  const h = location.hash;
+  const isHome = (h === '' || h === '#' || h === '#home');
+  const show = isHome && currentUser && !currentUser._isAdmin && _policyNoticeActive() && !_policyBannerDismissed;
   if (!show) { wrap.style.display = 'none'; return; }
   const textEl = document.getElementById('policyNoticeBannerText');
   if (textEl) textEl.textContent = t('policyNotice.banner');
@@ -11491,6 +11495,7 @@ function navigate(page, pushHistory) {
   if (typeof updateFloatingAuthCta === 'function') updateFloatingAuthCta(pageName);
 
   if (pageName === 'home') { loadCampaigns(); if (typeof renderPolicyNoticeBanner === 'function') renderPolicyNoticeBanner(); }
+  else { const _pnb = document.getElementById('policyNoticeBannerWrap'); if (_pnb) _pnb.style.display = 'none'; }  // 배너는 fixed 오버레이 → 홈 외 페이지에선 숨김
   if (pageName === 'campaigns') loadCampaignsPage();
   if (pageName === 'mypage') {
     if (!currentUser) { navigate('login'); return; }


### PR DESCRIPTION
## 변경 요약
- 정책 통지 홈 배너를 sticky(공간 차지·hero를 아래로 밀어냄) → **fixed 오버레이**(hero 위에 겹쳐 떠서 콘텐츠를 밀지 않음, 스크롤 시 상단 고정)로 변경 — 사용자 요청
- GNB(.gnb 높이 56px) 바로 아래(top:56px) 고정. #appShell 의 transform 덕에 fixed 가 480px 셸 기준
- 홈 외 페이지에서 배너 숨김(navigate else + renderPolicyNoticeBanner 홈 가드 이중)

## 요청 외 추가 변경
- 없음

[via reviewer] GO — Warning 1(직접 호출 시 홈 가드) 반영
qa-tester: light (홈 배너 표시/숨김·스크롤 고정 수동 확인) — 개발서버에서 직접 검증 예정

🤖 Generated with [Claude Code](https://claude.com/claude-code)