### PR TITLE
feat(admin): channel status summary box in deliverable modal (사양 2 PR 2-a)

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -12,7 +12,7 @@
 // 회귀(2026-05-12 PR #182 머지 직후 발생)를 방지하기 위한 자동 reload 가드.
 // sessionStorage 차단 환경(시크릿 모드 일부, 쿠키 차단)에서는 자연스럽게 skip.
 (function(){
-  var CURRENT_BUILD = 'v1779940993';
+  var CURRENT_BUILD = 'v1779941496';
   if (CURRENT_BUILD.indexOf('__') === 0) return; // 빌드 미적용 (dev/ 직접 열기) 시 skip
   try {
     var prev = sessionStorage.getItem('reverb.adminBuild');
@@ -1752,7 +1752,7 @@ textarea.form-input{resize:vertical;min-height:80px}
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-05-28 13:03 · b49723f</span>
+          <span class="admin-build-text">2026-05-28 13:11 · f28fcc5</span>
         </div>
       </div>
     </aside>
@@ -16814,6 +16814,43 @@ async function renderDelivCombinedBody(applicationId) {
   const receiptStatusBadge = receipt ? delivStatusBadge(receipt.status) : '';
   const resultStatusBadge = result ? delivStatusBadge(result.status) : '';
 
+  // 같은 신청의 「채널별 리뷰 이미지 상태 요약」 박스 (모달 하단)
+  //   사용자 Q6 결정 — 모달 하단 회색 박스. monitor + 채널 N개 캠페인에서만 노출.
+  //   각 채널의 최신 행 상태를 한 줄로 보여줘 검수자가 다른 채널 검수 누락을 인지하도록.
+  //   채널별 개별 검수는 각 행 클릭으로 별도 모달.
+  let channelSummaryBox = '';
+  if (rt === 'monitor') {
+    const campChannels = (camp.channel || '').split(',').map(c => c.trim()).filter(Boolean);
+    if (campChannels.length > 0) {
+      const latestByCh = {};
+      allDelivs.filter(d => d.kind === 'review_image' && d.post_channel).forEach(d => {
+        const prev = latestByCh[d.post_channel];
+        if (!prev || new Date(d.created_at) > new Date(prev.created_at)) latestByCh[d.post_channel] = d;
+      });
+      const stLabel = function(r) {
+        if (!r) return '<span style="color:var(--muted)">미제출</span>';
+        if (r.status === 'approved') return '<span style="color:#2D7A3E">✓ 승인</span>';
+        if (r.status === 'rejected') return '<span style="color:#C33">✗ 반려</span>';
+        if (r.status === 'draft') return '<span style="color:var(--muted)">임시저장</span>';
+        return '<span style="color:#B8741A">검수중</span>';
+      };
+      const chLabel = function(code) {
+        return (typeof getLookupLabel === 'function')
+          ? (getLookupLabel('channel', code, 'ko') || code)
+          : code;
+      };
+      const items = campChannels.map(function(ch) {
+        return '<span><strong>' + esc(chLabel(ch)) + '</strong> ' + stLabel(latestByCh[ch]) + '</span>';
+      });
+      const receiptItem = '<span><strong>영수증</strong> ' + stLabel(receipt) + '</span>';
+      channelSummaryBox = `
+        <div style="margin-top:16px;padding:12px 14px;background:#f7f7f7;border-radius:8px;font-size:12px;line-height:1.8">
+          <div style="font-weight:600;color:var(--muted);font-size:11px;margin-bottom:4px">같은 신청의 채널별 결과물 상태</div>
+          ${receiptItem} · ${items.join(' · ')}
+        </div>`;
+    }
+  }
+
   body.innerHTML = `
     <div class="deliv-combined-grid">
       ${showReceipt
@@ -16830,6 +16867,7 @@ async function renderDelivCombinedBody(applicationId) {
         <div class="deliv-combined-panel-body">${renderDelivPanelContent(result, resultEvents)}</div>
       </div>
     </div>
+    ${channelSummaryBox}
   `;
 }
 

--- a/dev/js/admin-deliverables.js
+++ b/dev/js/admin-deliverables.js
@@ -635,6 +635,43 @@ async function renderDelivCombinedBody(applicationId) {
   const receiptStatusBadge = receipt ? delivStatusBadge(receipt.status) : '';
   const resultStatusBadge = result ? delivStatusBadge(result.status) : '';
 
+  // 같은 신청의 「채널별 리뷰 이미지 상태 요약」 박스 (모달 하단)
+  //   사용자 Q6 결정 — 모달 하단 회색 박스. monitor + 채널 N개 캠페인에서만 노출.
+  //   각 채널의 최신 행 상태를 한 줄로 보여줘 검수자가 다른 채널 검수 누락을 인지하도록.
+  //   채널별 개별 검수는 각 행 클릭으로 별도 모달.
+  let channelSummaryBox = '';
+  if (rt === 'monitor') {
+    const campChannels = (camp.channel || '').split(',').map(c => c.trim()).filter(Boolean);
+    if (campChannels.length > 0) {
+      const latestByCh = {};
+      allDelivs.filter(d => d.kind === 'review_image' && d.post_channel).forEach(d => {
+        const prev = latestByCh[d.post_channel];
+        if (!prev || new Date(d.created_at) > new Date(prev.created_at)) latestByCh[d.post_channel] = d;
+      });
+      const stLabel = function(r) {
+        if (!r) return '<span style="color:var(--muted)">미제출</span>';
+        if (r.status === 'approved') return '<span style="color:#2D7A3E">✓ 승인</span>';
+        if (r.status === 'rejected') return '<span style="color:#C33">✗ 반려</span>';
+        if (r.status === 'draft') return '<span style="color:var(--muted)">임시저장</span>';
+        return '<span style="color:#B8741A">검수중</span>';
+      };
+      const chLabel = function(code) {
+        return (typeof getLookupLabel === 'function')
+          ? (getLookupLabel('channel', code, 'ko') || code)
+          : code;
+      };
+      const items = campChannels.map(function(ch) {
+        return '<span><strong>' + esc(chLabel(ch)) + '</strong> ' + stLabel(latestByCh[ch]) + '</span>';
+      });
+      const receiptItem = '<span><strong>영수증</strong> ' + stLabel(receipt) + '</span>';
+      channelSummaryBox = `
+        <div style="margin-top:16px;padding:12px 14px;background:#f7f7f7;border-radius:8px;font-size:12px;line-height:1.8">
+          <div style="font-weight:600;color:var(--muted);font-size:11px;margin-bottom:4px">같은 신청의 채널별 결과물 상태</div>
+          ${receiptItem} · ${items.join(' · ')}
+        </div>`;
+    }
+  }
+
   body.innerHTML = `
     <div class="deliv-combined-grid">
       ${showReceipt
@@ -651,6 +688,7 @@ async function renderDelivCombinedBody(applicationId) {
         <div class="deliv-combined-panel-body">${renderDelivPanelContent(result, resultEvents)}</div>
       </div>
     </div>
+    ${channelSummaryBox}
   `;
 }
 


### PR DESCRIPTION
## 변경
검수 모달 하단에 monitor + 채널 N개 캠페인의 「채널별 결과물 상태」 회색 요약 박스 추가 (사용자 Q6 결정).

## 후속 (PR 3b·3c·3d로 분리)
- 결과물 관리 목록 행 분리 (신청 단위 → 신청+채널 단위, 자료구조 재설계)
- 진행현황 채널별 칩
- 알림 트리거(159) + 메일 템플릿

## 게이트
- reviewer: GO (✓/✗ 유니코드 Warning — 텍스트 동반이라 실용상 OK)
- qa: PR 1+2 운영 묶음과 함께 Full

🤖 Generated with [Claude Code](https://claude.com/claude-code)