### PR TITLE
feat(excel): channel-set group sheets in multi-export deliverables

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -12,7 +12,7 @@
 // 회귀(2026-05-12 PR #182 머지 직후 발생)를 방지하기 위한 자동 reload 가드.
 // sessionStorage 차단 환경(시크릿 모드 일부, 쿠키 차단)에서는 자연스럽게 skip.
 (function(){
-  var CURRENT_BUILD = 'v1779949532';
+  var CURRENT_BUILD = 'v1779950705';
   if (CURRENT_BUILD.indexOf('__') === 0) return; // 빌드 미적용 (dev/ 직접 열기) 시 skip
   try {
     var prev = sessionStorage.getItem('reverb.adminBuild');
@@ -1780,7 +1780,7 @@ textarea.form-input{resize:vertical;min-height:80px}
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-05-28 15:25 · 118336f</span>
+          <span class="admin-build-text">2026-05-28 15:45 · 7bffd98</span>
         </div>
       </div>
     </aside>
@@ -17851,42 +17851,56 @@ async function exportSelectedCampaignsDeliverables(idsOverride) {
     // 시트1 캠페인 정보 (기존 유지)
     _buildCampaignSummarySheet(wb, camps, appsByCampId);
 
-    // ── monitor 다채널 캠페인은 단일 엑셀과 동일한 형식의 별도 시트로 분리 (사양 2 PR 3 단계 b)
-    //   사용자 의도: '같은 정보를 한 건만 볼지 여러 건을 볼지의 차이' — 다중도 단일 시트 형식 그대로,
-    //   다만 캠페인 N개를 한 파일에 시트로 묶음. 비monitor·monitor 채널 없음은 아래 통합 시트로 폴백.
-    var monitorMultiCamps = camps.filter(function(c) {
-      return c.recruit_type === 'monitor' && (c.channel || '').split(',').map(function(x){return x.trim();}).filter(Boolean).length > 0;
+    // ── monitor 캠페인을 채널 조합별로 그룹화해 시트 분리 (사양 2 PR 3 단계 b)
+    //   사용자 의도: 캠페인별 시트가 아닌 「리뷰 · {채널 조합}」 시트. 같은 채널 구성 캠페인은 한 시트에 묶임.
+    //   예: 「리뷰 · Qoo10」 / 「리뷰 · Qoo10/LIPS」 / 「리뷰 · @cosme」
+    //   비monitor·monitor 채널 없음 캠페인은 아래 통합 시트로 폴백.
+    try { await fetchLookups('channel'); } catch(e) { /* 라벨 폴백 OK */ }
+    var monitorGroups = {};  // {sortedKey: {channels:[code...], campIds:Set}}
+    camps.forEach(function(c) {
+      if (c.recruit_type !== 'monitor') return;
+      var chs = (c.channel || '').split(',').map(function(x){return x.trim();}).filter(Boolean).slice().sort();
+      if (chs.length === 0) return;
+      var key = chs.join('|');
+      if (!monitorGroups[key]) monitorGroups[key] = {channels: chs, campIds: {}};
+      monitorGroups[key].campIds[c.id] = true;
     });
-    var monitorMultiIds = {};
-    monitorMultiCamps.forEach(function(c){ monitorMultiIds[c.id] = true; });
-    if (monitorMultiCamps.length > 0) {
-      try { await fetchLookups('channel'); } catch(e) { /* 라벨 폴백 OK */ }
-      // 시트명 충돌 방지 — 31자 제한 + 동명이인 처리
-      var usedSheetNames = {};
-      var pickSheetName = function(c) {
-        var base = (c.campaign_no || c.title || '결과물').replace(/[\\\/\?\*\[\]:]/g, '_').substring(0, 28);
-        if (!base) base = '결과물';
-        var name = base, i = 2;
-        while (usedSheetNames[name]) { name = base.substring(0, 28 - String(i).length - 1) + '_' + i; i++; }
-        usedSheetNames[name] = true;
-        return name;
-      };
-      for (var mi = 0; mi < monitorMultiCamps.length; mi++) {
-        var mc = monitorMultiCamps[mi];
-        var mcDelivs = allDelivs.filter(function(d){ return d.campaign_id === mc.id; });
-        var mcChannels = (mc.channel || '').split(',').map(function(x){return x.trim();}).filter(Boolean);
-        await _exportCampDelivsMonitorMulti(mc, mcDelivs, usersById, mcChannels, {
-          wb: wb,
-          sheetName: pickSheetName(mc),
-          imgBuffers: imgBuffers,  // 위에서 일괄 다운로드한 버퍼 재사용
-          skipDownload: true
-        });
-      }
+    var monitorCovered = {};  // monitor 그룹으로 처리된 캠페인 id (통합 시트에서 제외 대상)
+    Object.values(monitorGroups).forEach(function(g) {
+      Object.keys(g.campIds).forEach(function(id){ monitorCovered[id] = true; });
+    });
+
+    var chLabelOf = function(code) {
+      return (typeof getLookupLabel === 'function') ? (getLookupLabel('channel', code, 'ko') || code) : code;
+    };
+    var usedSheetNames = {'캠페인 정보': true};  // 시트1 이름 충돌 방지
+    var pickGroupSheetName = function(channels) {
+      var labels = channels.map(chLabelOf).join('/');
+      var base = ('리뷰 · ' + labels).replace(/[\\\/\?\*\[\]:]/g, function(m){ return m === '/' ? '/' : '_'; });
+      base = base.substring(0, 28);
+      var name = base, i = 2;
+      while (usedSheetNames[name]) { name = base.substring(0, 28 - String(i).length - 1) + '_' + i; i++; }
+      usedSheetNames[name] = true;
+      return name;
+    };
+    var groupKeys = Object.keys(monitorGroups).sort(function(a,b) {
+      return monitorGroups[a].channels.length - monitorGroups[b].channels.length || a.localeCompare(b);
+    });
+    for (var gi = 0; gi < groupKeys.length; gi++) {
+      var grp = monitorGroups[groupKeys[gi]];
+      var grpCamps = camps.filter(function(c){ return grp.campIds[c.id]; });
+      var grpDelivs = allDelivs.filter(function(d){ return grp.campIds[d.campaign_id]; });
+      var sheetName = pickGroupSheetName(grp.channels);
+      _buildMonitorGroupSheet(wb, sheetName, grpCamps, grp.channels, grpDelivs, usersById, imgBuffers);
     }
 
-    // 통합 시트는 monitor 다채널 외 캠페인의 결과물만 그룹핑
-    groupList = groupList.filter(function(g) { return !(g.camp && monitorMultiIds[g.camp.id]); });
+    // 통합 시트는 monitor 그룹으로 처리된 캠페인 외 결과물만 (비monitor + monitor 채널 없음)
+    groupList = groupList.filter(function(g) { return !(g.camp && monitorCovered[g.camp.id]); });
     var hasOtherCamps = groupList.length > 0;
+
+    // 통합 시트 — monitor 그룹으로 처리되지 않은 결과물(비monitor + monitor 채널 없음)만 있을 때 생성.
+    //   monitor 그룹만 있고 통합 대상이 없으면 빈 시트 생성하지 않음 (사용자 지적: '탭이 세개나 생겨').
+    if (hasOtherCamps) {
 
     // 시트2 결과물 — 24컬럼 (캠페인 2 + 인플루언서 7 + 영수증 9 + 결과물 6)
     // 영수증 9컬럼: 타입 / 제출일 / 검수일 / 상태 / 주문번호 / 구매일 / 구매금액 / 이미지 / URL (마이그레이션 128)
@@ -18021,6 +18035,7 @@ async function exportSelectedCampaignsDeliverables(idsOverride) {
         ws.addImage(sImgId, 'W' + rowNum + ':W' + rowNum);
       }
     });
+    }  // end if (hasOtherCamps)
 
     var buf = await wb.xlsx.writeBuffer();
     var blob = new Blob([buf], { type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' });
@@ -18676,6 +18691,187 @@ async function _exportCampDelivsMonitorMulti(camp, delivs, userById, campChannel
   link.click();
   setTimeout(function(){ URL.revokeObjectURL(link.href); }, 1000);
   toast('엑셀 다운로드 완료 (' + groupList.length + '건, 채널 ' + N + '개)');
+}
+
+// 사양 2 PR 3 단계 b — 다중 엑셀의 「리뷰 · {채널 조합}」 그룹 시트 빌더.
+//   같은 채널 구성(예: qoo10, qoo10/lips)의 캠페인 N개를 한 시트에 묶음.
+//   컬럼 = 캠페인 2 + 인플 7 + 영수증 9 + 채널 N × 6.
+//   행 = (campaign_id, application_id) 단위.
+function _buildMonitorGroupSheet(wb, sheetName, grpCamps, channels, delivs, userById, imgBuffers) {
+  // 그룹핑
+  var groups = {};
+  delivs.forEach(function(d) {
+    var key = d.campaign_id + '|' + (d.application_id || ('user-' + d.user_id));
+    if (!groups[key]) {
+      var camp = grpCamps.find(function(c){ return c.id === d.campaign_id; }) || {};
+      groups[key] = {key:key, camp:camp, application_id:d.application_id, user_id:d.user_id, receipt:null, reviewByCh:{}};
+    }
+    var g = groups[key];
+    var subAt = d.updated_at || d.submitted_at || '';
+    if (d.kind === 'receipt') {
+      if (!g.receipt || subAt > (g.receipt.updated_at || g.receipt.submitted_at || '')) g.receipt = d;
+    } else if (d.kind === 'review_image' && d.post_channel) {
+      var prev = g.reviewByCh[d.post_channel];
+      if (!prev || subAt > (prev.updated_at || prev.submitted_at || '')) g.reviewByCh[d.post_channel] = d;
+    }
+  });
+  var groupList = Object.values(groups).sort(function(a, b) {
+    var ca = (a.camp.campaign_no || '').toString();
+    var cb = (b.camp.campaign_no || '').toString();
+    if (ca !== cb) return ca.localeCompare(cb, 'ja');
+    var ua = userById[a.user_id] || {}, ub = userById[b.user_id] || {};
+    return (ua.name_kanji || ua.name || '').localeCompare(ub.name_kanji || ub.name || '', 'ja');
+  });
+
+  // 컬럼 계산
+  var CAMP_COLS = 2, INFO_COLS = 7, RECEIPT_COLS = 9, CH_COLS = 6;
+  var N = channels.length;
+  var totalCols = CAMP_COLS + INFO_COLS + RECEIPT_COLS + CH_COLS * N;
+  var lastColLetter = _excelColLetter(totalCols);
+  var receiptImgCol = CAMP_COLS + INFO_COLS + RECEIPT_COLS - 1;  // 영수증 이미지 컬럼
+
+  var chLabelOf = function(code) {
+    return (typeof getLookupLabel === 'function') ? (getLookupLabel('channel', code, 'ko') || code) : code;
+  };
+
+  var ws = wb.addWorksheet(sheetName);
+
+  // row 1: 그룹 제목
+  ws.mergeCells('A1:' + lastColLetter + '1');
+  var t = ws.getCell('A1');
+  t.value = '채널 조합 「' + channels.map(chLabelOf).join(' / ') + '」  (' + grpCamps.length + '개 캠페인)';
+  t.font = {bold:true, size:14};
+  t.alignment = {vertical:'middle'};
+  ws.getRow(1).height = 26;
+
+  // row 2: 메타
+  ws.mergeCells('A2:' + lastColLetter + '2');
+  var m = ws.getCell('A2');
+  m.value = '캠페인 ' + grpCamps.length + '개  ·  신청 ' + groupList.length + '건  ·  결과물 ' + delivs.length + '건  ·  생성일: ' + new Date().toLocaleString('ko-KR');
+  m.font = {color:{argb:'FF888888'}, size:11};
+  ws.getRow(2).height = 20;
+
+  // row 3: 그룹 헤더 (캠페인 / 인플 / 영수증 / 채널 N개)
+  ws.mergeCells('A3:B3'); ws.getCell('A3').value = '캠페인';
+  ws.mergeCells('C3:I3'); ws.getCell('C3').value = '인플루언서 정보';
+  ws.mergeCells('J3:R3'); ws.getCell('J3').value = '영수증';
+  channels.forEach(function(ch, i) {
+    var s = CAMP_COLS + INFO_COLS + RECEIPT_COLS + 1 + i * CH_COLS;
+    var e = s + CH_COLS - 1;
+    ws.mergeCells(_excelColLetter(s) + '3:' + _excelColLetter(e) + '3');
+    ws.getCell(_excelColLetter(s) + '3').value = '「' + chLabelOf(ch) + '」 리뷰';
+  });
+  ['A3','C3','J3'].concat(channels.map(function(_, i){ return _excelColLetter(CAMP_COLS + INFO_COLS + RECEIPT_COLS + 1 + i * CH_COLS) + '3'; })).forEach(function(addr) {
+    var c = ws.getCell(addr);
+    c.font = {bold:true, color:{argb:'FF222222'}};
+    c.alignment = {vertical:'middle', horizontal:'center'};
+    c.fill = {type:'pattern', pattern:'solid', fgColor:{argb:'FFE8E8E8'}};
+  });
+  ws.getRow(3).height = 22;
+
+  // row 4: 컬럼 헤더
+  var headerValues = [
+    '캠페인 번호', '캠페인 제목',
+    '이름(한자)', '이름(가타카나)', '계정 아이디(이메일)', 'Instagram URL', 'TikTok URL', 'X URL', 'YouTube URL',
+    '타입', '제출일', '검수일', '상태', '주문번호', '구매일', '구매금액', '이미지', 'URL'
+  ];
+  channels.forEach(function() {
+    headerValues.push('타입', '제출일', '검수일', '상태', '이미지', 'URL');
+  });
+  ws.getRow(4).values = headerValues;
+  ws.getRow(4).font = {bold:true, color:{argb:'FF222222'}};
+  ws.getRow(4).fill = {type:'pattern', pattern:'solid', fgColor:{argb:'FFF0F0F0'}};
+  ws.getRow(4).alignment = {vertical:'middle', horizontal:'center'};
+  ws.getRow(4).height = 24;
+
+  var colWidths = [
+    18, 28,
+    18, 18, 28, 36, 36, 36, 36,
+    12, 12, 12, 10, 18, 12, 12, 16, 32
+  ];
+  channels.forEach(function() { colWidths.push(12, 12, 12, 10, 16, 32); });
+  ws.columns = colWidths.map(function(w) { return {width:w}; });
+
+  var statusLabelMap = {pending:'검수대기', approved:'승인', rejected:'반려'};
+  var renderDeliv6 = function(d) {
+    if (!d) return ['', '', '', '', '', ''];
+    var sub = d.submitted_at ? new Date(d.submitted_at).toLocaleDateString('ko-KR') : '';
+    var rev = d.reviewed_at ? new Date(d.reviewed_at).toLocaleDateString('ko-KR') : '';
+    var st = statusLabelMap[d.status] || d.status || '';
+    var urlVal = '';
+    if (d.receipt_url) {
+      var iu = /^https?:\/\//.test(d.receipt_url) ? d.receipt_url
+        : (db?.storage?.from ? db.storage.from('campaign-images').getPublicUrl(d.receipt_url)?.data?.publicUrl : d.receipt_url);
+      urlVal = {text:'리뷰 이미지 보기', hyperlink:iu};
+    }
+    return ['리뷰 이미지', sub, rev, st, '', urlVal];
+  };
+  var renderReceipt9 = function(d) {
+    if (!d) return ['', '', '', '', '', '', '', '', ''];
+    var base = renderDeliv6(d);
+    base[0] = '영수증';
+    if (d.receipt_url && base[5] && base[5].text) base[5].text = '영수증 보기';
+    var orderNo = d.order_number || '';
+    var purchaseDate = d.purchase_date || '';
+    var amt = (d.purchase_amount === null || d.purchase_amount === undefined || d.purchase_amount === '')
+      ? '' : Number(d.purchase_amount);
+    return [base[0], base[1], base[2], base[3], orderNo, purchaseDate, amt, base[4], base[5]];
+  };
+
+  // 본문
+  groupList.forEach(function(g, i) {
+    var rowNum = 5 + i;
+    var u = userById[g.user_id] || {};
+    var cc = g.camp || {};
+    var row = ws.getRow(rowNum);
+    row.height = 84;
+
+    var receiptCells = renderReceipt9(g.receipt);
+    var vals = [
+      cc.campaign_no || '', cc.title || '',
+      u.name_kanji || u.name || '—',
+      u.name_kana || '',
+      u.email || '',
+      _excelSnsUrl('instagram', u.ig),
+      _excelSnsUrl('tiktok', u.tiktok),
+      _excelSnsUrl('x', u.x),
+      _excelSnsUrl('youtube', u.youtube),
+      receiptCells[0], receiptCells[1], receiptCells[2], receiptCells[3], receiptCells[4], receiptCells[5], receiptCells[6], receiptCells[7], receiptCells[8]
+    ];
+    channels.forEach(function(ch) {
+      var cells = renderDeliv6(g.reviewByCh[ch]);
+      vals.push(cells[0], cells[1], cells[2], cells[3], cells[4], cells[5]);
+    });
+    row.values = vals;
+    row.alignment = {vertical:'middle', wrapText:true};
+
+    var receiptUrlCol = CAMP_COLS + INFO_COLS + RECEIPT_COLS;  // 18
+    var linkCols = [receiptUrlCol];
+    channels.forEach(function(_, ci) {
+      linkCols.push(CAMP_COLS + INFO_COLS + RECEIPT_COLS + 1 + ci * CH_COLS + 5);
+    });
+    linkCols.forEach(function(col) {
+      var cell = row.getCell(col);
+      if (cell && cell.value && cell.value.hyperlink) cell.font = {color:{argb:'FFE8344E'}, underline:true};
+    });
+
+    if (g.receipt && imgBuffers[g.receipt.id]) {
+      var rImgId = wb.addImage({buffer:imgBuffers[g.receipt.id].buffer, extension:imgBuffers[g.receipt.id].ext});
+      var imgColL = _excelColLetter(receiptImgCol);
+      ws.addImage(rImgId, imgColL + rowNum + ':' + imgColL + rowNum);
+    }
+    channels.forEach(function(ch, ci) {
+      var d = g.reviewByCh[ch];
+      if (d && imgBuffers[d.id]) {
+        var dImgId = wb.addImage({buffer:imgBuffers[d.id].buffer, extension:imgBuffers[d.id].ext});
+        var imgCol = CAMP_COLS + INFO_COLS + RECEIPT_COLS + 1 + ci * CH_COLS + 4;
+        var imgColL = _excelColLetter(imgCol);
+        ws.addImage(dImgId, imgColL + rowNum + ':' + imgColL + rowNum);
+      }
+    });
+  });
+
+  return ws;
 }
 
 

--- a/dev/js/admin-excel.js
+++ b/dev/js/admin-excel.js
@@ -487,42 +487,56 @@ async function exportSelectedCampaignsDeliverables(idsOverride) {
     // 시트1 캠페인 정보 (기존 유지)
     _buildCampaignSummarySheet(wb, camps, appsByCampId);
 
-    // ── monitor 다채널 캠페인은 단일 엑셀과 동일한 형식의 별도 시트로 분리 (사양 2 PR 3 단계 b)
-    //   사용자 의도: '같은 정보를 한 건만 볼지 여러 건을 볼지의 차이' — 다중도 단일 시트 형식 그대로,
-    //   다만 캠페인 N개를 한 파일에 시트로 묶음. 비monitor·monitor 채널 없음은 아래 통합 시트로 폴백.
-    var monitorMultiCamps = camps.filter(function(c) {
-      return c.recruit_type === 'monitor' && (c.channel || '').split(',').map(function(x){return x.trim();}).filter(Boolean).length > 0;
+    // ── monitor 캠페인을 채널 조합별로 그룹화해 시트 분리 (사양 2 PR 3 단계 b)
+    //   사용자 의도: 캠페인별 시트가 아닌 「리뷰 · {채널 조합}」 시트. 같은 채널 구성 캠페인은 한 시트에 묶임.
+    //   예: 「리뷰 · Qoo10」 / 「리뷰 · Qoo10/LIPS」 / 「리뷰 · @cosme」
+    //   비monitor·monitor 채널 없음 캠페인은 아래 통합 시트로 폴백.
+    try { await fetchLookups('channel'); } catch(e) { /* 라벨 폴백 OK */ }
+    var monitorGroups = {};  // {sortedKey: {channels:[code...], campIds:Set}}
+    camps.forEach(function(c) {
+      if (c.recruit_type !== 'monitor') return;
+      var chs = (c.channel || '').split(',').map(function(x){return x.trim();}).filter(Boolean).slice().sort();
+      if (chs.length === 0) return;
+      var key = chs.join('|');
+      if (!monitorGroups[key]) monitorGroups[key] = {channels: chs, campIds: {}};
+      monitorGroups[key].campIds[c.id] = true;
     });
-    var monitorMultiIds = {};
-    monitorMultiCamps.forEach(function(c){ monitorMultiIds[c.id] = true; });
-    if (monitorMultiCamps.length > 0) {
-      try { await fetchLookups('channel'); } catch(e) { /* 라벨 폴백 OK */ }
-      // 시트명 충돌 방지 — 31자 제한 + 동명이인 처리
-      var usedSheetNames = {};
-      var pickSheetName = function(c) {
-        var base = (c.campaign_no || c.title || '결과물').replace(/[\\\/\?\*\[\]:]/g, '_').substring(0, 28);
-        if (!base) base = '결과물';
-        var name = base, i = 2;
-        while (usedSheetNames[name]) { name = base.substring(0, 28 - String(i).length - 1) + '_' + i; i++; }
-        usedSheetNames[name] = true;
-        return name;
-      };
-      for (var mi = 0; mi < monitorMultiCamps.length; mi++) {
-        var mc = monitorMultiCamps[mi];
-        var mcDelivs = allDelivs.filter(function(d){ return d.campaign_id === mc.id; });
-        var mcChannels = (mc.channel || '').split(',').map(function(x){return x.trim();}).filter(Boolean);
-        await _exportCampDelivsMonitorMulti(mc, mcDelivs, usersById, mcChannels, {
-          wb: wb,
-          sheetName: pickSheetName(mc),
-          imgBuffers: imgBuffers,  // 위에서 일괄 다운로드한 버퍼 재사용
-          skipDownload: true
-        });
-      }
+    var monitorCovered = {};  // monitor 그룹으로 처리된 캠페인 id (통합 시트에서 제외 대상)
+    Object.values(monitorGroups).forEach(function(g) {
+      Object.keys(g.campIds).forEach(function(id){ monitorCovered[id] = true; });
+    });
+
+    var chLabelOf = function(code) {
+      return (typeof getLookupLabel === 'function') ? (getLookupLabel('channel', code, 'ko') || code) : code;
+    };
+    var usedSheetNames = {'캠페인 정보': true};  // 시트1 이름 충돌 방지
+    var pickGroupSheetName = function(channels) {
+      var labels = channels.map(chLabelOf).join('/');
+      var base = ('리뷰 · ' + labels).replace(/[\\\/\?\*\[\]:]/g, function(m){ return m === '/' ? '/' : '_'; });
+      base = base.substring(0, 28);
+      var name = base, i = 2;
+      while (usedSheetNames[name]) { name = base.substring(0, 28 - String(i).length - 1) + '_' + i; i++; }
+      usedSheetNames[name] = true;
+      return name;
+    };
+    var groupKeys = Object.keys(monitorGroups).sort(function(a,b) {
+      return monitorGroups[a].channels.length - monitorGroups[b].channels.length || a.localeCompare(b);
+    });
+    for (var gi = 0; gi < groupKeys.length; gi++) {
+      var grp = monitorGroups[groupKeys[gi]];
+      var grpCamps = camps.filter(function(c){ return grp.campIds[c.id]; });
+      var grpDelivs = allDelivs.filter(function(d){ return grp.campIds[d.campaign_id]; });
+      var sheetName = pickGroupSheetName(grp.channels);
+      _buildMonitorGroupSheet(wb, sheetName, grpCamps, grp.channels, grpDelivs, usersById, imgBuffers);
     }
 
-    // 통합 시트는 monitor 다채널 외 캠페인의 결과물만 그룹핑
-    groupList = groupList.filter(function(g) { return !(g.camp && monitorMultiIds[g.camp.id]); });
+    // 통합 시트는 monitor 그룹으로 처리된 캠페인 외 결과물만 (비monitor + monitor 채널 없음)
+    groupList = groupList.filter(function(g) { return !(g.camp && monitorCovered[g.camp.id]); });
     var hasOtherCamps = groupList.length > 0;
+
+    // 통합 시트 — monitor 그룹으로 처리되지 않은 결과물(비monitor + monitor 채널 없음)만 있을 때 생성.
+    //   monitor 그룹만 있고 통합 대상이 없으면 빈 시트 생성하지 않음 (사용자 지적: '탭이 세개나 생겨').
+    if (hasOtherCamps) {
 
     // 시트2 결과물 — 24컬럼 (캠페인 2 + 인플루언서 7 + 영수증 9 + 결과물 6)
     // 영수증 9컬럼: 타입 / 제출일 / 검수일 / 상태 / 주문번호 / 구매일 / 구매금액 / 이미지 / URL (마이그레이션 128)
@@ -657,6 +671,7 @@ async function exportSelectedCampaignsDeliverables(idsOverride) {
         ws.addImage(sImgId, 'W' + rowNum + ':W' + rowNum);
       }
     });
+    }  // end if (hasOtherCamps)
 
     var buf = await wb.xlsx.writeBuffer();
     var blob = new Blob([buf], { type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' });
@@ -1312,6 +1327,187 @@ async function _exportCampDelivsMonitorMulti(camp, delivs, userById, campChannel
   link.click();
   setTimeout(function(){ URL.revokeObjectURL(link.href); }, 1000);
   toast('엑셀 다운로드 완료 (' + groupList.length + '건, 채널 ' + N + '개)');
+}
+
+// 사양 2 PR 3 단계 b — 다중 엑셀의 「리뷰 · {채널 조합}」 그룹 시트 빌더.
+//   같은 채널 구성(예: qoo10, qoo10/lips)의 캠페인 N개를 한 시트에 묶음.
+//   컬럼 = 캠페인 2 + 인플 7 + 영수증 9 + 채널 N × 6.
+//   행 = (campaign_id, application_id) 단위.
+function _buildMonitorGroupSheet(wb, sheetName, grpCamps, channels, delivs, userById, imgBuffers) {
+  // 그룹핑
+  var groups = {};
+  delivs.forEach(function(d) {
+    var key = d.campaign_id + '|' + (d.application_id || ('user-' + d.user_id));
+    if (!groups[key]) {
+      var camp = grpCamps.find(function(c){ return c.id === d.campaign_id; }) || {};
+      groups[key] = {key:key, camp:camp, application_id:d.application_id, user_id:d.user_id, receipt:null, reviewByCh:{}};
+    }
+    var g = groups[key];
+    var subAt = d.updated_at || d.submitted_at || '';
+    if (d.kind === 'receipt') {
+      if (!g.receipt || subAt > (g.receipt.updated_at || g.receipt.submitted_at || '')) g.receipt = d;
+    } else if (d.kind === 'review_image' && d.post_channel) {
+      var prev = g.reviewByCh[d.post_channel];
+      if (!prev || subAt > (prev.updated_at || prev.submitted_at || '')) g.reviewByCh[d.post_channel] = d;
+    }
+  });
+  var groupList = Object.values(groups).sort(function(a, b) {
+    var ca = (a.camp.campaign_no || '').toString();
+    var cb = (b.camp.campaign_no || '').toString();
+    if (ca !== cb) return ca.localeCompare(cb, 'ja');
+    var ua = userById[a.user_id] || {}, ub = userById[b.user_id] || {};
+    return (ua.name_kanji || ua.name || '').localeCompare(ub.name_kanji || ub.name || '', 'ja');
+  });
+
+  // 컬럼 계산
+  var CAMP_COLS = 2, INFO_COLS = 7, RECEIPT_COLS = 9, CH_COLS = 6;
+  var N = channels.length;
+  var totalCols = CAMP_COLS + INFO_COLS + RECEIPT_COLS + CH_COLS * N;
+  var lastColLetter = _excelColLetter(totalCols);
+  var receiptImgCol = CAMP_COLS + INFO_COLS + RECEIPT_COLS - 1;  // 영수증 이미지 컬럼
+
+  var chLabelOf = function(code) {
+    return (typeof getLookupLabel === 'function') ? (getLookupLabel('channel', code, 'ko') || code) : code;
+  };
+
+  var ws = wb.addWorksheet(sheetName);
+
+  // row 1: 그룹 제목
+  ws.mergeCells('A1:' + lastColLetter + '1');
+  var t = ws.getCell('A1');
+  t.value = '채널 조합 「' + channels.map(chLabelOf).join(' / ') + '」  (' + grpCamps.length + '개 캠페인)';
+  t.font = {bold:true, size:14};
+  t.alignment = {vertical:'middle'};
+  ws.getRow(1).height = 26;
+
+  // row 2: 메타
+  ws.mergeCells('A2:' + lastColLetter + '2');
+  var m = ws.getCell('A2');
+  m.value = '캠페인 ' + grpCamps.length + '개  ·  신청 ' + groupList.length + '건  ·  결과물 ' + delivs.length + '건  ·  생성일: ' + new Date().toLocaleString('ko-KR');
+  m.font = {color:{argb:'FF888888'}, size:11};
+  ws.getRow(2).height = 20;
+
+  // row 3: 그룹 헤더 (캠페인 / 인플 / 영수증 / 채널 N개)
+  ws.mergeCells('A3:B3'); ws.getCell('A3').value = '캠페인';
+  ws.mergeCells('C3:I3'); ws.getCell('C3').value = '인플루언서 정보';
+  ws.mergeCells('J3:R3'); ws.getCell('J3').value = '영수증';
+  channels.forEach(function(ch, i) {
+    var s = CAMP_COLS + INFO_COLS + RECEIPT_COLS + 1 + i * CH_COLS;
+    var e = s + CH_COLS - 1;
+    ws.mergeCells(_excelColLetter(s) + '3:' + _excelColLetter(e) + '3');
+    ws.getCell(_excelColLetter(s) + '3').value = '「' + chLabelOf(ch) + '」 리뷰';
+  });
+  ['A3','C3','J3'].concat(channels.map(function(_, i){ return _excelColLetter(CAMP_COLS + INFO_COLS + RECEIPT_COLS + 1 + i * CH_COLS) + '3'; })).forEach(function(addr) {
+    var c = ws.getCell(addr);
+    c.font = {bold:true, color:{argb:'FF222222'}};
+    c.alignment = {vertical:'middle', horizontal:'center'};
+    c.fill = {type:'pattern', pattern:'solid', fgColor:{argb:'FFE8E8E8'}};
+  });
+  ws.getRow(3).height = 22;
+
+  // row 4: 컬럼 헤더
+  var headerValues = [
+    '캠페인 번호', '캠페인 제목',
+    '이름(한자)', '이름(가타카나)', '계정 아이디(이메일)', 'Instagram URL', 'TikTok URL', 'X URL', 'YouTube URL',
+    '타입', '제출일', '검수일', '상태', '주문번호', '구매일', '구매금액', '이미지', 'URL'
+  ];
+  channels.forEach(function() {
+    headerValues.push('타입', '제출일', '검수일', '상태', '이미지', 'URL');
+  });
+  ws.getRow(4).values = headerValues;
+  ws.getRow(4).font = {bold:true, color:{argb:'FF222222'}};
+  ws.getRow(4).fill = {type:'pattern', pattern:'solid', fgColor:{argb:'FFF0F0F0'}};
+  ws.getRow(4).alignment = {vertical:'middle', horizontal:'center'};
+  ws.getRow(4).height = 24;
+
+  var colWidths = [
+    18, 28,
+    18, 18, 28, 36, 36, 36, 36,
+    12, 12, 12, 10, 18, 12, 12, 16, 32
+  ];
+  channels.forEach(function() { colWidths.push(12, 12, 12, 10, 16, 32); });
+  ws.columns = colWidths.map(function(w) { return {width:w}; });
+
+  var statusLabelMap = {pending:'검수대기', approved:'승인', rejected:'반려'};
+  var renderDeliv6 = function(d) {
+    if (!d) return ['', '', '', '', '', ''];
+    var sub = d.submitted_at ? new Date(d.submitted_at).toLocaleDateString('ko-KR') : '';
+    var rev = d.reviewed_at ? new Date(d.reviewed_at).toLocaleDateString('ko-KR') : '';
+    var st = statusLabelMap[d.status] || d.status || '';
+    var urlVal = '';
+    if (d.receipt_url) {
+      var iu = /^https?:\/\//.test(d.receipt_url) ? d.receipt_url
+        : (db?.storage?.from ? db.storage.from('campaign-images').getPublicUrl(d.receipt_url)?.data?.publicUrl : d.receipt_url);
+      urlVal = {text:'리뷰 이미지 보기', hyperlink:iu};
+    }
+    return ['리뷰 이미지', sub, rev, st, '', urlVal];
+  };
+  var renderReceipt9 = function(d) {
+    if (!d) return ['', '', '', '', '', '', '', '', ''];
+    var base = renderDeliv6(d);
+    base[0] = '영수증';
+    if (d.receipt_url && base[5] && base[5].text) base[5].text = '영수증 보기';
+    var orderNo = d.order_number || '';
+    var purchaseDate = d.purchase_date || '';
+    var amt = (d.purchase_amount === null || d.purchase_amount === undefined || d.purchase_amount === '')
+      ? '' : Number(d.purchase_amount);
+    return [base[0], base[1], base[2], base[3], orderNo, purchaseDate, amt, base[4], base[5]];
+  };
+
+  // 본문
+  groupList.forEach(function(g, i) {
+    var rowNum = 5 + i;
+    var u = userById[g.user_id] || {};
+    var cc = g.camp || {};
+    var row = ws.getRow(rowNum);
+    row.height = 84;
+
+    var receiptCells = renderReceipt9(g.receipt);
+    var vals = [
+      cc.campaign_no || '', cc.title || '',
+      u.name_kanji || u.name || '—',
+      u.name_kana || '',
+      u.email || '',
+      _excelSnsUrl('instagram', u.ig),
+      _excelSnsUrl('tiktok', u.tiktok),
+      _excelSnsUrl('x', u.x),
+      _excelSnsUrl('youtube', u.youtube),
+      receiptCells[0], receiptCells[1], receiptCells[2], receiptCells[3], receiptCells[4], receiptCells[5], receiptCells[6], receiptCells[7], receiptCells[8]
+    ];
+    channels.forEach(function(ch) {
+      var cells = renderDeliv6(g.reviewByCh[ch]);
+      vals.push(cells[0], cells[1], cells[2], cells[3], cells[4], cells[5]);
+    });
+    row.values = vals;
+    row.alignment = {vertical:'middle', wrapText:true};
+
+    var receiptUrlCol = CAMP_COLS + INFO_COLS + RECEIPT_COLS;  // 18
+    var linkCols = [receiptUrlCol];
+    channels.forEach(function(_, ci) {
+      linkCols.push(CAMP_COLS + INFO_COLS + RECEIPT_COLS + 1 + ci * CH_COLS + 5);
+    });
+    linkCols.forEach(function(col) {
+      var cell = row.getCell(col);
+      if (cell && cell.value && cell.value.hyperlink) cell.font = {color:{argb:'FFE8344E'}, underline:true};
+    });
+
+    if (g.receipt && imgBuffers[g.receipt.id]) {
+      var rImgId = wb.addImage({buffer:imgBuffers[g.receipt.id].buffer, extension:imgBuffers[g.receipt.id].ext});
+      var imgColL = _excelColLetter(receiptImgCol);
+      ws.addImage(rImgId, imgColL + rowNum + ':' + imgColL + rowNum);
+    }
+    channels.forEach(function(ch, ci) {
+      var d = g.reviewByCh[ch];
+      if (d && imgBuffers[d.id]) {
+        var dImgId = wb.addImage({buffer:imgBuffers[d.id].buffer, extension:imgBuffers[d.id].ext});
+        var imgCol = CAMP_COLS + INFO_COLS + RECEIPT_COLS + 1 + ci * CH_COLS + 4;
+        var imgColL = _excelColLetter(imgCol);
+        ws.addImage(dImgId, imgColL + rowNum + ':' + imgColL + rowNum);
+      }
+    });
+  });
+
+  return ws;
 }
 
 


### PR DESCRIPTION
사용자 의도: 다중 엑셀에서 캠페인별이 아닌 '리뷰 · {채널 조합}' 시트로 그룹화. 빈 통합 시트 회귀 방지.

🤖 Generated with [Claude Code](https://claude.com/claude-code)