### PR TITLE
fix(i18n): 푸터·SNS 카드·회사정보 모달 언어 토글 반영

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -12,7 +12,7 @@
 // 회귀(2026-05-12 PR #182 머지 직후 발생)를 방지하기 위한 자동 reload 가드.
 // sessionStorage 차단 환경(시크릿 모드 일부, 쿠키 차단)에서는 자연스럽게 skip.
 (function(){
-  var CURRENT_BUILD = 'v1779873887';
+  var CURRENT_BUILD = 'v1779877582';
   if (CURRENT_BUILD.indexOf('__') === 0) return; // 빌드 미적용 (dev/ 직접 열기) 시 skip
   try {
     var prev = sessionStorage.getItem('reverb.adminBuild');
@@ -1750,7 +1750,7 @@ textarea.form-input{resize:vertical;min-height:80px}
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-05-27 18:24 · b4644ff</span>
+          <span class="admin-build-text">2026-05-27 19:26 · e63e4b4</span>
         </div>
       </div>
     </aside>
@@ -8390,7 +8390,8 @@ function closeLoginPrompt(e) {
 
 // ── 회사정보 / 이용약관 / 개인정보 모달 ──
 function openLegalModal(kind) {
-  const titles = {about:'会社紹介', terms:'利用規約', privacy:'個人情報処理方針'};
+  const _t = (typeof t === 'function') ? t : (k) => k;  // admin 빌드엔 i18n 미포함 → 방어
+  const titles = {about: _t('legal.about'), terms: _t('legal.termsTitle'), privacy: _t('legal.privacyTitle')};
   const $t = document.getElementById('legalTitle');
   const $b = document.getElementById('legalBody');
   const $m = document.getElementById('legalModal');
@@ -8406,16 +8407,17 @@ function closeLegalModal() {
   document.body.style.overflow = '';
 }
 function buildLegalContent(kind) {
+  const _t = (typeof t === 'function') ? t : (k) => k;  // admin 빌드엔 i18n 미포함 → 방어
   if (kind === 'about') {
     return `
-      <h3>会社情報</h3>
+      <h3>${esc(_t('footer.aboutHeading'))}</h3>
       <dl>
-        <dt>会社名</dt><dd>株式会社ジェイファン（JFUN Corp.）</dd>
-        <dt>所在地</dt><dd>ソウル市 衿川区 加山デジタル1路 128 STX V-Tower 1201号</dd>
-        <dt>代表者</dt><dd>ジュ・ヒョンホ</dd>
-        <dt>お問い合わせ</dt><dd>公式LINE <a href="https://line.me/R/ti/p/@reverb.jp" target="_blank" rel="noopener">@reverb.jp</a></dd>
+        <dt>${esc(_t('footer.companyLabel'))}</dt><dd>${esc(_t('footer.companyName'))}（JFUN Corp.）</dd>
+        <dt>${esc(_t('footer.locationLabel'))}</dt><dd>${esc(_t('footer.locationValue'))}</dd>
+        <dt>${esc(_t('footer.representativeLabel'))}</dt><dd>${esc(_t('footer.representativeValue'))}</dd>
+        <dt>${esc(_t('footer.contactLabel'))}</dt><dd>${esc(_t('footer.officialLine'))} <a href="https://line.me/R/ti/p/@reverb.jp" target="_blank" rel="noopener">@reverb.jp</a></dd>
       </dl>
-      <p>REVERBは、日本で活動するインフルエンサーの皆さまと、韓国の人気Kブランドをつなぐ体験型プラットフォームです。</p>
+      <p>${esc(_t('footer.aboutText'))}</p>
     `;
   }
   // terms·privacy 는 별도 페이지(#page-legal, openLegalPage/legal.js)로 표시.

--- a/dev/index.html
+++ b/dev/index.html
@@ -384,8 +384,8 @@ window._supabaseLoaded = false;
           </div>
           <div style="flex:1">
             <div style="font-family:'Sora',sans-serif;font-weight:800;font-size:15px;color:#fff;margin-bottom:3px">REVERB <span style="font-size:11px;font-weight:600;opacity:.85">INSTAGRAM</span></div>
-            <div style="font-size:12px;color:rgba(255,255,255,.95);font-weight:600;line-height:1.5">公式アカウントをフォローして最新キャンペーン情報を受け取る</div>
-            <div style="font-size:11px;color:rgba(255,255,255,.65);margin-top:2px">@reverb_jp をフォロー →</div>
+            <div style="font-size:12px;color:rgba(255,255,255,.95);font-weight:600;line-height:1.5" data-i18n="detail.igFollowCta">公式アカウントをフォローして最新キャンペーン情報を受け取る</div>
+            <div style="font-size:11px;color:rgba(255,255,255,.65);margin-top:2px" data-i18n="detail.igFollowSub">@reverb_jp をフォロー →</div>
           </div>
         </div>
         <!-- LINE 카드 -->
@@ -395,9 +395,9 @@ window._supabaseLoaded = false;
           </div>
           <div style="flex:1">
             <div style="font-family:'Sora',sans-serif;font-weight:800;font-size:15px;color:#fff;margin-bottom:3px">REVERB <span style="font-size:11px;font-weight:600;opacity:.85">LINE</span></div>
-            <div style="font-size:12px;color:rgba(255,255,255,.95);font-weight:600;line-height:1.5">LINE公式アカウントを追加して最新キャンペーン情報を受け取りましょう。</div>
-            <div style="font-size:11px;color:rgba(255,255,255,.8);margin-top:3px">友だち検索「@reverb.jp」</div>
-            <div style="display:inline-block;background:rgba(255,255,255,.2);border:1px solid rgba(255,255,255,.4);border-radius:20px;padding:3px 10px;font-size:10px;font-weight:700;color:#fff;margin-top:5px">Reverbチャンネル登録はRequiredです <span class="material-icons-round notranslate" translate="no" style="font-size:10px;vertical-align:middle">check</span></div>
+            <div style="font-size:12px;color:rgba(255,255,255,.95);font-weight:600;line-height:1.5" data-i18n="detail.lineAddCta">LINE公式アカウントを追加して最新キャンペーン情報を受け取りましょう。</div>
+            <div style="font-size:11px;color:rgba(255,255,255,.8);margin-top:3px" data-i18n="detail.lineAddSub">友だち検索「@reverb.jp」</div>
+            <div style="display:inline-block;background:rgba(255,255,255,.2);border:1px solid rgba(255,255,255,.4);border-radius:20px;padding:3px 10px;font-size:10px;font-weight:700;color:#fff;margin-top:5px"><span data-i18n="detail.channelRequired">Reverbチャンネル登録は必須です</span> <span class="material-icons-round notranslate" translate="no" style="font-size:10px;vertical-align:middle">check</span></div>
           </div>
         </div>
       </div>
@@ -407,17 +407,17 @@ window._supabaseLoaded = false;
   <!-- ── FOOTER ── -->
   <footer class="site-footer">
     <div class="container">
-      <div class="footer-brand">株式会社ジェイファン</div>
+      <div class="footer-brand" data-i18n="footer.companyName">株式会社ジェイファン</div>
       <dl class="footer-info">
-        <div><dt>会社名</dt><dd>株式会社ジェイファン</dd></div>
-        <div><dt>所在地</dt><dd>ソウル市 衿川区 加山デジタル1路 128 STX V-Tower 1201号</dd></div>
-        <div><dt>代表者</dt><dd>ジュ・ヒョンホ</dd></div>
-        <div><dt>お問い合わせ</dt><dd>公式LINE <a href="https://line.me/R/ti/p/@reverb.jp" target="_blank" rel="noopener">@reverb.jp</a></dd></div>
+        <div><dt data-i18n="footer.companyLabel">会社名</dt><dd data-i18n="footer.companyName">株式会社ジェイファン</dd></div>
+        <div><dt data-i18n="footer.locationLabel">所在地</dt><dd data-i18n="footer.locationValue">ソウル市 衿川区 加山デジタル1路 128 STX V-Tower 1201号</dd></div>
+        <div><dt data-i18n="footer.representativeLabel">代表者</dt><dd data-i18n="footer.representativeValue">ジュ・ヒョンホ</dd></div>
+        <div><dt data-i18n="footer.contactLabel">お問い合わせ</dt><dd><span data-i18n="footer.officialLine">公式LINE</span> <a href="https://line.me/R/ti/p/@reverb.jp" target="_blank" rel="noopener">@reverb.jp</a></dd></div>
       </dl>
       <div class="footer-links">
-        <a href="#about" onclick="event.preventDefault();openLegalModal('about')">会社紹介</a>
-        <a href="#terms" onclick="event.preventDefault();openLegalPage('terms','ja')">利用規約</a>
-        <a href="#privacy" onclick="event.preventDefault();openLegalPage('privacy','ja')">個人情報処理方針</a>
+        <a href="#about" onclick="event.preventDefault();openLegalModal('about')" data-i18n="legal.about">会社紹介</a>
+        <a href="#terms" onclick="event.preventDefault();openLegalPage('terms')" data-i18n="legal.termsTitle">利用規約</a>
+        <a href="#privacy" onclick="event.preventDefault();openLegalPage('privacy')" data-i18n="legal.privacyTitle">個人情報処理方針</a>
       </div>
       <div class="footer-sns">
         <a href="https://www.instagram.com/reverb_jp" target="_blank" rel="noopener" aria-label="Instagram">
@@ -488,8 +488,8 @@ window._supabaseLoaded = false;
           </div>
           <div style="flex:1">
             <div style="font-family:'Sora',sans-serif;font-weight:800;font-size:14px;color:#fff;margin-bottom:2px">REVERB <span style="font-size:10px;font-weight:600;opacity:.85">INSTAGRAM</span></div>
-            <div style="font-size:11px;color:rgba(255,255,255,.95);font-weight:600;line-height:1.5">公式アカウントをフォローして最新キャンペーン情報を受け取る</div>
-            <div style="font-size:10px;color:rgba(255,255,255,.65);margin-top:2px">@reverb_jp をフォロー →</div>
+            <div style="font-size:11px;color:rgba(255,255,255,.95);font-weight:600;line-height:1.5" data-i18n="detail.igFollowCta">公式アカウントをフォローして最新キャンペーン情報を受け取る</div>
+            <div style="font-size:10px;color:rgba(255,255,255,.65);margin-top:2px" data-i18n="detail.igFollowSub">@reverb_jp をフォロー →</div>
           </div>
         </div>
         <div style="background:linear-gradient(135deg,#3AC05A 0%,#06A434 100%);border-radius:14px;padding:16px 18px;display:flex;align-items:center;gap:14px;cursor:pointer" onclick="window.open('https://line.me/R/ti/p/@reverb.jp','_blank')">
@@ -498,9 +498,9 @@ window._supabaseLoaded = false;
           </div>
           <div style="flex:1">
             <div style="font-family:'Sora',sans-serif;font-weight:800;font-size:14px;color:#fff;margin-bottom:2px">REVERB <span style="font-size:10px;font-weight:600;opacity:.85">LINE</span></div>
-            <div style="font-size:11px;color:rgba(255,255,255,.95);font-weight:600;line-height:1.5">LINE公式アカウントを追加して最新キャンペーン情報を受け取りましょう。</div>
-            <div style="font-size:10px;color:rgba(255,255,255,.8);margin-top:2px">友だち検索「@reverb.jp」</div>
-            <div style="display:inline-block;background:rgba(255,255,255,.2);border:1px solid rgba(255,255,255,.4);border-radius:20px;padding:2px 9px;font-size:10px;font-weight:700;color:#fff;margin-top:4px">Reverbチャンネル登録はRequiredです <span class="material-icons-round notranslate" translate="no" style="font-size:10px;vertical-align:middle">check</span></div>
+            <div style="font-size:11px;color:rgba(255,255,255,.95);font-weight:600;line-height:1.5" data-i18n="detail.lineAddCta">LINE公式アカウントを追加して最新キャンペーン情報を受け取りましょう。</div>
+            <div style="font-size:10px;color:rgba(255,255,255,.8);margin-top:2px" data-i18n="detail.lineAddSub">友だち検索「@reverb.jp」</div>
+            <div style="display:inline-block;background:rgba(255,255,255,.2);border:1px solid rgba(255,255,255,.4);border-radius:20px;padding:2px 9px;font-size:10px;font-weight:700;color:#fff;margin-top:4px"><span data-i18n="detail.channelRequired">Reverbチャンネル登録は必須です</span> <span class="material-icons-round notranslate" translate="no" style="font-size:10px;vertical-align:middle">check</span></div>
           </div>
         </div>
       </div>

--- a/dev/js/ui.js
+++ b/dev/js/ui.js
@@ -698,7 +698,8 @@ function closeLoginPrompt(e) {
 
 // ── 회사정보 / 이용약관 / 개인정보 모달 ──
 function openLegalModal(kind) {
-  const titles = {about:'会社紹介', terms:'利用規約', privacy:'個人情報処理方針'};
+  const _t = (typeof t === 'function') ? t : (k) => k;  // admin 빌드엔 i18n 미포함 → 방어
+  const titles = {about: _t('legal.about'), terms: _t('legal.termsTitle'), privacy: _t('legal.privacyTitle')};
   const $t = document.getElementById('legalTitle');
   const $b = document.getElementById('legalBody');
   const $m = document.getElementById('legalModal');
@@ -714,16 +715,17 @@ function closeLegalModal() {
   document.body.style.overflow = '';
 }
 function buildLegalContent(kind) {
+  const _t = (typeof t === 'function') ? t : (k) => k;  // admin 빌드엔 i18n 미포함 → 방어
   if (kind === 'about') {
     return `
-      <h3>会社情報</h3>
+      <h3>${esc(_t('footer.aboutHeading'))}</h3>
       <dl>
-        <dt>会社名</dt><dd>株式会社ジェイファン（JFUN Corp.）</dd>
-        <dt>所在地</dt><dd>ソウル市 衿川区 加山デジタル1路 128 STX V-Tower 1201号</dd>
-        <dt>代表者</dt><dd>ジュ・ヒョンホ</dd>
-        <dt>お問い合わせ</dt><dd>公式LINE <a href="https://line.me/R/ti/p/@reverb.jp" target="_blank" rel="noopener">@reverb.jp</a></dd>
+        <dt>${esc(_t('footer.companyLabel'))}</dt><dd>${esc(_t('footer.companyName'))}（JFUN Corp.）</dd>
+        <dt>${esc(_t('footer.locationLabel'))}</dt><dd>${esc(_t('footer.locationValue'))}</dd>
+        <dt>${esc(_t('footer.representativeLabel'))}</dt><dd>${esc(_t('footer.representativeValue'))}</dd>
+        <dt>${esc(_t('footer.contactLabel'))}</dt><dd>${esc(_t('footer.officialLine'))} <a href="https://line.me/R/ti/p/@reverb.jp" target="_blank" rel="noopener">@reverb.jp</a></dd>
       </dl>
-      <p>REVERBは、日本で活動するインフルエンサーの皆さまと、韓国の人気Kブランドをつなぐ体験型プラットフォームです。</p>
+      <p>${esc(_t('footer.aboutText'))}</p>
     `;
   }
   // terms·privacy 는 별도 페이지(#page-legal, openLegalPage/legal.js)로 표시.

--- a/dev/lib/i18n/ja.js
+++ b/dev/lib/i18n/ja.js
@@ -315,6 +315,20 @@ window.I18N_JA = {
     about: '会社紹介',
   },
 
+  // 푸터 회사 정보
+  footer: {
+    aboutHeading: '会社情報',
+    companyLabel: '会社名',
+    locationLabel: '所在地',
+    representativeLabel: '代表者',
+    contactLabel: 'お問い合わせ',
+    companyName: '株式会社ジェイファン',
+    locationValue: 'ソウル市 衿川区 加山デジタル1路 128 STX V-Tower 1201号',
+    representativeValue: 'ジュ・ヒョンホ',
+    officialLine: '公式LINE',
+    aboutText: 'REVERBは、日本で活動するインフルエンサーの皆さまと、韓国の人気Kブランドをつなぐ体験型プラットフォームです。',
+  },
+
   // 캠페인 상세
   detail: {
     recruitType: '募集タイプ',

--- a/dev/lib/i18n/ko.js
+++ b/dev/lib/i18n/ko.js
@@ -303,6 +303,20 @@ window.I18N_KO = {
     about: '회사 소개',
   },
 
+  // 푸터 회사 정보
+  footer: {
+    aboutHeading: '회사 정보',
+    companyLabel: '회사명',
+    locationLabel: '소재지',
+    representativeLabel: '대표자',
+    contactLabel: '문의',
+    companyName: '주식회사 제이펀',
+    locationValue: '서울특별시 금천구 가산디지털1로 128 STX V타워 1201호',
+    representativeValue: '주현호',
+    officialLine: '공식 LINE',
+    aboutText: 'REVERB는 일본에서 활동하는 인플루언서와 한국 인기 K브랜드를 잇는 체험형 플랫폼입니다.',
+  },
+
   detail: {
     recruitType: '모집 타입',
     recruitPeriod: '모집 기간',

--- a/index.html
+++ b/index.html
@@ -1042,8 +1042,8 @@ textarea.form-input{resize:vertical;min-height:80px}
           </div>
           <div style="flex:1">
             <div style="font-family:'Sora',sans-serif;font-weight:800;font-size:15px;color:#fff;margin-bottom:3px">REVERB <span style="font-size:11px;font-weight:600;opacity:.85">INSTAGRAM</span></div>
-            <div style="font-size:12px;color:rgba(255,255,255,.95);font-weight:600;line-height:1.5">公式アカウントをフォローして最新キャンペーン情報を受け取る</div>
-            <div style="font-size:11px;color:rgba(255,255,255,.65);margin-top:2px">@reverb_jp をフォロー →</div>
+            <div style="font-size:12px;color:rgba(255,255,255,.95);font-weight:600;line-height:1.5" data-i18n="detail.igFollowCta">公式アカウントをフォローして最新キャンペーン情報を受け取る</div>
+            <div style="font-size:11px;color:rgba(255,255,255,.65);margin-top:2px" data-i18n="detail.igFollowSub">@reverb_jp をフォロー →</div>
           </div>
         </div>
         <!-- LINE 카드 -->
@@ -1053,9 +1053,9 @@ textarea.form-input{resize:vertical;min-height:80px}
           </div>
           <div style="flex:1">
             <div style="font-family:'Sora',sans-serif;font-weight:800;font-size:15px;color:#fff;margin-bottom:3px">REVERB <span style="font-size:11px;font-weight:600;opacity:.85">LINE</span></div>
-            <div style="font-size:12px;color:rgba(255,255,255,.95);font-weight:600;line-height:1.5">LINE公式アカウントを追加して最新キャンペーン情報を受け取りましょう。</div>
-            <div style="font-size:11px;color:rgba(255,255,255,.8);margin-top:3px">友だち検索「@reverb.jp」</div>
-            <div style="display:inline-block;background:rgba(255,255,255,.2);border:1px solid rgba(255,255,255,.4);border-radius:20px;padding:3px 10px;font-size:10px;font-weight:700;color:#fff;margin-top:5px">Reverbチャンネル登録はRequiredです <span class="material-icons-round notranslate" translate="no" style="font-size:10px;vertical-align:middle">check</span></div>
+            <div style="font-size:12px;color:rgba(255,255,255,.95);font-weight:600;line-height:1.5" data-i18n="detail.lineAddCta">LINE公式アカウントを追加して最新キャンペーン情報を受け取りましょう。</div>
+            <div style="font-size:11px;color:rgba(255,255,255,.8);margin-top:3px" data-i18n="detail.lineAddSub">友だち検索「@reverb.jp」</div>
+            <div style="display:inline-block;background:rgba(255,255,255,.2);border:1px solid rgba(255,255,255,.4);border-radius:20px;padding:3px 10px;font-size:10px;font-weight:700;color:#fff;margin-top:5px"><span data-i18n="detail.channelRequired">Reverbチャンネル登録は必須です</span> <span class="material-icons-round notranslate" translate="no" style="font-size:10px;vertical-align:middle">check</span></div>
           </div>
         </div>
       </div>
@@ -1065,17 +1065,17 @@ textarea.form-input{resize:vertical;min-height:80px}
   <!-- ── FOOTER ── -->
   <footer class="site-footer">
     <div class="container">
-      <div class="footer-brand">株式会社ジェイファン</div>
+      <div class="footer-brand" data-i18n="footer.companyName">株式会社ジェイファン</div>
       <dl class="footer-info">
-        <div><dt>会社名</dt><dd>株式会社ジェイファン</dd></div>
-        <div><dt>所在地</dt><dd>ソウル市 衿川区 加山デジタル1路 128 STX V-Tower 1201号</dd></div>
-        <div><dt>代表者</dt><dd>ジュ・ヒョンホ</dd></div>
-        <div><dt>お問い合わせ</dt><dd>公式LINE <a href="https://line.me/R/ti/p/@reverb.jp" target="_blank" rel="noopener">@reverb.jp</a></dd></div>
+        <div><dt data-i18n="footer.companyLabel">会社名</dt><dd data-i18n="footer.companyName">株式会社ジェイファン</dd></div>
+        <div><dt data-i18n="footer.locationLabel">所在地</dt><dd data-i18n="footer.locationValue">ソウル市 衿川区 加山デジタル1路 128 STX V-Tower 1201号</dd></div>
+        <div><dt data-i18n="footer.representativeLabel">代表者</dt><dd data-i18n="footer.representativeValue">ジュ・ヒョンホ</dd></div>
+        <div><dt data-i18n="footer.contactLabel">お問い合わせ</dt><dd><span data-i18n="footer.officialLine">公式LINE</span> <a href="https://line.me/R/ti/p/@reverb.jp" target="_blank" rel="noopener">@reverb.jp</a></dd></div>
       </dl>
       <div class="footer-links">
-        <a href="#about" onclick="event.preventDefault();openLegalModal('about')">会社紹介</a>
-        <a href="#terms" onclick="event.preventDefault();openLegalPage('terms','ja')">利用規約</a>
-        <a href="#privacy" onclick="event.preventDefault();openLegalPage('privacy','ja')">個人情報処理方針</a>
+        <a href="#about" onclick="event.preventDefault();openLegalModal('about')" data-i18n="legal.about">会社紹介</a>
+        <a href="#terms" onclick="event.preventDefault();openLegalPage('terms')" data-i18n="legal.termsTitle">利用規約</a>
+        <a href="#privacy" onclick="event.preventDefault();openLegalPage('privacy')" data-i18n="legal.privacyTitle">個人情報処理方針</a>
       </div>
       <div class="footer-sns">
         <a href="https://www.instagram.com/reverb_jp" target="_blank" rel="noopener" aria-label="Instagram">
@@ -1146,8 +1146,8 @@ textarea.form-input{resize:vertical;min-height:80px}
           </div>
           <div style="flex:1">
             <div style="font-family:'Sora',sans-serif;font-weight:800;font-size:14px;color:#fff;margin-bottom:2px">REVERB <span style="font-size:10px;font-weight:600;opacity:.85">INSTAGRAM</span></div>
-            <div style="font-size:11px;color:rgba(255,255,255,.95);font-weight:600;line-height:1.5">公式アカウントをフォローして最新キャンペーン情報を受け取る</div>
-            <div style="font-size:10px;color:rgba(255,255,255,.65);margin-top:2px">@reverb_jp をフォロー →</div>
+            <div style="font-size:11px;color:rgba(255,255,255,.95);font-weight:600;line-height:1.5" data-i18n="detail.igFollowCta">公式アカウントをフォローして最新キャンペーン情報を受け取る</div>
+            <div style="font-size:10px;color:rgba(255,255,255,.65);margin-top:2px" data-i18n="detail.igFollowSub">@reverb_jp をフォロー →</div>
           </div>
         </div>
         <div style="background:linear-gradient(135deg,#3AC05A 0%,#06A434 100%);border-radius:14px;padding:16px 18px;display:flex;align-items:center;gap:14px;cursor:pointer" onclick="window.open('https://line.me/R/ti/p/@reverb.jp','_blank')">
@@ -1156,9 +1156,9 @@ textarea.form-input{resize:vertical;min-height:80px}
           </div>
           <div style="flex:1">
             <div style="font-family:'Sora',sans-serif;font-weight:800;font-size:14px;color:#fff;margin-bottom:2px">REVERB <span style="font-size:10px;font-weight:600;opacity:.85">LINE</span></div>
-            <div style="font-size:11px;color:rgba(255,255,255,.95);font-weight:600;line-height:1.5">LINE公式アカウントを追加して最新キャンペーン情報を受け取りましょう。</div>
-            <div style="font-size:10px;color:rgba(255,255,255,.8);margin-top:2px">友だち検索「@reverb.jp」</div>
-            <div style="display:inline-block;background:rgba(255,255,255,.2);border:1px solid rgba(255,255,255,.4);border-radius:20px;padding:2px 9px;font-size:10px;font-weight:700;color:#fff;margin-top:4px">Reverbチャンネル登録はRequiredです <span class="material-icons-round notranslate" translate="no" style="font-size:10px;vertical-align:middle">check</span></div>
+            <div style="font-size:11px;color:rgba(255,255,255,.95);font-weight:600;line-height:1.5" data-i18n="detail.lineAddCta">LINE公式アカウントを追加して最新キャンペーン情報を受け取りましょう。</div>
+            <div style="font-size:10px;color:rgba(255,255,255,.8);margin-top:2px" data-i18n="detail.lineAddSub">友だち検索「@reverb.jp」</div>
+            <div style="display:inline-block;background:rgba(255,255,255,.2);border:1px solid rgba(255,255,255,.4);border-radius:20px;padding:2px 9px;font-size:10px;font-weight:700;color:#fff;margin-top:4px"><span data-i18n="detail.channelRequired">Reverbチャンネル登録は必須です</span> <span class="material-icons-round notranslate" translate="no" style="font-size:10px;vertical-align:middle">check</span></div>
           </div>
         </div>
       </div>
@@ -2796,6 +2796,20 @@ window.I18N_JA = {
     about: '会社紹介',
   },
 
+  // 푸터 회사 정보
+  footer: {
+    aboutHeading: '会社情報',
+    companyLabel: '会社名',
+    locationLabel: '所在地',
+    representativeLabel: '代表者',
+    contactLabel: 'お問い合わせ',
+    companyName: '株式会社ジェイファン',
+    locationValue: 'ソウル市 衿川区 加山デジタル1路 128 STX V-Tower 1201号',
+    representativeValue: 'ジュ・ヒョンホ',
+    officialLine: '公式LINE',
+    aboutText: 'REVERBは、日本で活動するインフルエンサーの皆さまと、韓国の人気Kブランドをつなぐ体験型プラットフォームです。',
+  },
+
   // 캠페인 상세
   detail: {
     recruitType: '募集タイプ',
@@ -3423,6 +3437,20 @@ window.I18N_KO = {
     termsTitle: '서비스 이용약관',
     privacyTitle: '개인정보 처리방침',
     about: '회사 소개',
+  },
+
+  // 푸터 회사 정보
+  footer: {
+    aboutHeading: '회사 정보',
+    companyLabel: '회사명',
+    locationLabel: '소재지',
+    representativeLabel: '대표자',
+    contactLabel: '문의',
+    companyName: '주식회사 제이펀',
+    locationValue: '서울특별시 금천구 가산디지털1로 128 STX V타워 1201호',
+    representativeValue: '주현호',
+    officialLine: '공식 LINE',
+    aboutText: 'REVERB는 일본에서 활동하는 인플루언서와 한국 인기 K브랜드를 잇는 체험형 플랫폼입니다.',
   },
 
   detail: {
@@ -7448,7 +7476,8 @@ function closeLoginPrompt(e) {
 
 // ── 회사정보 / 이용약관 / 개인정보 모달 ──
 function openLegalModal(kind) {
-  const titles = {about:'会社紹介', terms:'利用規約', privacy:'個人情報処理方針'};
+  const _t = (typeof t === 'function') ? t : (k) => k;  // admin 빌드엔 i18n 미포함 → 방어
+  const titles = {about: _t('legal.about'), terms: _t('legal.termsTitle'), privacy: _t('legal.privacyTitle')};
   const $t = document.getElementById('legalTitle');
   const $b = document.getElementById('legalBody');
   const $m = document.getElementById('legalModal');
@@ -7464,16 +7493,17 @@ function closeLegalModal() {
   document.body.style.overflow = '';
 }
 function buildLegalContent(kind) {
+  const _t = (typeof t === 'function') ? t : (k) => k;  // admin 빌드엔 i18n 미포함 → 방어
   if (kind === 'about') {
     return `
-      <h3>会社情報</h3>
+      <h3>${esc(_t('footer.aboutHeading'))}</h3>
       <dl>
-        <dt>会社名</dt><dd>株式会社ジェイファン（JFUN Corp.）</dd>
-        <dt>所在地</dt><dd>ソウル市 衿川区 加山デジタル1路 128 STX V-Tower 1201号</dd>
-        <dt>代表者</dt><dd>ジュ・ヒョンホ</dd>
-        <dt>お問い合わせ</dt><dd>公式LINE <a href="https://line.me/R/ti/p/@reverb.jp" target="_blank" rel="noopener">@reverb.jp</a></dd>
+        <dt>${esc(_t('footer.companyLabel'))}</dt><dd>${esc(_t('footer.companyName'))}（JFUN Corp.）</dd>
+        <dt>${esc(_t('footer.locationLabel'))}</dt><dd>${esc(_t('footer.locationValue'))}</dd>
+        <dt>${esc(_t('footer.representativeLabel'))}</dt><dd>${esc(_t('footer.representativeValue'))}</dd>
+        <dt>${esc(_t('footer.contactLabel'))}</dt><dd>${esc(_t('footer.officialLine'))} <a href="https://line.me/R/ti/p/@reverb.jp" target="_blank" rel="noopener">@reverb.jp</a></dd>
       </dl>
-      <p>REVERBは、日本で活動するインフルエンサーの皆さまと、韓国の人気Kブランドをつなぐ体験型プラットフォームです。</p>
+      <p>${esc(_t('footer.aboutText'))}</p>
     `;
   }
   // terms·privacy 는 별도 페이지(#page-legal, openLegalPage/legal.js)로 표시.


### PR DESCRIPTION
## 변경 요약
- 홈·캠페인 푸터, SNS 카드(IG/LINE), 회사정보 모달이 data-i18n 없이 일본어 하드코딩이라 한국어 토글 시 일본어 고착되던 문제 수정
- SNS 카드: 설명·CTA·채널등록 안내 data-i18n 연결 + 영어 'Required' 제거(→ 必須/필수)
- 푸터: 회사명·회사정보·링크 data-i18n + 약관 링크 'ja' 고정 제거(한국어 토글 시 일본어 약관 뜨던 버그)
- 회사정보 모달(ui.js): t() i18n화 + admin 빌드 방어 폴백
- footer.* 신규 i18n 키(한/일)

## ⚠️ 확인 필요 — 회사 법적 정보 한국어 표기
- ko 추정값: 회사명 '주식회사 제이펀' / 소재지 '서울특별시 금천구 가산디지털1로 128 STX V타워 1201호' / 대표자 '주현호'
- **법인 정식 정보라 정확한 한국어 표기 확인 부탁** (틀리면 i18n 키 1줄 수정)

[via reviewer] GO — Critical 2건(div '>' 누락, t() 폴백) 반영
qa-tester: light (홈/캠페인 언어 토글 + 회사정보 모달)

🤖 Generated with [Claude Code](https://claude.com/claude-code)