### PR TITLE
hotfix(admin): proxy deliverable status badge — 「대리 등록」 single label

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -12,7 +12,7 @@
 // 회귀(2026-05-12 PR #182 머지 직후 발생)를 방지하기 위한 자동 reload 가드.
 // sessionStorage 차단 환경(시크릿 모드 일부, 쿠키 차단)에서는 자연스럽게 skip.
 (function(){
-  var CURRENT_BUILD = 'v1779964640';
+  var CURRENT_BUILD = 'v1779964904';
   if (CURRENT_BUILD.indexOf('__') === 0) return; // 빌드 미적용 (dev/ 직접 열기) 시 skip
   try {
     var prev = sessionStorage.getItem('reverb.adminBuild');
@@ -1833,7 +1833,7 @@ textarea.form-input{resize:vertical;min-height:80px}
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-05-28 19:37 · 0ba1934</span>
+          <span class="admin-build-text">2026-05-28 19:41 · 8f945ad</span>
         </div>
       </div>
     </aside>
@@ -16956,10 +16956,12 @@ function renderDelivStatusCell(d, slot, rt) {
       preview = `<a href="${esc(d.post_url)}" target="_blank" rel="noopener" onclick="event.stopPropagation()" style="font-size:10px;color:var(--dark-pink);text-decoration:none;display:inline-block;max-width:100px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;vertical-align:middle">${esc(host)}</a>`;
     }
   }
-  const proxyBadge = d.submitted_by_admin
-    ? `<span class="deliv-proxy-badge" title="관리자 대리 등록"><span class="material-icons-round">support_agent</span>대리</span>`
-    : '';
-  return `<div style="display:flex;align-items:center;gap:6px">${preview}${delivStatusBadge(d.status)}${proxyBadge}</div>`;
+  // 마이그레이션 160: 대리 등록 행은 status 배지를 「대리 등록」으로 교체 (자동 승인이라 "승인" 표기 무의미)
+  // 사용자 결정 2026-05-28: 「승인 + 작은 대리 마커」 중복 → 단일 「대리 등록」 배지로 통합
+  const statusBadgeHtml = d.submitted_by_admin
+    ? `<span style="background:#FEF3C7;color:#92400E;border:1px solid #FBBF24;font-size:11px;font-weight:600;padding:2px 8px;border-radius:3px" title="관리자 대리 등록·자동 승인">대리 등록</span>`
+    : delivStatusBadge(d.status);
+  return `<div style="display:flex;align-items:center;gap:6px">${preview}${statusBadgeHtml}</div>`;
 }
 
 function statusLabelKo(status) {

--- a/dev/js/admin-deliverables.js
+++ b/dev/js/admin-deliverables.js
@@ -430,10 +430,12 @@ function renderDelivStatusCell(d, slot, rt) {
       preview = `<a href="${esc(d.post_url)}" target="_blank" rel="noopener" onclick="event.stopPropagation()" style="font-size:10px;color:var(--dark-pink);text-decoration:none;display:inline-block;max-width:100px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;vertical-align:middle">${esc(host)}</a>`;
     }
   }
-  const proxyBadge = d.submitted_by_admin
-    ? `<span class="deliv-proxy-badge" title="관리자 대리 등록"><span class="material-icons-round">support_agent</span>대리</span>`
-    : '';
-  return `<div style="display:flex;align-items:center;gap:6px">${preview}${delivStatusBadge(d.status)}${proxyBadge}</div>`;
+  // 마이그레이션 160: 대리 등록 행은 status 배지를 「대리 등록」으로 교체 (자동 승인이라 "승인" 표기 무의미)
+  // 사용자 결정 2026-05-28: 「승인 + 작은 대리 마커」 중복 → 단일 「대리 등록」 배지로 통합
+  const statusBadgeHtml = d.submitted_by_admin
+    ? `<span style="background:#FEF3C7;color:#92400E;border:1px solid #FBBF24;font-size:11px;font-weight:600;padding:2px 8px;border-radius:3px" title="관리자 대리 등록·자동 승인">대리 등록</span>`
+    : delivStatusBadge(d.status);
+  return `<div style="display:flex;align-items:center;gap:6px">${preview}${statusBadgeHtml}</div>`;
 }
 
 function statusLabelKo(status) {


### PR DESCRIPTION
## 변경 요약

결과물 관리 페인 결과물 셀 status 배지 단일화. 대리 등록 행에서 「승인+대리」 중복 표기 → 「대리 등록」(노랑) 단일 노출.

DB·정책 변경 없음. 클라이언트 렌더만.

🤖 Generated with [Claude Code](https://claude.com/claude-code)