### PR TITLE
fix(routing): single pushState per page entry across mypage flows

### DIFF
--- a/dev/js/app.js
+++ b/dev/js/app.js
@@ -133,7 +133,9 @@ window.addEventListener('popstate', function(e) {
   if (page === 'mypage' || page.startsWith('mypage-')) {
     navigate('mypage', false);
     const sub = e.state?.sub || (page.startsWith('mypage-') ? page.replace('mypage-','') : null);
-    if (sub) openMypageSub(sub); else closeMypageSub();
+    // popstate 는 이미 history 가 그 entry 로 이동한 상태 — openMypageSub 의 pushState 를 또 호출하면
+    // 새 entry 가 추가돼 뒤로가기가 어긋남. false 전달로 push 스킵.
+    if (sub) openMypageSub(sub, false); else closeMypageSub();
   } else if (page.startsWith('detail-')) {
     openCampaign(page.replace('detail-',''));
   } else if (page.startsWith('messages-')) {
@@ -405,7 +407,8 @@ async function init() {
   } else if (hash && hash.startsWith('mypage-')) {
     const sub = hash.replace('mypage-','');
     navigate('mypage', false);
-    openMypageSub(sub);
+    // 새로고침 init — URL 이 이미 #mypage-sub 라 openMypageSub 의 pushState 는 동일 entry 중복.
+    openMypageSub(sub, false);
   } else if (hash && hash.startsWith('messages-')) {
     // 응모건 메시지 페이지 새로고침 복원 — openMessagesPage 가 캐시(_myApps) 보장
     const appId = hash.replace('messages-','');
@@ -413,9 +416,12 @@ async function init() {
     else navigate('mypage', false);
   } else if (hash === 'activity') {
     // 활동관리 페이지 새로고침 — _activityAppId·_activityCamp 글로벌이 NULL 이라 데이터 복원 불가.
-    // 빈 폼만 노출되어 사용자 혼란(영수증·결과물 내역 안 보임, 뒤로가기 무반응) → 응모이력으로 안전 폴백.
+    // 빈 폼·뒤로가기 회귀 → 응모이력으로 안전 폴백.
+    // history 정리: 현재 entry 의 URL/state 자체를 #mypage-applications 로 replaceState
+    // (#activity entry 가 stack 에 남으면 뒤로가기 시 또 마주침). openMypageSub 도 false 로 호출.
+    history.replaceState({page:'mypage', sub:'applications'}, '', '#mypage-applications');
     navigate('mypage', false);
-    if (typeof openMypageSub === 'function') openMypageSub('applications');
+    if (typeof openMypageSub === 'function') openMypageSub('applications', false);
   } else if (hash && hash !== 'home') {
     navigate(hash, false);
   } else {

--- a/dev/js/application.js
+++ b/dev/js/application.js
@@ -584,7 +584,7 @@ async function openActivityPage(applicationId, campaignId, from) {
           <div style="font-size:36px;color:var(--muted);margin-bottom:12px"><span class="material-icons-round notranslate" translate="no" style="font-size:48px">cancel</span></div>
           <div style="font-size:15px;font-weight:700;color:var(--ink);margin-bottom:8px" data-i18n="appHistory.cancelBlocked.title">この応募はキャンセルされました</div>
           <div style="font-size:13px;color:var(--muted);margin-bottom:20px;line-height:1.7" data-i18n="appHistory.cancelBlocked.body">応募履歴に戻る場合は下のボタンをタップ</div>
-          <button class="btn btn-primary" onclick="navigate('mypage');openMypageSub('applications')" data-i18n="appHistory.cancelBlocked.backBtn">応募履歴に戻る</button>`;
+          <button class="btn btn-primary" onclick="navigate('mypage', false);openMypageSub('applications')" data-i18n="appHistory.cancelBlocked.backBtn">応募履歴に戻る</button>`;
         // 페이지 헤더 + 안내. 다른 폼/섹션은 모두 가린다.
         const main = root.querySelector('.page-content') || root;
         // 기존 자식 모두 숨김 후 안내만 노출

--- a/dev/js/mypage.js
+++ b/dev/js/mypage.js
@@ -432,11 +432,14 @@ async function toggleMarketingEmail(checked) {
   }
 }
 
-function openMypageSub(sub) {
+function openMypageSub(sub, pushHistory) {
   document.querySelectorAll('#page-mypage .mypage-view').forEach(v => v.classList.remove('active'));
   const target = $('mypage-sub-' + sub);
   if (target) target.classList.add('active');
-  history.pushState({page:'mypage', sub}, '', '#mypage-' + sub);
+  // 사용자 클릭 등 새 진입은 push (기본), popstate·새로고침 init·내부 폴백 등은 false 전달 → entry 누적 방지.
+  if (pushHistory !== false) {
+    history.pushState({page:'mypage', sub}, '', '#mypage-' + sub);
+  }
 }
 
 // 마이페이지 랜딩(목차) 화면이 제거되어, 서브 화면을 닫으면 응모이력을 기본 화면으로 보여준다.

--- a/dev/js/notifications.js
+++ b/dev/js/notifications.js
@@ -69,7 +69,7 @@ function renderNavMenu() {
     html += `<div class="nav-accordion${_navMypageOpen ? ' open' : ''}" id="navMypageAccordion">`;
     html += subs.map((s, i) => `
       ${i>0 ? '<div class="nav-divider-sub"></div>' : ''}
-      <button class="nav-subitem" onclick="navigate('mypage');openMypageSub('${s.sub}');closeNavPanel()">
+      <button class="nav-subitem" onclick="navigate('mypage', false);openMypageSub('${s.sub}');closeNavPanel()">
         <span class="nav-label">${esc(s.label)}</span>
         ${s.unreg ? `<span class="nav-unreg-badge">${esc(t('common.unregistered'))}</span>` : ''}
       </button>
@@ -320,7 +320,7 @@ async function onNotifItemClick(id, kind, refTable, refId) {
     toast(t('notif.refMissing'), 'warn');
   } else {
     // ref 없는 일반 알림: 응모이력으로 이동
-    if (typeof navigate === 'function') { navigate('mypage'); openMypageSub('applications'); }
+    if (typeof navigate === 'function') { navigate('mypage', false); openMypageSub('applications'); }
   }
   refreshNotifBadge();
 }

--- a/index.html
+++ b/index.html
@@ -8932,7 +8932,7 @@ async function openActivityPage(applicationId, campaignId, from) {
           <div style="font-size:36px;color:var(--muted);margin-bottom:12px"><span class="material-icons-round notranslate" translate="no" style="font-size:48px">cancel</span></div>
           <div style="font-size:15px;font-weight:700;color:var(--ink);margin-bottom:8px" data-i18n="appHistory.cancelBlocked.title">この応募はキャンセルされました</div>
           <div style="font-size:13px;color:var(--muted);margin-bottom:20px;line-height:1.7" data-i18n="appHistory.cancelBlocked.body">応募履歴に戻る場合は下のボタンをタップ</div>
-          <button class="btn btn-primary" onclick="navigate('mypage');openMypageSub('applications')" data-i18n="appHistory.cancelBlocked.backBtn">応募履歴に戻る</button>`;
+          <button class="btn btn-primary" onclick="navigate('mypage', false);openMypageSub('applications')" data-i18n="appHistory.cancelBlocked.backBtn">応募履歴に戻る</button>`;
         // 페이지 헤더 + 안내. 다른 폼/섹션은 모두 가린다.
         const main = root.querySelector('.page-content') || root;
         // 기존 자식 모두 숨김 후 안내만 노출
@@ -9756,7 +9756,7 @@ function renderNavMenu() {
     html += `<div class="nav-accordion${_navMypageOpen ? ' open' : ''}" id="navMypageAccordion">`;
     html += subs.map((s, i) => `
       ${i>0 ? '<div class="nav-divider-sub"></div>' : ''}
-      <button class="nav-subitem" onclick="navigate('mypage');openMypageSub('${s.sub}');closeNavPanel()">
+      <button class="nav-subitem" onclick="navigate('mypage', false);openMypageSub('${s.sub}');closeNavPanel()">
         <span class="nav-label">${esc(s.label)}</span>
         ${s.unreg ? `<span class="nav-unreg-badge">${esc(t('common.unregistered'))}</span>` : ''}
       </button>
@@ -10007,7 +10007,7 @@ async function onNotifItemClick(id, kind, refTable, refId) {
     toast(t('notif.refMissing'), 'warn');
   } else {
     // ref 없는 일반 알림: 응모이력으로 이동
-    if (typeof navigate === 'function') { navigate('mypage'); openMypageSub('applications'); }
+    if (typeof navigate === 'function') { navigate('mypage', false); openMypageSub('applications'); }
   }
   refreshNotifBadge();
 }
@@ -10466,11 +10466,14 @@ async function toggleMarketingEmail(checked) {
   }
 }
 
-function openMypageSub(sub) {
+function openMypageSub(sub, pushHistory) {
   document.querySelectorAll('#page-mypage .mypage-view').forEach(v => v.classList.remove('active'));
   const target = $('mypage-sub-' + sub);
   if (target) target.classList.add('active');
-  history.pushState({page:'mypage', sub}, '', '#mypage-' + sub);
+  // 사용자 클릭 등 새 진입은 push (기본), popstate·새로고침 init·내부 폴백 등은 false 전달 → entry 누적 방지.
+  if (pushHistory !== false) {
+    history.pushState({page:'mypage', sub}, '', '#mypage-' + sub);
+  }
 }
 
 // 마이페이지 랜딩(목차) 화면이 제거되어, 서브 화면을 닫으면 응모이력을 기본 화면으로 보여준다.
@@ -11730,7 +11733,9 @@ window.addEventListener('popstate', function(e) {
   if (page === 'mypage' || page.startsWith('mypage-')) {
     navigate('mypage', false);
     const sub = e.state?.sub || (page.startsWith('mypage-') ? page.replace('mypage-','') : null);
-    if (sub) openMypageSub(sub); else closeMypageSub();
+    // popstate 는 이미 history 가 그 entry 로 이동한 상태 — openMypageSub 의 pushState 를 또 호출하면
+    // 새 entry 가 추가돼 뒤로가기가 어긋남. false 전달로 push 스킵.
+    if (sub) openMypageSub(sub, false); else closeMypageSub();
   } else if (page.startsWith('detail-')) {
     openCampaign(page.replace('detail-',''));
   } else if (page.startsWith('messages-')) {
@@ -12002,7 +12007,8 @@ async function init() {
   } else if (hash && hash.startsWith('mypage-')) {
     const sub = hash.replace('mypage-','');
     navigate('mypage', false);
-    openMypageSub(sub);
+    // 새로고침 init — URL 이 이미 #mypage-sub 라 openMypageSub 의 pushState 는 동일 entry 중복.
+    openMypageSub(sub, false);
   } else if (hash && hash.startsWith('messages-')) {
     // 응모건 메시지 페이지 새로고침 복원 — openMessagesPage 가 캐시(_myApps) 보장
     const appId = hash.replace('messages-','');
@@ -12010,9 +12016,12 @@ async function init() {
     else navigate('mypage', false);
   } else if (hash === 'activity') {
     // 활동관리 페이지 새로고침 — _activityAppId·_activityCamp 글로벌이 NULL 이라 데이터 복원 불가.
-    // 빈 폼만 노출되어 사용자 혼란(영수증·결과물 내역 안 보임, 뒤로가기 무반응) → 응모이력으로 안전 폴백.
+    // 빈 폼·뒤로가기 회귀 → 응모이력으로 안전 폴백.
+    // history 정리: 현재 entry 의 URL/state 자체를 #mypage-applications 로 replaceState
+    // (#activity entry 가 stack 에 남으면 뒤로가기 시 또 마주침). openMypageSub 도 false 로 호출.
+    history.replaceState({page:'mypage', sub:'applications'}, '', '#mypage-applications');
     navigate('mypage', false);
-    if (typeof openMypageSub === 'function') openMypageSub('applications');
+    if (typeof openMypageSub === 'function') openMypageSub('applications', false);
   } else if (hash && hash !== 'home') {
     navigate(hash, false);
   } else {


### PR DESCRIPTION
사용자 지적: '응모이력→활동관리 새로고침 후 뒤로가기 3번 필요. 전체 라우팅 문제.'

근본 원인 — history.pushState 중복 누적:
1. openMypageSub 가 항상 pushState (popstate·init 호출 시도 push)
2. 햄버거 메뉴 'navigate(mypage);openMypageSub(sub)' 패턴이 push 2회
3. init #activity 분기가 replaceState 없이 mypage-applications push 추가

수정:
- openMypageSub(sub, pushHistory) 옵션 추가 (navigate 와 일관)
- popstate·init mypage-/activity 분기 모두 false 전달
- 햄버거·알림 콜백: navigate('mypage', false) + openMypageSub
- activity 분기: history.replaceState 로 URL 치환

🤖 Generated with [Claude Code](https://claude.com/claude-code)