### PR TITLE
fix(admin): 모달 리사이즈 폭 튐 + 헤더 없는 모달 이동

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -12,7 +12,7 @@
 // 회귀(2026-05-12 PR #182 머지 직후 발생)를 방지하기 위한 자동 reload 가드.
 // sessionStorage 차단 환경(시크릿 모드 일부, 쿠키 차단)에서는 자연스럽게 skip.
 (function(){
-  var CURRENT_BUILD = 'v1780029877';
+  var CURRENT_BUILD = 'v1780030941';
   if (CURRENT_BUILD.indexOf('__') === 0) return; // 빌드 미적용 (dev/ 직접 열기) 시 skip
   try {
     var prev = sessionStorage.getItem('reverb.adminBuild');
@@ -1866,7 +1866,7 @@ textarea.form-input{resize:vertical;min-height:80px}
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-05-29 13:44 · d26fce2</span>
+          <span class="admin-build-text">2026-05-29 14:02 · a2bd081</span>
         </div>
       </div>
     </aside>
@@ -9643,25 +9643,36 @@ function makeModalDraggableResizable(modalEl) {
   // transform 기반 정중앙 → 드래그/리사이즈 시작 시 1회 left/top/width/height px 로 고정(transform 해제).
   //   + max-width/height 제한 해제 → 리사이즈로 화면 끝까지 넓게 볼 수 있음(닫았다 열면 위 초기화로 기본 크기 복원).
   const pinPosition = () => {
-    modalEl.style.maxWidth = 'none';
-    modalEl.style.maxHeight = 'none';
     // 인라인 transform 이 '' (CSS translate(-50%,-50%) 활성) 또는 다른 값이면 px 로 고정.
     // 'none'(이미 고정됨)일 때만 스킵 — 빈 문자열을 falsy 로 누락하면 드래그 시작 시 모달이 왼쪽으로 튐.
     if (modalEl.style.transform !== 'none') {
-      const r = modalEl.getBoundingClientRect();
+      const r = modalEl.getBoundingClientRect();   // ★ max 해제 전 현재 크기 측정 (94vw 등이 max 풀리며 튀는 것 방지)
       modalEl.style.left = r.left + 'px';
       modalEl.style.top = r.top + 'px';
       modalEl.style.width = r.width + 'px';
       modalEl.style.height = r.height + 'px';
       modalEl.style.transform = 'none';
     }
+    // width/height 를 현재 px 로 고정한 뒤에 max 제한 해제 → 리사이즈로만 넓어지고 클릭 즉시 튀지 않음.
+    modalEl.style.maxWidth = 'none';
+    modalEl.style.maxHeight = 'none';
   };
 
-  // ── 헤더 드래그(이동) ──
-  const header = modalEl.querySelector('.modal-header');
+  // ── 드래그(이동) 핸들 결정 ──
+  //   기본은 .modal-header. 헤더 없는 모달(lookup/pset/cset/nset/faq 등)은
+  //   .modal-body 안 첫 요소(제목 div, id=xxxModalTitle)를 드래그 핸들로 사용.
+  let dragHandle = modalEl.querySelector('.modal-header');
+  if (!dragHandle) {
+    const bodyEl = modalEl.querySelector('.modal-body');
+    if (bodyEl && bodyEl.firstElementChild) {
+      dragHandle = bodyEl.firstElementChild;
+      dragHandle.style.cursor = 'move';
+      dragHandle.style.userSelect = 'none';
+    }
+  }
   let drag = null;
-  if (header) {
-    header.addEventListener('mousedown', (e) => {
+  if (dragHandle) {
+    dragHandle.addEventListener('mousedown', (e) => {
       if (e.target.closest('.modal-close, input, textarea, select, button, a')) return;
       pinPosition();
       const r = modalEl.getBoundingClientRect();

--- a/dev/js/admin-core.js
+++ b/dev/js/admin-core.js
@@ -604,25 +604,36 @@ function makeModalDraggableResizable(modalEl) {
   // transform 기반 정중앙 → 드래그/리사이즈 시작 시 1회 left/top/width/height px 로 고정(transform 해제).
   //   + max-width/height 제한 해제 → 리사이즈로 화면 끝까지 넓게 볼 수 있음(닫았다 열면 위 초기화로 기본 크기 복원).
   const pinPosition = () => {
-    modalEl.style.maxWidth = 'none';
-    modalEl.style.maxHeight = 'none';
     // 인라인 transform 이 '' (CSS translate(-50%,-50%) 활성) 또는 다른 값이면 px 로 고정.
     // 'none'(이미 고정됨)일 때만 스킵 — 빈 문자열을 falsy 로 누락하면 드래그 시작 시 모달이 왼쪽으로 튐.
     if (modalEl.style.transform !== 'none') {
-      const r = modalEl.getBoundingClientRect();
+      const r = modalEl.getBoundingClientRect();   // ★ max 해제 전 현재 크기 측정 (94vw 등이 max 풀리며 튀는 것 방지)
       modalEl.style.left = r.left + 'px';
       modalEl.style.top = r.top + 'px';
       modalEl.style.width = r.width + 'px';
       modalEl.style.height = r.height + 'px';
       modalEl.style.transform = 'none';
     }
+    // width/height 를 현재 px 로 고정한 뒤에 max 제한 해제 → 리사이즈로만 넓어지고 클릭 즉시 튀지 않음.
+    modalEl.style.maxWidth = 'none';
+    modalEl.style.maxHeight = 'none';
   };
 
-  // ── 헤더 드래그(이동) ──
-  const header = modalEl.querySelector('.modal-header');
+  // ── 드래그(이동) 핸들 결정 ──
+  //   기본은 .modal-header. 헤더 없는 모달(lookup/pset/cset/nset/faq 등)은
+  //   .modal-body 안 첫 요소(제목 div, id=xxxModalTitle)를 드래그 핸들로 사용.
+  let dragHandle = modalEl.querySelector('.modal-header');
+  if (!dragHandle) {
+    const bodyEl = modalEl.querySelector('.modal-body');
+    if (bodyEl && bodyEl.firstElementChild) {
+      dragHandle = bodyEl.firstElementChild;
+      dragHandle.style.cursor = 'move';
+      dragHandle.style.userSelect = 'none';
+    }
+  }
   let drag = null;
-  if (header) {
-    header.addEventListener('mousedown', (e) => {
+  if (dragHandle) {
+    dragHandle.addEventListener('mousedown', (e) => {
       if (e.target.closest('.modal-close, input, textarea, select, button, a')) return;
       pinPosition();
       const r = modalEl.getBoundingClientRect();


### PR DESCRIPTION
운영 피드백 2종: ①리사이즈 첫 클릭 시 폭 최대로 튐(pinPosition max 해제 순서) ②헤더 없는 모달(lookup/번들/faq) 이동 불가(제목 div를 드래그 핸들로). [via reviewer] GO

🤖 Generated with [Claude Code](https://claude.com/claude-code)