### PR TITLE
feat(admin): proxy modal UX — combobox search + entry from review modal

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -12,7 +12,7 @@
 // 회귀(2026-05-12 PR #182 머지 직후 발생)를 방지하기 위한 자동 reload 가드.
 // sessionStorage 차단 환경(시크릿 모드 일부, 쿠키 차단)에서는 자연스럽게 skip.
 (function(){
-  var CURRENT_BUILD = 'v1779959438';
+  var CURRENT_BUILD = 'v1779960768';
   if (CURRENT_BUILD.indexOf('__') === 0) return; // 빌드 미적용 (dev/ 직접 열기) 시 skip
   try {
     var prev = sessionStorage.getItem('reverb.adminBuild');
@@ -1744,6 +1744,21 @@ textarea.form-input{resize:vertical;min-height:80px}
 /* 「대리 등록만 보기」 필터 토글 */
 .deliv-proxy-filter-label{display:inline-flex;align-items:center;gap:4px;font-size:12px;cursor:pointer;height:32px;color:var(--ink)}
 
+/* ─── 관리자 대리 등록 모달 — 검색 가능 드롭다운 (combobox) ────────── */
+.admin-proxy-combobox{position:relative}
+.admin-proxy-combobox-input{width:100%;padding:8px 10px;border:1px solid var(--line);border-radius:6px;font-size:13px;background:#fff}
+.admin-proxy-combobox-input:disabled{background:#F3F4F6;color:var(--muted);cursor:not-allowed}
+.admin-proxy-combobox-input:focus{outline:none;border-color:var(--pink)}
+.admin-proxy-combobox-list{display:none;position:absolute;top:100%;left:0;right:0;z-index:10;max-height:240px;overflow-y:auto;background:#fff;border:1px solid var(--line);border-top:none;border-radius:0 0 6px 6px;box-shadow:0 4px 12px rgba(0,0,0,.06);margin-top:-1px}
+.admin-proxy-combobox-list.open{display:block}
+.admin-proxy-combobox-list .item{padding:8px 10px;font-size:13px;color:var(--ink);cursor:pointer;border-bottom:1px solid var(--line)}
+.admin-proxy-combobox-list .item:last-child{border-bottom:none}
+.admin-proxy-combobox-list .item:hover,
+.admin-proxy-combobox-list .item.focused{background:#FFF5F8;color:var(--dark-pink)}
+.admin-proxy-combobox-list .item.disabled{color:var(--muted);cursor:not-allowed;background:#F9FAFB}
+.admin-proxy-combobox-list .item-meta{font-size:11px;color:var(--muted);margin-top:2px}
+.admin-proxy-combobox-list .empty{padding:14px 10px;text-align:center;color:var(--muted);font-size:12px}
+
 </style>
 </head>
 <body style="background:#F8F5F8">
@@ -1818,7 +1833,7 @@ textarea.form-input{resize:vertical;min-height:80px}
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-05-28 18:10 · c6169d5</span>
+          <span class="admin-build-text">2026-05-28 18:32 · 00cc4e3</span>
         </div>
       </div>
     </aside>
@@ -4177,6 +4192,10 @@ textarea.form-input{resize:vertical;min-height:80px}
       <div style="text-align:center;padding:40px"><span class="spinner"></span></div>
     </div>
     <div class="modal-footer" style="padding:14px 22px;border-top:1px solid var(--line);display:flex;gap:8px;justify-content:flex-end">
+      <button class="btn btn-ghost btn-sm" id="delivCombinedProxyBtn" onclick="openAdminProxyFromCombined()" title="이 신청에 결과물을 관리자가 대신 등록·즉시 승인합니다" style="background:#FEF3C7;color:#92400E;border:1px solid #FBBF24;font-weight:600">
+        <span class="material-icons-round notranslate" translate="no" style="font-size:14px;vertical-align:middle">add_task</span>
+        대리 등록
+      </button>
       <button class="btn btn-ghost" onclick="closeDelivCombined()">닫기</button>
     </div>
   </div>
@@ -4220,13 +4239,26 @@ textarea.form-input{resize:vertical;min-height:80px}
         <strong>주의:</strong> 본 기능은 인플루언서가 배송 지연 등 사유로 결과물을 직접 등록할 수 없을 때 운영자가 대신 등록·즉시 승인하는 도구입니다. 인플루언서에게 「結果物が登録されました」 알림이 발송됩니다.
       </div>
       <div class="admin-proxy-modal-form">
-        <!-- 1. 신청 선택 (approved 만) -->
+        <!-- 1-a. 캠페인 검색·선택 (단어 포함 필터, 클릭 또는 ↑↓+Enter) -->
         <div class="form-row required">
-          <label>신청 선택</label>
-          <select id="adminProxyApp" class="form-input" onchange="onAdminProxyAppChange()">
-            <option value="">— 승인된 신청을 선택하세요 —</option>
-          </select>
-          <span class="form-help">캠페인 + 인플루언서 이름으로 검색됩니다. 승인 완료된 신청만 표시됩니다.</span>
+          <label>캠페인 선택</label>
+          <div class="admin-proxy-combobox" id="adminProxyCampCombobox">
+            <input type="text" id="adminProxyCampInput" class="admin-proxy-combobox-input" placeholder="캠페인명·브랜드·번호 검색 (전체 보려면 비워두고 클릭)" autocomplete="off" data-lpignore="true" data-1p-ignore="true" oninput="onAdminProxyCampInput()" onfocus="showAdminProxyCampList()">
+            <input type="hidden" id="adminProxyCampId" value="">
+            <div class="admin-proxy-combobox-list" id="adminProxyCampList"></div>
+          </div>
+          <span class="form-help">승인된 신청이 있는 캠페인만 노출. 비워두고 클릭하면 전체 목록.</span>
+        </div>
+
+        <!-- 1-b. 인플루언서 검색·선택 (캠페인 선택 후 활성, 그 캠페인의 approved 신청자만) -->
+        <div class="form-row required">
+          <label>인플루언서 선택</label>
+          <div class="admin-proxy-combobox" id="adminProxyInfCombobox">
+            <input type="text" id="adminProxyInfInput" class="admin-proxy-combobox-input" placeholder="이름·가나·이메일 검색" autocomplete="off" data-lpignore="true" data-1p-ignore="true" oninput="onAdminProxyInfInput()" onfocus="showAdminProxyInfList()" disabled>
+            <input type="hidden" id="adminProxyApp" value="">
+            <div class="admin-proxy-combobox-list" id="adminProxyInfList"></div>
+          </div>
+          <span class="form-help">먼저 캠페인을 선택하세요. 그 캠페인의 승인된 인플루언서만 표시됩니다.</span>
         </div>
 
         <!-- 2. 결과물 종류 선택 (캠페인 recruit_type 따라 노출) -->
@@ -17157,6 +17189,13 @@ async function openDelivCombined(applicationId) {
   const modal = $('delivCombinedModal');
   if (!modal) return;
   _delivCombinedRefreshAppId = applicationId;
+  // 검수 모달 「대리 등록」 버튼은 campaign_admin 이상에게만 노출 (campaign_manager 차단)
+  // RPC 자체에 is_campaign_admin() 가드 있어 우회 시도해도 안전하지만, UI 일관성 차원에서 사전 차단
+  const proxyBtn = $('delivCombinedProxyBtn');
+  if (proxyBtn) {
+    const isManager = (typeof currentAdminInfo !== 'undefined' && currentAdminInfo?.role === 'campaign_manager');
+    proxyBtn.style.display = isManager ? 'none' : '';
+  }
   openModal('delivCombinedModal');
   await renderDelivCombinedBody(applicationId);
 }
@@ -17603,7 +17642,7 @@ let _adminProxyApps = [];       // approved 신청 + 캠페인 + 인플 join
 let _adminProxyReasons = [];    // admin_proxy_reason lookup 캐시
 let _adminProxyChannels = {};   // channel code → name_ko 라벨
 
-async function openAdminProxyModal() {
+async function openAdminProxyModal(presetAppId) {
   const m = $('adminProxyDelivModal');
   if (!m) return;
   _resetAdminProxyForm();
@@ -17618,12 +17657,33 @@ async function openAdminProxyModal() {
     _adminProxyApps = appsResult;
     _adminProxyReasons = reasonsResult;
     _adminProxyChannels = channelsResult;
-    _populateAdminProxyAppDropdown();
     _populateAdminProxyReasonDropdown();
+    // 검수 모달에서 진입한 경우 캠페인·인플 자동 선택
+    if (presetAppId) {
+      const app = _adminProxyApps.find(a => a.id === presetAppId);
+      if (app) {
+        selectAdminProxyCamp(app.campaign_id, /*silent*/true);
+        selectAdminProxyInf(app.id, /*silent*/true);
+      }
+    }
   } catch (err) {
     console.error('[admin-proxy] 데이터 로드 실패', err);
     toast('데이터 로드 실패: ' + (err.message || err), 'error');
   }
+}
+
+// 검수 모달에서 「대리 등록」 진입 — 현재 신청 ID 가져와서 자동 선택
+// _delivCombinedRefreshAppId 는 openDelivCombined() 가 저장하는 신청 ID
+async function openAdminProxyFromCombined() {
+  const appId = (typeof _delivCombinedRefreshAppId !== 'undefined' && _delivCombinedRefreshAppId)
+    ? _delivCombinedRefreshAppId
+    : null;
+  if (!appId) {
+    toast('현재 신청을 식별할 수 없습니다. 결과물 목록의 「검수」 버튼으로 다시 열어주세요.', 'error');
+    return;
+  }
+  closeDelivCombined();
+  await openAdminProxyModal(appId);
 }
 
 function closeAdminProxyModal() {
@@ -17633,8 +17693,20 @@ function closeAdminProxyModal() {
 }
 
 function _resetAdminProxyForm() {
-  ['adminProxyApp','adminProxyKind','adminProxyOrderNo','adminProxyPurchaseDate','adminProxyPurchaseAmount','adminProxyPostUrl','adminProxyPostChannel','adminProxyReviewChannel','adminProxyReasonCode','adminProxyReason'].forEach(id => {
+  // combobox 2종 + kind/사유/메모/이미지/파일 입력 초기화
+  ['adminProxyApp','adminProxyCampId','adminProxyKind','adminProxyOrderNo','adminProxyPurchaseDate','adminProxyPurchaseAmount','adminProxyPostUrl','adminProxyPostChannel','adminProxyReviewChannel','adminProxyReasonCode','adminProxyReason'].forEach(id => {
     const el = $(id); if (el) el.value = '';
+  });
+  // combobox 검색 input (text)
+  ['adminProxyCampInput','adminProxyInfInput'].forEach(id => {
+    const el = $(id); if (el) el.value = '';
+  });
+  // 인플 input 은 캠페인 미선택 시 disabled
+  const infInput = $('adminProxyInfInput');
+  if (infInput) infInput.disabled = true;
+  // 리스트 닫기
+  ['adminProxyCampList','adminProxyInfList'].forEach(id => {
+    const el = $(id); if (el) { el.classList.remove('open'); el.innerHTML = ''; }
   });
   ['adminProxyReceiptImage','adminProxyReviewImage'].forEach(id => {
     const el = $(id); if (el) el.value = '';
@@ -17646,7 +17718,7 @@ function _resetAdminProxyForm() {
     const el = $(id); if (el) el.classList.remove('active');
   });
   const kindSelect = $('adminProxyKind');
-  if (kindSelect) { kindSelect.innerHTML = '<option value="">— 먼저 신청을 선택하세요 —</option>'; kindSelect.disabled = true; }
+  if (kindSelect) { kindSelect.innerHTML = '<option value="">— 먼저 인플루언서를 선택하세요 —</option>'; kindSelect.disabled = true; }
 }
 
 async function _loadAdminProxyApprovedApps() {
@@ -17696,19 +17768,6 @@ async function _loadAdminProxyChannelLabels() {
   return map;
 }
 
-function _populateAdminProxyAppDropdown() {
-  const sel = $('adminProxyApp');
-  if (!sel) return;
-  const opts = ['<option value="">— 승인된 신청을 선택하세요 —</option>'];
-  _adminProxyApps.forEach(a => {
-    const inf = a.influencers || {};
-    const camp = a.campaigns || {};
-    const label = `${camp.campaign_no || '—'} · ${camp.title || ''} (${camp.brand || ''}) · ${inf.name || ''}${inf.name_kana ? '(' + inf.name_kana + ')' : ''}`;
-    opts.push(`<option value="${esc(a.id)}">${esc(label)}</option>`);
-  });
-  sel.innerHTML = opts.join('');
-}
-
 function _populateAdminProxyReasonDropdown() {
   const sel = $('adminProxyReasonCode');
   if (!sel) return;
@@ -17719,24 +17778,150 @@ function _populateAdminProxyReasonDropdown() {
   sel.innerHTML = opts.join('');
 }
 
-function onAdminProxyAppChange() {
-  const appId = $('adminProxyApp')?.value;
-  const kindSel = $('adminProxyKind');
-  if (!kindSel) return;
-  // 종류 옵션 분기
-  if (!appId) {
-    kindSel.innerHTML = '<option value="">— 먼저 신청을 선택하세요 —</option>';
-    kindSel.disabled = true;
-    onAdminProxyKindChange();
+// ── combobox: 캠페인 검색·선택 ────────────────────────────────────
+function showAdminProxyCampList() {
+  const list = $('adminProxyCampList');
+  if (!list) return;
+  list.classList.add('open');
+  _renderAdminProxyCampList($('adminProxyCampInput')?.value || '');
+}
+
+function onAdminProxyCampInput() {
+  const q = $('adminProxyCampInput')?.value || '';
+  // 입력 시 hidden 비움 (선택 확정 전 상태)
+  const hid = $('adminProxyCampId'); if (hid) hid.value = '';
+  // 캠페인 변경되면 인플·종류 모두 리셋
+  _resetAdminProxyInfState();
+  _renderAdminProxyCampList(q);
+  showAdminProxyCampList();
+}
+
+function _renderAdminProxyCampList(query) {
+  const list = $('adminProxyCampList');
+  if (!list) return;
+  // 캠페인 후보 = 승인 신청이 있는 캠페인 unique (id 기준)
+  const campMap = new Map();
+  _adminProxyApps.forEach(a => {
+    if (!a.campaigns) return;
+    if (!campMap.has(a.campaigns.id)) campMap.set(a.campaigns.id, a.campaigns);
+  });
+  const q = (query || '').trim().toLowerCase();
+  const filtered = Array.from(campMap.values()).filter(c => {
+    if (!q) return true;
+    return matchSearchTokens(q, [c.title, c.brand, c.campaign_no]);
+  });
+  if (!filtered.length) {
+    list.innerHTML = '<div class="empty">일치하는 캠페인 없음</div>';
     return;
   }
-  const app = _adminProxyApps.find(a => a.id === appId);
+  list.innerHTML = filtered.slice(0, 100).map(c => {
+    const meta = `${c.brand || ''} · ${c.campaign_no || '—'} · ${c.recruit_type || ''}`;
+    return `<div class="item" onmousedown="selectAdminProxyCamp('${esc(c.id)}')">
+      <div>${esc(c.title || '제목 없음')}</div>
+      <div class="item-meta">${esc(meta)}</div>
+    </div>`;
+  }).join('');
+}
+
+function selectAdminProxyCamp(campId, silent) {
+  const app = _adminProxyApps.find(a => a.campaign_id === campId);
   if (!app || !app.campaigns) return;
+  const camp = app.campaigns;
+  const hid = $('adminProxyCampId'); if (hid) hid.value = campId;
+  const inp = $('adminProxyCampInput');
+  if (inp) inp.value = `${camp.title || ''} (${camp.brand || ''})`;
+  const list = $('adminProxyCampList'); if (list) list.classList.remove('open');
+  // 인플 input 활성화 + 검색 리스트 미리 렌더
+  const infInput = $('adminProxyInfInput');
+  if (infInput) { infInput.disabled = false; infInput.value = ''; }
+  const infHid = $('adminProxyApp'); if (infHid) infHid.value = '';
+  _renderAdminProxyInfList('');
+  // 종류 옵션도 리셋 (인플 미선택 상태)
+  const kindSel = $('adminProxyKind');
+  if (kindSel) { kindSel.innerHTML = '<option value="">— 먼저 인플루언서를 선택하세요 —</option>'; kindSel.disabled = true; }
+  onAdminProxyKindChange();
+  if (!silent && infInput) infInput.focus();
+}
+
+// ── combobox: 인플 검색·선택 (선택된 캠페인 내) ───────────────────
+function showAdminProxyInfList() {
+  const list = $('adminProxyInfList');
+  if (!list) return;
+  list.classList.add('open');
+  _renderAdminProxyInfList($('adminProxyInfInput')?.value || '');
+}
+
+function onAdminProxyInfInput() {
+  const q = $('adminProxyInfInput')?.value || '';
+  // 입력 시 hidden 비움 (선택 확정 전 상태)
+  const hid = $('adminProxyApp'); if (hid) hid.value = '';
+  // 인플 변경되면 종류 리셋
+  const kindSel = $('adminProxyKind');
+  if (kindSel) { kindSel.innerHTML = '<option value="">— 먼저 인플루언서를 선택하세요 —</option>'; kindSel.disabled = true; }
+  onAdminProxyKindChange();
+  _renderAdminProxyInfList(q);
+  showAdminProxyInfList();
+}
+
+function _renderAdminProxyInfList(query) {
+  const list = $('adminProxyInfList');
+  if (!list) return;
+  const campId = $('adminProxyCampId')?.value;
+  if (!campId) {
+    list.innerHTML = '<div class="empty">먼저 캠페인을 선택하세요</div>';
+    return;
+  }
+  const inCampApps = _adminProxyApps.filter(a => a.campaign_id === campId);
+  const q = (query || '').trim().toLowerCase();
+  const filtered = inCampApps.filter(a => {
+    if (!q) return true;
+    const inf = a.influencers || {};
+    return matchSearchTokens(q, [inf.name, inf.name_kana, inf.email]);
+  });
+  if (!filtered.length) {
+    list.innerHTML = '<div class="empty">' + (q ? '일치하는 인플루언서 없음' : '승인된 인플루언서 없음') + '</div>';
+    return;
+  }
+  list.innerHTML = filtered.slice(0, 100).map(a => {
+    const inf = a.influencers || {};
+    const meta = `${inf.name_kana || ''}${inf.name_kana && inf.email ? ' · ' : ''}${inf.email || ''}`;
+    return `<div class="item" onmousedown="selectAdminProxyInf('${esc(a.id)}')">
+      <div>${esc(inf.name || '이름 없음')}</div>
+      <div class="item-meta">${esc(meta)}</div>
+    </div>`;
+  }).join('');
+}
+
+function selectAdminProxyInf(appId, silent) {
+  const app = _adminProxyApps.find(a => a.id === appId);
+  if (!app) return;
+  const inf = app.influencers || {};
+  const hid = $('adminProxyApp'); if (hid) hid.value = appId;
+  const inp = $('adminProxyInfInput');
+  if (inp) inp.value = `${inf.name || ''}${inf.name_kana ? ' (' + inf.name_kana + ')' : ''}`;
+  const list = $('adminProxyInfList'); if (list) list.classList.remove('open');
+  // 결과물 종류 옵션 활성화 (기존 onAdminProxyAppChange 로직 인라인)
+  _refreshAdminProxyKindOptions(app);
+}
+
+function _resetAdminProxyInfState() {
+  // 캠페인 변경 또는 폼 초기화 시 인플 + 종류 모두 리셋
+  const infInput = $('adminProxyInfInput');
+  if (infInput) { infInput.value = ''; infInput.disabled = true; }
+  const infHid = $('adminProxyApp'); if (infHid) infHid.value = '';
+  const infList = $('adminProxyInfList'); if (infList) { infList.classList.remove('open'); infList.innerHTML = ''; }
+  const kindSel = $('adminProxyKind');
+  if (kindSel) { kindSel.innerHTML = '<option value="">— 먼저 인플루언서를 선택하세요 —</option>'; kindSel.disabled = true; }
+  onAdminProxyKindChange();
+}
+
+function _refreshAdminProxyKindOptions(app) {
+  const kindSel = $('adminProxyKind');
+  if (!kindSel || !app || !app.campaigns) return;
   const rt = app.campaigns.recruit_type;
   const opts = ['<option value="">— 결과물 종류 선택 —</option>'];
   if (rt === 'monitor') {
     opts.push('<option value="receipt">영수증 (영수증·주문번호·구매일·금액)</option>');
-    // review_image 는 사양 2 운영 후 자동 활성 — 채널이 등록되어 있고 lookup 캐시에 코드가 있으면 노출
     const channels = (app.campaigns.channel || '').split(',').map(s => s.trim()).filter(Boolean);
     if (channels.length > 0) {
       opts.push('<option value="review_image">리뷰 이미지 (채널별)</option>');
@@ -17748,6 +17933,18 @@ function onAdminProxyAppChange() {
   kindSel.disabled = false;
   onAdminProxyKindChange();
 }
+
+// 외부 클릭 시 combobox 리스트 자동 닫기 (모달 외 클릭 또는 다른 영역 클릭)
+document.addEventListener('click', function(e) {
+  const camp = $('adminProxyCampCombobox');
+  const inf = $('adminProxyInfCombobox');
+  if (camp && !camp.contains(e.target)) {
+    const list = $('adminProxyCampList'); if (list) list.classList.remove('open');
+  }
+  if (inf && !inf.contains(e.target)) {
+    const list = $('adminProxyInfList'); if (list) list.classList.remove('open');
+  }
+});
 
 function onAdminProxyKindChange() {
   const kind = $('adminProxyKind')?.value;

--- a/dev/admin/index.html
+++ b/dev/admin/index.html
@@ -2492,6 +2492,10 @@
       <div style="text-align:center;padding:40px"><span class="spinner"></span></div>
     </div>
     <div class="modal-footer" style="padding:14px 22px;border-top:1px solid var(--line);display:flex;gap:8px;justify-content:flex-end">
+      <button class="btn btn-ghost btn-sm" id="delivCombinedProxyBtn" onclick="openAdminProxyFromCombined()" title="이 신청에 결과물을 관리자가 대신 등록·즉시 승인합니다" style="background:#FEF3C7;color:#92400E;border:1px solid #FBBF24;font-weight:600">
+        <span class="material-icons-round notranslate" translate="no" style="font-size:14px;vertical-align:middle">add_task</span>
+        대리 등록
+      </button>
       <button class="btn btn-ghost" onclick="closeDelivCombined()">닫기</button>
     </div>
   </div>
@@ -2535,13 +2539,26 @@
         <strong>주의:</strong> 본 기능은 인플루언서가 배송 지연 등 사유로 결과물을 직접 등록할 수 없을 때 운영자가 대신 등록·즉시 승인하는 도구입니다. 인플루언서에게 「結果物が登録されました」 알림이 발송됩니다.
       </div>
       <div class="admin-proxy-modal-form">
-        <!-- 1. 신청 선택 (approved 만) -->
+        <!-- 1-a. 캠페인 검색·선택 (단어 포함 필터, 클릭 또는 ↑↓+Enter) -->
         <div class="form-row required">
-          <label>신청 선택</label>
-          <select id="adminProxyApp" class="form-input" onchange="onAdminProxyAppChange()">
-            <option value="">— 승인된 신청을 선택하세요 —</option>
-          </select>
-          <span class="form-help">캠페인 + 인플루언서 이름으로 검색됩니다. 승인 완료된 신청만 표시됩니다.</span>
+          <label>캠페인 선택</label>
+          <div class="admin-proxy-combobox" id="adminProxyCampCombobox">
+            <input type="text" id="adminProxyCampInput" class="admin-proxy-combobox-input" placeholder="캠페인명·브랜드·번호 검색 (전체 보려면 비워두고 클릭)" autocomplete="off" data-lpignore="true" data-1p-ignore="true" oninput="onAdminProxyCampInput()" onfocus="showAdminProxyCampList()">
+            <input type="hidden" id="adminProxyCampId" value="">
+            <div class="admin-proxy-combobox-list" id="adminProxyCampList"></div>
+          </div>
+          <span class="form-help">승인된 신청이 있는 캠페인만 노출. 비워두고 클릭하면 전체 목록.</span>
+        </div>
+
+        <!-- 1-b. 인플루언서 검색·선택 (캠페인 선택 후 활성, 그 캠페인의 approved 신청자만) -->
+        <div class="form-row required">
+          <label>인플루언서 선택</label>
+          <div class="admin-proxy-combobox" id="adminProxyInfCombobox">
+            <input type="text" id="adminProxyInfInput" class="admin-proxy-combobox-input" placeholder="이름·가나·이메일 검색" autocomplete="off" data-lpignore="true" data-1p-ignore="true" oninput="onAdminProxyInfInput()" onfocus="showAdminProxyInfList()" disabled>
+            <input type="hidden" id="adminProxyApp" value="">
+            <div class="admin-proxy-combobox-list" id="adminProxyInfList"></div>
+          </div>
+          <span class="form-help">먼저 캠페인을 선택하세요. 그 캠페인의 승인된 인플루언서만 표시됩니다.</span>
         </div>
 
         <!-- 2. 결과물 종류 선택 (캠페인 recruit_type 따라 노출) -->

--- a/dev/css/admin.css
+++ b/dev/css/admin.css
@@ -1295,3 +1295,18 @@
 
 /* 「대리 등록만 보기」 필터 토글 */
 .deliv-proxy-filter-label{display:inline-flex;align-items:center;gap:4px;font-size:12px;cursor:pointer;height:32px;color:var(--ink)}
+
+/* ─── 관리자 대리 등록 모달 — 검색 가능 드롭다운 (combobox) ────────── */
+.admin-proxy-combobox{position:relative}
+.admin-proxy-combobox-input{width:100%;padding:8px 10px;border:1px solid var(--line);border-radius:6px;font-size:13px;background:#fff}
+.admin-proxy-combobox-input:disabled{background:#F3F4F6;color:var(--muted);cursor:not-allowed}
+.admin-proxy-combobox-input:focus{outline:none;border-color:var(--pink)}
+.admin-proxy-combobox-list{display:none;position:absolute;top:100%;left:0;right:0;z-index:10;max-height:240px;overflow-y:auto;background:#fff;border:1px solid var(--line);border-top:none;border-radius:0 0 6px 6px;box-shadow:0 4px 12px rgba(0,0,0,.06);margin-top:-1px}
+.admin-proxy-combobox-list.open{display:block}
+.admin-proxy-combobox-list .item{padding:8px 10px;font-size:13px;color:var(--ink);cursor:pointer;border-bottom:1px solid var(--line)}
+.admin-proxy-combobox-list .item:last-child{border-bottom:none}
+.admin-proxy-combobox-list .item:hover,
+.admin-proxy-combobox-list .item.focused{background:#FFF5F8;color:var(--dark-pink)}
+.admin-proxy-combobox-list .item.disabled{color:var(--muted);cursor:not-allowed;background:#F9FAFB}
+.admin-proxy-combobox-list .item-meta{font-size:11px;color:var(--muted);margin-top:2px}
+.admin-proxy-combobox-list .empty{padding:14px 10px;text-align:center;color:var(--muted);font-size:12px}

--- a/dev/js/admin-deliverables.js
+++ b/dev/js/admin-deliverables.js
@@ -663,6 +663,13 @@ async function openDelivCombined(applicationId) {
   const modal = $('delivCombinedModal');
   if (!modal) return;
   _delivCombinedRefreshAppId = applicationId;
+  // 검수 모달 「대리 등록」 버튼은 campaign_admin 이상에게만 노출 (campaign_manager 차단)
+  // RPC 자체에 is_campaign_admin() 가드 있어 우회 시도해도 안전하지만, UI 일관성 차원에서 사전 차단
+  const proxyBtn = $('delivCombinedProxyBtn');
+  if (proxyBtn) {
+    const isManager = (typeof currentAdminInfo !== 'undefined' && currentAdminInfo?.role === 'campaign_manager');
+    proxyBtn.style.display = isManager ? 'none' : '';
+  }
   openModal('delivCombinedModal');
   await renderDelivCombinedBody(applicationId);
 }
@@ -1109,7 +1116,7 @@ let _adminProxyApps = [];       // approved 신청 + 캠페인 + 인플 join
 let _adminProxyReasons = [];    // admin_proxy_reason lookup 캐시
 let _adminProxyChannels = {};   // channel code → name_ko 라벨
 
-async function openAdminProxyModal() {
+async function openAdminProxyModal(presetAppId) {
   const m = $('adminProxyDelivModal');
   if (!m) return;
   _resetAdminProxyForm();
@@ -1124,12 +1131,33 @@ async function openAdminProxyModal() {
     _adminProxyApps = appsResult;
     _adminProxyReasons = reasonsResult;
     _adminProxyChannels = channelsResult;
-    _populateAdminProxyAppDropdown();
     _populateAdminProxyReasonDropdown();
+    // 검수 모달에서 진입한 경우 캠페인·인플 자동 선택
+    if (presetAppId) {
+      const app = _adminProxyApps.find(a => a.id === presetAppId);
+      if (app) {
+        selectAdminProxyCamp(app.campaign_id, /*silent*/true);
+        selectAdminProxyInf(app.id, /*silent*/true);
+      }
+    }
   } catch (err) {
     console.error('[admin-proxy] 데이터 로드 실패', err);
     toast('데이터 로드 실패: ' + (err.message || err), 'error');
   }
+}
+
+// 검수 모달에서 「대리 등록」 진입 — 현재 신청 ID 가져와서 자동 선택
+// _delivCombinedRefreshAppId 는 openDelivCombined() 가 저장하는 신청 ID
+async function openAdminProxyFromCombined() {
+  const appId = (typeof _delivCombinedRefreshAppId !== 'undefined' && _delivCombinedRefreshAppId)
+    ? _delivCombinedRefreshAppId
+    : null;
+  if (!appId) {
+    toast('현재 신청을 식별할 수 없습니다. 결과물 목록의 「검수」 버튼으로 다시 열어주세요.', 'error');
+    return;
+  }
+  closeDelivCombined();
+  await openAdminProxyModal(appId);
 }
 
 function closeAdminProxyModal() {
@@ -1139,8 +1167,20 @@ function closeAdminProxyModal() {
 }
 
 function _resetAdminProxyForm() {
-  ['adminProxyApp','adminProxyKind','adminProxyOrderNo','adminProxyPurchaseDate','adminProxyPurchaseAmount','adminProxyPostUrl','adminProxyPostChannel','adminProxyReviewChannel','adminProxyReasonCode','adminProxyReason'].forEach(id => {
+  // combobox 2종 + kind/사유/메모/이미지/파일 입력 초기화
+  ['adminProxyApp','adminProxyCampId','adminProxyKind','adminProxyOrderNo','adminProxyPurchaseDate','adminProxyPurchaseAmount','adminProxyPostUrl','adminProxyPostChannel','adminProxyReviewChannel','adminProxyReasonCode','adminProxyReason'].forEach(id => {
     const el = $(id); if (el) el.value = '';
+  });
+  // combobox 검색 input (text)
+  ['adminProxyCampInput','adminProxyInfInput'].forEach(id => {
+    const el = $(id); if (el) el.value = '';
+  });
+  // 인플 input 은 캠페인 미선택 시 disabled
+  const infInput = $('adminProxyInfInput');
+  if (infInput) infInput.disabled = true;
+  // 리스트 닫기
+  ['adminProxyCampList','adminProxyInfList'].forEach(id => {
+    const el = $(id); if (el) { el.classList.remove('open'); el.innerHTML = ''; }
   });
   ['adminProxyReceiptImage','adminProxyReviewImage'].forEach(id => {
     const el = $(id); if (el) el.value = '';
@@ -1152,7 +1192,7 @@ function _resetAdminProxyForm() {
     const el = $(id); if (el) el.classList.remove('active');
   });
   const kindSelect = $('adminProxyKind');
-  if (kindSelect) { kindSelect.innerHTML = '<option value="">— 먼저 신청을 선택하세요 —</option>'; kindSelect.disabled = true; }
+  if (kindSelect) { kindSelect.innerHTML = '<option value="">— 먼저 인플루언서를 선택하세요 —</option>'; kindSelect.disabled = true; }
 }
 
 async function _loadAdminProxyApprovedApps() {
@@ -1202,19 +1242,6 @@ async function _loadAdminProxyChannelLabels() {
   return map;
 }
 
-function _populateAdminProxyAppDropdown() {
-  const sel = $('adminProxyApp');
-  if (!sel) return;
-  const opts = ['<option value="">— 승인된 신청을 선택하세요 —</option>'];
-  _adminProxyApps.forEach(a => {
-    const inf = a.influencers || {};
-    const camp = a.campaigns || {};
-    const label = `${camp.campaign_no || '—'} · ${camp.title || ''} (${camp.brand || ''}) · ${inf.name || ''}${inf.name_kana ? '(' + inf.name_kana + ')' : ''}`;
-    opts.push(`<option value="${esc(a.id)}">${esc(label)}</option>`);
-  });
-  sel.innerHTML = opts.join('');
-}
-
 function _populateAdminProxyReasonDropdown() {
   const sel = $('adminProxyReasonCode');
   if (!sel) return;
@@ -1225,24 +1252,150 @@ function _populateAdminProxyReasonDropdown() {
   sel.innerHTML = opts.join('');
 }
 
-function onAdminProxyAppChange() {
-  const appId = $('adminProxyApp')?.value;
-  const kindSel = $('adminProxyKind');
-  if (!kindSel) return;
-  // 종류 옵션 분기
-  if (!appId) {
-    kindSel.innerHTML = '<option value="">— 먼저 신청을 선택하세요 —</option>';
-    kindSel.disabled = true;
-    onAdminProxyKindChange();
+// ── combobox: 캠페인 검색·선택 ────────────────────────────────────
+function showAdminProxyCampList() {
+  const list = $('adminProxyCampList');
+  if (!list) return;
+  list.classList.add('open');
+  _renderAdminProxyCampList($('adminProxyCampInput')?.value || '');
+}
+
+function onAdminProxyCampInput() {
+  const q = $('adminProxyCampInput')?.value || '';
+  // 입력 시 hidden 비움 (선택 확정 전 상태)
+  const hid = $('adminProxyCampId'); if (hid) hid.value = '';
+  // 캠페인 변경되면 인플·종류 모두 리셋
+  _resetAdminProxyInfState();
+  _renderAdminProxyCampList(q);
+  showAdminProxyCampList();
+}
+
+function _renderAdminProxyCampList(query) {
+  const list = $('adminProxyCampList');
+  if (!list) return;
+  // 캠페인 후보 = 승인 신청이 있는 캠페인 unique (id 기준)
+  const campMap = new Map();
+  _adminProxyApps.forEach(a => {
+    if (!a.campaigns) return;
+    if (!campMap.has(a.campaigns.id)) campMap.set(a.campaigns.id, a.campaigns);
+  });
+  const q = (query || '').trim().toLowerCase();
+  const filtered = Array.from(campMap.values()).filter(c => {
+    if (!q) return true;
+    return matchSearchTokens(q, [c.title, c.brand, c.campaign_no]);
+  });
+  if (!filtered.length) {
+    list.innerHTML = '<div class="empty">일치하는 캠페인 없음</div>';
     return;
   }
-  const app = _adminProxyApps.find(a => a.id === appId);
+  list.innerHTML = filtered.slice(0, 100).map(c => {
+    const meta = `${c.brand || ''} · ${c.campaign_no || '—'} · ${c.recruit_type || ''}`;
+    return `<div class="item" onmousedown="selectAdminProxyCamp('${esc(c.id)}')">
+      <div>${esc(c.title || '제목 없음')}</div>
+      <div class="item-meta">${esc(meta)}</div>
+    </div>`;
+  }).join('');
+}
+
+function selectAdminProxyCamp(campId, silent) {
+  const app = _adminProxyApps.find(a => a.campaign_id === campId);
   if (!app || !app.campaigns) return;
+  const camp = app.campaigns;
+  const hid = $('adminProxyCampId'); if (hid) hid.value = campId;
+  const inp = $('adminProxyCampInput');
+  if (inp) inp.value = `${camp.title || ''} (${camp.brand || ''})`;
+  const list = $('adminProxyCampList'); if (list) list.classList.remove('open');
+  // 인플 input 활성화 + 검색 리스트 미리 렌더
+  const infInput = $('adminProxyInfInput');
+  if (infInput) { infInput.disabled = false; infInput.value = ''; }
+  const infHid = $('adminProxyApp'); if (infHid) infHid.value = '';
+  _renderAdminProxyInfList('');
+  // 종류 옵션도 리셋 (인플 미선택 상태)
+  const kindSel = $('adminProxyKind');
+  if (kindSel) { kindSel.innerHTML = '<option value="">— 먼저 인플루언서를 선택하세요 —</option>'; kindSel.disabled = true; }
+  onAdminProxyKindChange();
+  if (!silent && infInput) infInput.focus();
+}
+
+// ── combobox: 인플 검색·선택 (선택된 캠페인 내) ───────────────────
+function showAdminProxyInfList() {
+  const list = $('adminProxyInfList');
+  if (!list) return;
+  list.classList.add('open');
+  _renderAdminProxyInfList($('adminProxyInfInput')?.value || '');
+}
+
+function onAdminProxyInfInput() {
+  const q = $('adminProxyInfInput')?.value || '';
+  // 입력 시 hidden 비움 (선택 확정 전 상태)
+  const hid = $('adminProxyApp'); if (hid) hid.value = '';
+  // 인플 변경되면 종류 리셋
+  const kindSel = $('adminProxyKind');
+  if (kindSel) { kindSel.innerHTML = '<option value="">— 먼저 인플루언서를 선택하세요 —</option>'; kindSel.disabled = true; }
+  onAdminProxyKindChange();
+  _renderAdminProxyInfList(q);
+  showAdminProxyInfList();
+}
+
+function _renderAdminProxyInfList(query) {
+  const list = $('adminProxyInfList');
+  if (!list) return;
+  const campId = $('adminProxyCampId')?.value;
+  if (!campId) {
+    list.innerHTML = '<div class="empty">먼저 캠페인을 선택하세요</div>';
+    return;
+  }
+  const inCampApps = _adminProxyApps.filter(a => a.campaign_id === campId);
+  const q = (query || '').trim().toLowerCase();
+  const filtered = inCampApps.filter(a => {
+    if (!q) return true;
+    const inf = a.influencers || {};
+    return matchSearchTokens(q, [inf.name, inf.name_kana, inf.email]);
+  });
+  if (!filtered.length) {
+    list.innerHTML = '<div class="empty">' + (q ? '일치하는 인플루언서 없음' : '승인된 인플루언서 없음') + '</div>';
+    return;
+  }
+  list.innerHTML = filtered.slice(0, 100).map(a => {
+    const inf = a.influencers || {};
+    const meta = `${inf.name_kana || ''}${inf.name_kana && inf.email ? ' · ' : ''}${inf.email || ''}`;
+    return `<div class="item" onmousedown="selectAdminProxyInf('${esc(a.id)}')">
+      <div>${esc(inf.name || '이름 없음')}</div>
+      <div class="item-meta">${esc(meta)}</div>
+    </div>`;
+  }).join('');
+}
+
+function selectAdminProxyInf(appId, silent) {
+  const app = _adminProxyApps.find(a => a.id === appId);
+  if (!app) return;
+  const inf = app.influencers || {};
+  const hid = $('adminProxyApp'); if (hid) hid.value = appId;
+  const inp = $('adminProxyInfInput');
+  if (inp) inp.value = `${inf.name || ''}${inf.name_kana ? ' (' + inf.name_kana + ')' : ''}`;
+  const list = $('adminProxyInfList'); if (list) list.classList.remove('open');
+  // 결과물 종류 옵션 활성화 (기존 onAdminProxyAppChange 로직 인라인)
+  _refreshAdminProxyKindOptions(app);
+}
+
+function _resetAdminProxyInfState() {
+  // 캠페인 변경 또는 폼 초기화 시 인플 + 종류 모두 리셋
+  const infInput = $('adminProxyInfInput');
+  if (infInput) { infInput.value = ''; infInput.disabled = true; }
+  const infHid = $('adminProxyApp'); if (infHid) infHid.value = '';
+  const infList = $('adminProxyInfList'); if (infList) { infList.classList.remove('open'); infList.innerHTML = ''; }
+  const kindSel = $('adminProxyKind');
+  if (kindSel) { kindSel.innerHTML = '<option value="">— 먼저 인플루언서를 선택하세요 —</option>'; kindSel.disabled = true; }
+  onAdminProxyKindChange();
+}
+
+function _refreshAdminProxyKindOptions(app) {
+  const kindSel = $('adminProxyKind');
+  if (!kindSel || !app || !app.campaigns) return;
   const rt = app.campaigns.recruit_type;
   const opts = ['<option value="">— 결과물 종류 선택 —</option>'];
   if (rt === 'monitor') {
     opts.push('<option value="receipt">영수증 (영수증·주문번호·구매일·금액)</option>');
-    // review_image 는 사양 2 운영 후 자동 활성 — 채널이 등록되어 있고 lookup 캐시에 코드가 있으면 노출
     const channels = (app.campaigns.channel || '').split(',').map(s => s.trim()).filter(Boolean);
     if (channels.length > 0) {
       opts.push('<option value="review_image">리뷰 이미지 (채널별)</option>');
@@ -1254,6 +1407,18 @@ function onAdminProxyAppChange() {
   kindSel.disabled = false;
   onAdminProxyKindChange();
 }
+
+// 외부 클릭 시 combobox 리스트 자동 닫기 (모달 외 클릭 또는 다른 영역 클릭)
+document.addEventListener('click', function(e) {
+  const camp = $('adminProxyCampCombobox');
+  const inf = $('adminProxyInfCombobox');
+  if (camp && !camp.contains(e.target)) {
+    const list = $('adminProxyCampList'); if (list) list.classList.remove('open');
+  }
+  if (inf && !inf.contains(e.target)) {
+    const list = $('adminProxyInfList'); if (list) list.classList.remove('open');
+  }
+});
 
 function onAdminProxyKindChange() {
   const kind = $('adminProxyKind')?.value;


### PR DESCRIPTION
## 변경 요약

사용자 피드백 2건 즉시 반영:
1. **신청 선택 단일 드롭다운 → 캠페인 검색 + 인플 검색 2단 combobox** — 입력 시 텍스트 포함 항목 필터, 미입력 시 전체 목록, 외부 클릭 자동 닫힘
2. **결과물 검수 모달에서 「대리 등록」 진입** — `delivCombinedModal` 푸터에 노랑 버튼 추가, 클릭 시 캠페인·인플 자동 선택된 상태로 모달 진입

## reviewer 처리

WARN 3건 중 1건 즉시 반영:
- ✅ 「대리 등록」 버튼을 `campaign_manager` 일 때 숨김 (RPC 가드 + UI 2중 안전망)

후속 hotfix 분리:
- WARN 1: `modal-body overflow:auto` 가 combobox dropdown 240px 클리핑 위험 → 실제 사용 시 보고되면 `position:fixed + getBoundingClientRect` 로 즉시 fix
- WARN 3: `confirm()` / `prompt()` → `showConfirm` 교체 (PR 2 WARN 2 와 함께 별도 개선)

## 후속 hotfix 백로그 (운영 배포 전 처리 권장)
- 다중 캠페인 결과물 엑셀 통합 시트 「대리 등록」 컬럼
- monitor 그룹 시트 「대리 등록」 컬럼 (사양 2 review_image 대리 등록은 사양 2 운영 후)
- combobox dropdown 클리핑 위험 (CSS 분리 또는 position:fixed)
- `confirm()`/`prompt()` → `showConfirm`

[via reviewer] WARN 3건 검토 + 권한 가드 즉시 반영

🤖 Generated with [Claude Code](https://claude.com/claude-code)