### PR TITLE
feat: add LIPS and @cosme as monitor-only review channels

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,7 +124,7 @@
 ### 캠페인 관리
 - CRUD + 복제 + 삭제(확인모달) + 순서변경 모드 + 더보기 메뉴(결과물 엑셀·신청자 엑셀·변경 이력)
 - **캠페인 번호 채번**: `B{brand_seq}-A{app_seq}-C{camp_seq}` (외부 캠페인은 `B{brand_seq}-C{ext_seq}`). 자릿수 brand 4/신청 3/캠 3. 신규 INSERT 시 트리거 자동 채번. 캠페인 등록 폼은 brands 드롭다운 + 신청 cascade + 신규 brand 인라인 모달 패턴. 기존 v1 `CAMP-YYYY-NNNN`/`JFUN-{Q|N}-YYYYMMDD-NNN` 은 `legacy_no` 컬럼·`numbering_legacy_map` 에 보존
-- **캠페인 등록/편집 폼**: 4개 섹션 그룹핑 (기본정보/제품정보/모집조건/콘텐츠가이드). 모집타입 라디오버튼 UI, 채널은 복수 선택 체크박스(Instagram/X/Qoo10/TikTok/YouTube, 콤마 구분 저장 `"instagram,x"`). 채널 2개+ 선택 시 `or`/`&` 라디오 노출 → `campaigns.channel_match`. 자격 검증은 `primary_channel` 단일 기준
+- **캠페인 등록/편집 폼**: 4개 섹션 그룹핑 (기본정보/제품정보/모집조건/콘텐츠가이드). 모집타입 라디오버튼 UI, 채널은 복수 선택 체크박스(Instagram/X/Qoo10/TikTok/YouTube/LIPS/@cosme, 콤마 구분 저장 `"instagram,x"`. LIPS·@cosme는 리뷰어형 전용 — `lookup_values.recruit_types=['monitor']`). 채널 2개+ 선택 시 `or`/`&` 라디오 노출 → `campaigns.channel_match`. 자격 검증은 `primary_channel` 단일 기준
 - **콘텐츠 가이드 리치 텍스트** (Quill v2, 3개 필드): Notion 복사·붙여넣기 서식 유지. 이미지 태그는 저장 시 제거. XSS 방어 DOMPurify 저장+렌더 이중 sanitize. 헬퍼는 `dev/lib/shared.js`
 - **참여방법·주의사항·NG 미니 에디터**: 굵게/기울이기/링크/이미지 첨부 가능. 이미지는 `campaign-images/content/` 업로드 (5MB / jpg·png·webp) → `<img class="rich-img">` 삽입. 클릭 팝오버로 Small/Medium/Large/Original 크기 조정. XSS 방어는 src 화이트리스트 (https + `*.supabase.co`)
 - **캠페인 목록**: 썸네일+이미지수, 상태/타입 드롭다운 필터, 검색(캠페인명+브랜드+제품+campaign_no), 헤더 정렬(조회/신청/등록일/수정일 ▲▼), D-day 라벨, 승인수/모집수 표시 + 대기 배지

