### PR TITLE
fix(admin): 대리 등록 모달 드래그 회귀 수정 (.open 전환)

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -12,7 +12,7 @@
 // 회귀(2026-05-12 PR #182 머지 직후 발생)를 방지하기 위한 자동 reload 가드.
 // sessionStorage 차단 환경(시크릿 모드 일부, 쿠키 차단)에서는 자연스럽게 skip.
 (function(){
-  var CURRENT_BUILD = 'v1780034951';
+  var CURRENT_BUILD = 'v1780035503';
   if (CURRENT_BUILD.indexOf('__') === 0) return; // 빌드 미적용 (dev/ 직접 열기) 시 skip
   try {
     var prev = sessionStorage.getItem('reverb.adminBuild');
@@ -1891,7 +1891,7 @@ textarea.form-input{resize:vertical;min-height:80px}
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-05-29 15:09 · 79d963d</span>
+          <span class="admin-build-text">2026-05-29 15:18 · c3298d2</span>
         </div>
       </div>
     </aside>
@@ -18039,7 +18039,7 @@ async function openAdminProxyModal(presetAppId) {
   const m = $('adminProxyDelivModal');
   if (!m) return;
   _resetAdminProxyForm();
-  m.style.display = 'flex';
+  m.classList.add('open');  // display 직접 조작 대신 .open (드래그 MutationObserver 감지 + 잔류 방지)
   // 데이터 병렬 로드
   try {
     const [appsResult, reasonsResult, channelsResult] = await Promise.all([
@@ -18081,7 +18081,7 @@ async function openAdminProxyFromCombined() {
 
 function closeAdminProxyModal() {
   const m = $('adminProxyDelivModal');
-  if (m) m.style.display = 'none';
+  if (m) m.classList.remove('open');  // .open 제거로 닫기 (display:flex 잔류 방지)
   _resetAdminProxyForm();
 }
 

--- a/dev/js/admin-deliverables.js
+++ b/dev/js/admin-deliverables.js
@@ -1261,7 +1261,7 @@ async function openAdminProxyModal(presetAppId) {
   const m = $('adminProxyDelivModal');
   if (!m) return;
   _resetAdminProxyForm();
-  m.style.display = 'flex';
+  m.classList.add('open');  // display 직접 조작 대신 .open (드래그 MutationObserver 감지 + 잔류 방지)
   // 데이터 병렬 로드
   try {
     const [appsResult, reasonsResult, channelsResult] = await Promise.all([
@@ -1303,7 +1303,7 @@ async function openAdminProxyFromCombined() {
 
 function closeAdminProxyModal() {
   const m = $('adminProxyDelivModal');
-  if (m) m.style.display = 'none';
+  if (m) m.classList.remove('open');  // .open 제거로 닫기 (display:flex 잔류 방지)
   _resetAdminProxyForm();
 }
 


### PR DESCRIPTION
adminProxyDelivModal이 display 직접 조작이라 드래그 MutationObserver 미감지 → .open 클래스로 전환해 드래그·리사이즈 적용 + 잔류 버그 해소. [via reviewer] GO

🤖 Generated with [Claude Code](https://claude.com/claude-code)