### PR TITLE
docs(spec): 모달·채널지정 구현 결과 기록 + QA 스크린샷 gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,5 @@ node_modules/
 HANDOFF.md
 .vercel
 .env*.local
+modal-*.png
+*-modal.png

--- a/docs/specs/2026-05-28-admin-modal-draggable.md
+++ b/docs/specs/2026-05-28-admin-modal-draggable.md
@@ -271,6 +271,20 @@ function openInfluencerDetailModal(id) {
 
 ---
 
-## 구현 결과 (개발 세션이 채울 것)
+## 구현 결과
 
-(개발 세션이 작업 분할 A~C 진행 후 작성)
+**구현일:** 2026-05-29
+**관련 커밋/PR:** dev — 초판(afa6244) + 수정 PR #377·#378(정중앙·폭튐·헤더없는모달·8방향) → 운영 dev→main PR #383(main 9e26ae5).
+
+### 초안 대비 변경 사항
+- **추가**: 8방향 리사이즈(초안은 우하단 `resize:both` 1방향, v2 백로그였으나 사용자 요청으로 상하좌우+4모서리 핸들 + 방향별 커서로 구현). 가로 폭 확장(드래그/리사이즈 시 max-width/height 해제, dataset.origMaxW 백업·재열림 복원).
+- **달라진 것**:
+  - 초안 "현재 상태: 화면 가운데 고정"은 부정확 — 실제는 하단 바텀시트(`align-items:flex-end`). 정중앙은 `transform:translate(-50%,-50%)`로 구현(초안의 rect 측정 방식은 렌더 타이밍에 중앙 하단 치우침 발생 → transform으로 교체).
+  - 초안 CSS `width:480px` 강제 제거 → 각 모달 인라인 max-width(480~1280px) 존중(width 강제 시 전 모달이 480으로 좁아지는 버그).
+  - 적용 방식: 초안의 "open 함수마다 헬퍼 호출" 대신 MutationObserver(overlay .open 감지) 단일 지점 — open 방식(openModal/classList) 혼재 대응. 단 display 직접 조작 모달은 미감지(adminProxy 별도 .open 전환, [[project_deliverable_channel_assign]] 후속 통일에서 처리).
+- **빠진 것**: 위치·크기 localStorage 저장, 더블클릭 최대화 — v2 백로그.
+
+### 구현 중 기술 결정 사항
+- `pinPosition()`: 드래그/리사이즈 시작 시 현재 크기 px 고정 → 그 다음 max 해제(순서 중요, 안 그러면 width:94vw 튐). transform 조건 `!== 'none'`(빈 문자열 포함, 안 하면 왼쪽 튐).
+- 드래그 핸들: `.modal-header` 우선 → 없으면 `.modal-body` 첫 요소 fallback.
+- 인플 빌드 격리(admin.css/admin-core.js 관리자 빌드 전용). [[project_admin_modal_ux]] 통합 기록.

--- a/docs/specs/2026-05-29-admin-modal-structure-unify.md
+++ b/docs/specs/2026-05-29-admin-modal-structure-unify.md
@@ -169,10 +169,17 @@ lookupEditModal · faqEditModal · psetEditModal · csetEditModal · nsetEditMod
 ## 10. 약관·법률 영향
 없음 (순수 UI 구조).
 
-## 11. 구현 결과 (개발 세션이 채울 것)
-```
-구현일:
-관련 커밋/PR:
-초안 대비 변경:
-구현 중 기술 결정:
-```
+## 11. 구현 결과
+
+**구현일:** 2026-05-29
+**관련 커밋/PR:** dev PR #379·#380·#381(미분리 5개 + 계정 4개 + footer 전역 CSS) + #382(adminProxy .open 회귀) → 운영 dev→main PR #383(main 9e26ae5).
+
+### 초안 대비 변경
+- **추가**: 관리자 계정 모달 4개(addAdmin·resetPw·deleteAdmin·adminEmailSubs) footer 클래스화(초안 미분리 5개 외 추가 통일). adminProxyDelivModal `.open` 전환(display 직접 조작이라 드래그 미적용 회귀 + 잔류 버그 동시 해소).
+- **달라진 것**: footer/header CSS 스코프 — 초안은 `#page-admin` 한정 권고였으나, **미분리 모달이 #page-admin 밖(body 직속)이라 스코프가 안 먹어** 전역 정의로 변경(admin.css가 관리자 빌드 전용이라 인플 영향 0). `.modal-header`/`.modal-title`도 전역 표준화(border-bottom·16px).
+- **빠진 것**: PR 3(분리형 모달 인라인 footer 클래스 교체) — 백로그. adminNoticeEditModal footer(id 인라인)도 미통일.
+
+### 구현 중 기술 결정
+- 미분리 5개 재구조화 시 제목 div의 `id`(xxxModalTitle) + 폼 필드 id 전부 보존 → 저장/렌더 함수 무변경(검증 완료).
+- **교훈(핵심)**: 드래그 적용 MutationObserver가 overlay `class` 변화만 감지하므로, 모달은 반드시 `classList.add('open')`으로 열 것. `style.display` 직접 조작 모달은 드래그 미적용(adminProxy 회귀).
+- 인라인 style 가진 모달은 인라인 우선이라 기존 외관 유지, 인라인 없는 모달만 전역 표준 적용.

--- a/docs/specs/2026-05-29-deliverable-channel-assign.md
+++ b/docs/specs/2026-05-29-deliverable-channel-assign.md
@@ -281,15 +281,18 @@ async function assignReviewImageChannel(deliverableId, postChannel) {
 
 ---
 
-## 9. 구현 결과 (개발 세션이 채울 것)
+## 9. 구현 결과
 
-```
-구현일:
-관련 커밋/PR:
+**구현일:** 2026-05-29
+**관련 커밋/PR:** dev PR #373(마이그 162 + storage + UI) → 운영 dev→main PR #374. 백필 패치는 운영 직접 적용.
+
 ### 초안 대비 변경 사항
-- 추가된 것:
-- 빠진 것:
-- 달라진 것:
+- 추가된 것: 단일채널 백필 패치(`supabase/patches/2026-05-29-backfill-...sql`, 운영 340행 적용) — 다채널 채널지정 RPC와 별개로 단일채널 367건은 데이터 백필로 즉시 해결(NOT EXISTS + DISTINCT ON 충돌 회피). 사용자 결정으로 구버전 NULL 29건은 삭제 안 하고 보존(과거 제출·승인 이력).
+- 빠진 것: PR 3(오지정 해제 버튼 + 셀 "채널 미분류 N" 칩) — 백로그.
+- 달라진 것: 없음(설계 5종 추천안 전체 수용).
+
 ### 구현 중 기술 결정 사항
-- 확정 마이그레이션 번호:
-```
+- **확정 마이그레이션 번호: 162** (admin-proxy PR 5는 163으로 밀림 — 메모리 정정).
+- delete RPC의 audit INSERT 제거(CASCADE로 즉시 소멸하는 무의미 코드) + 한계 주석.
+- assign RPC 해제 분기 `pending/draft` 허용(초안 pending만 → draft 추가, reviewer 지적).
+- 운영 배포 완료. 운영자가 다채널 26건 검수 모달에서 채널 지정 완료. 남은 다채널 2건은 두 채널 다 신버전 채워진 중복.


### PR DESCRIPTION
이번 세션 운영 배포 작업 3건의 사양서 구현 결과 섹션 작성(docs-tracking 규칙). 코드 변경 없음. 🤖 Generated with [Claude Code](https://claude.com/claude-code)