### PR TITLE
fix(migration): hotfix 160 — lookup_values_kind_check extension

### DIFF
--- a/supabase/migrations/160_admin_proxy_deliverable.sql
+++ b/supabase/migrations/160_admin_proxy_deliverable.sql
@@ -94,9 +94,42 @@ COMMENT ON COLUMN public.deliverables.submitted_by_admin_at IS
 
 
 -- ============================================================
+-- 섹션 1-b: lookup_values.kind CHECK 확장 — admin_proxy_reason 추가
+--   현재 (144 누적): 11종 — channel/category/content_type/ng_item/reject_reason/
+--   blacklist_reason/violation_reason/caution/admin_email_kind/cancel_reason/
+--   message_hide_reason
+--   추가: admin_proxy_reason (12종 → 12종 + 1)
+--   DROP CONSTRAINT IF EXISTS 패턴으로 멱등성 확보 (재실행 안전)
+-- ============================================================
+
+ALTER TABLE public.lookup_values DROP CONSTRAINT IF EXISTS lookup_values_kind_check;
+
+ALTER TABLE public.lookup_values
+  ADD CONSTRAINT lookup_values_kind_check
+  CHECK (kind IN (
+    'channel',
+    'category',
+    'content_type',
+    'ng_item',
+    'reject_reason',
+    'blacklist_reason',
+    'violation_reason',
+    'caution',
+    'admin_email_kind',
+    'cancel_reason',
+    'message_hide_reason',
+    'admin_proxy_reason'
+  ));
+
+COMMENT ON COLUMN public.lookup_values.kind IS
+  'channel | category | content_type | ng_item | reject_reason | blacklist_reason | violation_reason | caution | admin_email_kind | cancel_reason | message_hide_reason | admin_proxy_reason';
+
+
+-- ============================================================
 -- 섹션 2: lookup_values — 사유 코드 4건 시드 (admin_proxy_reason kind)
 --   기준 데이터 관리 페인(#lookups)에서 운영자가 추가·수정 가능.
 --   ON CONFLICT (kind, code) DO NOTHING — 재실행 안전
+--   섹션 1-b 의 CHECK 확장이 선행되어야 INSERT 가능
 -- ============================================================
 
 INSERT INTO public.lookup_values (kind, code, name_ko, name_ja, sort_order, active)


### PR DESCRIPTION
## 변경 요약

PR #347 (마이그레이션 160) 첫 SQL Editor 적용 시 `lookup_values_kind_check` CHECK 위반(현재 144 누적 11종 한정)으로 전체 트랜잭션 rollback.

160 파일에 섹션 1-b 추가:
- `lookup_values_kind_check` DROP/ADD 로 `admin_proxy_reason` kind 12번째로 추가
- 섹션 2(사유 코드 4건 시드) 의 선행 조건

160 본체는 이미 멱등(`IF NOT EXISTS`·`ON CONFLICT DO NOTHING`·`CREATE OR REPLACE FUNCTION`)이라 다시 일괄 실행 안전.

## 요청 외 추가 변경

없음 (마이그레이션 160 보강만)

🤖 Generated with [Claude Code](https://claude.com/claude-code)