### PR TITLE
fix(admin): 모달 footer/header CSS 전역화 (통일 표준 적용)

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -12,7 +12,7 @@
 // 회귀(2026-05-12 PR #182 머지 직후 발생)를 방지하기 위한 자동 reload 가드.
 // sessionStorage 차단 환경(시크릿 모드 일부, 쿠키 차단)에서는 자연스럽게 skip.
 (function(){
-  var CURRENT_BUILD = 'v1780034027';
+  var CURRENT_BUILD = 'v1780034373';
   if (CURRENT_BUILD.indexOf('__') === 0) return; // 빌드 미적용 (dev/ 직접 열기) 시 skip
   try {
     var prev = sessionStorage.getItem('reverb.adminBuild');
@@ -1792,11 +1792,21 @@ textarea.form-input{resize:vertical;min-height:80px}
 .modal-rsz-se{bottom:0;right:0;width:14px;height:14px;cursor:nwse-resize}
 .modal-rsz-sw{bottom:0;left:0;width:14px;height:14px;cursor:nesw-resize}
 
-/* ── 관리자 모달 표준 footer (2026-05-29 모달 구조 통일) ── */
-/* 인플 공용 .modal 에 영향 없도록 #page-admin 스코프 한정 (인플 앱 .modal-footer 사용처 0 확인). */
-/* 다수 모달이 이미 class="modal-footer"+인라인 style 로 쓰던 패턴을 클래스 규칙화 + flex-shrink:0 보강 */
-/* (리사이즈로 세로 짧게 줄여도 버튼 영역이 찌부러지지 않고 하단 고정). 폭/패딩 인라인은 기존 우선. */
-#page-admin .modal-footer{
+/* ── 관리자 모달 표준 구조 (2026-05-29 모달 구조 통일) ── */
+/* admin.css 는 관리자 빌드 전용(인플 빌드 CLIENT_CSS 에 미포함)이라 전역 정의해도 인플 영향 0. */
+/* 미분리 모달 등은 #page-admin 밖(body 직속)이라 #page-admin 스코프가 안 먹음 → 전역으로 정의. */
+/* 인라인 header/footer style 가진 기존 모달은 인라인 우선(기존 외관 유지), 인라인 없는 모달은 아래 표준 적용. */
+/* components.css 의 .modal-header/.modal-title 보다 뒤에 로드되어 관리자 모달에서만 덮음. */
+.modal-header{
+  display:flex;
+  align-items:center;
+  justify-content:space-between;
+  padding:18px 22px 12px;
+  border-bottom:1px solid var(--line);
+  flex-shrink:0;
+}
+.modal-title{ font-size:16px; font-weight:700; color:var(--ink); }
+.modal-footer{
   display:flex;
   gap:8px;
   align-items:center;
@@ -1805,7 +1815,7 @@ textarea.form-input{resize:vertical;min-height:80px}
   border-top:1px solid var(--line);
   flex-shrink:0;
 }
-#page-admin .modal-footer-aux{ margin-right:auto; }  /* 좌측 보조요소(상태 pill·삭제 버튼) 고정 */
+.modal-footer-aux{ margin-right:auto; }  /* 좌측 보조요소(상태 pill·삭제 버튼) 고정 */
 
 </style>
 </head>
@@ -1881,7 +1891,7 @@ textarea.form-input{resize:vertical;min-height:80px}
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-05-29 14:53 · 075e830</span>
+          <span class="admin-build-text">2026-05-29 14:59 · ef2058e</span>
         </div>
       </div>
     </aside>

--- a/dev/css/admin.css
+++ b/dev/css/admin.css
@@ -1344,11 +1344,21 @@
 .modal-rsz-se{bottom:0;right:0;width:14px;height:14px;cursor:nwse-resize}
 .modal-rsz-sw{bottom:0;left:0;width:14px;height:14px;cursor:nesw-resize}
 
-/* ── 관리자 모달 표준 footer (2026-05-29 모달 구조 통일) ── */
-/* 인플 공용 .modal 에 영향 없도록 #page-admin 스코프 한정 (인플 앱 .modal-footer 사용처 0 확인). */
-/* 다수 모달이 이미 class="modal-footer"+인라인 style 로 쓰던 패턴을 클래스 규칙화 + flex-shrink:0 보강 */
-/* (리사이즈로 세로 짧게 줄여도 버튼 영역이 찌부러지지 않고 하단 고정). 폭/패딩 인라인은 기존 우선. */
-#page-admin .modal-footer{
+/* ── 관리자 모달 표준 구조 (2026-05-29 모달 구조 통일) ── */
+/* admin.css 는 관리자 빌드 전용(인플 빌드 CLIENT_CSS 에 미포함)이라 전역 정의해도 인플 영향 0. */
+/* 미분리 모달 등은 #page-admin 밖(body 직속)이라 #page-admin 스코프가 안 먹음 → 전역으로 정의. */
+/* 인라인 header/footer style 가진 기존 모달은 인라인 우선(기존 외관 유지), 인라인 없는 모달은 아래 표준 적용. */
+/* components.css 의 .modal-header/.modal-title 보다 뒤에 로드되어 관리자 모달에서만 덮음. */
+.modal-header{
+  display:flex;
+  align-items:center;
+  justify-content:space-between;
+  padding:18px 22px 12px;
+  border-bottom:1px solid var(--line);
+  flex-shrink:0;
+}
+.modal-title{ font-size:16px; font-weight:700; color:var(--ink); }
+.modal-footer{
   display:flex;
   gap:8px;
   align-items:center;
@@ -1357,4 +1367,4 @@
   border-top:1px solid var(--line);
   flex-shrink:0;
 }
-#page-admin .modal-footer-aux{ margin-right:auto; }  /* 좌측 보조요소(상태 pill·삭제 버튼) 고정 */
+.modal-footer-aux{ margin-right:auto; }  /* 좌측 보조요소(상태 pill·삭제 버튼) 고정 */


### PR DESCRIPTION
미분리 5개 모달이 #page-admin 밖이라 footer 좌측 깨짐 → admin.css(관리자 전용) 전역 표준 CSS로 수정. header 하단 구분선 + footer 우측+상단 구분선 통일. [via reviewer] GO

🤖 Generated with [Claude Code](https://claude.com/claude-code)