### PR TITLE
docs(spec): split PR 5 evidence attachment into separate prod deploy cycle

### DIFF
--- a/docs/specs/2026-05-28-admin-proxy-deliverable.md
+++ b/docs/specs/2026-05-28-admin-proxy-deliverable.md
@@ -227,11 +227,12 @@ GRANT EXECUTE ON FUNCTION public.admin_create_deliverable_proxy(uuid, text, text
 - 개수 제한: **최대 5장 · 장당 5MB**
 - 회수 시: **Storage 자동 삭제** (deliverables 행 + audit + Storage 파일 전부 정리 — 운영 흔적 완전 제거, 기존 CASCADE 정책과 일관)
 - 진행 시점: **별도 PR 5 로 다음 세션**에 진행
+- **운영 배포도 분리** (2026-05-28 사용자 명시) — 본 사양 PR 1·2·3·UX 개선·161(알림 body 정정) 묶음의 운영 배포 사이클과 별도로, PR 5(증빙 첨부, 마이그레이션 162) 는 자체 운영 배포 사이클을 갖는다. dev 검증·게이트도 독립
 
 **필요한 변경 영역**:
 1. **마이그레이션 162** (착수 시점에 `ls supabase/migrations/ | tail -3` 으로 최신 재확인 — 본 사양 갱신 시점 161 까지 사용 중):
    - `deliverables` 컬럼 추가 — `submitted_by_admin_evidence jsonb NULL` (배열, `[{path, name, size, mime}]`)
-   - `admin_create_deliverable_proxy` RPC 시그니처 확장 — `p_evidence_paths jsonb DEFAULT '[]'::jsonb` 추가 (DEFAULT 두면 기존 클라 호출도 호환). 161 에 추가된 `v_reason_label` 변수·사유 라벨 lookup 로직 유지
+   - `admin_create_deliverable_proxy` RPC 시그니처 확장 — `p_evidence_paths jsonb DEFAULT '[]'::jsonb` 추가 (DEFAULT 두면 기존 클라 호출도 호환). **묶음 A(마이그레이션 161) 운영 적용 완료 전제** — 161 에 추가된 `v_reason_label` 변수·사유 라벨 lookup 로직 유지하여 본문 재정의
    - `admin_revoke_proxy_deliverable` RPC 본문 보강 — DELETE 직전 `submitted_by_admin_evidence` jsonb 에서 `path` 추출 후 `storage.objects` 정리 호출 (또는 별도 헬퍼 함수 `_delete_proxy_evidence(paths)` 신설)
 2. **Storage 버킷 신설**: `admin-proxy-evidence`
    - 비공개 (public=false)
@@ -337,3 +338,6 @@ GRANT EXECUTE ON FUNCTION public.admin_create_deliverable_proxy(uuid, text, text
 - **`admin_revoke_proxy_deliverable` audit 영구 보존 미지원** — `deliverable_events.deliverable_id ON DELETE CASCADE` 로 결과물 DELETE 시 audit 도 함께 삭제됨. 향후 영구 감사 필요 시 별도 `admin_proxy_revoke_log` audit-only 테이블 분리 권장 (현재는 운영 빈도 낮음 + 운영자 매뉴얼로 보완)
 - **개발서버 검토만 완료** — PR 1·2·3 모두 dev 머지·개발 DB 적용·스모크 완료. 운영 배포는 별도 협의 (메시지 본체 PR 5·6 보류 분과 일정 묶기 가능)
 - **알림 body 표현 확정 (마이그레이션 161, 2026-05-28 사용자 발견 정정)**: §11 시나리오 6 의 초안 표현 「結果物が登録されました — 배송 지연으로 운영 측에서 등록」 → 실제 구현은 title `結果物が登録されました` + body `運営側で結果物を登録・承認しました。理由: {사유 라벨 일본어}` (사유 메모는 운영 내부로 인플 알림 미포함, §6 정책 일치)
+- **운영 배포 묶음 분리 확정 (2026-05-28 사용자 명시)**:
+  - **묶음 A (선행)**: PR 1·2·3·UX 개선·161 = 마이그레이션 160·161 + RPC 본체 + 결과물 관리 UI + 진행 현황·엑셀·인플 화면 + combobox UX + 알림 body 정정. dev 누적 완료 상태, 운영 배포 후보 (메시지 본체 PR 5·6 약관 D-7 통지·다중채널 결과물 운영 분 등 다른 보류 묶음과 일정 협의 가능)
+  - **묶음 B (후행, 별도 사이클)**: PR 5 = 마이그레이션 162 + 증빙 첨부 컬럼·Storage 버킷·UI 추가. **묶음 A 운영 배포 이후 독립 사이클**로 진행. dev 검증·운영 협의 모두 별도


### PR DESCRIPTION
## 변경 요약

사용자 명시 결정 (2026-05-28): 증빙 파일 첨부 기능은 별도 PR + **별도 운영 배포 사이클**로 분리.

## 운영 배포 묶음 (확정)

| 묶음 | 구성 | 상태 |
|---|---|---|
| **A — 선행** | PR 1·2·3·UX 개선·161 (마이그레이션 160·161 + RPC 본체 + 결과물 관리 UI + 진행 현황·엑셀·인플 화면 + combobox + 알림 body 정정) | dev 누적 완료, 운영 배포 후보 |
| **B — 후행, 별도 사이클** | PR 5 (마이그레이션 162 + 증빙 첨부 컬럼·Storage 버킷·UI) | 다음 세션 미착수. 묶음 A 운영 배포 이후 독립 진행 |

## 변경 영역

- 코드·DB 변경 없음. 사양서 정책 기록만 (2곳)
- §9 PR 5 사용자 결정 5번째 항목 「운영 배포 분리」 추가
- 「구현 결과」 섹션 운영 배포 묶음 A/B 분리 확정 메모

[via reviewer] WARN 1건(묶음 A 전제 명시) 즉시 반영, GO

🤖 Generated with [Claude Code](https://claude.com/claude-code)