### PR TITLE
feat(admin): PR 3 + hotfix — pane marker, excel column, influencer notice, modal schema-cache fix

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -12,7 +12,7 @@
 // 회귀(2026-05-12 PR #182 머지 직후 발생)를 방지하기 위한 자동 reload 가드.
 // sessionStorage 차단 환경(시크릿 모드 일부, 쿠키 차단)에서는 자연스럽게 skip.
 (function(){
-  var CURRENT_BUILD = 'v1779958413';
+  var CURRENT_BUILD = 'v1779959438';
   if (CURRENT_BUILD.indexOf('__') === 0) return; // 빌드 미적용 (dev/ 직접 열기) 시 skip
   try {
     var prev = sessionStorage.getItem('reverb.adminBuild');
@@ -1818,7 +1818,7 @@ textarea.form-input{resize:vertical;min-height:80px}
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-05-28 17:53 · aed1c8e</span>
+          <span class="admin-build-text">2026-05-28 18:10 · c6169d5</span>
         </div>
       </div>
     </aside>
@@ -6006,7 +6006,7 @@ async function fetchDeliverablesByCampaign(campaignId) {
   if (!db) return [];
   try {
     const {data, error} = await db?.from('deliverables')
-      .select('id, application_id, user_id, kind, status, reviewed_at, submitted_at, updated_at, version, post_url, post_channel, receipt_url, purchase_date, purchase_amount, reject_reason')
+      .select('id, application_id, user_id, kind, status, reviewed_at, submitted_at, updated_at, version, post_url, post_channel, receipt_url, purchase_date, purchase_amount, reject_reason, submitted_by_admin, submitted_by_admin_reason_code, submitted_by_admin_reason, submitted_by_admin_at')
       .eq('campaign_id', campaignId)
       .order('submitted_at', {ascending: false});
     if (error) throw error;
@@ -17650,14 +17650,32 @@ function _resetAdminProxyForm() {
 }
 
 async function _loadAdminProxyApprovedApps() {
+  // PostgREST schema cache 가 applications.campaign_id / applications.user_id 의 FK 임베드를
+  // 인식 못 하는 사례(스키마 새로고침 지연 등)가 있어 분리 쿼리 + 클라이언트 join 패턴 사용.
   if (!db) return [];
-  const {data, error} = await db?.from('applications').select(`
-    id, status, campaign_id, user_id,
-    campaigns:campaign_id (id, title, brand, recruit_type, channel, campaign_no),
-    influencers:user_id (id, name, name_kana, email)
-  `).eq('status', 'approved').order('reviewed_at', {ascending: false}).limit(500);
+  // 1. approved 신청만 (status·reviewed_at 정렬)
+  const {data: apps, error} = await db?.from('applications')
+    .select('id, status, campaign_id, user_id, reviewed_at')
+    .eq('status', 'approved')
+    .order('reviewed_at', {ascending: false})
+    .limit(500);
   if (error) throw error;
-  return (data || []).filter(a => a.campaigns && a.influencers);
+  if (!apps || !apps.length) return [];
+  // 2. 관련 캠페인 + 인플 별도 IN 쿼리 (병렬)
+  const campIds = [...new Set(apps.map(a => a.campaign_id).filter(Boolean))];
+  const userIds = [...new Set(apps.map(a => a.user_id).filter(Boolean))];
+  const [campRes, infRes] = await Promise.all([
+    campIds.length ? db?.from('campaigns').select('id, title, brand, recruit_type, channel, campaign_no').in('id', campIds) : {data: []},
+    userIds.length ? db?.from('influencers').select('id, name, name_kana, email').in('id', userIds) : {data: []}
+  ]);
+  const campMap = {};
+  (campRes?.data || []).forEach(c => { campMap[c.id] = c; });
+  const infMap = {};
+  (infRes?.data || []).forEach(u => { infMap[u.id] = u; });
+  // 3. 클라이언트 join — 캠페인·인플 둘 다 있는 것만 노출 (RLS 누락 행 자동 필터)
+  return apps
+    .map(a => ({...a, campaigns: campMap[a.campaign_id], influencers: infMap[a.user_id]}))
+    .filter(a => a.campaigns && a.influencers);
 }
 
 async function _loadAdminProxyReasons() {
@@ -18890,10 +18908,12 @@ async function exportCampaignDeliverables(campId) {
     ws.getRow(2).height = 20;
 
     // 그룹 헤더 (3행) — 인플루언서 7컬럼 / 영수증 9컬럼 / 결과물 6컬럼 (마이그레이션 128로 영수증 6→9 확장)
+    // 마이그레이션 160: W컬럼 「대리 등록」 추가 (1컬럼, 신청 단위 통합 표시)
     ws.mergeCells('A3:G3'); ws.getCell('A3').value = '인플루언서 정보';
     ws.mergeCells('H3:P3'); ws.getCell('H3').value = '영수증';
     ws.mergeCells('Q3:V3'); ws.getCell('Q3').value = '결과물';
-    ['A3','H3','Q3'].forEach(function(addr) {
+    ws.getCell('W3').value = '대리 등록';
+    ['A3','H3','Q3','W3'].forEach(function(addr) {
       var c = ws.getCell(addr);
       c.font = {bold: true, color: {argb: 'FF222222'}};
       c.alignment = {vertical: 'middle', horizontal: 'center'};
@@ -18903,21 +18923,24 @@ async function exportCampaignDeliverables(campId) {
 
     // 컬럼 헤더 (4행)
     // 영수증 9컬럼: 타입 / 제출일 / 검수일 / 상태 / 주문번호 / 구매일 / 구매금액 / 이미지 / URL
+    // W컬럼 「관리자 · 사유」: 영수증 또는 결과물 중 1건이라도 대리 등록이면 표시
     ws.getRow(4).values = [
       '이름(한자)', '이름(가타카나)', '계정 아이디(이메일)', 'Instagram URL', 'TikTok URL', 'X URL', 'YouTube URL',
       '타입', '제출일', '검수일', '상태', '주문번호', '구매일', '구매금액', '이미지', 'URL',
-      '타입', '제출일', '검수일', '상태', '이미지', 'URL'
+      '타입', '제출일', '검수일', '상태', '이미지', 'URL',
+      '관리자 · 사유'
     ];
     ws.getRow(4).font = {bold: true, color: {argb: 'FF222222'}};
     ws.getRow(4).fill = {type: 'pattern', pattern: 'solid', fgColor: {argb: 'FFF0F0F0'}};
     ws.getRow(4).alignment = {vertical: 'middle', horizontal: 'center'};
     ws.getRow(4).height = 24;
 
-    // 컬럼 너비 (이름 18·이메일 28·SNS URL 36, 영수증 9컬럼·결과물 6컬럼)
+    // 컬럼 너비 (이름 18·이메일 28·SNS URL 36, 영수증 9컬럼·결과물 6컬럼·대리 등록 1컬럼)
     ws.columns = [
       {width: 18}, {width: 18}, {width: 28}, {width: 36}, {width: 36}, {width: 36}, {width: 36},
       {width: 12}, {width: 12}, {width: 12}, {width: 10}, {width: 18}, {width: 12}, {width: 12}, {width: 16}, {width: 32},
-      {width: 12}, {width: 12}, {width: 12}, {width: 10}, {width: 16}, {width: 32}
+      {width: 12}, {width: 12}, {width: 12}, {width: 10}, {width: 16}, {width: 32},
+      {width: 28}
     ];
 
     // SNS URL 변환은 공용 _excelSnsUrl 헬퍼 사용 (handle → 전체 URL)
@@ -18970,6 +18993,17 @@ async function exportCampaignDeliverables(campId) {
 
       var receiptCells = renderReceiptCells9(g.receipt);
       var resultCells = renderDeliverableCells(g.result);
+      // 마이그레이션 160: 대리 등록 1컬럼 — 영수증 또는 결과물 중 1건이라도 submitted_by_admin 이면 "사유 라벨 (영수증/결과물 표시)" 한 줄
+      var proxyParts = [];
+      if (g.receipt && g.receipt.submitted_by_admin) {
+        var rReason = _excelProxyReasonKo(g.receipt.submitted_by_admin_reason_code);
+        proxyParts.push('영수증 · ' + rReason);
+      }
+      if (g.result && g.result.submitted_by_admin) {
+        var dReason = _excelProxyReasonKo(g.result.submitted_by_admin_reason_code);
+        proxyParts.push('결과물 · ' + dReason);
+      }
+      var proxyCell = proxyParts.length ? proxyParts.join(' / ') : '';
 
       row.values = [
         // 인플루언서 정보 7컬럼
@@ -18983,7 +19017,9 @@ async function exportCampaignDeliverables(campId) {
         // 영수증 9컬럼
         receiptCells[0], receiptCells[1], receiptCells[2], receiptCells[3], receiptCells[4], receiptCells[5], receiptCells[6], receiptCells[7], receiptCells[8],
         // 결과물 6컬럼
-        resultCells[0], resultCells[1], resultCells[2], resultCells[3], resultCells[4], resultCells[5]
+        resultCells[0], resultCells[1], resultCells[2], resultCells[3], resultCells[4], resultCells[5],
+        // 대리 등록 1컬럼
+        proxyCell
       ];
       row.alignment = {vertical: 'middle', wrapText: true};
 
@@ -19448,6 +19484,18 @@ function _buildMonitorGroupSheet(wb, sheetName, grpCamps, channels, delivs, user
 }
 
 
+
+// 마이그레이션 160: 엑셀 대리 등록 사유 코드 → 한국어 라벨 (시드 4건 인라인, 관리자 엑셀 한국어 UI)
+function _excelProxyReasonKo(code) {
+  if (!code) return '—';
+  var map = {
+    shipping_delay:      '배송 지연',
+    system_error:        '시스템 오류',
+    inflexible_deadline: '기간 외 합의 처리',
+    other:               '기타'
+  };
+  return map[code] || code;
+}
 
 // ═════════════════════════════════════════════════════════════════
 // REVERB ADMIN — dev/js/admin-dashboard.js
@@ -20019,12 +20067,17 @@ function renderDelivCell(list, appStatus, selectedChannels, channelMatch, isPost
   if (counts.approved) parts.push(`<span style="color:#2D7A3E">승인 ${counts.approved}</span>`);
   if (counts.pending) parts.push(`<span style="color:#B8741A">검수대기 ${counts.pending}</span>`);
   if (counts.rejected) parts.push(`<span style="color:#C33">반려 ${counts.rejected}</span>`);
+  // 마이그레이션 160: 결과물 중 1개라도 대리 등록이면 ⊕ 마커 + 호버 툴팁
+  const proxyCount = list.filter(d => d.submitted_by_admin).length;
+  const proxyMarker = proxyCount > 0
+    ? ` <span style="display:inline-block;background:#FEF3C7;color:#92400E;border:1px solid #FBBF24;font-size:9px;font-weight:700;padding:0 4px;border-radius:3px;line-height:14px" title="관리자 대리 등록 ${proxyCount}건">⊕${proxyCount > 1 ? proxyCount : ''}</span>`
+    : '';
   const complete = isApplicationComplete(list, selectedChannels, channelMatch, isPostType);
   const completeBadge = complete
     ? '<div style="display:inline-block;margin-top:3px;background:#E4F5E8;color:#2D7A3E;font-size:10px;font-weight:700;padding:2px 6px;border-radius:3px">완료</div>'
     : '';
   const latest = list[0];
-  return `<div style="font-size:10px">${parts.join(' · ')}</div>
+  return `<div style="font-size:10px">${parts.join(' · ')}${proxyMarker}</div>
     ${completeBadge}
     <button class="btn btn-ghost btn-xs" style="margin-top:3px;font-size:10px;padding:2px 6px" onclick="openDelivDetail('${latest.id}')">상세</button>`;
 }

--- a/dev/js/admin-applications.js
+++ b/dev/js/admin-applications.js
@@ -171,12 +171,17 @@ function renderDelivCell(list, appStatus, selectedChannels, channelMatch, isPost
   if (counts.approved) parts.push(`<span style="color:#2D7A3E">승인 ${counts.approved}</span>`);
   if (counts.pending) parts.push(`<span style="color:#B8741A">검수대기 ${counts.pending}</span>`);
   if (counts.rejected) parts.push(`<span style="color:#C33">반려 ${counts.rejected}</span>`);
+  // 마이그레이션 160: 결과물 중 1개라도 대리 등록이면 ⊕ 마커 + 호버 툴팁
+  const proxyCount = list.filter(d => d.submitted_by_admin).length;
+  const proxyMarker = proxyCount > 0
+    ? ` <span style="display:inline-block;background:#FEF3C7;color:#92400E;border:1px solid #FBBF24;font-size:9px;font-weight:700;padding:0 4px;border-radius:3px;line-height:14px" title="관리자 대리 등록 ${proxyCount}건">⊕${proxyCount > 1 ? proxyCount : ''}</span>`
+    : '';
   const complete = isApplicationComplete(list, selectedChannels, channelMatch, isPostType);
   const completeBadge = complete
     ? '<div style="display:inline-block;margin-top:3px;background:#E4F5E8;color:#2D7A3E;font-size:10px;font-weight:700;padding:2px 6px;border-radius:3px">완료</div>'
     : '';
   const latest = list[0];
-  return `<div style="font-size:10px">${parts.join(' · ')}</div>
+  return `<div style="font-size:10px">${parts.join(' · ')}${proxyMarker}</div>
     ${completeBadge}
     <button class="btn btn-ghost btn-xs" style="margin-top:3px;font-size:10px;padding:2px 6px" onclick="openDelivDetail('${latest.id}')">상세</button>`;
 }

--- a/dev/js/admin-deliverables.js
+++ b/dev/js/admin-deliverables.js
@@ -1156,14 +1156,32 @@ function _resetAdminProxyForm() {
 }
 
 async function _loadAdminProxyApprovedApps() {
+  // PostgREST schema cache 가 applications.campaign_id / applications.user_id 의 FK 임베드를
+  // 인식 못 하는 사례(스키마 새로고침 지연 등)가 있어 분리 쿼리 + 클라이언트 join 패턴 사용.
   if (!db) return [];
-  const {data, error} = await db?.from('applications').select(`
-    id, status, campaign_id, user_id,
-    campaigns:campaign_id (id, title, brand, recruit_type, channel, campaign_no),
-    influencers:user_id (id, name, name_kana, email)
-  `).eq('status', 'approved').order('reviewed_at', {ascending: false}).limit(500);
+  // 1. approved 신청만 (status·reviewed_at 정렬)
+  const {data: apps, error} = await db?.from('applications')
+    .select('id, status, campaign_id, user_id, reviewed_at')
+    .eq('status', 'approved')
+    .order('reviewed_at', {ascending: false})
+    .limit(500);
   if (error) throw error;
-  return (data || []).filter(a => a.campaigns && a.influencers);
+  if (!apps || !apps.length) return [];
+  // 2. 관련 캠페인 + 인플 별도 IN 쿼리 (병렬)
+  const campIds = [...new Set(apps.map(a => a.campaign_id).filter(Boolean))];
+  const userIds = [...new Set(apps.map(a => a.user_id).filter(Boolean))];
+  const [campRes, infRes] = await Promise.all([
+    campIds.length ? db?.from('campaigns').select('id, title, brand, recruit_type, channel, campaign_no').in('id', campIds) : {data: []},
+    userIds.length ? db?.from('influencers').select('id, name, name_kana, email').in('id', userIds) : {data: []}
+  ]);
+  const campMap = {};
+  (campRes?.data || []).forEach(c => { campMap[c.id] = c; });
+  const infMap = {};
+  (infRes?.data || []).forEach(u => { infMap[u.id] = u; });
+  // 3. 클라이언트 join — 캠페인·인플 둘 다 있는 것만 노출 (RLS 누락 행 자동 필터)
+  return apps
+    .map(a => ({...a, campaigns: campMap[a.campaign_id], influencers: infMap[a.user_id]}))
+    .filter(a => a.campaigns && a.influencers);
 }
 
 async function _loadAdminProxyReasons() {

--- a/dev/js/admin-excel.js
+++ b/dev/js/admin-excel.js
@@ -955,10 +955,12 @@ async function exportCampaignDeliverables(campId) {
     ws.getRow(2).height = 20;
 
     // 그룹 헤더 (3행) — 인플루언서 7컬럼 / 영수증 9컬럼 / 결과물 6컬럼 (마이그레이션 128로 영수증 6→9 확장)
+    // 마이그레이션 160: W컬럼 「대리 등록」 추가 (1컬럼, 신청 단위 통합 표시)
     ws.mergeCells('A3:G3'); ws.getCell('A3').value = '인플루언서 정보';
     ws.mergeCells('H3:P3'); ws.getCell('H3').value = '영수증';
     ws.mergeCells('Q3:V3'); ws.getCell('Q3').value = '결과물';
-    ['A3','H3','Q3'].forEach(function(addr) {
+    ws.getCell('W3').value = '대리 등록';
+    ['A3','H3','Q3','W3'].forEach(function(addr) {
       var c = ws.getCell(addr);
       c.font = {bold: true, color: {argb: 'FF222222'}};
       c.alignment = {vertical: 'middle', horizontal: 'center'};
@@ -968,21 +970,24 @@ async function exportCampaignDeliverables(campId) {
 
     // 컬럼 헤더 (4행)
     // 영수증 9컬럼: 타입 / 제출일 / 검수일 / 상태 / 주문번호 / 구매일 / 구매금액 / 이미지 / URL
+    // W컬럼 「관리자 · 사유」: 영수증 또는 결과물 중 1건이라도 대리 등록이면 표시
     ws.getRow(4).values = [
       '이름(한자)', '이름(가타카나)', '계정 아이디(이메일)', 'Instagram URL', 'TikTok URL', 'X URL', 'YouTube URL',
       '타입', '제출일', '검수일', '상태', '주문번호', '구매일', '구매금액', '이미지', 'URL',
-      '타입', '제출일', '검수일', '상태', '이미지', 'URL'
+      '타입', '제출일', '검수일', '상태', '이미지', 'URL',
+      '관리자 · 사유'
     ];
     ws.getRow(4).font = {bold: true, color: {argb: 'FF222222'}};
     ws.getRow(4).fill = {type: 'pattern', pattern: 'solid', fgColor: {argb: 'FFF0F0F0'}};
     ws.getRow(4).alignment = {vertical: 'middle', horizontal: 'center'};
     ws.getRow(4).height = 24;
 
-    // 컬럼 너비 (이름 18·이메일 28·SNS URL 36, 영수증 9컬럼·결과물 6컬럼)
+    // 컬럼 너비 (이름 18·이메일 28·SNS URL 36, 영수증 9컬럼·결과물 6컬럼·대리 등록 1컬럼)
     ws.columns = [
       {width: 18}, {width: 18}, {width: 28}, {width: 36}, {width: 36}, {width: 36}, {width: 36},
       {width: 12}, {width: 12}, {width: 12}, {width: 10}, {width: 18}, {width: 12}, {width: 12}, {width: 16}, {width: 32},
-      {width: 12}, {width: 12}, {width: 12}, {width: 10}, {width: 16}, {width: 32}
+      {width: 12}, {width: 12}, {width: 12}, {width: 10}, {width: 16}, {width: 32},
+      {width: 28}
     ];
 
     // SNS URL 변환은 공용 _excelSnsUrl 헬퍼 사용 (handle → 전체 URL)
@@ -1035,6 +1040,17 @@ async function exportCampaignDeliverables(campId) {
 
       var receiptCells = renderReceiptCells9(g.receipt);
       var resultCells = renderDeliverableCells(g.result);
+      // 마이그레이션 160: 대리 등록 1컬럼 — 영수증 또는 결과물 중 1건이라도 submitted_by_admin 이면 "사유 라벨 (영수증/결과물 표시)" 한 줄
+      var proxyParts = [];
+      if (g.receipt && g.receipt.submitted_by_admin) {
+        var rReason = _excelProxyReasonKo(g.receipt.submitted_by_admin_reason_code);
+        proxyParts.push('영수증 · ' + rReason);
+      }
+      if (g.result && g.result.submitted_by_admin) {
+        var dReason = _excelProxyReasonKo(g.result.submitted_by_admin_reason_code);
+        proxyParts.push('결과물 · ' + dReason);
+      }
+      var proxyCell = proxyParts.length ? proxyParts.join(' / ') : '';
 
       row.values = [
         // 인플루언서 정보 7컬럼
@@ -1048,7 +1064,9 @@ async function exportCampaignDeliverables(campId) {
         // 영수증 9컬럼
         receiptCells[0], receiptCells[1], receiptCells[2], receiptCells[3], receiptCells[4], receiptCells[5], receiptCells[6], receiptCells[7], receiptCells[8],
         // 결과물 6컬럼
-        resultCells[0], resultCells[1], resultCells[2], resultCells[3], resultCells[4], resultCells[5]
+        resultCells[0], resultCells[1], resultCells[2], resultCells[3], resultCells[4], resultCells[5],
+        // 대리 등록 1컬럼
+        proxyCell
       ];
       row.alignment = {vertical: 'middle', wrapText: true};
 
@@ -1513,3 +1531,15 @@ function _buildMonitorGroupSheet(wb, sheetName, grpCamps, channels, delivs, user
 }
 
 
+
+// 마이그레이션 160: 엑셀 대리 등록 사유 코드 → 한국어 라벨 (시드 4건 인라인, 관리자 엑셀 한국어 UI)
+function _excelProxyReasonKo(code) {
+  if (!code) return '—';
+  var map = {
+    shipping_delay:      '배송 지연',
+    system_error:        '시스템 오류',
+    inflexible_deadline: '기간 외 합의 처리',
+    other:               '기타'
+  };
+  return map[code] || code;
+}

--- a/dev/js/application.js
+++ b/dev/js/application.js
@@ -974,6 +974,10 @@ function renderActivityReceiptList(delivs) {
     const reasonBox = (r.status === 'rejected' && r.reject_reason)
       ? `<div style="margin-top:8px;padding:8px 10px;background:#FFF5F5;border-left:3px solid #C33;border-radius:6px;font-size:11px;color:#C33;white-space:pre-wrap;line-height:1.5">${esc(r.reject_reason)}</div>`
       : '';
+    // 마이그레이션 160: 관리자 대리 등록 행이면 한 줄 일본어 설명 상시 노출 (사용자 결정 2026-05-28)
+    const proxyBox = r.submitted_by_admin
+      ? `<div style="margin-top:8px;padding:8px 10px;background:#FEF3C7;border-left:3px solid #FBBF24;border-radius:6px;font-size:11px;color:#92400E;line-height:1.5">${activityProxyNoticeJa(r)}</div>`
+      : '';
     return `
     <div style="padding:12px;background:var(--surface);border:1px solid var(--outline);border-radius:12px;margin-bottom:8px">
       <div style="display:flex;align-items:center;gap:12px">
@@ -987,6 +991,7 @@ function renderActivityReceiptList(delivs) {
           ${rightCol}
         </div>
       </div>
+      ${proxyBox}
       ${reasonBox}
     </div>`;
   }).join('');
@@ -1034,6 +1039,10 @@ function renderActivityReviewImageList(delivs, channels) {
       const reasonBox = (row.status === 'rejected' && row.reject_reason)
         ? `<div style="margin-top:8px;padding:8px 10px;background:#FFF5F5;border-left:3px solid #C33;border-radius:6px;font-size:11px;color:#C33;white-space:pre-wrap;line-height:1.5">${esc(row.reject_reason)}</div>`
         : '';
+      // 마이그레이션 160: 관리자 대리 등록 노랑 박스 (사양 2 운영 후 review_image 대리 등록 활성)
+      const proxyBox = row.submitted_by_admin
+        ? `<div style="margin-top:8px;padding:8px 10px;background:#FEF3C7;border-left:3px solid #FBBF24;border-radius:6px;font-size:11px;color:#92400E;line-height:1.5">${activityProxyNoticeJa(row)}</div>`
+        : '';
       const thumb = row.receipt_url
         ? `<img src="${esc(imgThumb(row.receipt_url,112,80))}" data-orig="${esc(row.receipt_url)}" loading="lazy" decoding="async" style="width:100%;height:100%;object-fit:contain;cursor:pointer;background:#f5f5f5" onerror="if(this.src!==this.dataset.orig){this.src=this.dataset.orig}" onclick="window.open('${esc(row.receipt_url)}','_blank')">`
         : '';
@@ -1043,6 +1052,7 @@ function renderActivityReviewImageList(delivs, channels) {
           <div style="flex:1;min-width:0">${stBadge}</div>
           <div style="display:flex;flex-direction:column;align-items:flex-end;gap:4px">${rightCol}</div>
         </div>
+        ${proxyBox}
         ${reasonBox}`;
     }
 
@@ -1097,6 +1107,10 @@ function renderActivityPostList(delivs) {
     const reasonBox = (d.status === 'rejected' && d.reject_reason)
       ? `<div style="margin-top:8px;padding:8px 10px;background:#FFF5F5;border-left:3px solid #C33;border-radius:6px;font-size:11px;color:#C33;white-space:pre-wrap;line-height:1.5">${esc(d.reject_reason)}</div>`
       : '';
+    // 마이그레이션 160: 관리자 대리 등록 노랑 박스
+    const proxyBox = d.submitted_by_admin
+      ? `<div style="margin-top:8px;padding:8px 10px;background:#FEF3C7;border-left:3px solid #FBBF24;border-radius:6px;font-size:11px;color:#92400E;line-height:1.5">${activityProxyNoticeJa(d)}</div>`
+      : '';
     return `
     <div style="padding:12px;background:var(--surface);border:1px solid var(--outline);border-radius:12px;margin-bottom:8px">
       <div style="display:flex;align-items:center;justify-content:space-between;gap:8px;margin-bottom:6px">
@@ -1105,6 +1119,7 @@ function renderActivityPostList(delivs) {
       </div>
       <a href="${esc(d.post_url||'')}" target="_blank" rel="noopener" style="font-size:12px;color:var(--dark-pink);word-break:break-all;text-decoration:none">${esc(d.post_url||'')}</a>
       <div style="font-size:10px;color:var(--muted);margin-top:4px">${formatDate(d.submitted_at)}</div>
+      ${proxyBox}
       ${reasonBox}
     </div>`;
   }).join('');
@@ -1115,6 +1130,22 @@ function activityStatusBadge(status) {
   if (status === 'approved') return `<span style="background:#E4F5E8;color:#2D7A3E;font-size:10px;font-weight:600;padding:2px 7px;border-radius:3px">${t('delivStatus.approved')}</span>`;
   if (status === 'rejected') return `<span style="background:#FFE4E4;color:#C33;font-size:10px;font-weight:600;padding:2px 7px;border-radius:3px">${t('delivStatus.rejected')}</span>`;
   return `<span style="background:#FFF4E4;color:#B8741A;font-size:10px;font-weight:600;padding:2px 7px;border-radius:3px">${t('delivStatus.pending')}</span>`;
+}
+
+// 마이그레이션 160: 인플 화면 「운영 측에서 등록」 한 줄 일본어 안내 (사용자 결정 2026-05-28)
+// 사유 메모(자유 텍스트)는 운영 내부 정보이므로 노출하지 않고 사유 라벨만 노출.
+function activityProxyNoticeJa(deliverable) {
+  if (!deliverable || !deliverable.submitted_by_admin) return '';
+  const code = deliverable.submitted_by_admin_reason_code || '';
+  // 시드 4건 인라인 일본어 매핑 (마이그레이션 160 lookup_values admin_proxy_reason)
+  const REASON_JA = {
+    shipping_delay:      '配送遅延',
+    system_error:        'システムエラー',
+    inflexible_deadline: '期間外協議',
+    other:               'その他'
+  };
+  const reasonJa = REASON_JA[code] || code || '—';
+  return `運営側で登録 — ${esc(reasonJa)}`;
 }
 
 function previewReceipt(input) {

--- a/dev/lib/storage.js
+++ b/dev/lib/storage.js
@@ -761,7 +761,7 @@ async function fetchDeliverablesByCampaign(campaignId) {
   if (!db) return [];
   try {
     const {data, error} = await db?.from('deliverables')
-      .select('id, application_id, user_id, kind, status, reviewed_at, submitted_at, updated_at, version, post_url, post_channel, receipt_url, purchase_date, purchase_amount, reject_reason')
+      .select('id, application_id, user_id, kind, status, reviewed_at, submitted_at, updated_at, version, post_url, post_channel, receipt_url, purchase_date, purchase_amount, reject_reason, submitted_by_admin, submitted_by_admin_reason_code, submitted_by_admin_reason, submitted_by_admin_at')
       .eq('campaign_id', campaignId)
       .order('submitted_at', {ascending: false});
     if (error) throw error;

--- a/docs/specs/2026-05-28-admin-proxy-deliverable.md
+++ b/docs/specs/2026-05-28-admin-proxy-deliverable.md
@@ -262,13 +262,38 @@ GRANT EXECUTE ON FUNCTION public.admin_create_deliverable_proxy(uuid, text, text
 
 ## 구현 결과
 
-(개발 세션이 채울 것)
-
-**구현일:**
-**관련 커밋:**
+**구현일:** 2026-05-28 (개발서버 dev 머지 완료)
+**관련 PR:**
+- PR 1 — DB + RPC + storage.js 래퍼 (#347, merge commit `7107972`)
+- 핫픽스 — `lookup_values_kind_check` 보강 (#348, merge commit `28f7406`)
+- PR 2 — 결과물 관리 페인 UI (#349, merge commit `39829ec`)
+- PR 3 — 진행 현황 마커 + 엑셀 컬럼 + 인플 화면 안내 (이 PR)
+**운영 배포:** 보류 (개발서버 검토 완료 후 사용자 결정 대기)
 
 ### 초안 대비 변경 사항
--
+
+#### 추가된 것
+- **`lookup_values_kind_check` CHECK 확장** (PR 1 핫픽스 #348) — 마이그레이션 160 본문에 `admin_proxy_reason` kind 등록 누락 → SQL Editor 첫 적용 시 23514 위반 → 섹션 1-b 신설로 DROP/ADD 패턴 보강. 멱등성 유지
+- **super_admin 전용 회수 RPC** `admin_revoke_proxy_deliverable(p_deliverable_id, p_reason)` — 사용자 결정 2026-05-28 「되돌리기 비활성 + 회수 버튼 분리」. `deliverable_events.action='admin_proxy_revoke'` audit 1건 INSERT 후 DELETE. `deliverable_events.deliverable_id ON DELETE CASCADE` 동작으로 audit 도 함께 삭제 — 운영 매뉴얼·검수 모달 안내 박스에 명시
+- **UNIQUE 사전 체크** RPC 본문 — `post` URL 중복 / `review_image` 채널 중복 시 한국어 친화 RAISE (23505)
+- **신청 상태 가드** — RPC 가 `applications.status='approved'` 만 허용 (사용자 결정. pending/rejected 신청은 모달 드롭다운에도 미노출)
+- **부분 인덱스** `idx_deliverables_proxy ON (submitted_by_admin) WHERE submitted_by_admin IS NOT NULL` — 「대리 등록만 보기」 필터·엑셀 컬럼 채움 쿼리 가속
+- **`fetchDeliverablesByCampaign` SELECT 컬럼 4종 추가** (PR 3 reviewer Critical) — camp-applicants 페인 ⊕ 마커 식별을 위해 필수
+- **`admin-deliverables.js` 인라인 `_adminDetectChannelFromUrl`** — admin 빌드에 `application.js` 미포함이라 채널 자동 판별 미러 복제
+
+#### 빠진 것 (후속 hotfix 분리)
+- **다중 캠페인 결과물 엑셀 통합 시트의 「대리 등록」 컬럼** — `dev/js/admin-excel.js` line 545~ 영역. 후속 hotfix로 분리 (시간 절약). 단일 캠페인 결과물 엑셀 W컬럼은 PR 3 에 포함
+- **monitor 그룹 시트 `_buildMonitorGroupSheet`의 「대리 등록」 컬럼** — 사양 2(다중채널 결과물) PR 4 영역. `review_image` 대리 등록 자체가 사양 2 운영 후 활성이라 우선순위 낮음. 사양 2 운영 시점에 함께 적용
+- **모달 `confirm()` / `prompt()` → `showConfirm` 교체** — PR 2 reviewer WARN 2. 회수 빈도 낮음 + UI 일관성은 후속 개선 PR로 분리
 
 ### 구현 중 기술 결정 사항
--
+
+- **마이그레이션 번호**: 사양서 작성 시 「착수 시 재확인」 명시 → 실착수 시점 159가 최신 확인 후 **160** 사용
+- **`deliverable_events.action` CHECK + `notifications.kind` CHECK 확장**을 사양서 §3 본문에는 SQL 명시 없었으나, planner 검토에서 누락 식별 → 마이그레이션 160 섹션 3·4에 DROP/ADD 패턴으로 보강
+- **`actor_id` 컬럼 명칭** — 사양서 §3-3 RPC 본문 `changed_by` 가 035 실제 컬럼명 `actor_id` 와 불일치 → 실제 컬럼명으로 보정
+- **`campaign_id`** — `deliverables.campaign_id NOT NULL` 확인 후 RPC INSERT 에 누락 없도록 `v_app_campaign_id` 변수 추가 (사양서 §3-3 본문 누락분 보완)
+- **인플 사유 메모(자유 텍스트) 미노출 정책** — 운영 내부 정보로 사양서 §6 명시. `activityProxyNoticeJa(deliverable)` 가 사유 라벨(`shipping_delay` 등 시드 4종)만 일본어로 표시. 「メモ」 필드 자체를 노출 X
+- **인플 화면 일본어 문구** — 사용자 결정 §1 표 「運営側で登録 — {사유 라벨}」 그대로
+- **사유 코드 한국어 매핑 시드 4건 인라인** — `_proxyReasonLabelKo` (admin-deliverables.js), `_excelProxyReasonKo` (admin-excel.js), `activityProxyNoticeJa` 의 `REASON_JA` (application.js) 3곳에 각각 인라인 매핑. 추후 lookup_values 에 5번째 코드 추가되면 영문 코드 폴백 (관리자가 `#lookups` 페인에서 추가하면 자동으로 본 함수에서 영문 그대로 노출 + UI 식별 가능)
+- **`admin_revoke_proxy_deliverable` audit 영구 보존 미지원** — `deliverable_events.deliverable_id ON DELETE CASCADE` 로 결과물 DELETE 시 audit 도 함께 삭제됨. 향후 영구 감사 필요 시 별도 `admin_proxy_revoke_log` audit-only 테이블 분리 권장 (현재는 운영 빈도 낮음 + 운영자 매뉴얼로 보완)
+- **개발서버 검토만 완료** — PR 1·2·3 모두 dev 머지·개발 DB 적용·스모크 완료. 운영 배포는 별도 협의 (메시지 본체 PR 5·6 보류 분과 일정 묶기 가능)

--- a/index.html
+++ b/index.html
@@ -4748,7 +4748,7 @@ async function fetchDeliverablesByCampaign(campaignId) {
   if (!db) return [];
   try {
     const {data, error} = await db?.from('deliverables')
-      .select('id, application_id, user_id, kind, status, reviewed_at, submitted_at, updated_at, version, post_url, post_channel, receipt_url, purchase_date, purchase_amount, reject_reason')
+      .select('id, application_id, user_id, kind, status, reviewed_at, submitted_at, updated_at, version, post_url, post_channel, receipt_url, purchase_date, purchase_amount, reject_reason, submitted_by_admin, submitted_by_admin_reason_code, submitted_by_admin_reason, submitted_by_admin_at')
       .eq('campaign_id', campaignId)
       .order('submitted_at', {ascending: false});
     if (error) throw error;
@@ -9410,6 +9410,10 @@ function renderActivityReceiptList(delivs) {
     const reasonBox = (r.status === 'rejected' && r.reject_reason)
       ? `<div style="margin-top:8px;padding:8px 10px;background:#FFF5F5;border-left:3px solid #C33;border-radius:6px;font-size:11px;color:#C33;white-space:pre-wrap;line-height:1.5">${esc(r.reject_reason)}</div>`
       : '';
+    // 마이그레이션 160: 관리자 대리 등록 행이면 한 줄 일본어 설명 상시 노출 (사용자 결정 2026-05-28)
+    const proxyBox = r.submitted_by_admin
+      ? `<div style="margin-top:8px;padding:8px 10px;background:#FEF3C7;border-left:3px solid #FBBF24;border-radius:6px;font-size:11px;color:#92400E;line-height:1.5">${activityProxyNoticeJa(r)}</div>`
+      : '';
     return `
     <div style="padding:12px;background:var(--surface);border:1px solid var(--outline);border-radius:12px;margin-bottom:8px">
       <div style="display:flex;align-items:center;gap:12px">
@@ -9423,6 +9427,7 @@ function renderActivityReceiptList(delivs) {
           ${rightCol}
         </div>
       </div>
+      ${proxyBox}
       ${reasonBox}
     </div>`;
   }).join('');
@@ -9470,6 +9475,10 @@ function renderActivityReviewImageList(delivs, channels) {
       const reasonBox = (row.status === 'rejected' && row.reject_reason)
         ? `<div style="margin-top:8px;padding:8px 10px;background:#FFF5F5;border-left:3px solid #C33;border-radius:6px;font-size:11px;color:#C33;white-space:pre-wrap;line-height:1.5">${esc(row.reject_reason)}</div>`
         : '';
+      // 마이그레이션 160: 관리자 대리 등록 노랑 박스 (사양 2 운영 후 review_image 대리 등록 활성)
+      const proxyBox = row.submitted_by_admin
+        ? `<div style="margin-top:8px;padding:8px 10px;background:#FEF3C7;border-left:3px solid #FBBF24;border-radius:6px;font-size:11px;color:#92400E;line-height:1.5">${activityProxyNoticeJa(row)}</div>`
+        : '';
       const thumb = row.receipt_url
         ? `<img src="${esc(imgThumb(row.receipt_url,112,80))}" data-orig="${esc(row.receipt_url)}" loading="lazy" decoding="async" style="width:100%;height:100%;object-fit:contain;cursor:pointer;background:#f5f5f5" onerror="if(this.src!==this.dataset.orig){this.src=this.dataset.orig}" onclick="window.open('${esc(row.receipt_url)}','_blank')">`
         : '';
@@ -9479,6 +9488,7 @@ function renderActivityReviewImageList(delivs, channels) {
           <div style="flex:1;min-width:0">${stBadge}</div>
           <div style="display:flex;flex-direction:column;align-items:flex-end;gap:4px">${rightCol}</div>
         </div>
+        ${proxyBox}
         ${reasonBox}`;
     }
 
@@ -9533,6 +9543,10 @@ function renderActivityPostList(delivs) {
     const reasonBox = (d.status === 'rejected' && d.reject_reason)
       ? `<div style="margin-top:8px;padding:8px 10px;background:#FFF5F5;border-left:3px solid #C33;border-radius:6px;font-size:11px;color:#C33;white-space:pre-wrap;line-height:1.5">${esc(d.reject_reason)}</div>`
       : '';
+    // 마이그레이션 160: 관리자 대리 등록 노랑 박스
+    const proxyBox = d.submitted_by_admin
+      ? `<div style="margin-top:8px;padding:8px 10px;background:#FEF3C7;border-left:3px solid #FBBF24;border-radius:6px;font-size:11px;color:#92400E;line-height:1.5">${activityProxyNoticeJa(d)}</div>`
+      : '';
     return `
     <div style="padding:12px;background:var(--surface);border:1px solid var(--outline);border-radius:12px;margin-bottom:8px">
       <div style="display:flex;align-items:center;justify-content:space-between;gap:8px;margin-bottom:6px">
@@ -9541,6 +9555,7 @@ function renderActivityPostList(delivs) {
       </div>
       <a href="${esc(d.post_url||'')}" target="_blank" rel="noopener" style="font-size:12px;color:var(--dark-pink);word-break:break-all;text-decoration:none">${esc(d.post_url||'')}</a>
       <div style="font-size:10px;color:var(--muted);margin-top:4px">${formatDate(d.submitted_at)}</div>
+      ${proxyBox}
       ${reasonBox}
     </div>`;
   }).join('');
@@ -9551,6 +9566,22 @@ function activityStatusBadge(status) {
   if (status === 'approved') return `<span style="background:#E4F5E8;color:#2D7A3E;font-size:10px;font-weight:600;padding:2px 7px;border-radius:3px">${t('delivStatus.approved')}</span>`;
   if (status === 'rejected') return `<span style="background:#FFE4E4;color:#C33;font-size:10px;font-weight:600;padding:2px 7px;border-radius:3px">${t('delivStatus.rejected')}</span>`;
   return `<span style="background:#FFF4E4;color:#B8741A;font-size:10px;font-weight:600;padding:2px 7px;border-radius:3px">${t('delivStatus.pending')}</span>`;
+}
+
+// 마이그레이션 160: 인플 화면 「운영 측에서 등록」 한 줄 일본어 안내 (사용자 결정 2026-05-28)
+// 사유 메모(자유 텍스트)는 운영 내부 정보이므로 노출하지 않고 사유 라벨만 노출.
+function activityProxyNoticeJa(deliverable) {
+  if (!deliverable || !deliverable.submitted_by_admin) return '';
+  const code = deliverable.submitted_by_admin_reason_code || '';
+  // 시드 4건 인라인 일본어 매핑 (마이그레이션 160 lookup_values admin_proxy_reason)
+  const REASON_JA = {
+    shipping_delay:      '配送遅延',
+    system_error:        'システムエラー',
+    inflexible_deadline: '期間外協議',
+    other:               'その他'
+  };
+  const reasonJa = REASON_JA[code] || code || '—';
+  return `運営側で登録 — ${esc(reasonJa)}`;
 }
 
 function previewReceipt(input) {


### PR DESCRIPTION
## 변경 요약

「관리자 결과물 대리 등록」 사양서 **PR 3** + 사용자 발견 핫픽스.

### PR 3 (사양서 §4-5 + §5 단일 + §6)
- 캠페인 진행 현황(`#camp-applicants`) 결과물 셀 옆 노랑 ⊕ 마커 (건수 표시 + 호버 툴팁)
- 단일 캠페인 결과물 엑셀 W컬럼 「대리 등록」 (그룹 헤더 + 컬럼 헤더 + 본문)
- 인플 활동관리 3종 카드(영수증·게시물·리뷰 이미지) 노랑 안내 박스 + 일본어 한 줄 「運営側で登録 — {사유 일본어}」

### Hotfix (사용자 스크린샷 보고)
- 대리 등록 모달 데이터 로드 시 `Could not find a relationship between 'applications' and 'campaign_id' in the schema cache` 에러 → `_loadAdminProxyApprovedApps` 를 nested select 에서 분리 쿼리 + 클라이언트 join 패턴으로 전환

### reviewer Critical 반영
- `fetchDeliverablesByCampaign` SELECT 에 `submitted_by_admin*` 4컬럼 추가 (camp-applicants 페인 ⊕ 마커가 항상 0건이던 버그 차단)

### reviewer WARN 반영
- 인플 화면 일본어 문구 「運営側で登録しました 〜」 → 「運営側で登録 — 」 (사양서 §1 결정 일치)
- 사양서 「구현 결과」 섹션 작성 (PR 1·2·3 + 핫픽스 #348 머지 커밋 + 초안 대비 변경 + 기술 결정 사항)

## 미적용 (후속 hotfix 분리)
- 다중 캠페인 결과물 엑셀 통합 시트 「대리 등록」 컬럼
- monitor 그룹 시트 `_buildMonitorGroupSheet` 「대리 등록」 컬럼 (사양 2 review_image 대리 등록은 사양 2 운영 후 활성이라 함께)
- 모달 `confirm()`/`prompt()` → `showConfirm` 교체 (PR 2 WARN 2)

## 관련 사양서

- `docs/specs/2026-05-28-admin-proxy-deliverable.md` — 「구현 결과」 섹션 작성 완료

## 운영 배포 게이트

본 PR 머지로 PR 1·2·3 모두 dev 검증 완료. 운영 배포는 별도 협의.

[via reviewer] PR 3 BLOCK + WARN 모두 반영, 사용자 핫픽스 동봉

🤖 Generated with [Claude Code](https://claude.com/claude-code)