### PR TITLE
feat(admin): column headers + click-to-expand on messages inbox

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -12,7 +12,7 @@
 // 회귀(2026-05-12 PR #182 머지 직후 발생)를 방지하기 위한 자동 reload 가드.
 // sessionStorage 차단 환경(시크릿 모드 일부, 쿠키 차단)에서는 자연스럽게 skip.
 (function(){
-  var CURRENT_BUILD = 'v1779946849';
+  var CURRENT_BUILD = 'v1779947254';
   if (CURRENT_BUILD.indexOf('__') === 0) return; // 빌드 미적용 (dev/ 직접 열기) 시 skip
   try {
     var prev = sessionStorage.getItem('reverb.adminBuild');
@@ -1522,7 +1522,14 @@ textarea.form-input{resize:vertical;min-height:80px}
    ════════════════════════════════════════════════════════════ */
 /* 받은편지함 3단 패널 — 단계 진행형 너비 */
 .inbox-3pane{display:flex;gap:0;flex:1;min-height:0;height:calc(100vh - 150px);border:1px solid var(--line);border-radius:12px;overflow:hidden;background:#fff}
-.inbox-col{overflow-y:auto;min-height:0}
+.inbox-col{display:flex;flex-direction:column;min-height:0;min-width:0}
+.inbox-col-body{flex:1;overflow-y:auto;min-height:0}
+/* 각 영역 상단 제목 헤더 — 캠페인·대화 목록은 클릭으로 영역 확장 토글, 대화 내용은 정적 */
+.inbox-col-header{flex-shrink:0;display:flex;align-items:center;justify-content:space-between;gap:6px;padding:10px 14px;font-size:13px;font-weight:700;color:var(--ink);background:var(--surface-dim);border-bottom:1px solid var(--line);cursor:pointer;user-select:none;transition:background .15s ease}
+.inbox-col-header:hover{background:var(--light-pink)}
+.inbox-col-header-static{cursor:default}
+.inbox-col-header-static:hover{background:var(--surface-dim)}
+.inbox-col-header-icon{font-size:16px;color:var(--muted);opacity:.7}
 .inbox-col-camps{border-right:1px solid var(--line);background:var(--surface-container-low)}
 .inbox-col-threads{border-right:1px solid var(--line)}
 .inbox-col-view{display:flex;flex-direction:column}
@@ -1762,7 +1769,7 @@ textarea.form-input{resize:vertical;min-height:80px}
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-05-28 14:40 · db59881</span>
+          <span class="admin-build-text">2026-05-28 14:47 · 0889008</span>
         </div>
       </div>
     </aside>
@@ -2769,9 +2776,26 @@ textarea.form-input{resize:vertical;min-height:80px}
             </div>
           </div>
           <div class="inbox-3pane stage-campaigns">
-            <div class="inbox-col inbox-col-camps" id="inboxCampaigns"></div>
-            <div class="inbox-col inbox-col-threads" id="inboxThreads"></div>
-            <div class="inbox-col inbox-col-view" id="inboxThreadView"></div>
+            <div class="inbox-col inbox-col-camps">
+              <div class="inbox-col-header" onclick="setInboxStageCampaigns()" title="클릭하면 캠페인 목록을 넓게 봅니다">
+                <span>캠페인</span>
+                <span class="material-icons-round notranslate inbox-col-header-icon" translate="no">unfold_more</span>
+              </div>
+              <div class="inbox-col-body" id="inboxCampaigns"></div>
+            </div>
+            <div class="inbox-col inbox-col-threads">
+              <div class="inbox-col-header" onclick="setInboxStageThreads()" title="클릭하면 대화 목록을 넓게 봅니다">
+                <span>대화 목록</span>
+                <span class="material-icons-round notranslate inbox-col-header-icon" translate="no">unfold_more</span>
+              </div>
+              <div class="inbox-col-body" id="inboxThreads"></div>
+            </div>
+            <div class="inbox-col inbox-col-view">
+              <div class="inbox-col-header inbox-col-header-static">
+                <span>대화 내용</span>
+              </div>
+              <div class="inbox-col-body" id="inboxThreadView"></div>
+            </div>
           </div>
         </div>
 
@@ -13798,6 +13822,27 @@ async function loadMessagesInbox() {
   const wrap = document.getElementById('inboxThreadView');
   if (wrap) wrap.innerHTML = '<div class="inbox-empty">대화를 선택하세요.</div>';
   await refreshInboxData();
+  updateInboxStage();
+}
+
+// 캠페인 영역 확장 — 헤더 클릭 시 캠페인·대화 선택 모두 해제 → updateInboxStage 가 stage-campaigns 로 전환.
+//   (사용자: '캠페인 제목 영역 클릭하면 캠페인 영역이 넓어지게')
+function setInboxStageCampaigns() {
+  _inboxSelectedCampaign = null;
+  _admMsgAppId = null;
+  const v = document.getElementById('inboxThreadView');
+  if (v) v.innerHTML = '';
+  renderInboxCampaignList();
+  renderInboxThreadList();
+  updateInboxStage();
+}
+
+// 대화 목록 영역 확장 — 대화 선택만 해제하고 캠페인 선택은 유지 → stage-threads (캠페인 선택 상태일 때만 의미).
+function setInboxStageThreads() {
+  _admMsgAppId = null;
+  const v = document.getElementById('inboxThreadView');
+  if (v) v.innerHTML = '';
+  renderInboxThreadList();
   updateInboxStage();
 }
 

--- a/dev/admin/index.html
+++ b/dev/admin/index.html
@@ -1138,9 +1138,26 @@
             </div>
           </div>
           <div class="inbox-3pane stage-campaigns">
-            <div class="inbox-col inbox-col-camps" id="inboxCampaigns"></div>
-            <div class="inbox-col inbox-col-threads" id="inboxThreads"></div>
-            <div class="inbox-col inbox-col-view" id="inboxThreadView"></div>
+            <div class="inbox-col inbox-col-camps">
+              <div class="inbox-col-header" onclick="setInboxStageCampaigns()" title="클릭하면 캠페인 목록을 넓게 봅니다">
+                <span>캠페인</span>
+                <span class="material-icons-round notranslate inbox-col-header-icon" translate="no">unfold_more</span>
+              </div>
+              <div class="inbox-col-body" id="inboxCampaigns"></div>
+            </div>
+            <div class="inbox-col inbox-col-threads">
+              <div class="inbox-col-header" onclick="setInboxStageThreads()" title="클릭하면 대화 목록을 넓게 봅니다">
+                <span>대화 목록</span>
+                <span class="material-icons-round notranslate inbox-col-header-icon" translate="no">unfold_more</span>
+              </div>
+              <div class="inbox-col-body" id="inboxThreads"></div>
+            </div>
+            <div class="inbox-col inbox-col-view">
+              <div class="inbox-col-header inbox-col-header-static">
+                <span>대화 내용</span>
+              </div>
+              <div class="inbox-col-body" id="inboxThreadView"></div>
+            </div>
           </div>
         </div>
 

--- a/dev/css/admin.css
+++ b/dev/css/admin.css
@@ -1074,7 +1074,14 @@
    ════════════════════════════════════════════════════════════ */
 /* 받은편지함 3단 패널 — 단계 진행형 너비 */
 .inbox-3pane{display:flex;gap:0;flex:1;min-height:0;height:calc(100vh - 150px);border:1px solid var(--line);border-radius:12px;overflow:hidden;background:#fff}
-.inbox-col{overflow-y:auto;min-height:0}
+.inbox-col{display:flex;flex-direction:column;min-height:0;min-width:0}
+.inbox-col-body{flex:1;overflow-y:auto;min-height:0}
+/* 각 영역 상단 제목 헤더 — 캠페인·대화 목록은 클릭으로 영역 확장 토글, 대화 내용은 정적 */
+.inbox-col-header{flex-shrink:0;display:flex;align-items:center;justify-content:space-between;gap:6px;padding:10px 14px;font-size:13px;font-weight:700;color:var(--ink);background:var(--surface-dim);border-bottom:1px solid var(--line);cursor:pointer;user-select:none;transition:background .15s ease}
+.inbox-col-header:hover{background:var(--light-pink)}
+.inbox-col-header-static{cursor:default}
+.inbox-col-header-static:hover{background:var(--surface-dim)}
+.inbox-col-header-icon{font-size:16px;color:var(--muted);opacity:.7}
 .inbox-col-camps{border-right:1px solid var(--line);background:var(--surface-container-low)}
 .inbox-col-threads{border-right:1px solid var(--line)}
 .inbox-col-view{display:flex;flex-direction:column}

--- a/dev/js/admin-messaging.js
+++ b/dev/js/admin-messaging.js
@@ -65,6 +65,27 @@ async function loadMessagesInbox() {
   updateInboxStage();
 }
 
+// 캠페인 영역 확장 — 헤더 클릭 시 캠페인·대화 선택 모두 해제 → updateInboxStage 가 stage-campaigns 로 전환.
+//   (사용자: '캠페인 제목 영역 클릭하면 캠페인 영역이 넓어지게')
+function setInboxStageCampaigns() {
+  _inboxSelectedCampaign = null;
+  _admMsgAppId = null;
+  const v = document.getElementById('inboxThreadView');
+  if (v) v.innerHTML = '';
+  renderInboxCampaignList();
+  renderInboxThreadList();
+  updateInboxStage();
+}
+
+// 대화 목록 영역 확장 — 대화 선택만 해제하고 캠페인 선택은 유지 → stage-threads (캠페인 선택 상태일 때만 의미).
+function setInboxStageThreads() {
+  _admMsgAppId = null;
+  const v = document.getElementById('inboxThreadView');
+  if (v) v.innerHTML = '';
+  renderInboxThreadList();
+  updateInboxStage();
+}
+
 // 단계 진행형 너비 — 선택 진척에 따라 활성 단을 넓힘 (메신저 드릴다운)
 //   캠페인 미선택 → 캠페인 목록 전체폭 / 캠페인 선택 → 대화 상대 목록 확대 / 대화 선택 → 대화 내용 확대
 function updateInboxStage() {


### PR DESCRIPTION
각 영역(캠페인/대화목록/대화내용) 상단 제목 헤더 추가. 캠페인·대화목록 헤더 클릭 시 해당 영역으로 stage 전환되어 넓어짐.

🤖 Generated with [Claude Code](https://claude.com/claude-code)