### PR TITLE
fix(activity): redirect to applications history on direct reload

### DIFF
--- a/dev/js/app.js
+++ b/dev/js/app.js
@@ -411,6 +411,11 @@ async function init() {
     const appId = hash.replace('messages-','');
     if (typeof openMessagesPage === 'function') openMessagesPage(appId, 'mypage', false);
     else navigate('mypage', false);
+  } else if (hash === 'activity') {
+    // 활동관리 페이지 새로고침 — _activityAppId·_activityCamp 글로벌이 NULL 이라 데이터 복원 불가.
+    // 빈 폼만 노출되어 사용자 혼란(영수증·결과물 내역 안 보임, 뒤로가기 무반응) → 응모이력으로 안전 폴백.
+    navigate('mypage', false);
+    if (typeof openMypageSub === 'function') openMypageSub('applications');
   } else if (hash && hash !== 'home') {
     navigate(hash, false);
   } else {

--- a/dev/js/application.js
+++ b/dev/js/application.js
@@ -753,7 +753,9 @@ function onPostUrlInputChange() {
 }
 
 function navigateBackFromActivity() {
-  if (_activityFrom === 'mypage') {
+  // 새로고침으로 직접 진입한 경우 _activityCampId·_activityFrom 모두 NULL —
+  // openCampaign(undefined) 무반응 회귀 방지. 안전하게 응모이력으로 폴백.
+  if (_activityFrom === 'mypage' || !_activityCampId) {
     navigate('mypage');
     openMypageSub('applications');
   } else {

--- a/index.html
+++ b/index.html
@@ -9087,7 +9087,9 @@ function onPostUrlInputChange() {
 }
 
 function navigateBackFromActivity() {
-  if (_activityFrom === 'mypage') {
+  // 새로고침으로 직접 진입한 경우 _activityCampId·_activityFrom 모두 NULL —
+  // openCampaign(undefined) 무반응 회귀 방지. 안전하게 응모이력으로 폴백.
+  if (_activityFrom === 'mypage' || !_activityCampId) {
     navigate('mypage');
     openMypageSub('applications');
   } else {
@@ -11989,6 +11991,11 @@ async function init() {
     const appId = hash.replace('messages-','');
     if (typeof openMessagesPage === 'function') openMessagesPage(appId, 'mypage', false);
     else navigate('mypage', false);
+  } else if (hash === 'activity') {
+    // 활동관리 페이지 새로고침 — _activityAppId·_activityCamp 글로벌이 NULL 이라 데이터 복원 불가.
+    // 빈 폼만 노출되어 사용자 혼란(영수증·결과물 내역 안 보임, 뒤로가기 무반응) → 응모이력으로 안전 폴백.
+    navigate('mypage', false);
+    if (typeof openMypageSub === 'function') openMypageSub('applications');
   } else if (hash && hash !== 'home') {
     navigate(hash, false);
   } else {


### PR DESCRIPTION
활동관리 페이지(#activity) 새로고침 직접 진입 시 빈 폼만 표시되고 뒤로가기 무반응 회귀 핫픽스.

- app.js 초기 라우팅에 hash==='activity' 분기 → mypage applications 자동 리다이렉트
- navigateBackFromActivity: _activityCampId 없으면 mypage applications 폴백

🤖 Generated with [Claude Code](https://claude.com/claude-code)