### PR TITLE
fix(admin): camp-applicants 「대리 N」 badge + deliv combined modal SELECT columns

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -12,7 +12,7 @@
 // 회귀(2026-05-12 PR #182 머지 직후 발생)를 방지하기 위한 자동 reload 가드.
 // sessionStorage 차단 환경(시크릿 모드 일부, 쿠키 차단)에서는 자연스럽게 skip.
 (function(){
-  var CURRENT_BUILD = 'v1779964511';
+  var CURRENT_BUILD = 'v1779964640';
   if (CURRENT_BUILD.indexOf('__') === 0) return; // 빌드 미적용 (dev/ 직접 열기) 시 skip
   try {
     var prev = sessionStorage.getItem('reverb.adminBuild');
@@ -1833,7 +1833,7 @@ textarea.form-input{resize:vertical;min-height:80px}
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-05-28 19:35 · 9cd3fcf</span>
+          <span class="admin-build-text">2026-05-28 19:37 · 0ba1934</span>
         </div>
       </div>
     </aside>
@@ -17222,6 +17222,7 @@ async function renderDelivCombinedBody(applicationId) {
       order_number, purchase_date, purchase_amount,
       reject_reason, reject_template_code,
       submitted_at, reviewed_at, updated_at, reviewed_by,
+      submitted_by_admin, submitted_by_admin_reason_code, submitted_by_admin_reason, submitted_by_admin_at,
       campaigns:campaign_id (id, campaign_no, title, brand, recruit_type, channel)
     `).eq('application_id', applicationId).neq('status', 'draft').order('submitted_at', {ascending: false});
     if (delivRes?.error) console.error('[deliv-combined deliv]', delivRes.error);

--- a/admin/index.html
+++ b/admin/index.html
@@ -12,7 +12,7 @@
 // 회귀(2026-05-12 PR #182 머지 직후 발생)를 방지하기 위한 자동 reload 가드.
 // sessionStorage 차단 환경(시크릿 모드 일부, 쿠키 차단)에서는 자연스럽게 skip.
 (function(){
-  var CURRENT_BUILD = 'v1779964216';
+  var CURRENT_BUILD = 'v1779964511';
   if (CURRENT_BUILD.indexOf('__') === 0) return; // 빌드 미적용 (dev/ 직접 열기) 시 skip
   try {
     var prev = sessionStorage.getItem('reverb.adminBuild');
@@ -1833,7 +1833,7 @@ textarea.form-input{resize:vertical;min-height:80px}
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-05-28 19:30 · 8fcce11</span>
+          <span class="admin-build-text">2026-05-28 19:35 · 9cd3fcf</span>
         </div>
       </div>
     </aside>
@@ -20273,10 +20273,11 @@ function renderDelivCell(list, appStatus, selectedChannels, channelMatch, isPost
   if (counts.approved) parts.push(`<span style="color:#2D7A3E">승인 ${counts.approved}</span>`);
   if (counts.pending) parts.push(`<span style="color:#B8741A">검수대기 ${counts.pending}</span>`);
   if (counts.rejected) parts.push(`<span style="color:#C33">반려 ${counts.rejected}</span>`);
-  // 마이그레이션 160: 결과물 중 1개라도 대리 등록이면 ⊕ 마커 + 호버 툴팁
+  // 마이그레이션 160: 결과물 중 1개라도 대리 등록이면 「대리 N」 텍스트 배지 + 호버 툴팁
+  // 결과물 관리 페인의 「대리」 배지와 일관성 (사용자 결정 2026-05-28: 기호 단독→텍스트 배지)
   const proxyCount = list.filter(d => d.submitted_by_admin).length;
   const proxyMarker = proxyCount > 0
-    ? ` <span style="display:inline-block;background:#FEF3C7;color:#92400E;border:1px solid #FBBF24;font-size:9px;font-weight:700;padding:0 4px;border-radius:3px;line-height:14px" title="관리자 대리 등록 ${proxyCount}건">⊕${proxyCount > 1 ? proxyCount : ''}</span>`
+    ? ` <span style="display:inline-block;background:#FEF3C7;color:#92400E;border:1px solid #FBBF24;font-size:10px;font-weight:700;padding:1px 6px;border-radius:3px;line-height:14px;white-space:nowrap" title="관리자 대리 등록 ${proxyCount}건">대리${proxyCount > 1 ? ' ' + proxyCount : ''}</span>`
     : '';
   const complete = isApplicationComplete(list, selectedChannels, channelMatch, isPostType);
   const completeBadge = complete

--- a/dev/js/admin-applications.js
+++ b/dev/js/admin-applications.js
@@ -171,10 +171,11 @@ function renderDelivCell(list, appStatus, selectedChannels, channelMatch, isPost
   if (counts.approved) parts.push(`<span style="color:#2D7A3E">승인 ${counts.approved}</span>`);
   if (counts.pending) parts.push(`<span style="color:#B8741A">검수대기 ${counts.pending}</span>`);
   if (counts.rejected) parts.push(`<span style="color:#C33">반려 ${counts.rejected}</span>`);
-  // 마이그레이션 160: 결과물 중 1개라도 대리 등록이면 ⊕ 마커 + 호버 툴팁
+  // 마이그레이션 160: 결과물 중 1개라도 대리 등록이면 「대리 N」 텍스트 배지 + 호버 툴팁
+  // 결과물 관리 페인의 「대리」 배지와 일관성 (사용자 결정 2026-05-28: 기호 단독→텍스트 배지)
   const proxyCount = list.filter(d => d.submitted_by_admin).length;
   const proxyMarker = proxyCount > 0
-    ? ` <span style="display:inline-block;background:#FEF3C7;color:#92400E;border:1px solid #FBBF24;font-size:9px;font-weight:700;padding:0 4px;border-radius:3px;line-height:14px" title="관리자 대리 등록 ${proxyCount}건">⊕${proxyCount > 1 ? proxyCount : ''}</span>`
+    ? ` <span style="display:inline-block;background:#FEF3C7;color:#92400E;border:1px solid #FBBF24;font-size:10px;font-weight:700;padding:1px 6px;border-radius:3px;line-height:14px;white-space:nowrap" title="관리자 대리 등록 ${proxyCount}건">대리${proxyCount > 1 ? ' ' + proxyCount : ''}</span>`
     : '';
   const complete = isApplicationComplete(list, selectedChannels, channelMatch, isPostType);
   const completeBadge = complete

--- a/dev/js/admin-deliverables.js
+++ b/dev/js/admin-deliverables.js
@@ -696,6 +696,7 @@ async function renderDelivCombinedBody(applicationId) {
       order_number, purchase_date, purchase_amount,
       reject_reason, reject_template_code,
       submitted_at, reviewed_at, updated_at, reviewed_by,
+      submitted_by_admin, submitted_by_admin_reason_code, submitted_by_admin_reason, submitted_by_admin_at,
       campaigns:campaign_id (id, campaign_no, title, brand, recruit_type, channel)
     `).eq('application_id', applicationId).neq('status', 'draft').order('submitted_at', {ascending: false});
     if (delivRes?.error) console.error('[deliv-combined deliv]', delivRes.error);


### PR DESCRIPTION
## 변경 요약

운영 묶음 A 출시 직후 발견된 UX·기능 버그 2건 핫픽스.

### 1. 캠페인 진행 현황 ⊕ → 「대리 N」 텍스트 배지
- 사용자 의견: ⊕ 기호 단독은 호버 안 하면 의미 식별 어려움. 결과물 관리 페인의 「대리」 배지와 일관성 부족
- `renderDelivCell` proxyMarker 텍스트화 — 1건 「대리」 / 2건+ 「대리 N」
- 노랑 톤·툴팁·위치는 동일

### 2. 검수 합본 모달 안내 박스 + 「대리 등록 회수」 버튼 미표시 (qa S5 PARTIAL 해소)
- 원인: `renderDelivCombinedBody` 의 deliverables SELECT 에 `submitted_by_admin*` 4컬럼 누락 → `d.submitted_by_admin = undefined` → 분기 진입 실패 → 회수·안내 모두 비표시
- 수정: SELECT 절에 4컬럼 추가
- 효과: 대리 등록 행 상단 노랑 안내 박스 표시 + 「되돌리기」 비활성 + super_admin 「대리 등록 회수」 빨강 버튼 노출

## 운영 핫픽스 게이트
사용자 명시 「운영 즉시」 — dev 머지 직후 main PR 생성·머지·Vercel 자동 배포.

🤖 Generated with [Claude Code](https://claude.com/claude-code)