--- a/admin/index.html
+++ b/admin/index.html
@@ -12,7 +12,7 @@
 // 회귀(2026-05-12 PR #182 머지 직후 발생)를 방지하기 위한 자동 reload 가드.
 // sessionStorage 차단 환경(시크릿 모드 일부, 쿠키 차단)에서는 자연스럽게 skip.
 (function(){
-  var CURRENT_BUILD = 'v1779936651';
+  var CURRENT_BUILD = 'v1779939145';
   if (CURRENT_BUILD.indexOf('__') === 0) return; // 빌드 미적용 (dev/ 직접 열기) 시 skip
   try {
     var prev = sessionStorage.getItem('reverb.adminBuild');
@@ -1752,7 +1752,7 @@ textarea.form-input{resize:vertical;min-height:80px}
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-05-28 11:50 · 3ab125c</span>
+          <span class="admin-build-text">2026-05-28 12:32 · 0b58642</span>
         </div>
       </div>
     </aside>

--- a/dev/index.html
+++ b/dev/index.html
@@ -694,6 +694,8 @@ window._supabaseLoaded = false;
             <option value="tiktok">TikTok</option>
             <option value="youtube">YouTube</option>
             <option value="qoo10">Qoo10</option>
+            <option value="lips">LIPS</option>
+            <option value="cosme">@cosme</option>
             <option value="other">その他</option>
           </select>
           <div class="form-hint" style="font-size:11px;color:var(--muted);margin-top:4px" data-i18n="activity.postChannelHint">URLからチャンネルを自動判別できませんでした</div>

--- a/dev/js/application.js
+++ b/dev/js/application.js
@@ -706,13 +706,15 @@ function detectChannelFromUrl(url) {
     if (host === 'youtube.com' || host === 'youtu.be' || host.endsWith('.youtube.com')) return 'youtube';
     if (host === 'x.com' || host === 'twitter.com' || host.endsWith('.twitter.com')) return 'x';
     if (host.includes('qoo10.jp')) return 'qoo10';
+    if (host.includes('lipscosme.com')) return 'lips';
+    if (host === 'cosme.net' || host.endsWith('.cosme.net')) return 'cosme';
     return null;
   } catch(e) { return null; }
 }
 
 const CHANNEL_LABELS = {
   instagram: 'Instagram', tiktok: 'TikTok', youtube: 'YouTube',
-  x: 'X (Twitter)', qoo10: 'Qoo10'
+  x: 'X (Twitter)', qoo10: 'Qoo10', lips: 'LIPS', cosme: '@cosme'
 };
 function getChannelLabelLocal(code) {
   return CHANNEL_LABELS[code] || t('channelLabel.other');

--- a/docs/specs/2026-05-27-lips-cosme-channels.md
+++ b/docs/specs/2026-05-27-lips-cosme-channels.md
@@ -1,0 +1,132 @@
+# LIPS·@cosme 모집 채널 추가 — 전체 구현 사양서
+
+**작성일:** 2026-05-27 (초안) / **재작성:** 2026-05-28 (Qoo10 패턴 정정)
+**작성 세션:** 기획/설계
+**배경:** 챌린저스 벤치마크(`docs/research/2026-05-27-challengers-benchmark.md`) 권고 H. 일본 뷰티 핵심 리뷰 플랫폼 LIPS(lipscosme.com)·@cosme(cosme.net)를 인플루언서 캠페인 채널로 추가.
+
+---
+
+## 0. 정정 이력 (2026-05-28)
+
+초안은 LIPS·@cosme를 SNS 채널(인플 핸들·팔로워 수집)로 잘못 가정. 사용자 정정으로 **둘 다 Qoo10 패턴(인플 계정 미수집, 리뷰어 캠페인 전용 마켓 채널)**으로 통일.
+
+| 영역 | 초안 | 정정 후 |
+|---|---|---|
+| 채널 성격 | LIPS는 SNS 패턴(자격검증) / @cosme 자격 면제 | **둘 다 Qoo10 패턴, 인플 계정 미수집** |
+| `influencers` 컬럼 추가 | 4개 추가(lips/lips_followers/cosme/cosme_followers) | **추가 없음** |
+| `CHANNEL_META` 단일화 | 신설 | **불필요** (인플 식별 안 함) |
+| 마이페이지 SNS 폼 | LIPS·@cosme 입력란 2세트 | **수정 없음** |
+| 엑셀 SNS 컬럼 | 4→6 확장 | **수정 없음** |
+| 다이제스트 메일 SNS 배열 | 확장 | **수정 없음** |
+| 약관 | 수집 항목 추가(중대 변경 낮음) | **개정 불필요** |
+| PR 분할 | 4개 | **단일 PR로 축소** |
+
+---
+
+## 1. 확정 사항 (사용자 결정 2026-05-28)
+
+| 항목 | 결정 |
+|---|---|
+| 채널 성격 | **마켓·리뷰 플랫폼 채널** — Qoo10과 동일 패턴 |
+| 인플 식별 수집 | **없음** (계정·팔로워 모두 받지 않음) |
+| 적용 모집 유형 | **리뷰어(monitor) 전용** — `lookup_values.recruit_types=['monitor']` |
+| 자격 검증 | 리뷰어 자체가 팔로워 체크 스킵 → 별도 면제 처리 불필요 |
+| URL 자동 판별 | **불필요** — 결과물은 「리뷰 이미지(스크린샷)」로 받음. 도메인 인식 무용 |
+| 마이그레이션 번호 | 작업 시점 `ls supabase/migrations/` 재확인 (본 사양 작성 시 156이 최신) |
+
+## 2. 핵심 설계 (Qoo10 패턴 미러)
+
+Qoo10이 현재 동작하는 방식 그대로:
+- `lookup_values` channel 1행만 등록 (인플 테이블 컬럼 없음)
+- 캠페인 등록 폼의 채널 옵션에 노출
+- 인플루언서 마이페이지·SNS 입력 폼에는 **추가하지 않음**
+- 인플 목록·엑셀의 SNS 컬럼 영역 손대지 않음
+- 결과물(리뷰 이미지)은 「리뷰어 캠페인 결과물 모델 확장」 사양에서 채널별 카드로 처리 — 본 사양은 채널 등록만 담당
+
+## 3. 데이터 모델 (마이그레이션 1개)
+
+**lookup_values 2건 추가**:
+```sql
+INSERT INTO lookup_values (kind, code, name_ko, name_ja, sort_order, recruit_types) VALUES
+  ('channel', 'lips',  'LIPS',  'LIPS',  60, ARRAY['monitor']),
+  ('channel', 'cosme', '@cosme','@cosme', 70, ARRAY['monitor'])
+ON CONFLICT (kind, code) DO NOTHING;
+```
+
+`influencers` 테이블 컬럼 추가 없음. 행 단위 보안 정책 변경 없음. 기존 1,398행 영향 없음.
+
+## 4. URL 자동 판별 (결과물 리뷰 URL 한정)
+
+`dev/js/application.js` `detectChannelFromUrl()`에 도메인 2개 추가:
+- `host.includes('lipscosme.com')` → `'lips'`
+- `host.endsWith('cosme.net')` → `'cosme'` (`my.cosme.net` 포함)
+
+추적 파라미터(`?_gl=`, `_ga=`) 제거는 결과물 저장 시점에 처리(혹은 표시 시점에 trim).
+
+(인플 프로필 URL 추출·핸들 추출 로직은 불필요 — 인플 식별 안 함.)
+
+## 5. 영향 파일
+
+- `dev/js/application.js` — `detectChannelFromUrl()` 도메인 2개 + `CHANNEL_LABELS` 라벨 2개
+- `dev/index.html` — 결과물 제출 수동 채널 드롭다운에 LIPS·@cosme 옵션 추가
+- `dev/lib/i18n/{ja,ko}.js` — LIPS·@cosme 라벨
+- `supabase/migrations/[작업 시점 확인]_lips_cosme_channels.sql`
+- `docs/FEATURE_SPEC.md` + `CLAUDE.md` — 채널 추가 한 줄
+
+**수정 불필요(초안과 달리):**
+- 인플 마이페이지 SNS 폼
+- 인플 목록 컬럼·정렬·검색
+- 관리자 엑셀 SNS 컬럼
+- 다이제스트 메일 SNS 표시
+- `dev/lib/shared.js` `CHANNEL_META` 객체
+
+## 6. PR 분할
+
+**단일 PR로 충분.** 마이그레이션 1개 + 코드 변경 매우 작음.
+
+게이트:
+- reverb-supabase-expert (마이그레이션)
+- reverb-reviewer (commit 직전)
+- reverb-qa-tester Light (관리자 캠페인 등록 채널 옵션 + 결과물 URL 판별 회귀)
+
+## 7. 검증
+
+- 캠페인 등록 폼 채널 옵션에 「LIPS」·「@cosme」 노출 (recruit_type=monitor 선택 시)
+- 채널 = `'qoo10,cosme'`인 monitor 캠페인 저장 정상
+- 결과물 제출에서 LIPS·@cosme URL을 입력 시 자동 채널 인식
+- 인플 마이페이지·관리자 인플 목록·엑셀에서 **회귀 없음** (SNS 영역 미변경)
+- 기존 1,398행 영향 없음
+
+## 8. 약관·개인정보 영향
+
+**없음.** 신규 수집 항목 없음. 약관·개인정보처리방침 개정 불필요.
+
+## 9. 의존·후속
+
+본 사양 완료 후 → 「리뷰어 캠페인 결과물 모델 확장」(`docs/specs/2026-05-28-multichannel-deliverable-split.md`) 착수 가능.
+이유: 「Qoo10 & @cosme」 같은 캠페인을 만들려면 @cosme·LIPS 채널이 lookup에 먼저 존재해야 함.
+
+---
+
+## 구현 결과
+
+**구현일:** 2026-05-28
+**관련 커밋:** feature/lips-cosme-channels (PR 머지 후 갱신)
+**브랜치:** feature/lips-cosme-channels (메인 폴더 분기)
+
+### 초안 대비 변경 사항
+- 변경 없음 — 사양서 §0 정정판(2026-05-28) 그대로 구현
+- 인플 마이페이지 SNS 폼·관리자 인플 목록·엑셀 SNS 컬럼·다이제스트 메일 SNS 표시 전부 미수정 (Qoo10 패턴)
+
+### 구현 중 기술 결정 사항
+- **마이그레이션 번호 157 점유** — 다른 세션 동시 작성 없음 확인(2026-05-28 운영 일괄 출시 직후)
+- **i18n 라벨 추가 생략** — 현행 `dev/lib/i18n/{ja,ko}.js`의 `channelLabel` 객체는 `other`만 있고 그 외 채널은 `CHANNEL_LABELS` (application.js) 객체에서 직접 처리. 사양 §5의 "i18n 라벨" 항목은 코드측 `CHANNEL_LABELS`에 lips/cosme 추가로 충족
+- **cosme 도메인 매칭 강화** — 사양서 `host.endsWith('cosme.net')` 권고를 `host === 'cosme.net' || host.endsWith('.cosme.net')`로 확장. `cosme.net` 정확 매칭 + 서브도메인(my.cosme.net 등) 양쪽 커버
+- **인플 마이페이지 `profilePrimarySns` 셀렉트 미수정** (사양 §5 명시 — SNS 계정 미수집)
+- **PostgREST 자동 동기** — 캠페인 등록 폼의 채널 체크박스는 `lookup_values(kind='channel', recruit_types && ARRAY['monitor'])`을 동적 쿼리하므로 코드 변경 없이 LIPS·@cosme가 자동 노출됨
+
+### 변경 파일
+- `supabase/migrations/157_lips_cosme_channels.sql` (신규)
+- `dev/js/application.js` (`detectChannelFromUrl` 도메인 2개 + `CHANNEL_LABELS` 라벨 2개)
+- `dev/index.html` (`#postChannelManual` 셀렉트 옵션 2개)
+- 빌드 산출물 `index.html` · `admin/index.html`

--- a/index.html
+++ b/index.html
@@ -1354,6 +1354,8 @@ textarea.form-input{resize:vertical;min-height:80px}
             <option value="tiktok">TikTok</option>
             <option value="youtube">YouTube</option>
             <option value="qoo10">Qoo10</option>
+            <option value="lips">LIPS</option>
+            <option value="cosme">@cosme</option>
             <option value="other">その他</option>
           </select>
           <div class="form-hint" style="font-size:11px;color:var(--muted);margin-top:4px" data-i18n="activity.postChannelHint">URLからチャンネルを自動判別できませんでした</div>
@@ -9035,13 +9037,15 @@ function detectChannelFromUrl(url) {
     if (host === 'youtube.com' || host === 'youtu.be' || host.endsWith('.youtube.com')) return 'youtube';
     if (host === 'x.com' || host === 'twitter.com' || host.endsWith('.twitter.com')) return 'x';
     if (host.includes('qoo10.jp')) return 'qoo10';
+    if (host.includes('lipscosme.com')) return 'lips';
+    if (host === 'cosme.net' || host.endsWith('.cosme.net')) return 'cosme';
     return null;
   } catch(e) { return null; }
 }
 
 const CHANNEL_LABELS = {
   instagram: 'Instagram', tiktok: 'TikTok', youtube: 'YouTube',
-  x: 'X (Twitter)', qoo10: 'Qoo10'
+  x: 'X (Twitter)', qoo10: 'Qoo10', lips: 'LIPS', cosme: '@cosme'
 };
 function getChannelLabelLocal(code) {
   return CHANNEL_LABELS[code] || t('channelLabel.other');

--- a/supabase/migrations/157_lips_cosme_channels.sql
+++ b/supabase/migrations/157_lips_cosme_channels.sql
@@ -1,0 +1,31 @@
+-- ============================================
+-- 마이그레이션 157: LIPS·@cosme 채널 추가
+-- 의존: 024 (lookup_values 테이블), 025 (recruit_types 컬럼)
+-- 대상: 개발서버 + 운영서버
+-- 요약: 일본 뷰티 리뷰 플랫폼 LIPS·@cosme를 채널로 등록.
+--       Qoo10 패턴(인플 계정 미수집, 리뷰어 캠페인 전용).
+--       influencers 컬럼 추가 없음. 기존 1,398행 영향 없음.
+-- 사양서: docs/specs/2026-05-27-lips-cosme-channels.md
+-- 위험도: 최하 (INSERT 2행, ON CONFLICT DO NOTHING 멱등)
+-- ============================================
+
+INSERT INTO lookup_values (kind, code, name_ko, name_ja, sort_order, recruit_types) VALUES
+  ('channel', 'lips',  'LIPS',   'LIPS',   60, ARRAY['monitor']),
+  ('channel', 'cosme', '@cosme', '@cosme', 70, ARRAY['monitor'])
+ON CONFLICT (kind, code) DO NOTHING;
+
+-- ============================================
+-- 운영 검증 쿼리 (적용 후 SQL Editor에서 실행)
+-- ============================================
+-- SELECT id, kind, code, name_ko, name_ja, sort_order, recruit_types, active
+--   FROM lookup_values
+--  WHERE kind = 'channel' AND code IN ('lips', 'cosme')
+--  ORDER BY sort_order;
+-- 기대 결과: 2행 (lips sort_order=60 / cosme sort_order=70, recruit_types='{monitor}', active=true)
+
+-- ============================================
+-- 롤백 SQL (필요 시 아래 BEGIN 블록 실행)
+-- ============================================
+-- BEGIN;
+--   DELETE FROM lookup_values WHERE kind = 'channel' AND code IN ('lips', 'cosme');
+-- COMMIT;


### PR DESCRIPTION
## 변경 요약
일본 뷰티 핵심 리뷰 플랫폼 LIPS·@cosme를 리뷰어형(monitor) 캠페인 채널로 추가. Qoo10 패턴 미러(인플 계정·팔로워 미수집).

## 변경 내용
- 마이그레이션 157 — `lookup_values` 2건 INSERT (lips sort_order=60, cosme sort_order=70, recruit_types=['monitor'])
- `dev/js/application.js` — `detectChannelFromUrl`에 lipscosme.com·cosme.net 매칭, `CHANNEL_LABELS` 라벨 추가
- `dev/index.html` — 결과물 제출 수동 채널 드롭다운 옵션 2개
- `CLAUDE.md` — 캠페인 등록 폼 채널 목록 갱신
- `docs/specs/2026-05-27-lips-cosme-channels.md` — 구현 결과 채움

## 적용 상태
- ✅ 개발 DB 157 적용 완료 (lookup_values 2건 확인)
- ⏳ 운영 DB는 PR 2(사양 2 PR 1)와 묶어서 운영 배포 묶음 1에서 함께 적용 예정

## 검증
- reverb-supabase-expert: 마이그레이션 157 작성
- reverb-reviewer: GO (CLAUDE.md 채널 목록 1줄 수정 후 HOLD 해소)
- qa-tester: PR 1+2 운영 배포 묶음 직전 Full로 통합 (단순 변경 단독 qa 생략)

## 관련 사양서
- docs/specs/2026-05-27-lips-cosme-channels.md

## 후속 PR
- PR 2 (사양 2 PR 1) — 리뷰어 결과물 모델 확장: 단일 리뷰 이미지 카드 → 캠페인 채널 수만큼 N개 카드

## 요청 외 추가 변경
없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)