### PR TITLE
feat(excel): per-channel column expansion for monitor multi-channel deliverables (사양 2 PR 3 단계 a)

### DIFF
--- a/dev/js/admin-excel.js
+++ b/dev/js/admin-excel.js
@@ -819,6 +819,16 @@ async function exportCampaignDeliverables(campId) {
     var userById = {};
     (users || []).forEach(function(u){ if (u && u.id) userById[u.id] = u; });
 
+    // 3-1) monitor + 캠페인 채널 N개면 채널별 결과물 컬럼 펼침 (사양 2 PR 3, 2026-05-28)
+    //   gifting/visit·채널 없는 레거시 monitor는 기존 22컬럼 단일 결과물 코드 그대로.
+    var campChannels = (camp.recruit_type === 'monitor')
+      ? (camp.channel || '').split(',').map(function(c){ return c.trim(); }).filter(Boolean)
+      : [];
+    if (campChannels.length > 0) {
+      try { await fetchLookups('channel'); } catch(e) { /* 라벨 폴백 OK */ }
+      return await _exportCampDelivsMonitorMulti(camp, delivs, userById, campChannels);
+    }
+
     // 4) 영수증·리뷰 이미지 Image→Canvas로 jpeg 재인코딩 (CORS·포맷 호환성 보장)
     //    receipt(영수증) + review_image(monitor 2단계 리뷰 캡처) 모두 receipt_url 컬럼을 재사용
     var imgBuffers = {};


### PR DESCRIPTION
단일 캠페인 결과물 엑셀 — monitor + 채널 N개면 결과물 6컬럼을 채널 수만큼 펼침. 그 외는 기존 22컬럼 그대로.

- _excelColLetter / _exportCampDelivsMonitorMulti 함수 신규
- 영수증 9 + 채널 N × 6 컬럼 동적 헤더 + 본문
- 이미지 임베드 + 하이퍼링크 스타일 + 채널 라벨(getLookupLabel)
- 회귀: gifting/visit + 채널 없는 레거시 monitor 영향 없음

다음 단계 b — exportSelectedCampaignsDeliverables 합집합 분리.

[reviewer] GO

🤖 Generated with [Claude Code](https://claude.com/claude-code)