### PR TITLE
fix(notice): 배너 언어 토글 갱신 + 통지 메일 미발송 기록

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -12,7 +12,7 @@
 // 회귀(2026-05-12 PR #182 머지 직후 발생)를 방지하기 위한 자동 reload 가드.
 // sessionStorage 차단 환경(시크릿 모드 일부, 쿠키 차단)에서는 자연스럽게 skip.
 (function(){
-  var CURRENT_BUILD = 'v1779873307';
+  var CURRENT_BUILD = 'v1779873887';
   if (CURRENT_BUILD.indexOf('__') === 0) return; // 빌드 미적용 (dev/ 직접 열기) 시 skip
   try {
     var prev = sessionStorage.getItem('reverb.adminBuild');
@@ -1750,7 +1750,7 @@ textarea.form-input{resize:vertical;min-height:80px}
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-05-27 18:15 · 022efa4</span>
+          <span class="admin-build-text">2026-05-27 18:24 · b4644ff</span>
         </div>
       </div>
     </aside>
@@ -5010,8 +5010,7 @@ function renderPolicyNoticeBanner() {
   const isHome = (h === '' || h === '#' || h === '#home');
   const show = isHome && currentUser && !currentUser._isAdmin && _policyNoticeActive() && !_policyBannerDismissed && !_isPolicyNoticeDismissed();
   if (!show) { wrap.style.display = 'none'; return; }
-  const textEl = document.getElementById('policyNoticeBannerText');
-  if (textEl) textEl.textContent = t('policyNotice.banner');
+  // 배너 텍스트는 data-i18n="policyNotice.banner" 가 담당 → 언어 토글 시 applyI18n 이 자동 갱신
   wrap.style.display = '';
 }
 

--- a/dev/index.html
+++ b/dev/index.html
@@ -312,7 +312,7 @@ window._supabaseLoaded = false;
   <div id="policyNoticeBannerWrap" style="display:none">
     <div id="policyNoticeBanner">
       <span class="material-icons-round notranslate pn-banner-icon" translate="no">campaign</span>
-      <span class="pn-banner-text" id="policyNoticeBannerText"></span>
+      <span class="pn-banner-text" id="policyNoticeBannerText" data-i18n="policyNotice.banner"></span>
       <button class="pn-banner-detail" onclick="openPolicyNoticeFromBanner()" data-i18n="policyNotice.detailBtn"></button>
       <button class="pn-banner-close" onclick="dismissPolicyNoticeBanner()" aria-label="閉じる"><span class="material-icons-round notranslate" translate="no" style="font-size:18px">close</span></button>
     </div>

--- a/dev/lib/shared.js
+++ b/dev/lib/shared.js
@@ -600,8 +600,7 @@ function renderPolicyNoticeBanner() {
   const isHome = (h === '' || h === '#' || h === '#home');
   const show = isHome && currentUser && !currentUser._isAdmin && _policyNoticeActive() && !_policyBannerDismissed && !_isPolicyNoticeDismissed();
   if (!show) { wrap.style.display = 'none'; return; }
-  const textEl = document.getElementById('policyNoticeBannerText');
-  if (textEl) textEl.textContent = t('policyNotice.banner');
+  // 배너 텍스트는 data-i18n="policyNotice.banner" 가 담당 → 언어 토글 시 applyI18n 이 자동 갱신
   wrap.style.display = '';
 }
 

--- a/docs/notices/2026-05-27-message-feature-notice.md
+++ b/docs/notices/2026-05-27-message-feature-notice.md
@@ -4,7 +4,8 @@
 > - 기능명 「메시지」 → 「お問い合わせ／문의하기」 전면 리브랜딩
 > - 시행일 **2026-05-27(즉시)**, "추가되었습니다/개정되었습니다" 완료형
 > - 항목 구조: 기능 / 위치 / 사용 / 보관
-> - **실제 발송 문안의 최신본은 코드가 source**: 메일 = `supabase/functions/notify-policy-change/`(index.ts subject·text + _templates html), 앱 공지 = i18n `policyNotice` 키(`dev/lib/i18n/{ja,ko}.js`)
+> - **통지 수단 = 앱 공지(로그인 팝업·홈 배너)만. 도입 통지 메일(notify-policy-change)은 발송 안 함** (2026-05-27 사용자 결정). 메일 발송기·발송 로그(마이그레이션 153) 코드는 보존(운영 호출만 안 함, 향후 재사용)
+> - 앱 공지 문안 source: i18n `policyNotice` 키(`dev/lib/i18n/{ja,ko}.js`). 메일 문안(아래 본문·`notify-policy-change`)은 미발송이나 이력 보존
 > - 아래 본문은 초안(사전 통지·「메시지」 버전) — 이력 참고용으로 보존
 >
 > 인플루언서 대상이므로 **일본어가 실제 발송본**, 한국어는 검토용 병기.

--- a/index.html
+++ b/index.html
@@ -970,7 +970,7 @@ textarea.form-input{resize:vertical;min-height:80px}
   <div id="policyNoticeBannerWrap" style="display:none">
     <div id="policyNoticeBanner">
       <span class="material-icons-round notranslate pn-banner-icon" translate="no">campaign</span>
-      <span class="pn-banner-text" id="policyNoticeBannerText"></span>
+      <span class="pn-banner-text" id="policyNoticeBannerText" data-i18n="policyNotice.banner"></span>
       <button class="pn-banner-detail" onclick="openPolicyNoticeFromBanner()" data-i18n="policyNotice.detailBtn"></button>
       <button class="pn-banner-close" onclick="dismissPolicyNoticeBanner()" aria-label="閉じる"><span class="material-icons-round notranslate" translate="no" style="font-size:18px">close</span></button>
     </div>
@@ -2465,8 +2465,7 @@ function renderPolicyNoticeBanner() {
   const isHome = (h === '' || h === '#' || h === '#home');
   const show = isHome && currentUser && !currentUser._isAdmin && _policyNoticeActive() && !_policyBannerDismissed && !_isPolicyNoticeDismissed();
   if (!show) { wrap.style.display = 'none'; return; }
-  const textEl = document.getElementById('policyNoticeBannerText');
-  if (textEl) textEl.textContent = t('policyNotice.banner');
+  // 배너 텍스트는 data-i18n="policyNotice.banner" 가 담당 → 언어 토글 시 applyI18n 이 자동 갱신
   wrap.style.display = '';
 }
 


### PR DESCRIPTION
## 변경 요약
- 홈 통지 배너 텍스트가 언어 토글 시 한국어로 고착되던 버그 수정 — JS textContent → `data-i18n` 속성으로 변경해 언어 전환 시 자동 갱신
- docs 문안 문서에 '통지는 앱 공지만, 도입 통지 메일(notify-policy-change) 미발송, 메일 코드 보존' 결정 기록 (사용자 결정)

## 요청 외 추가 변경
- 없음

[via reviewer] GO — Critical 0
qa-tester: skip (버그 수정·문서 기록)

🤖 Generated with [Claude Code](https://claude.com/claude-code)