### PR TITLE
fix(deliverable): UPDATE existing row on review_image re-submit

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -12,7 +12,7 @@
 // 회귀(2026-05-12 PR #182 머지 직후 발생)를 방지하기 위한 자동 reload 가드.
 // sessionStorage 차단 환경(시크릿 모드 일부, 쿠키 차단)에서는 자연스럽게 skip.
 (function(){
-  var CURRENT_BUILD = 'v1779946358';
+  var CURRENT_BUILD = 'v1779946566';
   if (CURRENT_BUILD.indexOf('__') === 0) return; // 빌드 미적용 (dev/ 직접 열기) 시 skip
   try {
     var prev = sessionStorage.getItem('reverb.adminBuild');
@@ -1762,7 +1762,7 @@ textarea.form-input{resize:vertical;min-height:80px}
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-05-28 14:32 · 2e7fe57</span>
+          <span class="admin-build-text">2026-05-28 14:36 · 3a07890</span>
         </div>
       </div>
     </aside>
@@ -5833,18 +5833,34 @@ async function insertDraftDeliverable(payload) {
   if (!db) return null;
   let id = null;
   await retryWithRefresh(async () => {
-    // review_image + post_channel 지정 시: 마이그레이션 158 UNIQUE 부분 인덱스
-    //   (application_id, post_channel) WHERE kind='review_image' AND post_channel IS NOT NULL
-    // 충돌 방지 — 같은 신청+같은 채널의 기존 review_image 행(반려·승인·검수중 포함)을
-    // 모두 삭제 후 새 draft INSERT. 사양 §3-2 「재제출은 기존 행 교체」 정합.
-    // (이력은 deliverable_events 트리거 037이 보존)
+    // review_image + post_channel 지정 시: 마이그레이션 158 UNIQUE 부분 인덱스 충돌 방지.
+    //   DELETE+INSERT 패턴은 RLS DELETE 정책 부재 또는 트랜잭션 분리로 0행 삭제 시 UNIQUE 위반
+    //   ('이미 등록된 데이터' 토스트) 발생 — 사양 §3-2 「재제출은 기존 행 UPDATE」 권고로 전환.
+    //   기존 행 있으면 status='draft' 로 되돌리고 이미지·반려사유 비움. 없으면 아래 INSERT 진행.
+    //   (deliverable_events 이력은 037 트리거가 status 전이 시 자동 INSERT)
     if (payload.kind === 'review_image' && payload.post_channel) {
-      const {error: delErr} = await db?.from('deliverables')
-        .delete()
+      const {data: existing, error: selErr} = await db?.from('deliverables')
+        .select('id')
         .eq('application_id', payload.application_id)
         .eq('kind', 'review_image')
-        .eq('post_channel', payload.post_channel);
-      if (delErr) throw delErr;
+        .eq('post_channel', payload.post_channel)
+        .maybeSingle();
+      if (selErr) throw selErr;
+      if (existing?.id) {
+        const {error: upErr} = await db?.from('deliverables')
+          .update({
+            status: 'draft',
+            receipt_url: payload.receipt_url || null,
+            reject_reason: null,
+            reject_template_code: null,
+            reviewed_by: null,
+            reviewed_at: null
+          })
+          .eq('id', existing.id);
+        if (upErr) throw upErr;
+        id = existing.id;
+        return;  // 기존 행 갱신 완료 — INSERT 스킵
+      }
     }
     const row = {
       application_id: payload.application_id,
@@ -18089,6 +18105,16 @@ async function exportCampaignDeliverables(campId) {
     var users = await fetchInfluencers();
     var userById = {};
     (users || []).forEach(function(u){ if (u && u.id) userById[u.id] = u; });
+
+    // 3-1) monitor + 캠페인 채널 N개면 채널별 결과물 컬럼 펼침 (사양 2 PR 3, 2026-05-28)
+    //   gifting/visit·채널 없는 레거시 monitor는 기존 22컬럼 단일 결과물 코드 그대로.
+    var campChannels = (camp.recruit_type === 'monitor')
+      ? (camp.channel || '').split(',').map(function(c){ return c.trim(); }).filter(Boolean)
+      : [];
+    if (campChannels.length > 0) {
+      try { await fetchLookups('channel'); } catch(e) { /* 라벨 폴백 OK */ }
+      return await _exportCampDelivsMonitorMulti(camp, delivs, userById, campChannels);
+    }
 
     // 4) 영수증·리뷰 이미지 Image→Canvas로 jpeg 재인코딩 (CORS·포맷 호환성 보장)
     //    receipt(영수증) + review_image(monitor 2단계 리뷰 캡처) 모두 receipt_url 컬럼을 재사용

--- a/dev/lib/storage.js
+++ b/dev/lib/storage.js
@@ -768,18 +768,34 @@ async function insertDraftDeliverable(payload) {
   if (!db) return null;
   let id = null;
   await retryWithRefresh(async () => {
-    // review_image + post_channel 지정 시: 마이그레이션 158 UNIQUE 부분 인덱스
-    //   (application_id, post_channel) WHERE kind='review_image' AND post_channel IS NOT NULL
-    // 충돌 방지 — 같은 신청+같은 채널의 기존 review_image 행(반려·승인·검수중 포함)을
-    // 모두 삭제 후 새 draft INSERT. 사양 §3-2 「재제출은 기존 행 교체」 정합.
-    // (이력은 deliverable_events 트리거 037이 보존)
+    // review_image + post_channel 지정 시: 마이그레이션 158 UNIQUE 부분 인덱스 충돌 방지.
+    //   DELETE+INSERT 패턴은 RLS DELETE 정책 부재 또는 트랜잭션 분리로 0행 삭제 시 UNIQUE 위반
+    //   ('이미 등록된 데이터' 토스트) 발생 — 사양 §3-2 「재제출은 기존 행 UPDATE」 권고로 전환.
+    //   기존 행 있으면 status='draft' 로 되돌리고 이미지·반려사유 비움. 없으면 아래 INSERT 진행.
+    //   (deliverable_events 이력은 037 트리거가 status 전이 시 자동 INSERT)
     if (payload.kind === 'review_image' && payload.post_channel) {
-      const {error: delErr} = await db?.from('deliverables')
-        .delete()
+      const {data: existing, error: selErr} = await db?.from('deliverables')
+        .select('id')
         .eq('application_id', payload.application_id)
         .eq('kind', 'review_image')
-        .eq('post_channel', payload.post_channel);
-      if (delErr) throw delErr;
+        .eq('post_channel', payload.post_channel)
+        .maybeSingle();
+      if (selErr) throw selErr;
+      if (existing?.id) {
+        const {error: upErr} = await db?.from('deliverables')
+          .update({
+            status: 'draft',
+            receipt_url: payload.receipt_url || null,
+            reject_reason: null,
+            reject_template_code: null,
+            reviewed_by: null,
+            reviewed_at: null
+          })
+          .eq('id', existing.id);
+        if (upErr) throw upErr;
+        id = existing.id;
+        return;  // 기존 행 갱신 완료 — INSERT 스킵
+      }
     }
     const row = {
       application_id: payload.application_id,

--- a/index.html
+++ b/index.html
@@ -4755,18 +4755,34 @@ async function insertDraftDeliverable(payload) {
   if (!db) return null;
   let id = null;
   await retryWithRefresh(async () => {
-    // review_image + post_channel 지정 시: 마이그레이션 158 UNIQUE 부분 인덱스
-    //   (application_id, post_channel) WHERE kind='review_image' AND post_channel IS NOT NULL
-    // 충돌 방지 — 같은 신청+같은 채널의 기존 review_image 행(반려·승인·검수중 포함)을
-    // 모두 삭제 후 새 draft INSERT. 사양 §3-2 「재제출은 기존 행 교체」 정합.
-    // (이력은 deliverable_events 트리거 037이 보존)
+    // review_image + post_channel 지정 시: 마이그레이션 158 UNIQUE 부분 인덱스 충돌 방지.
+    //   DELETE+INSERT 패턴은 RLS DELETE 정책 부재 또는 트랜잭션 분리로 0행 삭제 시 UNIQUE 위반
+    //   ('이미 등록된 데이터' 토스트) 발생 — 사양 §3-2 「재제출은 기존 행 UPDATE」 권고로 전환.
+    //   기존 행 있으면 status='draft' 로 되돌리고 이미지·반려사유 비움. 없으면 아래 INSERT 진행.
+    //   (deliverable_events 이력은 037 트리거가 status 전이 시 자동 INSERT)
     if (payload.kind === 'review_image' && payload.post_channel) {
-      const {error: delErr} = await db?.from('deliverables')
-        .delete()
+      const {data: existing, error: selErr} = await db?.from('deliverables')
+        .select('id')
         .eq('application_id', payload.application_id)
         .eq('kind', 'review_image')
-        .eq('post_channel', payload.post_channel);
-      if (delErr) throw delErr;
+        .eq('post_channel', payload.post_channel)
+        .maybeSingle();
+      if (selErr) throw selErr;
+      if (existing?.id) {
+        const {error: upErr} = await db?.from('deliverables')
+          .update({
+            status: 'draft',
+            receipt_url: payload.receipt_url || null,
+            reject_reason: null,
+            reject_template_code: null,
+            reviewed_by: null,
+            reviewed_at: null
+          })
+          .eq('id', existing.id);
+        if (upErr) throw upErr;
+        id = existing.id;
+        return;  // 기존 행 갱신 완료 — INSERT 스킵
+      }
     }
     const row = {
       application_id: payload.application_id,


### PR DESCRIPTION
채널별 결과물 반려 후 재업로드 시 UNIQUE 인덱스(158) 충돌로 '이미 등록된 데이터' 토스트 발생. DELETE+INSERT → 기존 행 UPDATE 패턴으로 전환 (사양 §3-2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)