### PR TITLE
feat(admin): PR 2 — proxy deliverable submission UI

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -12,7 +12,7 @@
 // 회귀(2026-05-12 PR #182 머지 직후 발생)를 방지하기 위한 자동 reload 가드.
 // sessionStorage 차단 환경(시크릿 모드 일부, 쿠키 차단)에서는 자연스럽게 skip.
 (function(){
-  var CURRENT_BUILD = 'v1779956064';
+  var CURRENT_BUILD = 'v1779958413';
   if (CURRENT_BUILD.indexOf('__') === 0) return; // 빌드 미적용 (dev/ 직접 열기) 시 skip
   try {
     var prev = sessionStorage.getItem('reverb.adminBuild');
@@ -1706,6 +1706,44 @@ textarea.form-input{resize:vertical;min-height:80px}
 .faq-pv-step{margin:2px 0;padding-left:4px}
 .faq-pv-btn{display:inline-flex;align-items:center;gap:4px;margin-top:10px;padding:8px 14px;background:var(--pink);color:#fff;border-radius:10px;font-size:13px;font-weight:600}
 
+/* ─── 관리자 결과물 대리 등록 (마이그레이션 160) ────────────────── */
+/* 목록 행 배지: 대리 등록 식별 마커 */
+.deliv-proxy-badge{display:inline-flex;align-items:center;gap:2px;margin-left:6px;padding:2px 6px;background:#FEF3C7;color:#92400E;border:1px solid #FBBF24;border-radius:4px;font-size:11px;font-weight:600;line-height:1;white-space:nowrap;vertical-align:middle}
+.deliv-proxy-badge .material-icons-round{font-size:12px}
+
+/* 검수 모달 상단 안내 박스 */
+.deliv-proxy-notice{margin:0 0 14px;padding:10px 12px;background:#FEF3C7;border:1px solid #FBBF24;border-radius:8px;font-size:12px;line-height:1.55;color:#92400E}
+.deliv-proxy-notice strong{color:#78350F}
+.deliv-proxy-notice .deliv-proxy-meta{margin-top:4px;font-size:11px;color:#92400E;opacity:.85}
+.deliv-proxy-notice .deliv-proxy-cascade{display:block;margin-top:6px;padding-top:6px;border-top:1px dashed #FBBF24;font-size:11px;color:#78350F}
+
+/* 회수 버튼 (super_admin 전용) */
+.deliv-proxy-revoke-btn{margin-left:auto;padding:6px 12px;background:#DC2626;color:#fff;border:none;border-radius:6px;font-size:12px;font-weight:600;cursor:pointer}
+.deliv-proxy-revoke-btn:hover{background:#B91C1C}
+.deliv-proxy-revoke-btn[disabled]{background:#9CA3AF;cursor:not-allowed}
+
+/* 대리 등록 모달 폼 */
+.admin-proxy-modal-form{display:flex;flex-direction:column;gap:14px;padding:6px 0}
+.admin-proxy-modal-form .form-row{display:flex;flex-direction:column;gap:4px}
+.admin-proxy-modal-form .form-row label{font-size:12px;font-weight:600;color:var(--ink)}
+.admin-proxy-modal-form .form-row .form-help{font-size:11px;color:var(--muted)}
+.admin-proxy-modal-form .form-row.required label::after{content:" *";color:#DC2626}
+.admin-proxy-modal-form select,
+.admin-proxy-modal-form input[type="text"],
+.admin-proxy-modal-form input[type="date"],
+.admin-proxy-modal-form input[type="number"],
+.admin-proxy-modal-form input[type="url"],
+.admin-proxy-modal-form textarea{padding:8px 10px;border:1px solid var(--line);border-radius:6px;font-size:13px;background:#fff}
+.admin-proxy-modal-form textarea{min-height:64px;resize:vertical}
+.admin-proxy-kind-section{display:none;padding:12px;background:#F9FAFB;border:1px solid var(--line);border-radius:8px}
+.admin-proxy-kind-section.active{display:block}
+.admin-proxy-kind-section .kind-section-title{font-size:13px;font-weight:700;color:var(--ink);margin-bottom:10px}
+.admin-proxy-image-preview{margin-top:6px;max-width:180px;max-height:180px;border:1px solid var(--line);border-radius:6px;display:none}
+.admin-proxy-image-preview[src]{display:block}
+
+/* 「대리 등록만 보기」 필터 토글 */
+.deliv-proxy-filter-label{display:inline-flex;align-items:center;gap:4px;font-size:12px;cursor:pointer;height:32px;color:var(--ink)}
+
 </style>
 </head>
 <body style="background:#F8F5F8">
@@ -1780,7 +1818,7 @@ textarea.form-input{resize:vertical;min-height:80px}
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-05-28 17:14 · 18830d9</span>
+          <span class="admin-build-text">2026-05-28 17:53 · aed1c8e</span>
         </div>
       </div>
     </aside>
@@ -2685,6 +2723,10 @@ textarea.form-input{resize:vertical;min-height:80px}
           <div class="admin-sticky-header">
             <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:12px">
               <div style="font-size:16px;font-weight:700;color:var(--ink)">결과물 관리</div>
+              <button class="btn btn-primary btn-sm" onclick="openAdminProxyModal()" title="배송 지연 등으로 인플이 직접 등록 못 한 결과물을 관리자가 대신 등록·즉시 승인합니다">
+                <span class="material-icons-round" style="font-size:16px;vertical-align:middle">add_task</span>
+                관리자 대리 등록
+              </button>
             </div>
             <div style="display:flex;align-items:flex-end;gap:12px;flex-wrap:wrap">
               <div class="admin-filter-group">
@@ -2708,6 +2750,13 @@ textarea.form-input{resize:vertical;min-height:80px}
                 <label style="display:inline-flex;align-items:center;gap:4px;font-size:12px;cursor:pointer;height:32px">
                   <input type="checkbox" id="delivIncludeMissing" onchange="renderDeliverablesList()" checked style="margin:0">
                   <span>포함</span>
+                </label>
+              </div>
+              <div class="admin-filter-group" style="justify-content:flex-end">
+                <label>대리 등록</label>
+                <label class="deliv-proxy-filter-label" title="관리자가 대리 등록한 결과물만 표시">
+                  <input type="checkbox" id="delivProxyOnly" onchange="renderDeliverablesList()" style="margin:0">
+                  <span>만 보기</span>
                 </label>
               </div>
               <div class="admin-filter-group" style="justify-content:flex-end">
@@ -4155,6 +4204,102 @@ textarea.form-input{resize:vertical;min-height:80px}
     <div style="padding:14px 22px;border-top:1px solid var(--line);display:flex;gap:8px;justify-content:flex-end">
       <button class="btn btn-ghost" onclick="closeDelivRejectModal()">취소</button>
       <button class="btn btn-primary" onclick="submitDelivReject()" style="background:#C33;border-color:#C33">반려 처리</button>
+    </div>
+  </div>
+</div>
+
+<!-- 관리자 결과물 대리 등록·자동 승인 모달 (마이그레이션 160 — admin_create_deliverable_proxy RPC) -->
+<div class="modal-overlay" id="adminProxyDelivModal" style="z-index:620">
+  <div class="modal" style="max-width:620px;border-radius:16px;margin:auto;max-height:90vh;display:flex;flex-direction:column">
+    <div class="modal-header" style="padding:18px 22px 12px;border-bottom:1px solid var(--line)">
+      <div style="font-size:16px;font-weight:700;color:var(--ink)">관리자 결과물 대리 등록</div>
+      <button class="modal-close" onclick="closeAdminProxyModal()" aria-label="닫기">&times;</button>
+    </div>
+    <div class="modal-body" style="padding:18px 22px;overflow-y:auto">
+      <div style="padding:10px 12px;background:#FEF3C7;border:1px solid #FBBF24;border-radius:8px;font-size:12px;line-height:1.55;color:#92400E;margin-bottom:16px">
+        <strong>주의:</strong> 본 기능은 인플루언서가 배송 지연 등 사유로 결과물을 직접 등록할 수 없을 때 운영자가 대신 등록·즉시 승인하는 도구입니다. 인플루언서에게 「結果物が登録されました」 알림이 발송됩니다.
+      </div>
+      <div class="admin-proxy-modal-form">
+        <!-- 1. 신청 선택 (approved 만) -->
+        <div class="form-row required">
+          <label>신청 선택</label>
+          <select id="adminProxyApp" class="form-input" onchange="onAdminProxyAppChange()">
+            <option value="">— 승인된 신청을 선택하세요 —</option>
+          </select>
+          <span class="form-help">캠페인 + 인플루언서 이름으로 검색됩니다. 승인 완료된 신청만 표시됩니다.</span>
+        </div>
+
+        <!-- 2. 결과물 종류 선택 (캠페인 recruit_type 따라 노출) -->
+        <div class="form-row required">
+          <label>결과물 종류</label>
+          <select id="adminProxyKind" class="form-input" onchange="onAdminProxyKindChange()" disabled>
+            <option value="">— 먼저 신청을 선택하세요 —</option>
+          </select>
+          <span class="form-help">선택된 신청의 캠페인 모집 유형에 맞는 종류만 노출됩니다.</span>
+        </div>
+
+        <!-- 3-a. 영수증 폼 (receipt) -->
+        <div id="adminProxyReceiptSection" class="admin-proxy-kind-section">
+          <div class="kind-section-title">영수증 정보</div>
+          <div class="form-row required">
+            <label>영수증 이미지</label>
+            <input type="file" id="adminProxyReceiptImage" accept="image/*" onchange="onAdminProxyImageChange('receipt')">
+            <img id="adminProxyReceiptPreview" class="admin-proxy-image-preview" alt="영수증 미리보기">
+          </div>
+          <div class="form-row required"><label>주문번호</label><input type="text" id="adminProxyOrderNo" placeholder="예: 12341234"></div>
+          <div class="form-row required"><label>구매일</label><input type="date" id="adminProxyPurchaseDate"></div>
+          <div class="form-row required"><label>구매금액 (¥)</label><input type="number" id="adminProxyPurchaseAmount" min="0" step="1" placeholder="예: 1000"></div>
+        </div>
+
+        <!-- 3-b. 게시물 URL 폼 (post) -->
+        <div id="adminProxyPostSection" class="admin-proxy-kind-section">
+          <div class="kind-section-title">게시물 URL</div>
+          <div class="form-row required">
+            <label>게시물 URL</label>
+            <input type="url" id="adminProxyPostUrl" placeholder="https://www.instagram.com/p/... 또는 https://www.tiktok.com/@..." oninput="onAdminProxyPostUrlInput()">
+            <span class="form-help">URL 입력 시 채널이 자동 판별됩니다. 실패하면 아래 수동 선택.</span>
+          </div>
+          <div class="form-row required">
+            <label>채널 (자동 판별 / 수동)</label>
+            <select id="adminProxyPostChannel" class="form-input">
+              <option value="">— 자동 판별 대기 —</option>
+            </select>
+          </div>
+        </div>
+
+        <!-- 3-c. 리뷰 이미지 폼 (review_image — 사양 2 운영 후 자동 활성) -->
+        <div id="adminProxyReviewImageSection" class="admin-proxy-kind-section">
+          <div class="kind-section-title">리뷰 이미지 (채널별)</div>
+          <div class="form-row required">
+            <label>채널 선택</label>
+            <select id="adminProxyReviewChannel" class="form-input">
+              <option value="">— 캠페인 채널 중 선택 —</option>
+            </select>
+          </div>
+          <div class="form-row required">
+            <label>리뷰 이미지</label>
+            <input type="file" id="adminProxyReviewImage" accept="image/*" onchange="onAdminProxyImageChange('review_image')">
+            <img id="adminProxyReviewPreview" class="admin-proxy-image-preview" alt="리뷰 이미지 미리보기">
+          </div>
+        </div>
+
+        <!-- 4. 사유 코드 (필수) + 메모 (선택) -->
+        <div class="form-row required">
+          <label>사유 코드</label>
+          <select id="adminProxyReasonCode" class="form-input">
+            <option value="">— 사유를 선택하세요 —</option>
+          </select>
+        </div>
+        <div class="form-row">
+          <label>사유 메모 (선택)</label>
+          <textarea id="adminProxyReason" placeholder="예: 6/12 도착 확인, 인플 LINE 협의 완료" maxlength="500"></textarea>
+          <span class="form-help">운영 내부 메모. 인플루언서 화면에는 노출되지 않습니다.</span>
+        </div>
+      </div>
+    </div>
+    <div style="padding:14px 22px;border-top:1px solid var(--line);display:flex;gap:8px;justify-content:flex-end">
+      <button class="btn btn-ghost" onclick="closeAdminProxyModal()">취소</button>
+      <button class="btn btn-primary" id="adminProxySubmitBtn" onclick="submitAdminProxyDelivProxy()">대리 등록 및 자동 승인</button>
     </div>
   </div>
 </div>
@@ -5674,6 +5819,7 @@ async function fetchDeliverables(filters) {
         reject_reason, reject_template_code,
         reviewed_by, reviewed_at, submitted_at, updated_at,
         application_id, user_id, campaign_id,
+        submitted_by_admin, submitted_by_admin_reason_code, submitted_by_admin_reason, submitted_by_admin_at,
         campaigns:campaign_id (id, campaign_no, title, brand, recruit_type, channel, purchase_start, purchase_end, visit_start, visit_end, submission_end)
       `).neq('status', 'draft');
       if (filters?.status && filters.status !== 'all') q = q.eq('status', filters.status);
@@ -16392,6 +16538,7 @@ function resetDelivFiltersAndSort() {
   resetMultiFilter('delivCampMulti', '전체 캠페인');
   const q = $('delivSearch'); if (q) q.value = '';
   const cb = $('delivIncludeMissing'); if (cb) cb.checked = false;
+  const cb2 = $('delivProxyOnly'); if (cb2) cb2.checked = false;
   _delivSort = {col: null, dir: null};
   renderDeliverablesList();
 }
@@ -16463,6 +16610,7 @@ async function renderDeliverablesList() {
   const resultStatusVals = getMultiFilterValues('delivResultStatusMulti');
   const delivCampVals = getMultiFilterValues('delivCampMulti');
   const includeMissing = !!$('delivIncludeMissing')?.checked;
+  const proxyOnly = !!$('delivProxyOnly')?.checked;
   const search = ($('delivSearch')?.value || '').trim().toLowerCase();
 
   // deliverables 전체 조회 (status·kind는 클라이언트에서 분기)
@@ -16611,6 +16759,14 @@ async function renderDeliverablesList() {
       camp.title, camp.brand, camp.campaign_no,
     ]);
   });
+  // 「대리 등록만 보기」 필터 (마이그레이션 160) — 신청 그룹 안 deliverable 중 1개라도 submitted_by_admin 있으면 통과
+  // reviewByChannel 은 monitor 캠페인의 채널별 review_image 결과물 맵 (사양 2 운영 후 채워짐)
+  if (proxyOnly) {
+    filtered = filtered.filter(g => {
+      const all = [g.receipt, g.result, ...Object.values(g.reviewByChannel || {})].filter(Boolean);
+      return all.some(d => d && d.submitted_by_admin);
+    });
+  }
 
   updateFilterResetBtn('btnDelivFilterReset', ['delivRecruitTypeMulti','delivReceiptStatusMulti','delivResultStatusMulti','delivCampMulti'], 'delivSearch');
 
@@ -16768,7 +16924,10 @@ function renderDelivStatusCell(d, slot, rt) {
       preview = `<a href="${esc(d.post_url)}" target="_blank" rel="noopener" onclick="event.stopPropagation()" style="font-size:10px;color:var(--dark-pink);text-decoration:none;display:inline-block;max-width:100px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;vertical-align:middle">${esc(host)}</a>`;
     }
   }
-  return `<div style="display:flex;align-items:center;gap:6px">${preview}${delivStatusBadge(d.status)}</div>`;
+  const proxyBadge = d.submitted_by_admin
+    ? `<span class="deliv-proxy-badge" title="관리자 대리 등록"><span class="material-icons-round">support_agent</span>대리</span>`
+    : '';
+  return `<div style="display:flex;align-items:center;gap:6px">${preview}${delivStatusBadge(d.status)}${proxyBadge}</div>`;
 }
 
 function statusLabelKo(status) {
@@ -17371,6 +17530,13 @@ function renderDelivPanelContent(d, events) {
     return '<div style="text-align:center;color:var(--muted);padding:40px;font-size:13px">아직 제출되지 않았습니다.</div>';
   }
   let html = '';
+  // 관리자 대리 등록 행 (마이그레이션 160) — 상단 안내 박스 + 회수 버튼은 하단 별도 영역
+  if (d.submitted_by_admin) {
+    const reasonLabel = _proxyReasonLabelKo(d.submitted_by_admin_reason_code);
+    const at = d.submitted_by_admin_at ? formatDate(d.submitted_by_admin_at) : '';
+    const memo = d.submitted_by_admin_reason ? `<div class="deliv-proxy-meta">메모: ${esc(d.submitted_by_admin_reason)}</div>` : '';
+    html += `<div class="deliv-proxy-notice"><strong>관리자 대리 등록</strong> — 사유: ${esc(reasonLabel)}${at ? ' · ' + esc(at) : ''}${memo}<span class="deliv-proxy-cascade">회수 시 audit 로그도 함께 삭제됩니다 (영구 감사 미보존).</span></div>`;
+  }
   if (d.kind === 'receipt' || d.kind === 'review_image') {
     html += `<div style="text-align:center;margin-bottom:12px">
       ${d.receipt_url
@@ -17397,11 +17563,26 @@ function renderDelivPanelContent(d, events) {
     html += renderDeliverableEventsTimeline(events, 'panel-' + d.id);
     html += '</div>';
   }
+  // 대리 등록 행은 일반 「되돌리기」 비활성 + super_admin 전용 「대리 등록 회수」 버튼 (사용자 결정 2026-05-28)
+  const isProxy = !!d.submitted_by_admin;
+  const isSuperAdmin = (typeof currentAdminInfo !== 'undefined' && currentAdminInfo?.role === 'super_admin');
   if (d.status === 'pending') {
-    html += `<div style="display:flex;gap:6px;margin-top:12px;justify-content:flex-end">
-      <button class="btn btn-ghost btn-sm" style="color:#C33;border-color:#C33;font-size:12px;padding:6px 12px" onclick="openDelivRejectModal('${esc(d.id)}', ${d.version})">반려</button>
+    html += `<div style="display:flex;gap:6px;margin-top:12px;justify-content:flex-end;align-items:center">`;
+    if (isProxy && isSuperAdmin) {
+      html += `<button class="deliv-proxy-revoke-btn" onclick="revokeAdminProxyDeliv('${esc(d.id)}')" title="잘못 등록한 대리 등록을 회수합니다">대리 등록 회수</button>`;
+    }
+    html += `<button class="btn btn-ghost btn-sm" style="color:#C33;border-color:#C33;font-size:12px;padding:6px 12px" onclick="openDelivRejectModal('${esc(d.id)}', ${d.version})">반려</button>
       <button class="btn btn-primary btn-sm" style="font-size:12px;padding:6px 12px" onclick="approveDeliv('${esc(d.id)}', ${d.version})">승인</button>
     </div>`;
+  } else if (isProxy) {
+    // 대리 등록 행: 「되돌리기」 비활성 + super_admin은 「대리 등록 회수」만 가능
+    html += `<div style="display:flex;gap:6px;margin-top:12px;justify-content:flex-end;align-items:center">`;
+    if (isSuperAdmin) {
+      html += `<button class="deliv-proxy-revoke-btn" onclick="revokeAdminProxyDeliv('${esc(d.id)}')" title="잘못 등록한 대리 등록을 회수합니다">대리 등록 회수</button>`;
+    } else {
+      html += `<span style="font-size:11px;color:var(--muted)">대리 등록 행은 super_admin 만 회수 가능합니다.</span>`;
+    }
+    html += `</div>`;
   } else {
     html += `<div style="display:flex;gap:6px;margin-top:12px;justify-content:flex-end">
       <button class="btn btn-ghost btn-sm" style="font-size:12px;padding:6px 12px" onclick="revertDeliv('${esc(d.id)}', ${d.version})">검수대기로 되돌리기</button>
@@ -17411,6 +17592,346 @@ function renderDelivPanelContent(d, events) {
 }
 
 
+
+// ============================================================
+// 관리자 결과물 대리 등록·자동 승인 (마이그레이션 160)
+// 사양서: docs/specs/2026-05-28-admin-proxy-deliverable.md
+// RPC: admin_create_deliverable_proxy / admin_revoke_proxy_deliverable
+// ============================================================
+
+let _adminProxyApps = [];       // approved 신청 + 캠페인 + 인플 join
+let _adminProxyReasons = [];    // admin_proxy_reason lookup 캐시
+let _adminProxyChannels = {};   // channel code → name_ko 라벨
+
+async function openAdminProxyModal() {
+  const m = $('adminProxyDelivModal');
+  if (!m) return;
+  _resetAdminProxyForm();
+  m.style.display = 'flex';
+  // 데이터 병렬 로드
+  try {
+    const [appsResult, reasonsResult, channelsResult] = await Promise.all([
+      _loadAdminProxyApprovedApps(),
+      _loadAdminProxyReasons(),
+      _loadAdminProxyChannelLabels()
+    ]);
+    _adminProxyApps = appsResult;
+    _adminProxyReasons = reasonsResult;
+    _adminProxyChannels = channelsResult;
+    _populateAdminProxyAppDropdown();
+    _populateAdminProxyReasonDropdown();
+  } catch (err) {
+    console.error('[admin-proxy] 데이터 로드 실패', err);
+    toast('데이터 로드 실패: ' + (err.message || err), 'error');
+  }
+}
+
+function closeAdminProxyModal() {
+  const m = $('adminProxyDelivModal');
+  if (m) m.style.display = 'none';
+  _resetAdminProxyForm();
+}
+
+function _resetAdminProxyForm() {
+  ['adminProxyApp','adminProxyKind','adminProxyOrderNo','adminProxyPurchaseDate','adminProxyPurchaseAmount','adminProxyPostUrl','adminProxyPostChannel','adminProxyReviewChannel','adminProxyReasonCode','adminProxyReason'].forEach(id => {
+    const el = $(id); if (el) el.value = '';
+  });
+  ['adminProxyReceiptImage','adminProxyReviewImage'].forEach(id => {
+    const el = $(id); if (el) el.value = '';
+  });
+  ['adminProxyReceiptPreview','adminProxyReviewPreview'].forEach(id => {
+    const el = $(id); if (el) el.removeAttribute('src');
+  });
+  ['adminProxyReceiptSection','adminProxyPostSection','adminProxyReviewImageSection'].forEach(id => {
+    const el = $(id); if (el) el.classList.remove('active');
+  });
+  const kindSelect = $('adminProxyKind');
+  if (kindSelect) { kindSelect.innerHTML = '<option value="">— 먼저 신청을 선택하세요 —</option>'; kindSelect.disabled = true; }
+}
+
+async function _loadAdminProxyApprovedApps() {
+  if (!db) return [];
+  const {data, error} = await db?.from('applications').select(`
+    id, status, campaign_id, user_id,
+    campaigns:campaign_id (id, title, brand, recruit_type, channel, campaign_no),
+    influencers:user_id (id, name, name_kana, email)
+  `).eq('status', 'approved').order('reviewed_at', {ascending: false}).limit(500);
+  if (error) throw error;
+  return (data || []).filter(a => a.campaigns && a.influencers);
+}
+
+async function _loadAdminProxyReasons() {
+  if (!db) return [];
+  const {data, error} = await db?.from('lookup_values').select('code, name_ko, sort_order, active')
+    .eq('kind', 'admin_proxy_reason').eq('active', true).order('sort_order', {ascending: true});
+  if (error) throw error;
+  return data || [];
+}
+
+async function _loadAdminProxyChannelLabels() {
+  if (!db) return {};
+  const {data, error} = await db?.from('lookup_values').select('code, name_ko, name_ja')
+    .eq('kind', 'channel').eq('active', true);
+  if (error) return {};
+  const map = {};
+  (data || []).forEach(r => { map[r.code] = r.name_ja || r.name_ko || r.code; });
+  return map;
+}
+
+function _populateAdminProxyAppDropdown() {
+  const sel = $('adminProxyApp');
+  if (!sel) return;
+  const opts = ['<option value="">— 승인된 신청을 선택하세요 —</option>'];
+  _adminProxyApps.forEach(a => {
+    const inf = a.influencers || {};
+    const camp = a.campaigns || {};
+    const label = `${camp.campaign_no || '—'} · ${camp.title || ''} (${camp.brand || ''}) · ${inf.name || ''}${inf.name_kana ? '(' + inf.name_kana + ')' : ''}`;
+    opts.push(`<option value="${esc(a.id)}">${esc(label)}</option>`);
+  });
+  sel.innerHTML = opts.join('');
+}
+
+function _populateAdminProxyReasonDropdown() {
+  const sel = $('adminProxyReasonCode');
+  if (!sel) return;
+  const opts = ['<option value="">— 사유를 선택하세요 —</option>'];
+  _adminProxyReasons.forEach(r => {
+    opts.push(`<option value="${esc(r.code)}">${esc(r.name_ko)}</option>`);
+  });
+  sel.innerHTML = opts.join('');
+}
+
+function onAdminProxyAppChange() {
+  const appId = $('adminProxyApp')?.value;
+  const kindSel = $('adminProxyKind');
+  if (!kindSel) return;
+  // 종류 옵션 분기
+  if (!appId) {
+    kindSel.innerHTML = '<option value="">— 먼저 신청을 선택하세요 —</option>';
+    kindSel.disabled = true;
+    onAdminProxyKindChange();
+    return;
+  }
+  const app = _adminProxyApps.find(a => a.id === appId);
+  if (!app || !app.campaigns) return;
+  const rt = app.campaigns.recruit_type;
+  const opts = ['<option value="">— 결과물 종류 선택 —</option>'];
+  if (rt === 'monitor') {
+    opts.push('<option value="receipt">영수증 (영수증·주문번호·구매일·금액)</option>');
+    // review_image 는 사양 2 운영 후 자동 활성 — 채널이 등록되어 있고 lookup 캐시에 코드가 있으면 노출
+    const channels = (app.campaigns.channel || '').split(',').map(s => s.trim()).filter(Boolean);
+    if (channels.length > 0) {
+      opts.push('<option value="review_image">리뷰 이미지 (채널별)</option>');
+    }
+  } else {
+    opts.push('<option value="post">게시물 URL</option>');
+  }
+  kindSel.innerHTML = opts.join('');
+  kindSel.disabled = false;
+  onAdminProxyKindChange();
+}
+
+function onAdminProxyKindChange() {
+  const kind = $('adminProxyKind')?.value;
+  ['adminProxyReceiptSection','adminProxyPostSection','adminProxyReviewImageSection'].forEach(id => {
+    const el = $(id); if (el) el.classList.remove('active');
+  });
+  if (kind === 'receipt') {
+    $('adminProxyReceiptSection')?.classList.add('active');
+  } else if (kind === 'post') {
+    $('adminProxyPostSection')?.classList.add('active');
+    _populateAdminProxyPostChannelOptions();
+  } else if (kind === 'review_image') {
+    $('adminProxyReviewImageSection')?.classList.add('active');
+    _populateAdminProxyReviewChannelOptions();
+  }
+}
+
+function _populateAdminProxyPostChannelOptions() {
+  const sel = $('adminProxyPostChannel');
+  if (!sel) return;
+  const appId = $('adminProxyApp')?.value;
+  const app = _adminProxyApps.find(a => a.id === appId);
+  const channels = (app?.campaigns?.channel || '').split(',').map(s => s.trim()).filter(Boolean);
+  const opts = ['<option value="">— 자동 판별 대기 (또는 수동 선택) —</option>'];
+  channels.forEach(c => {
+    const label = _adminProxyChannels[c] || c;
+    opts.push(`<option value="${esc(c)}">${esc(label)}</option>`);
+  });
+  sel.innerHTML = opts.join('');
+}
+
+function _populateAdminProxyReviewChannelOptions() {
+  const sel = $('adminProxyReviewChannel');
+  if (!sel) return;
+  const appId = $('adminProxyApp')?.value;
+  const app = _adminProxyApps.find(a => a.id === appId);
+  const channels = (app?.campaigns?.channel || '').split(',').map(s => s.trim()).filter(Boolean);
+  const opts = ['<option value="">— 캠페인 채널 중 선택 —</option>'];
+  channels.forEach(c => {
+    const label = _adminProxyChannels[c] || c;
+    opts.push(`<option value="${esc(c)}">${esc(label)}</option>`);
+  });
+  sel.innerHTML = opts.join('');
+}
+
+// admin 빌드는 application.js 미포함이라 자체 채널 판별 인라인 (application.js 의 detectChannelFromUrl 미러)
+function _adminDetectChannelFromUrl(url) {
+  if (!url) return null;
+  try {
+    const u = new URL(url.trim());
+    const host = u.hostname.toLowerCase().replace(/^www\./, '');
+    if (host.includes('instagram.com')) return 'instagram';
+    if (host.includes('tiktok.com')) return 'tiktok';
+    if (host === 'youtube.com' || host === 'youtu.be' || host.endsWith('.youtube.com')) return 'youtube';
+    if (host === 'x.com' || host === 'twitter.com' || host.endsWith('.twitter.com')) return 'x';
+    if (host.includes('qoo10.jp')) return 'qoo10';
+    if (host.includes('lipscosme.com')) return 'lips';
+    if (host === 'cosme.net' || host.endsWith('.cosme.net')) return 'cosme';
+    return null;
+  } catch(e) { return null; }
+}
+
+function onAdminProxyPostUrlInput() {
+  const url = $('adminProxyPostUrl')?.value || '';
+  if (!url) return;
+  const guess = _adminDetectChannelFromUrl(url);
+  if (!guess) return;
+  const sel = $('adminProxyPostChannel');
+  if (!sel) return;
+  // 캠페인에 해당 채널이 등록된 경우만 자동 선택
+  const exists = Array.from(sel.options).some(o => o.value === guess);
+  if (exists) sel.value = guess;
+}
+
+function onAdminProxyImageChange(kind) {
+  const inputId = kind === 'receipt' ? 'adminProxyReceiptImage' : 'adminProxyReviewImage';
+  const previewId = kind === 'receipt' ? 'adminProxyReceiptPreview' : 'adminProxyReviewPreview';
+  const file = $(inputId)?.files?.[0];
+  if (!file) return;
+  const reader = new FileReader();
+  reader.onload = e => {
+    const img = $(previewId);
+    if (img) img.src = e.target.result;
+  };
+  reader.readAsDataURL(file);
+}
+
+async function submitAdminProxyDelivProxy() {
+  const appId = $('adminProxyApp')?.value;
+  const kind = $('adminProxyKind')?.value;
+  const reasonCode = $('adminProxyReasonCode')?.value;
+  const reason = ($('adminProxyReason')?.value || '').trim() || null;
+  if (!appId) return toast('신청을 선택하세요', 'error');
+  if (!kind) return toast('결과물 종류를 선택하세요', 'error');
+  if (!reasonCode) return toast('사유 코드를 선택하세요', 'error');
+
+  // kind 별 필수 필드 + 이미지 업로드
+  const payload = {applicationId: appId, kind, reasonCode, reason};
+  try {
+    if (kind === 'receipt') {
+      const file = $('adminProxyReceiptImage')?.files?.[0];
+      const orderNo = ($('adminProxyOrderNo')?.value || '').trim();
+      const date = $('adminProxyPurchaseDate')?.value;
+      const amount = $('adminProxyPurchaseAmount')?.value;
+      if (!file) return toast('영수증 이미지를 업로드하세요', 'error');
+      if (!orderNo) return toast('주문번호를 입력하세요', 'error');
+      if (!date) return toast('구매일을 선택하세요', 'error');
+      if (!amount) return toast('구매금액을 입력하세요', 'error');
+      const base64 = await _fileToBase64(file);
+      const url = await uploadImage(base64, 'receipt-' + Date.now() + '.jpg', 'receipts');
+      payload.imageUrl = url;
+      payload.orderNumber = orderNo;
+      payload.purchaseDate = date;
+      payload.purchaseAmount = parseFloat(amount);
+    } else if (kind === 'post') {
+      const url = ($('adminProxyPostUrl')?.value || '').trim();
+      const channel = $('adminProxyPostChannel')?.value;
+      if (!url) return toast('게시물 URL을 입력하세요', 'error');
+      if (!channel) return toast('채널을 선택하세요 (자동 판별 실패 시 수동)', 'error');
+      payload.postUrl = url;
+      payload.postChannel = channel;
+    } else if (kind === 'review_image') {
+      const file = $('adminProxyReviewImage')?.files?.[0];
+      const channel = $('adminProxyReviewChannel')?.value;
+      if (!channel) return toast('채널을 선택하세요', 'error');
+      if (!file) return toast('리뷰 이미지를 업로드하세요', 'error');
+      const base64 = await _fileToBase64(file);
+      const imageUrl = await uploadImage(base64, 'review-' + Date.now() + '.jpg', 'review-images');
+      payload.imageUrl = imageUrl;
+      payload.postChannel = channel;
+    }
+  } catch (uploadErr) {
+    console.error('[admin-proxy] 이미지 업로드 실패', uploadErr);
+    return toast('이미지 업로드 실패: ' + (uploadErr.message || uploadErr), 'error');
+  }
+
+  // 마지막 확인
+  if (!confirm('인플루언서에게 「結果物が登録されました」 알림이 발송됩니다. 진행할까요?')) return;
+
+  const btn = $('adminProxySubmitBtn');
+  if (btn) { btn.disabled = true; btn.textContent = '처리 중…'; }
+  try {
+    const newId = await adminCreateDeliverableProxy(payload);
+    toast('대리 등록·자동 승인 완료 (id ' + (newId || '').slice(0, 8) + ')', 'success');
+    closeAdminProxyModal();
+    if (typeof refreshPane === 'function') await refreshPane('deliverables');
+    else if (typeof renderDeliverablesList === 'function') await renderDeliverablesList();
+  } catch (err) {
+    console.error('[admin-proxy] RPC 실패', err);
+    toast('대리 등록 실패: ' + (err.message || err), 'error');
+  } finally {
+    if (btn) { btn.disabled = false; btn.textContent = '대리 등록 및 자동 승인'; }
+  }
+}
+
+function _fileToBase64(file) {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = e => resolve(e.target.result);
+    reader.onerror = reject;
+    reader.readAsDataURL(file);
+  });
+}
+
+async function revokeAdminProxyDeliv(deliverableId) {
+  if (!deliverableId) return;
+  if (typeof currentAdminInfo === 'undefined' || currentAdminInfo?.role !== 'super_admin') {
+    return toast('대리 등록 회수는 super_admin 권한이 필요합니다', 'error');
+  }
+  const reason = prompt('회수 사유를 입력하세요 (예: 잘못된 이미지 업로드, 금액 오타 등)');
+  if (reason === null) return; // 취소
+  if (!reason.trim()) return toast('회수 사유는 비워둘 수 없습니다', 'error');
+  if (!confirm('대리 등록을 회수합니다. 결과물 행과 audit 로그가 삭제됩니다 (복구 불가). 진행할까요?')) return;
+  try {
+    await adminRevokeProxyDeliverable(deliverableId, reason.trim());
+    toast('대리 등록 회수 완료', 'success');
+    closeDelivCombined();
+    if (typeof refreshPane === 'function') await refreshPane('deliverables');
+    else if (typeof renderDeliverablesList === 'function') await renderDeliverablesList();
+  } catch (err) {
+    console.error('[admin-proxy] 회수 실패', err);
+    toast('회수 실패: ' + (err.message || err), 'error');
+  }
+}
+
+// 마이그레이션 160 admin_proxy_reason 시드 4건 한국어 매핑 (관리자 UI)
+// lookup_values 에서 추가 코드가 생기면 그것은 영문 코드 그대로 폴백
+const _ADMIN_PROXY_REASON_KO = {
+  shipping_delay:      '배송 지연',
+  system_error:        '시스템 오류',
+  inflexible_deadline: '기간 외 합의 처리',
+  other:               '기타'
+};
+function _proxyReasonLabelKo(code) {
+  if (!code) return '—';
+  // 모달이 열려 있어 _adminProxyReasons 캐시가 있으면 우선 사용
+  if (Array.isArray(_adminProxyReasons) && _adminProxyReasons.length) {
+    const row = _adminProxyReasons.find(r => r.code === code);
+    if (row) return row.name_ko;
+  }
+  return _ADMIN_PROXY_REASON_KO[code] || code;
+}
 
 // ═════════════════════════════════════════════════════════════════
 // REVERB ADMIN — dev/js/admin-excel.js

--- a/dev/admin/index.html
+++ b/dev/admin/index.html
@@ -1036,6 +1036,10 @@
           <div class="admin-sticky-header">
             <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:12px">
               <div style="font-size:16px;font-weight:700;color:var(--ink)">결과물 관리</div>
+              <button class="btn btn-primary btn-sm" onclick="openAdminProxyModal()" title="배송 지연 등으로 인플이 직접 등록 못 한 결과물을 관리자가 대신 등록·즉시 승인합니다">
+                <span class="material-icons-round" style="font-size:16px;vertical-align:middle">add_task</span>
+                관리자 대리 등록
+              </button>
             </div>
             <div style="display:flex;align-items:flex-end;gap:12px;flex-wrap:wrap">
               <div class="admin-filter-group">
@@ -1059,6 +1063,13 @@
                 <label style="display:inline-flex;align-items:center;gap:4px;font-size:12px;cursor:pointer;height:32px">
                   <input type="checkbox" id="delivIncludeMissing" onchange="renderDeliverablesList()" checked style="margin:0">
                   <span>포함</span>
+                </label>
+              </div>
+              <div class="admin-filter-group" style="justify-content:flex-end">
+                <label>대리 등록</label>
+                <label class="deliv-proxy-filter-label" title="관리자가 대리 등록한 결과물만 표시">
+                  <input type="checkbox" id="delivProxyOnly" onchange="renderDeliverablesList()" style="margin:0">
+                  <span>만 보기</span>
                 </label>
               </div>
               <div class="admin-filter-group" style="justify-content:flex-end">
@@ -2508,6 +2519,102 @@
     <div style="padding:14px 22px;border-top:1px solid var(--line);display:flex;gap:8px;justify-content:flex-end">
       <button class="btn btn-ghost" onclick="closeDelivRejectModal()">취소</button>
       <button class="btn btn-primary" onclick="submitDelivReject()" style="background:#C33;border-color:#C33">반려 처리</button>
+    </div>
+  </div>
+</div>
+
+<!-- 관리자 결과물 대리 등록·자동 승인 모달 (마이그레이션 160 — admin_create_deliverable_proxy RPC) -->
+<div class="modal-overlay" id="adminProxyDelivModal" style="z-index:620">
+  <div class="modal" style="max-width:620px;border-radius:16px;margin:auto;max-height:90vh;display:flex;flex-direction:column">
+    <div class="modal-header" style="padding:18px 22px 12px;border-bottom:1px solid var(--line)">
+      <div style="font-size:16px;font-weight:700;color:var(--ink)">관리자 결과물 대리 등록</div>
+      <button class="modal-close" onclick="closeAdminProxyModal()" aria-label="닫기">&times;</button>
+    </div>
+    <div class="modal-body" style="padding:18px 22px;overflow-y:auto">
+      <div style="padding:10px 12px;background:#FEF3C7;border:1px solid #FBBF24;border-radius:8px;font-size:12px;line-height:1.55;color:#92400E;margin-bottom:16px">
+        <strong>주의:</strong> 본 기능은 인플루언서가 배송 지연 등 사유로 결과물을 직접 등록할 수 없을 때 운영자가 대신 등록·즉시 승인하는 도구입니다. 인플루언서에게 「結果物が登録されました」 알림이 발송됩니다.
+      </div>
+      <div class="admin-proxy-modal-form">
+        <!-- 1. 신청 선택 (approved 만) -->
+        <div class="form-row required">
+          <label>신청 선택</label>
+          <select id="adminProxyApp" class="form-input" onchange="onAdminProxyAppChange()">
+            <option value="">— 승인된 신청을 선택하세요 —</option>
+          </select>
+          <span class="form-help">캠페인 + 인플루언서 이름으로 검색됩니다. 승인 완료된 신청만 표시됩니다.</span>
+        </div>
+
+        <!-- 2. 결과물 종류 선택 (캠페인 recruit_type 따라 노출) -->
+        <div class="form-row required">
+          <label>결과물 종류</label>
+          <select id="adminProxyKind" class="form-input" onchange="onAdminProxyKindChange()" disabled>
+            <option value="">— 먼저 신청을 선택하세요 —</option>
+          </select>
+          <span class="form-help">선택된 신청의 캠페인 모집 유형에 맞는 종류만 노출됩니다.</span>
+        </div>
+
+        <!-- 3-a. 영수증 폼 (receipt) -->
+        <div id="adminProxyReceiptSection" class="admin-proxy-kind-section">
+          <div class="kind-section-title">영수증 정보</div>
+          <div class="form-row required">
+            <label>영수증 이미지</label>
+            <input type="file" id="adminProxyReceiptImage" accept="image/*" onchange="onAdminProxyImageChange('receipt')">
+            <img id="adminProxyReceiptPreview" class="admin-proxy-image-preview" alt="영수증 미리보기">
+          </div>
+          <div class="form-row required"><label>주문번호</label><input type="text" id="adminProxyOrderNo" placeholder="예: 12341234"></div>
+          <div class="form-row required"><label>구매일</label><input type="date" id="adminProxyPurchaseDate"></div>
+          <div class="form-row required"><label>구매금액 (¥)</label><input type="number" id="adminProxyPurchaseAmount" min="0" step="1" placeholder="예: 1000"></div>
+        </div>
+
+        <!-- 3-b. 게시물 URL 폼 (post) -->
+        <div id="adminProxyPostSection" class="admin-proxy-kind-section">
+          <div class="kind-section-title">게시물 URL</div>
+          <div class="form-row required">
+            <label>게시물 URL</label>
+            <input type="url" id="adminProxyPostUrl" placeholder="https://www.instagram.com/p/... 또는 https://www.tiktok.com/@..." oninput="onAdminProxyPostUrlInput()">
+            <span class="form-help">URL 입력 시 채널이 자동 판별됩니다. 실패하면 아래 수동 선택.</span>
+          </div>
+          <div class="form-row required">
+            <label>채널 (자동 판별 / 수동)</label>
+            <select id="adminProxyPostChannel" class="form-input">
+              <option value="">— 자동 판별 대기 —</option>
+            </select>
+          </div>
+        </div>
+
+        <!-- 3-c. 리뷰 이미지 폼 (review_image — 사양 2 운영 후 자동 활성) -->
+        <div id="adminProxyReviewImageSection" class="admin-proxy-kind-section">
+          <div class="kind-section-title">리뷰 이미지 (채널별)</div>
+          <div class="form-row required">
+            <label>채널 선택</label>
+            <select id="adminProxyReviewChannel" class="form-input">
+              <option value="">— 캠페인 채널 중 선택 —</option>
+            </select>
+          </div>
+          <div class="form-row required">
+            <label>리뷰 이미지</label>
+            <input type="file" id="adminProxyReviewImage" accept="image/*" onchange="onAdminProxyImageChange('review_image')">
+            <img id="adminProxyReviewPreview" class="admin-proxy-image-preview" alt="리뷰 이미지 미리보기">
+          </div>
+        </div>
+
+        <!-- 4. 사유 코드 (필수) + 메모 (선택) -->
+        <div class="form-row required">
+          <label>사유 코드</label>
+          <select id="adminProxyReasonCode" class="form-input">
+            <option value="">— 사유를 선택하세요 —</option>
+          </select>
+        </div>
+        <div class="form-row">
+          <label>사유 메모 (선택)</label>
+          <textarea id="adminProxyReason" placeholder="예: 6/12 도착 확인, 인플 LINE 협의 완료" maxlength="500"></textarea>
+          <span class="form-help">운영 내부 메모. 인플루언서 화면에는 노출되지 않습니다.</span>
+        </div>
+      </div>
+    </div>
+    <div style="padding:14px 22px;border-top:1px solid var(--line);display:flex;gap:8px;justify-content:flex-end">
+      <button class="btn btn-ghost" onclick="closeAdminProxyModal()">취소</button>
+      <button class="btn btn-primary" id="adminProxySubmitBtn" onclick="submitAdminProxyDelivProxy()">대리 등록 및 자동 승인</button>
     </div>
   </div>
 </div>

--- a/dev/css/admin.css
+++ b/dev/css/admin.css
@@ -1257,3 +1257,41 @@
 .faq-pv-line{margin:2px 0}
 .faq-pv-step{margin:2px 0;padding-left:4px}
 .faq-pv-btn{display:inline-flex;align-items:center;gap:4px;margin-top:10px;padding:8px 14px;background:var(--pink);color:#fff;border-radius:10px;font-size:13px;font-weight:600}
+
+/* ─── 관리자 결과물 대리 등록 (마이그레이션 160) ────────────────── */
+/* 목록 행 배지: 대리 등록 식별 마커 */
+.deliv-proxy-badge{display:inline-flex;align-items:center;gap:2px;margin-left:6px;padding:2px 6px;background:#FEF3C7;color:#92400E;border:1px solid #FBBF24;border-radius:4px;font-size:11px;font-weight:600;line-height:1;white-space:nowrap;vertical-align:middle}
+.deliv-proxy-badge .material-icons-round{font-size:12px}
+
+/* 검수 모달 상단 안내 박스 */
+.deliv-proxy-notice{margin:0 0 14px;padding:10px 12px;background:#FEF3C7;border:1px solid #FBBF24;border-radius:8px;font-size:12px;line-height:1.55;color:#92400E}
+.deliv-proxy-notice strong{color:#78350F}
+.deliv-proxy-notice .deliv-proxy-meta{margin-top:4px;font-size:11px;color:#92400E;opacity:.85}
+.deliv-proxy-notice .deliv-proxy-cascade{display:block;margin-top:6px;padding-top:6px;border-top:1px dashed #FBBF24;font-size:11px;color:#78350F}
+
+/* 회수 버튼 (super_admin 전용) */
+.deliv-proxy-revoke-btn{margin-left:auto;padding:6px 12px;background:#DC2626;color:#fff;border:none;border-radius:6px;font-size:12px;font-weight:600;cursor:pointer}
+.deliv-proxy-revoke-btn:hover{background:#B91C1C}
+.deliv-proxy-revoke-btn[disabled]{background:#9CA3AF;cursor:not-allowed}
+
+/* 대리 등록 모달 폼 */
+.admin-proxy-modal-form{display:flex;flex-direction:column;gap:14px;padding:6px 0}
+.admin-proxy-modal-form .form-row{display:flex;flex-direction:column;gap:4px}
+.admin-proxy-modal-form .form-row label{font-size:12px;font-weight:600;color:var(--ink)}
+.admin-proxy-modal-form .form-row .form-help{font-size:11px;color:var(--muted)}
+.admin-proxy-modal-form .form-row.required label::after{content:" *";color:#DC2626}
+.admin-proxy-modal-form select,
+.admin-proxy-modal-form input[type="text"],
+.admin-proxy-modal-form input[type="date"],
+.admin-proxy-modal-form input[type="number"],
+.admin-proxy-modal-form input[type="url"],
+.admin-proxy-modal-form textarea{padding:8px 10px;border:1px solid var(--line);border-radius:6px;font-size:13px;background:#fff}
+.admin-proxy-modal-form textarea{min-height:64px;resize:vertical}
+.admin-proxy-kind-section{display:none;padding:12px;background:#F9FAFB;border:1px solid var(--line);border-radius:8px}
+.admin-proxy-kind-section.active{display:block}
+.admin-proxy-kind-section .kind-section-title{font-size:13px;font-weight:700;color:var(--ink);margin-bottom:10px}
+.admin-proxy-image-preview{margin-top:6px;max-width:180px;max-height:180px;border:1px solid var(--line);border-radius:6px;display:none}
+.admin-proxy-image-preview[src]{display:block}
+
+/* 「대리 등록만 보기」 필터 토글 */
+.deliv-proxy-filter-label{display:inline-flex;align-items:center;gap:4px;font-size:12px;cursor:pointer;height:32px;color:var(--ink)}

--- a/dev/js/admin-deliverables.js
+++ b/dev/js/admin-deliverables.js
@@ -44,6 +44,7 @@ function resetDelivFiltersAndSort() {
   resetMultiFilter('delivCampMulti', '전체 캠페인');
   const q = $('delivSearch'); if (q) q.value = '';
   const cb = $('delivIncludeMissing'); if (cb) cb.checked = false;
+  const cb2 = $('delivProxyOnly'); if (cb2) cb2.checked = false;
   _delivSort = {col: null, dir: null};
   renderDeliverablesList();
 }
@@ -115,6 +116,7 @@ async function renderDeliverablesList() {
   const resultStatusVals = getMultiFilterValues('delivResultStatusMulti');
   const delivCampVals = getMultiFilterValues('delivCampMulti');
   const includeMissing = !!$('delivIncludeMissing')?.checked;
+  const proxyOnly = !!$('delivProxyOnly')?.checked;
   const search = ($('delivSearch')?.value || '').trim().toLowerCase();
 
   // deliverables 전체 조회 (status·kind는 클라이언트에서 분기)
@@ -263,6 +265,14 @@ async function renderDeliverablesList() {
       camp.title, camp.brand, camp.campaign_no,
     ]);
   });
+  // 「대리 등록만 보기」 필터 (마이그레이션 160) — 신청 그룹 안 deliverable 중 1개라도 submitted_by_admin 있으면 통과
+  // reviewByChannel 은 monitor 캠페인의 채널별 review_image 결과물 맵 (사양 2 운영 후 채워짐)
+  if (proxyOnly) {
+    filtered = filtered.filter(g => {
+      const all = [g.receipt, g.result, ...Object.values(g.reviewByChannel || {})].filter(Boolean);
+      return all.some(d => d && d.submitted_by_admin);
+    });
+  }
 
   updateFilterResetBtn('btnDelivFilterReset', ['delivRecruitTypeMulti','delivReceiptStatusMulti','delivResultStatusMulti','delivCampMulti'], 'delivSearch');
 
@@ -420,7 +430,10 @@ function renderDelivStatusCell(d, slot, rt) {
       preview = `<a href="${esc(d.post_url)}" target="_blank" rel="noopener" onclick="event.stopPropagation()" style="font-size:10px;color:var(--dark-pink);text-decoration:none;display:inline-block;max-width:100px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;vertical-align:middle">${esc(host)}</a>`;
     }
   }
-  return `<div style="display:flex;align-items:center;gap:6px">${preview}${delivStatusBadge(d.status)}</div>`;
+  const proxyBadge = d.submitted_by_admin
+    ? `<span class="deliv-proxy-badge" title="관리자 대리 등록"><span class="material-icons-round">support_agent</span>대리</span>`
+    : '';
+  return `<div style="display:flex;align-items:center;gap:6px">${preview}${delivStatusBadge(d.status)}${proxyBadge}</div>`;
 }
 
 function statusLabelKo(status) {
@@ -1023,6 +1036,13 @@ function renderDelivPanelContent(d, events) {
     return '<div style="text-align:center;color:var(--muted);padding:40px;font-size:13px">아직 제출되지 않았습니다.</div>';
   }
   let html = '';
+  // 관리자 대리 등록 행 (마이그레이션 160) — 상단 안내 박스 + 회수 버튼은 하단 별도 영역
+  if (d.submitted_by_admin) {
+    const reasonLabel = _proxyReasonLabelKo(d.submitted_by_admin_reason_code);
+    const at = d.submitted_by_admin_at ? formatDate(d.submitted_by_admin_at) : '';
+    const memo = d.submitted_by_admin_reason ? `<div class="deliv-proxy-meta">메모: ${esc(d.submitted_by_admin_reason)}</div>` : '';
+    html += `<div class="deliv-proxy-notice"><strong>관리자 대리 등록</strong> — 사유: ${esc(reasonLabel)}${at ? ' · ' + esc(at) : ''}${memo}<span class="deliv-proxy-cascade">회수 시 audit 로그도 함께 삭제됩니다 (영구 감사 미보존).</span></div>`;
+  }
   if (d.kind === 'receipt' || d.kind === 'review_image') {
     html += `<div style="text-align:center;margin-bottom:12px">
       ${d.receipt_url
@@ -1049,11 +1069,26 @@ function renderDelivPanelContent(d, events) {
     html += renderDeliverableEventsTimeline(events, 'panel-' + d.id);
     html += '</div>';
   }
+  // 대리 등록 행은 일반 「되돌리기」 비활성 + super_admin 전용 「대리 등록 회수」 버튼 (사용자 결정 2026-05-28)
+  const isProxy = !!d.submitted_by_admin;
+  const isSuperAdmin = (typeof currentAdminInfo !== 'undefined' && currentAdminInfo?.role === 'super_admin');
   if (d.status === 'pending') {
-    html += `<div style="display:flex;gap:6px;margin-top:12px;justify-content:flex-end">
-      <button class="btn btn-ghost btn-sm" style="color:#C33;border-color:#C33;font-size:12px;padding:6px 12px" onclick="openDelivRejectModal('${esc(d.id)}', ${d.version})">반려</button>
+    html += `<div style="display:flex;gap:6px;margin-top:12px;justify-content:flex-end;align-items:center">`;
+    if (isProxy && isSuperAdmin) {
+      html += `<button class="deliv-proxy-revoke-btn" onclick="revokeAdminProxyDeliv('${esc(d.id)}')" title="잘못 등록한 대리 등록을 회수합니다">대리 등록 회수</button>`;
+    }
+    html += `<button class="btn btn-ghost btn-sm" style="color:#C33;border-color:#C33;font-size:12px;padding:6px 12px" onclick="openDelivRejectModal('${esc(d.id)}', ${d.version})">반려</button>
       <button class="btn btn-primary btn-sm" style="font-size:12px;padding:6px 12px" onclick="approveDeliv('${esc(d.id)}', ${d.version})">승인</button>
     </div>`;
+  } else if (isProxy) {
+    // 대리 등록 행: 「되돌리기」 비활성 + super_admin은 「대리 등록 회수」만 가능
+    html += `<div style="display:flex;gap:6px;margin-top:12px;justify-content:flex-end;align-items:center">`;
+    if (isSuperAdmin) {
+      html += `<button class="deliv-proxy-revoke-btn" onclick="revokeAdminProxyDeliv('${esc(d.id)}')" title="잘못 등록한 대리 등록을 회수합니다">대리 등록 회수</button>`;
+    } else {
+      html += `<span style="font-size:11px;color:var(--muted)">대리 등록 행은 super_admin 만 회수 가능합니다.</span>`;
+    }
+    html += `</div>`;
   } else {
     html += `<div style="display:flex;gap:6px;margin-top:12px;justify-content:flex-end">
       <button class="btn btn-ghost btn-sm" style="font-size:12px;padding:6px 12px" onclick="revertDeliv('${esc(d.id)}', ${d.version})">검수대기로 되돌리기</button>
@@ -1063,3 +1098,343 @@ function renderDelivPanelContent(d, events) {
 }
 
 
+
+// ============================================================
+// 관리자 결과물 대리 등록·자동 승인 (마이그레이션 160)
+// 사양서: docs/specs/2026-05-28-admin-proxy-deliverable.md
+// RPC: admin_create_deliverable_proxy / admin_revoke_proxy_deliverable
+// ============================================================
+
+let _adminProxyApps = [];       // approved 신청 + 캠페인 + 인플 join
+let _adminProxyReasons = [];    // admin_proxy_reason lookup 캐시
+let _adminProxyChannels = {};   // channel code → name_ko 라벨
+
+async function openAdminProxyModal() {
+  const m = $('adminProxyDelivModal');
+  if (!m) return;
+  _resetAdminProxyForm();
+  m.style.display = 'flex';
+  // 데이터 병렬 로드
+  try {
+    const [appsResult, reasonsResult, channelsResult] = await Promise.all([
+      _loadAdminProxyApprovedApps(),
+      _loadAdminProxyReasons(),
+      _loadAdminProxyChannelLabels()
+    ]);
+    _adminProxyApps = appsResult;
+    _adminProxyReasons = reasonsResult;
+    _adminProxyChannels = channelsResult;
+    _populateAdminProxyAppDropdown();
+    _populateAdminProxyReasonDropdown();
+  } catch (err) {
+    console.error('[admin-proxy] 데이터 로드 실패', err);
+    toast('데이터 로드 실패: ' + (err.message || err), 'error');
+  }
+}
+
+function closeAdminProxyModal() {
+  const m = $('adminProxyDelivModal');
+  if (m) m.style.display = 'none';
+  _resetAdminProxyForm();
+}
+
+function _resetAdminProxyForm() {
+  ['adminProxyApp','adminProxyKind','adminProxyOrderNo','adminProxyPurchaseDate','adminProxyPurchaseAmount','adminProxyPostUrl','adminProxyPostChannel','adminProxyReviewChannel','adminProxyReasonCode','adminProxyReason'].forEach(id => {
+    const el = $(id); if (el) el.value = '';
+  });
+  ['adminProxyReceiptImage','adminProxyReviewImage'].forEach(id => {
+    const el = $(id); if (el) el.value = '';
+  });
+  ['adminProxyReceiptPreview','adminProxyReviewPreview'].forEach(id => {
+    const el = $(id); if (el) el.removeAttribute('src');
+  });
+  ['adminProxyReceiptSection','adminProxyPostSection','adminProxyReviewImageSection'].forEach(id => {
+    const el = $(id); if (el) el.classList.remove('active');
+  });
+  const kindSelect = $('adminProxyKind');
+  if (kindSelect) { kindSelect.innerHTML = '<option value="">— 먼저 신청을 선택하세요 —</option>'; kindSelect.disabled = true; }
+}
+
+async function _loadAdminProxyApprovedApps() {
+  if (!db) return [];
+  const {data, error} = await db?.from('applications').select(`
+    id, status, campaign_id, user_id,
+    campaigns:campaign_id (id, title, brand, recruit_type, channel, campaign_no),
+    influencers:user_id (id, name, name_kana, email)
+  `).eq('status', 'approved').order('reviewed_at', {ascending: false}).limit(500);
+  if (error) throw error;
+  return (data || []).filter(a => a.campaigns && a.influencers);
+}
+
+async function _loadAdminProxyReasons() {
+  if (!db) return [];
+  const {data, error} = await db?.from('lookup_values').select('code, name_ko, sort_order, active')
+    .eq('kind', 'admin_proxy_reason').eq('active', true).order('sort_order', {ascending: true});
+  if (error) throw error;
+  return data || [];
+}
+
+async function _loadAdminProxyChannelLabels() {
+  if (!db) return {};
+  const {data, error} = await db?.from('lookup_values').select('code, name_ko, name_ja')
+    .eq('kind', 'channel').eq('active', true);
+  if (error) return {};
+  const map = {};
+  (data || []).forEach(r => { map[r.code] = r.name_ja || r.name_ko || r.code; });
+  return map;
+}
+
+function _populateAdminProxyAppDropdown() {
+  const sel = $('adminProxyApp');
+  if (!sel) return;
+  const opts = ['<option value="">— 승인된 신청을 선택하세요 —</option>'];
+  _adminProxyApps.forEach(a => {
+    const inf = a.influencers || {};
+    const camp = a.campaigns || {};
+    const label = `${camp.campaign_no || '—'} · ${camp.title || ''} (${camp.brand || ''}) · ${inf.name || ''}${inf.name_kana ? '(' + inf.name_kana + ')' : ''}`;
+    opts.push(`<option value="${esc(a.id)}">${esc(label)}</option>`);
+  });
+  sel.innerHTML = opts.join('');
+}
+
+function _populateAdminProxyReasonDropdown() {
+  const sel = $('adminProxyReasonCode');
+  if (!sel) return;
+  const opts = ['<option value="">— 사유를 선택하세요 —</option>'];
+  _adminProxyReasons.forEach(r => {
+    opts.push(`<option value="${esc(r.code)}">${esc(r.name_ko)}</option>`);
+  });
+  sel.innerHTML = opts.join('');
+}
+
+function onAdminProxyAppChange() {
+  const appId = $('adminProxyApp')?.value;
+  const kindSel = $('adminProxyKind');
+  if (!kindSel) return;
+  // 종류 옵션 분기
+  if (!appId) {
+    kindSel.innerHTML = '<option value="">— 먼저 신청을 선택하세요 —</option>';
+    kindSel.disabled = true;
+    onAdminProxyKindChange();
+    return;
+  }
+  const app = _adminProxyApps.find(a => a.id === appId);
+  if (!app || !app.campaigns) return;
+  const rt = app.campaigns.recruit_type;
+  const opts = ['<option value="">— 결과물 종류 선택 —</option>'];
+  if (rt === 'monitor') {
+    opts.push('<option value="receipt">영수증 (영수증·주문번호·구매일·금액)</option>');
+    // review_image 는 사양 2 운영 후 자동 활성 — 채널이 등록되어 있고 lookup 캐시에 코드가 있으면 노출
+    const channels = (app.campaigns.channel || '').split(',').map(s => s.trim()).filter(Boolean);
+    if (channels.length > 0) {
+      opts.push('<option value="review_image">리뷰 이미지 (채널별)</option>');
+    }
+  } else {
+    opts.push('<option value="post">게시물 URL</option>');
+  }
+  kindSel.innerHTML = opts.join('');
+  kindSel.disabled = false;
+  onAdminProxyKindChange();
+}
+
+function onAdminProxyKindChange() {
+  const kind = $('adminProxyKind')?.value;
+  ['adminProxyReceiptSection','adminProxyPostSection','adminProxyReviewImageSection'].forEach(id => {
+    const el = $(id); if (el) el.classList.remove('active');
+  });
+  if (kind === 'receipt') {
+    $('adminProxyReceiptSection')?.classList.add('active');
+  } else if (kind === 'post') {
+    $('adminProxyPostSection')?.classList.add('active');
+    _populateAdminProxyPostChannelOptions();
+  } else if (kind === 'review_image') {
+    $('adminProxyReviewImageSection')?.classList.add('active');
+    _populateAdminProxyReviewChannelOptions();
+  }
+}
+
+function _populateAdminProxyPostChannelOptions() {
+  const sel = $('adminProxyPostChannel');
+  if (!sel) return;
+  const appId = $('adminProxyApp')?.value;
+  const app = _adminProxyApps.find(a => a.id === appId);
+  const channels = (app?.campaigns?.channel || '').split(',').map(s => s.trim()).filter(Boolean);
+  const opts = ['<option value="">— 자동 판별 대기 (또는 수동 선택) —</option>'];
+  channels.forEach(c => {
+    const label = _adminProxyChannels[c] || c;
+    opts.push(`<option value="${esc(c)}">${esc(label)}</option>`);
+  });
+  sel.innerHTML = opts.join('');
+}
+
+function _populateAdminProxyReviewChannelOptions() {
+  const sel = $('adminProxyReviewChannel');
+  if (!sel) return;
+  const appId = $('adminProxyApp')?.value;
+  const app = _adminProxyApps.find(a => a.id === appId);
+  const channels = (app?.campaigns?.channel || '').split(',').map(s => s.trim()).filter(Boolean);
+  const opts = ['<option value="">— 캠페인 채널 중 선택 —</option>'];
+  channels.forEach(c => {
+    const label = _adminProxyChannels[c] || c;
+    opts.push(`<option value="${esc(c)}">${esc(label)}</option>`);
+  });
+  sel.innerHTML = opts.join('');
+}
+
+// admin 빌드는 application.js 미포함이라 자체 채널 판별 인라인 (application.js 의 detectChannelFromUrl 미러)
+function _adminDetectChannelFromUrl(url) {
+  if (!url) return null;
+  try {
+    const u = new URL(url.trim());
+    const host = u.hostname.toLowerCase().replace(/^www\./, '');
+    if (host.includes('instagram.com')) return 'instagram';
+    if (host.includes('tiktok.com')) return 'tiktok';
+    if (host === 'youtube.com' || host === 'youtu.be' || host.endsWith('.youtube.com')) return 'youtube';
+    if (host === 'x.com' || host === 'twitter.com' || host.endsWith('.twitter.com')) return 'x';
+    if (host.includes('qoo10.jp')) return 'qoo10';
+    if (host.includes('lipscosme.com')) return 'lips';
+    if (host === 'cosme.net' || host.endsWith('.cosme.net')) return 'cosme';
+    return null;
+  } catch(e) { return null; }
+}
+
+function onAdminProxyPostUrlInput() {
+  const url = $('adminProxyPostUrl')?.value || '';
+  if (!url) return;
+  const guess = _adminDetectChannelFromUrl(url);
+  if (!guess) return;
+  const sel = $('adminProxyPostChannel');
+  if (!sel) return;
+  // 캠페인에 해당 채널이 등록된 경우만 자동 선택
+  const exists = Array.from(sel.options).some(o => o.value === guess);
+  if (exists) sel.value = guess;
+}
+
+function onAdminProxyImageChange(kind) {
+  const inputId = kind === 'receipt' ? 'adminProxyReceiptImage' : 'adminProxyReviewImage';
+  const previewId = kind === 'receipt' ? 'adminProxyReceiptPreview' : 'adminProxyReviewPreview';
+  const file = $(inputId)?.files?.[0];
+  if (!file) return;
+  const reader = new FileReader();
+  reader.onload = e => {
+    const img = $(previewId);
+    if (img) img.src = e.target.result;
+  };
+  reader.readAsDataURL(file);
+}
+
+async function submitAdminProxyDelivProxy() {
+  const appId = $('adminProxyApp')?.value;
+  const kind = $('adminProxyKind')?.value;
+  const reasonCode = $('adminProxyReasonCode')?.value;
+  const reason = ($('adminProxyReason')?.value || '').trim() || null;
+  if (!appId) return toast('신청을 선택하세요', 'error');
+  if (!kind) return toast('결과물 종류를 선택하세요', 'error');
+  if (!reasonCode) return toast('사유 코드를 선택하세요', 'error');
+
+  // kind 별 필수 필드 + 이미지 업로드
+  const payload = {applicationId: appId, kind, reasonCode, reason};
+  try {
+    if (kind === 'receipt') {
+      const file = $('adminProxyReceiptImage')?.files?.[0];
+      const orderNo = ($('adminProxyOrderNo')?.value || '').trim();
+      const date = $('adminProxyPurchaseDate')?.value;
+      const amount = $('adminProxyPurchaseAmount')?.value;
+      if (!file) return toast('영수증 이미지를 업로드하세요', 'error');
+      if (!orderNo) return toast('주문번호를 입력하세요', 'error');
+      if (!date) return toast('구매일을 선택하세요', 'error');
+      if (!amount) return toast('구매금액을 입력하세요', 'error');
+      const base64 = await _fileToBase64(file);
+      const url = await uploadImage(base64, 'receipt-' + Date.now() + '.jpg', 'receipts');
+      payload.imageUrl = url;
+      payload.orderNumber = orderNo;
+      payload.purchaseDate = date;
+      payload.purchaseAmount = parseFloat(amount);
+    } else if (kind === 'post') {
+      const url = ($('adminProxyPostUrl')?.value || '').trim();
+      const channel = $('adminProxyPostChannel')?.value;
+      if (!url) return toast('게시물 URL을 입력하세요', 'error');
+      if (!channel) return toast('채널을 선택하세요 (자동 판별 실패 시 수동)', 'error');
+      payload.postUrl = url;
+      payload.postChannel = channel;
+    } else if (kind === 'review_image') {
+      const file = $('adminProxyReviewImage')?.files?.[0];
+      const channel = $('adminProxyReviewChannel')?.value;
+      if (!channel) return toast('채널을 선택하세요', 'error');
+      if (!file) return toast('리뷰 이미지를 업로드하세요', 'error');
+      const base64 = await _fileToBase64(file);
+      const imageUrl = await uploadImage(base64, 'review-' + Date.now() + '.jpg', 'review-images');
+      payload.imageUrl = imageUrl;
+      payload.postChannel = channel;
+    }
+  } catch (uploadErr) {
+    console.error('[admin-proxy] 이미지 업로드 실패', uploadErr);
+    return toast('이미지 업로드 실패: ' + (uploadErr.message || uploadErr), 'error');
+  }
+
+  // 마지막 확인
+  if (!confirm('인플루언서에게 「結果物が登録されました」 알림이 발송됩니다. 진행할까요?')) return;
+
+  const btn = $('adminProxySubmitBtn');
+  if (btn) { btn.disabled = true; btn.textContent = '처리 중…'; }
+  try {
+    const newId = await adminCreateDeliverableProxy(payload);
+    toast('대리 등록·자동 승인 완료 (id ' + (newId || '').slice(0, 8) + ')', 'success');
+    closeAdminProxyModal();
+    if (typeof refreshPane === 'function') await refreshPane('deliverables');
+    else if (typeof renderDeliverablesList === 'function') await renderDeliverablesList();
+  } catch (err) {
+    console.error('[admin-proxy] RPC 실패', err);
+    toast('대리 등록 실패: ' + (err.message || err), 'error');
+  } finally {
+    if (btn) { btn.disabled = false; btn.textContent = '대리 등록 및 자동 승인'; }
+  }
+}
+
+function _fileToBase64(file) {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = e => resolve(e.target.result);
+    reader.onerror = reject;
+    reader.readAsDataURL(file);
+  });
+}
+
+async function revokeAdminProxyDeliv(deliverableId) {
+  if (!deliverableId) return;
+  if (typeof currentAdminInfo === 'undefined' || currentAdminInfo?.role !== 'super_admin') {
+    return toast('대리 등록 회수는 super_admin 권한이 필요합니다', 'error');
+  }
+  const reason = prompt('회수 사유를 입력하세요 (예: 잘못된 이미지 업로드, 금액 오타 등)');
+  if (reason === null) return; // 취소
+  if (!reason.trim()) return toast('회수 사유는 비워둘 수 없습니다', 'error');
+  if (!confirm('대리 등록을 회수합니다. 결과물 행과 audit 로그가 삭제됩니다 (복구 불가). 진행할까요?')) return;
+  try {
+    await adminRevokeProxyDeliverable(deliverableId, reason.trim());
+    toast('대리 등록 회수 완료', 'success');
+    closeDelivCombined();
+    if (typeof refreshPane === 'function') await refreshPane('deliverables');
+    else if (typeof renderDeliverablesList === 'function') await renderDeliverablesList();
+  } catch (err) {
+    console.error('[admin-proxy] 회수 실패', err);
+    toast('회수 실패: ' + (err.message || err), 'error');
+  }
+}
+
+// 마이그레이션 160 admin_proxy_reason 시드 4건 한국어 매핑 (관리자 UI)
+// lookup_values 에서 추가 코드가 생기면 그것은 영문 코드 그대로 폴백
+const _ADMIN_PROXY_REASON_KO = {
+  shipping_delay:      '배송 지연',
+  system_error:        '시스템 오류',
+  inflexible_deadline: '기간 외 합의 처리',
+  other:               '기타'
+};
+function _proxyReasonLabelKo(code) {
+  if (!code) return '—';
+  // 모달이 열려 있어 _adminProxyReasons 캐시가 있으면 우선 사용
+  if (Array.isArray(_adminProxyReasons) && _adminProxyReasons.length) {
+    const row = _adminProxyReasons.find(r => r.code === code);
+    if (row) return row.name_ko;
+  }
+  return _ADMIN_PROXY_REASON_KO[code] || code;
+}

--- a/dev/lib/storage.js
+++ b/dev/lib/storage.js
@@ -574,6 +574,7 @@ async function fetchDeliverables(filters) {
         reject_reason, reject_template_code,
         reviewed_by, reviewed_at, submitted_at, updated_at,
         application_id, user_id, campaign_id,
+        submitted_by_admin, submitted_by_admin_reason_code, submitted_by_admin_reason, submitted_by_admin_at,
         campaigns:campaign_id (id, campaign_no, title, brand, recruit_type, channel, purchase_start, purchase_end, visit_start, visit_end, submission_end)
       `).neq('status', 'draft');
       if (filters?.status && filters.status !== 'all') q = q.eq('status', filters.status);

--- a/index.html
+++ b/index.html
@@ -4561,6 +4561,7 @@ async function fetchDeliverables(filters) {
         reject_reason, reject_template_code,
         reviewed_by, reviewed_at, submitted_at, updated_at,
         application_id, user_id, campaign_id,
+        submitted_by_admin, submitted_by_admin_reason_code, submitted_by_admin_reason, submitted_by_admin_at,
         campaigns:campaign_id (id, campaign_no, title, brand, recruit_type, channel, purchase_start, purchase_end, visit_start, visit_end, submission_end)
       `).neq('status', 'draft');
       if (filters?.status && filters.status !== 'all') q = q.eq('status', filters.status);


### PR DESCRIPTION
## 변경 요약

「관리자 결과물 대리 등록·자동 승인」 사양서의 **PR 2 — 결과물 관리 페인 UI**.

- 페인 헤더에 「관리자 대리 등록」 버튼
- 「대리 등록만 보기」 필터 토글
- `#adminProxyDelivModal` 신규 모달 (신청 선택 → 종류 분기 → 사유 코드·메모 → 자동 승인)
- 종류별 폼: 영수증(이미지+3종 메타) / 게시물(URL+자동 채널 판별+수동 폴백) / 리뷰 이미지(채널+이미지, 사양 2 운영 후 자동 활성)
- 목록 결과물 셀 옆 「대리」 배지 (노랑)
- 검수 모달 상단 노랑 안내 박스 (관리자·사유·시점·CASCADE 안내)
- 「되돌리기」 비활성 + super_admin 전용 「대리 등록 회수」 버튼 (DELETE + audit CASCADE 안내)

## reviewer WARN 처리

5건 중 3건 즉시 반영:
- ✅ `proxyOnly` 필터 `g.reviews` → `g.reviewByChannel` (review_image 대리 등록 누락 방지)
- ✅ `db.from` → `db?.from` 3곳 (컨벤션 통일)
- ✅ admin 빌드에 `detectChannelFromUrl` 미포함 → `_adminDetectChannelFromUrl` 인라인 미러
- ⏸ `confirm()`/`prompt()` → `showConfirm` 교체는 별도 개선 PR (회수 빈도 낮음)
- ✅ CLAUDE.md `Database Schema` 갱신은 PR 1 (#347) 에 포함됨

## 후속 PR

- **PR 3** — 진행 현황 마커 + 엑셀 「대리 등록」 컬럼 + 인플 활동관리 「運営登録」 한 줄 설명

## 관련 사양서

- `docs/specs/2026-05-28-admin-proxy-deliverable.md` §4 (결과물 관리 페인 UI)

[via reviewer] WARN 5건 검토, 3건 즉시 반영 + 2건 별도 처리 명시

🤖 Generated with [Claude Code](https://claude.com/claude-code)