### PR TITLE
feat(admin): 결과물 관리 필터 재설계 PR1 — 캠페인 검색형 다중선택 + 검색 인플 전용

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -12,7 +12,7 @@
 // 회귀(2026-05-12 PR #182 머지 직후 발생)를 방지하기 위한 자동 reload 가드.
 // sessionStorage 차단 환경(시크릿 모드 일부, 쿠키 차단)에서는 자연스럽게 skip.
 (function(){
-  var CURRENT_BUILD = 'v1780035503';
+  var CURRENT_BUILD = 'v1780040903';
   if (CURRENT_BUILD.indexOf('__') === 0) return; // 빌드 미적용 (dev/ 직접 열기) 시 skip
   try {
     var prev = sessionStorage.getItem('reverb.adminBuild');
@@ -493,6 +493,11 @@ textarea.form-input{resize:vertical;min-height:80px}
 .mf-item-label{font-size:12px;color:var(--ink);white-space:normal;overflow-wrap:anywhere;word-break:break-word}
 .mf-item-count{color:var(--muted);font-weight:400;margin-left:2px}
 .mf-item-sub{font-size:10px;color:var(--muted);margin-top:1px;font-family:monospace}
+/* 검색형 멀티필터(opt-in) — 드롭 상단 고정 검색창 + 0건 안내 */
+.mf-search-box{position:sticky;top:-4px;background:#fff;padding:6px 8px;margin:-4px 0 4px;border-bottom:1px solid var(--surface-dim);z-index:1}
+.mf-search{width:100%;box-sizing:border-box;padding:6px 8px;font-size:12px;border:1px solid var(--outline);border-radius:6px;color:var(--ink);outline:none}
+.mf-search:focus{border-color:var(--primary)}
+.mf-search-empty{padding:10px 12px;font-size:12px;color:var(--muted);text-align:center}
 .admin-layout{display:grid;grid-template-columns:220px 1fr;height:100vh;transition:grid-template-columns .25s ease}
 .admin-layout.collapsed{grid-template-columns:56px 1fr}
 .admin-side{background:#1A0F18;padding:0;height:100%;overflow:hidden;flex-shrink:0;transition:width .25s ease;display:flex;flex-direction:column}
@@ -1891,7 +1896,7 @@ textarea.form-input{resize:vertical;min-height:80px}
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-05-29 15:18 · c3298d2</span>
+          <span class="admin-build-text">2026-05-29 16:48 · 942a6ec</span>
         </div>
       </div>
     </aside>
@@ -2769,7 +2774,7 @@ textarea.form-input{resize:vertical;min-height:80px}
                 <label>검색</label>
                 <div style="position:relative">
                   <span class="material-icons-round" style="position:absolute;left:8px;top:50%;transform:translateY(-50%);font-size:16px;color:var(--muted)">search</span>
-                  <input type="search" id="appSearch" class="admin-filter-search" autocomplete="off" data-lpignore="true" data-1p-ignore="true" readonly onfocus="this.removeAttribute('readonly')" placeholder="캠페인명 · 인플루언서명 · 캠페인번호 검색" oninput="renderAppCampList()">
+                  <input type="search" id="appSearch" class="admin-filter-search" autocomplete="off" data-lpignore="true" data-1p-ignore="true" readonly onfocus="this.removeAttribute('readonly')" placeholder="인플루언서명 · 이메일 검색" oninput="renderAppCampList()">
                 </div>
               </div>
             </div>
@@ -2840,7 +2845,7 @@ textarea.form-input{resize:vertical;min-height:80px}
                 <label>검색</label>
                 <div style="position:relative">
                   <span class="material-icons-round" style="position:absolute;left:8px;top:50%;transform:translateY(-50%);font-size:16px;color:var(--muted)">search</span>
-                  <input type="search" id="delivSearch" class="admin-filter-search" autocomplete="off" data-lpignore="true" data-1p-ignore="true" readonly onfocus="this.removeAttribute('readonly')" placeholder="인플루언서명 · 캠페인명 · 캠페인번호 검색" oninput="renderDeliverablesList()">
+                  <input type="search" id="delivSearch" class="admin-filter-search" autocomplete="off" data-lpignore="true" data-1p-ignore="true" readonly onfocus="this.removeAttribute('readonly')" placeholder="인플루언서명 · 이메일 검색" oninput="renderDeliverablesList()">
                 </div>
               </div>
             </div>
@@ -9482,7 +9487,7 @@ function resetMultiFilter(containerId, allLabel) {
   if (!wrap) return;
   const btn = wrap.querySelector('.mf-btn');
   const allCb = wrap.querySelector('input[value="all"]');
-  const items = wrap.querySelectorAll('.mf-drop input:not([value="all"])');
+  const items = wrap.querySelectorAll('.mf-drop input[type="checkbox"]:not([value="all"])');
   if (allCb) { allCb.checked = true; allCb.indeterminate = false; }
   items.forEach(c => c.checked = true); // 전체 = 모든 항목 체크 표시
   if (btn) { btn.textContent = allLabel; btn.classList.remove('has-selection'); }
@@ -9496,20 +9501,20 @@ function updateFilterResetBtn(btnId, multiIds, searchId) {
 }
 // 다중 선택 드롭다운 공통 헬퍼 — 옵션 리스트 변화 시에만 재생성, 이전 선택 상태 보존
 // options: [{value, label}]
-function syncMultiFilter(containerId, allLabel, options, onChange) {
+function syncMultiFilter(containerId, allLabel, options, onChange, opts = {}) {
   const wrap = $(containerId);
   if (!wrap) return;
   const drop = wrap.querySelector('.mf-drop');
   if (!drop) return;
-  // 옵션 키에 count·subLabel 포함 — 카운트 변경 시 재생성되어 (NN) 라벨 즉시 반영
-  const newKey = options.map(o => `${o.value}:${o.count ?? ''}:${o.subLabel || ''}`).join('|');
+  // 옵션 키에 count·subLabel·searchable 포함 — 카운트/검색형 변경 시 재생성되어 (NN) 라벨·검색창 즉시 반영
+  const newKey = options.map(o => `${o.value}:${o.count ?? ''}:${o.subLabel || ''}`).join('|') + (opts.searchable ? '|__search' : '');
   if (wrap.dataset.optKey === newKey && drop.children.length > 0) return;
   const prev = getMultiFilterValues(containerId);
-  createMultiFilter(containerId, allLabel, options, onChange);
+  createMultiFilter(containerId, allLabel, options, onChange, opts);
   wrap.dataset.optKey = newKey;
   if (prev.length > 0) {
-    // 일부 선택 상태 복원 — 모두 해제 후 prev 항목만 체크
-    const itemCbs = [...drop.querySelectorAll('input:not([value="all"])')];
+    // 일부 선택 상태 복원 — 모두 해제 후 prev 항목만 체크 (검색 input[type=search] 제외)
+    const itemCbs = [...drop.querySelectorAll('input[type="checkbox"]:not([value="all"])')];
     itemCbs.forEach(c => c.checked = false);
     prev.forEach(v => {
       const cb = drop.querySelector(`input[value="${CSS && CSS.escape ? CSS.escape(v) : v.replace(/"/g,'\\"')}"]`);
@@ -9527,7 +9532,7 @@ function syncMultiFilter(containerId, allLabel, options, onChange) {
 // options = [{value, label, subLabel?, count?}]
 //   - subLabel(있으면): 라벨 아래 회색 작은 글씨 (예: 캠페인 번호 B0019-C001)
 //   - count(0 이상의 정수면 표시, null/undefined면 미표시): 라벨 옆 (NN) 건수
-function createMultiFilter(containerId, allLabel, options, onChange) {
+function createMultiFilter(containerId, allLabel, options, onChange, opts = {}) {
   const wrap = $(containerId);
   if (!wrap) return;
   const btn = wrap.querySelector('.mf-btn');
@@ -9539,15 +9544,28 @@ function createMultiFilter(containerId, allLabel, options, onChange) {
     const subHtml = o.subLabel ? `<div class="mf-item-sub">${esc(o.subLabel)}</div>` : '';
     return `<label class="mf-item${o.subLabel ? ' has-sub' : ''}"><input type="checkbox" value="${esc(o.value)}" data-label="${esc(o.label)}"><div class="mf-item-text"><div class="mf-item-label">${esc(o.label)}${countHtml}</div>${subHtml}</div></label>`;
   };
+  // 검색형(opt-in) — 옵션이 많은 드롭다운(캠페인 등)에서만 사용. 기본 false → 기존 전 페인 무영향
+  const searchHtml = opts.searchable
+    ? `<div class="mf-search-box"><input type="search" class="mf-search" autocomplete="off" data-lpignore="true" data-1p-ignore="true" placeholder="${esc(opts.searchPlaceholder || '検索')}"></div>`
+    : '';
+  const emptyHtml = opts.searchable ? `<div class="mf-search-empty" style="display:none">일치하는 항목이 없습니다</div>` : '';
   // 드롭다운 아이템 생성 — 초기 상태: 모두 비체크 = 필터 없음 (전체 표시)
-  drop.innerHTML = `<label class="mf-item all-item"><input type="checkbox" value="all"><div class="mf-item-text"><div class="mf-item-label">${esc(allLabel)}</div></div></label>`
-    + options.map(renderOptionItem).join('');
+  drop.innerHTML = searchHtml
+    + `<label class="mf-item all-item"><input type="checkbox" value="all"><div class="mf-item-text"><div class="mf-item-label">${esc(allLabel)}</div></div></label>`
+    + options.map(renderOptionItem).join('')
+    + emptyHtml;
   btn.textContent = allLabel;
-  // 토글
-  btn.onclick = (e) => { e.stopPropagation(); drop.classList.toggle('open'); };
-  // 체크 로직
+  // 토글 — 검색형이면 열 때 검색 input 포커스
+  btn.onclick = (e) => {
+    e.stopPropagation();
+    drop.classList.toggle('open');
+    if (opts.searchable && drop.classList.contains('open')) {
+      const si = drop.querySelector('.mf-search'); if (si) setTimeout(() => si.focus(), 0);
+    }
+  };
+  // 체크 로직 — 옵션 체크박스만 (검색 input[type=search] 은 제외)
   const allCb = drop.querySelector('input[value="all"]');
-  const itemCbs = [...drop.querySelectorAll('input:not([value="all"])')];
+  const itemCbs = [...drop.querySelectorAll('input[type="checkbox"]:not([value="all"])')];
   const update = () => {
     const selected = itemCbs.filter(c => c.checked);
     if (selected.length === itemCbs.length) {
@@ -9581,6 +9599,24 @@ function createMultiFilter(containerId, allLabel, options, onChange) {
     update();
   };
   itemCbs.forEach(c => { c.onchange = update; });
+  // 검색형: 입력 시 옵션 행 show/hide (체크 상태·getMultiFilterValues 반환값 불변, 「전체」 항상 노출)
+  if (opts.searchable) {
+    const si = drop.querySelector('.mf-search');
+    const emptyEl = drop.querySelector('.mf-search-empty');
+    const optItems = [...drop.querySelectorAll('.mf-item:not(.all-item)')];
+    if (si) si.oninput = () => {
+      const q = (si.value || '').trim().toLowerCase();
+      let visible = 0;
+      optItems.forEach(item => {
+        const cb = item.querySelector('input[type="checkbox"]');
+        const sub = item.querySelector('.mf-item-sub')?.textContent || '';
+        const show = matchSearchTokens(q, [cb?.dataset.label || '', sub]);
+        item.style.display = show ? '' : 'none';
+        if (show) visible++;
+      });
+      if (emptyEl) emptyEl.style.display = visible === 0 ? '' : 'none';
+    };
+  }
   // 외부에서 prev 복원 후 다시 호출할 수 있도록 노출
   wrap._mfUpdate = update;
   // 바깥 클릭 닫기 (wrap 당 1회만 등록)
@@ -9595,7 +9631,7 @@ function getMultiFilterValues(containerId) {
   const allCb = wrap.querySelector('input[value="all"]');
   // 전체(모두 체크) = 필터 없음 → 빈 배열
   if (allCb?.checked && !allCb.indeterminate) return [];
-  return [...wrap.querySelectorAll('.mf-drop input:not([value="all"]):checked')].map(c => c.value);
+  return [...wrap.querySelectorAll('.mf-drop input[type="checkbox"]:not([value="all"]):checked')].map(c => c.value);
 }
 // 커스텀 confirm 모달 (Promise 반환)
 let _confirmResolver = null;
@@ -17004,9 +17040,9 @@ async function renderDeliverablesList() {
       if (!resultStatusVals.includes(s)) return false;
     }
     if (search) {
+      // 검색은 인플루언서 전용 (캠페인은 검색형 캠페인 드롭다운으로 분리)
       const inf = g.influencer || {};
-      const camp = g.campaign || {};
-      if (!matchSearchTokens(search, [inf.name, inf.name_kana, inf.email, camp.title, camp.brand, camp.campaign_no])) return false;
+      if (!matchSearchTokens(search, [inf.name, inf.name_kana, inf.email])) return false;
     }
     return true;
   };
@@ -17078,14 +17114,10 @@ async function renderDeliverablesList() {
       : (g.result ? g.result.status : 'none');
     return resultStatusVals.includes(s);
   });
-  // 검색 필터 — 단어 단위 AND 매칭 (matchSearchTokens, 전각/반각 공백 무관)
+  // 검색 필터 — 인플루언서 전용(단어 단위 AND, 전각/반각 공백 무관). 캠페인은 검색형 드롭다운으로 분리
   if (search) filtered = filtered.filter(g => {
     const inf = g.influencer || {};
-    const camp = g.campaign || {};
-    return matchSearchTokens(search, [
-      inf.name, inf.name_kana, inf.email,
-      camp.title, camp.brand, camp.campaign_no,
-    ]);
+    return matchSearchTokens(search, [inf.name, inf.name_kana, inf.email]);
   });
   // 「대리 등록만 보기」 필터 (마이그레이션 160) — 신청 그룹 안 deliverable 중 1개라도 submitted_by_admin 있으면 통과
   // reviewByChannel 은 monitor 캠페인의 채널별 review_image 결과물 맵 (사양 2 운영 후 채워짐)
@@ -20827,9 +20859,8 @@ async function renderAppCampList() {
   const searchVal = ($('appSearch')?.value || '').trim().toLowerCase();
   if (searchVal) {
     apps = apps.filter(a => {
-      const camp = camps.find(c => c.id === a.campaign_id) || {};
+      // 검색은 인플루언서 전용 (캠페인은 검색형 캠페인 드롭다운으로 분리)
       return matchSearchTokens(searchVal, [
-        camp.title, camp.brand, camp.brand_ko, camp.product, camp.product_ko, camp.campaign_no,
         a.user_name, a.user_email, a.cancel_reason, a.cancel_reason_code,
       ]);
     });
@@ -22649,7 +22680,8 @@ function syncCampMultiFilter(containerId, sortedCamps, onChange, counts) {
     subLabel: c.campaign_no || '',
     count: counts ? (counts[c.id] || 0) : null
   }));
-  syncMultiFilter(containerId, '전체 캠페인', options, onChange);
+  // 캠페인 목록이 길어 검색형 활성화 (delivCampMulti·appCampMulti 양쪽 자동 통일)
+  syncMultiFilter(containerId, '전체 캠페인', options, onChange, { searchable: true, searchPlaceholder: '캠페인명 · 번호 검색' });
 }
 
 // ════════════════════════════════════════════════════════════════════

--- a/dev/admin/index.html
+++ b/dev/admin/index.html
@@ -1009,7 +1009,7 @@
                 <label>검색</label>
                 <div style="position:relative">
                   <span class="material-icons-round" style="position:absolute;left:8px;top:50%;transform:translateY(-50%);font-size:16px;color:var(--muted)">search</span>
-                  <input type="search" id="appSearch" class="admin-filter-search" autocomplete="off" data-lpignore="true" data-1p-ignore="true" readonly onfocus="this.removeAttribute('readonly')" placeholder="캠페인명 · 인플루언서명 · 캠페인번호 검색" oninput="renderAppCampList()">
+                  <input type="search" id="appSearch" class="admin-filter-search" autocomplete="off" data-lpignore="true" data-1p-ignore="true" readonly onfocus="this.removeAttribute('readonly')" placeholder="인플루언서명 · 이메일 검색" oninput="renderAppCampList()">
                 </div>
               </div>
             </div>
@@ -1080,7 +1080,7 @@
                 <label>검색</label>
                 <div style="position:relative">
                   <span class="material-icons-round" style="position:absolute;left:8px;top:50%;transform:translateY(-50%);font-size:16px;color:var(--muted)">search</span>
-                  <input type="search" id="delivSearch" class="admin-filter-search" autocomplete="off" data-lpignore="true" data-1p-ignore="true" readonly onfocus="this.removeAttribute('readonly')" placeholder="인플루언서명 · 캠페인명 · 캠페인번호 검색" oninput="renderDeliverablesList()">
+                  <input type="search" id="delivSearch" class="admin-filter-search" autocomplete="off" data-lpignore="true" data-1p-ignore="true" readonly onfocus="this.removeAttribute('readonly')" placeholder="인플루언서명 · 이메일 검색" oninput="renderDeliverablesList()">
                 </div>
               </div>
             </div>

--- a/dev/css/admin.css
+++ b/dev/css/admin.css
@@ -45,6 +45,11 @@
 .mf-item-label{font-size:12px;color:var(--ink);white-space:normal;overflow-wrap:anywhere;word-break:break-word}
 .mf-item-count{color:var(--muted);font-weight:400;margin-left:2px}
 .mf-item-sub{font-size:10px;color:var(--muted);margin-top:1px;font-family:monospace}
+/* 검색형 멀티필터(opt-in) — 드롭 상단 고정 검색창 + 0건 안내 */
+.mf-search-box{position:sticky;top:-4px;background:#fff;padding:6px 8px;margin:-4px 0 4px;border-bottom:1px solid var(--surface-dim);z-index:1}
+.mf-search{width:100%;box-sizing:border-box;padding:6px 8px;font-size:12px;border:1px solid var(--outline);border-radius:6px;color:var(--ink);outline:none}
+.mf-search:focus{border-color:var(--primary)}
+.mf-search-empty{padding:10px 12px;font-size:12px;color:var(--muted);text-align:center}
 .admin-layout{display:grid;grid-template-columns:220px 1fr;height:100vh;transition:grid-template-columns .25s ease}
 .admin-layout.collapsed{grid-template-columns:56px 1fr}
 .admin-side{background:#1A0F18;padding:0;height:100%;overflow:hidden;flex-shrink:0;transition:width .25s ease;display:flex;flex-direction:column}

--- a/dev/js/admin-applications.js
+++ b/dev/js/admin-applications.js
@@ -341,9 +341,8 @@ async function renderAppCampList() {
   const searchVal = ($('appSearch')?.value || '').trim().toLowerCase();
   if (searchVal) {
     apps = apps.filter(a => {
-      const camp = camps.find(c => c.id === a.campaign_id) || {};
+      // 검색은 인플루언서 전용 (캠페인은 검색형 캠페인 드롭다운으로 분리)
       return matchSearchTokens(searchVal, [
-        camp.title, camp.brand, camp.brand_ko, camp.product, camp.product_ko, camp.campaign_no,
         a.user_name, a.user_email, a.cancel_reason, a.cancel_reason_code,
       ]);
     });

--- a/dev/js/admin-core.js
+++ b/dev/js/admin-core.js
@@ -403,7 +403,7 @@ function resetMultiFilter(containerId, allLabel) {
   if (!wrap) return;
   const btn = wrap.querySelector('.mf-btn');
   const allCb = wrap.querySelector('input[value="all"]');
-  const items = wrap.querySelectorAll('.mf-drop input:not([value="all"])');
+  const items = wrap.querySelectorAll('.mf-drop input[type="checkbox"]:not([value="all"])');
   if (allCb) { allCb.checked = true; allCb.indeterminate = false; }
   items.forEach(c => c.checked = true); // 전체 = 모든 항목 체크 표시
   if (btn) { btn.textContent = allLabel; btn.classList.remove('has-selection'); }
@@ -417,20 +417,20 @@ function updateFilterResetBtn(btnId, multiIds, searchId) {
 }
 // 다중 선택 드롭다운 공통 헬퍼 — 옵션 리스트 변화 시에만 재생성, 이전 선택 상태 보존
 // options: [{value, label}]
-function syncMultiFilter(containerId, allLabel, options, onChange) {
+function syncMultiFilter(containerId, allLabel, options, onChange, opts = {}) {
   const wrap = $(containerId);
   if (!wrap) return;
   const drop = wrap.querySelector('.mf-drop');
   if (!drop) return;
-  // 옵션 키에 count·subLabel 포함 — 카운트 변경 시 재생성되어 (NN) 라벨 즉시 반영
-  const newKey = options.map(o => `${o.value}:${o.count ?? ''}:${o.subLabel || ''}`).join('|');
+  // 옵션 키에 count·subLabel·searchable 포함 — 카운트/검색형 변경 시 재생성되어 (NN) 라벨·검색창 즉시 반영
+  const newKey = options.map(o => `${o.value}:${o.count ?? ''}:${o.subLabel || ''}`).join('|') + (opts.searchable ? '|__search' : '');
   if (wrap.dataset.optKey === newKey && drop.children.length > 0) return;
   const prev = getMultiFilterValues(containerId);
-  createMultiFilter(containerId, allLabel, options, onChange);
+  createMultiFilter(containerId, allLabel, options, onChange, opts);
   wrap.dataset.optKey = newKey;
   if (prev.length > 0) {
-    // 일부 선택 상태 복원 — 모두 해제 후 prev 항목만 체크
-    const itemCbs = [...drop.querySelectorAll('input:not([value="all"])')];
+    // 일부 선택 상태 복원 — 모두 해제 후 prev 항목만 체크 (검색 input[type=search] 제외)
+    const itemCbs = [...drop.querySelectorAll('input[type="checkbox"]:not([value="all"])')];
     itemCbs.forEach(c => c.checked = false);
     prev.forEach(v => {
       const cb = drop.querySelector(`input[value="${CSS && CSS.escape ? CSS.escape(v) : v.replace(/"/g,'\\"')}"]`);
@@ -448,7 +448,7 @@ function syncMultiFilter(containerId, allLabel, options, onChange) {
 // options = [{value, label, subLabel?, count?}]
 //   - subLabel(있으면): 라벨 아래 회색 작은 글씨 (예: 캠페인 번호 B0019-C001)
 //   - count(0 이상의 정수면 표시, null/undefined면 미표시): 라벨 옆 (NN) 건수
-function createMultiFilter(containerId, allLabel, options, onChange) {
+function createMultiFilter(containerId, allLabel, options, onChange, opts = {}) {
   const wrap = $(containerId);
   if (!wrap) return;
   const btn = wrap.querySelector('.mf-btn');
@@ -460,15 +460,28 @@ function createMultiFilter(containerId, allLabel, options, onChange) {
     const subHtml = o.subLabel ? `<div class="mf-item-sub">${esc(o.subLabel)}</div>` : '';
     return `<label class="mf-item${o.subLabel ? ' has-sub' : ''}"><input type="checkbox" value="${esc(o.value)}" data-label="${esc(o.label)}"><div class="mf-item-text"><div class="mf-item-label">${esc(o.label)}${countHtml}</div>${subHtml}</div></label>`;
   };
+  // 검색형(opt-in) — 옵션이 많은 드롭다운(캠페인 등)에서만 사용. 기본 false → 기존 전 페인 무영향
+  const searchHtml = opts.searchable
+    ? `<div class="mf-search-box"><input type="search" class="mf-search" autocomplete="off" data-lpignore="true" data-1p-ignore="true" placeholder="${esc(opts.searchPlaceholder || '検索')}"></div>`
+    : '';
+  const emptyHtml = opts.searchable ? `<div class="mf-search-empty" style="display:none">일치하는 항목이 없습니다</div>` : '';
   // 드롭다운 아이템 생성 — 초기 상태: 모두 비체크 = 필터 없음 (전체 표시)
-  drop.innerHTML = `<label class="mf-item all-item"><input type="checkbox" value="all"><div class="mf-item-text"><div class="mf-item-label">${esc(allLabel)}</div></div></label>`
-    + options.map(renderOptionItem).join('');
+  drop.innerHTML = searchHtml
+    + `<label class="mf-item all-item"><input type="checkbox" value="all"><div class="mf-item-text"><div class="mf-item-label">${esc(allLabel)}</div></div></label>`
+    + options.map(renderOptionItem).join('')
+    + emptyHtml;
   btn.textContent = allLabel;
-  // 토글
-  btn.onclick = (e) => { e.stopPropagation(); drop.classList.toggle('open'); };
-  // 체크 로직
+  // 토글 — 검색형이면 열 때 검색 input 포커스
+  btn.onclick = (e) => {
+    e.stopPropagation();
+    drop.classList.toggle('open');
+    if (opts.searchable && drop.classList.contains('open')) {
+      const si = drop.querySelector('.mf-search'); if (si) setTimeout(() => si.focus(), 0);
+    }
+  };
+  // 체크 로직 — 옵션 체크박스만 (검색 input[type=search] 은 제외)
   const allCb = drop.querySelector('input[value="all"]');
-  const itemCbs = [...drop.querySelectorAll('input:not([value="all"])')];
+  const itemCbs = [...drop.querySelectorAll('input[type="checkbox"]:not([value="all"])')];
   const update = () => {
     const selected = itemCbs.filter(c => c.checked);
     if (selected.length === itemCbs.length) {
@@ -502,6 +515,24 @@ function createMultiFilter(containerId, allLabel, options, onChange) {
     update();
   };
   itemCbs.forEach(c => { c.onchange = update; });
+  // 검색형: 입력 시 옵션 행 show/hide (체크 상태·getMultiFilterValues 반환값 불변, 「전체」 항상 노출)
+  if (opts.searchable) {
+    const si = drop.querySelector('.mf-search');
+    const emptyEl = drop.querySelector('.mf-search-empty');
+    const optItems = [...drop.querySelectorAll('.mf-item:not(.all-item)')];
+    if (si) si.oninput = () => {
+      const q = (si.value || '').trim().toLowerCase();
+      let visible = 0;
+      optItems.forEach(item => {
+        const cb = item.querySelector('input[type="checkbox"]');
+        const sub = item.querySelector('.mf-item-sub')?.textContent || '';
+        const show = matchSearchTokens(q, [cb?.dataset.label || '', sub]);
+        item.style.display = show ? '' : 'none';
+        if (show) visible++;
+      });
+      if (emptyEl) emptyEl.style.display = visible === 0 ? '' : 'none';
+    };
+  }
   // 외부에서 prev 복원 후 다시 호출할 수 있도록 노출
   wrap._mfUpdate = update;
   // 바깥 클릭 닫기 (wrap 당 1회만 등록)
@@ -516,7 +547,7 @@ function getMultiFilterValues(containerId) {
   const allCb = wrap.querySelector('input[value="all"]');
   // 전체(모두 체크) = 필터 없음 → 빈 배열
   if (allCb?.checked && !allCb.indeterminate) return [];
-  return [...wrap.querySelectorAll('.mf-drop input:not([value="all"]):checked')].map(c => c.value);
+  return [...wrap.querySelectorAll('.mf-drop input[type="checkbox"]:not([value="all"]):checked')].map(c => c.value);
 }
 // 커스텀 confirm 모달 (Promise 반환)
 let _confirmResolver = null;

--- a/dev/js/admin-deliverables.js
+++ b/dev/js/admin-deliverables.js
@@ -226,9 +226,9 @@ async function renderDeliverablesList() {
       if (!resultStatusVals.includes(s)) return false;
     }
     if (search) {
+      // 검색은 인플루언서 전용 (캠페인은 검색형 캠페인 드롭다운으로 분리)
       const inf = g.influencer || {};
-      const camp = g.campaign || {};
-      if (!matchSearchTokens(search, [inf.name, inf.name_kana, inf.email, camp.title, camp.brand, camp.campaign_no])) return false;
+      if (!matchSearchTokens(search, [inf.name, inf.name_kana, inf.email])) return false;
     }
     return true;
   };
@@ -300,14 +300,10 @@ async function renderDeliverablesList() {
       : (g.result ? g.result.status : 'none');
     return resultStatusVals.includes(s);
   });
-  // 검색 필터 — 단어 단위 AND 매칭 (matchSearchTokens, 전각/반각 공백 무관)
+  // 검색 필터 — 인플루언서 전용(단어 단위 AND, 전각/반각 공백 무관). 캠페인은 검색형 드롭다운으로 분리
   if (search) filtered = filtered.filter(g => {
     const inf = g.influencer || {};
-    const camp = g.campaign || {};
-    return matchSearchTokens(search, [
-      inf.name, inf.name_kana, inf.email,
-      camp.title, camp.brand, camp.campaign_no,
-    ]);
+    return matchSearchTokens(search, [inf.name, inf.name_kana, inf.email]);
   });
   // 「대리 등록만 보기」 필터 (마이그레이션 160) — 신청 그룹 안 deliverable 중 1개라도 submitted_by_admin 있으면 통과
   // reviewByChannel 은 monitor 캠페인의 채널별 review_image 결과물 맵 (사양 2 운영 후 채워짐)

--- a/dev/js/admin.js
+++ b/dev/js/admin.js
@@ -98,7 +98,8 @@ function syncCampMultiFilter(containerId, sortedCamps, onChange, counts) {
     subLabel: c.campaign_no || '',
     count: counts ? (counts[c.id] || 0) : null
   }));
-  syncMultiFilter(containerId, '전체 캠페인', options, onChange);
+  // 캠페인 목록이 길어 검색형 활성화 (delivCampMulti·appCampMulti 양쪽 자동 통일)
+  syncMultiFilter(containerId, '전체 캠페인', options, onChange, { searchable: true, searchPlaceholder: '캠페인명 · 번호 검색' });
 }
 
 // ════════════════════════════════════════════════════════════════════

--- a/docs/specs/2026-05-29-deliverables-filter-redesign.md
+++ b/docs/specs/2026-05-29-deliverables-filter-redesign.md
@@ -1,0 +1,176 @@
+# 결과물 관리 — 상단 필터 재설계
+**작성일:** 2026-05-29
+**작성 주체:** 기획/설계 세션
+**대상 화면:** 관리자 `/admin#deliverables` (결과물 관리 페인)
+**관련 규칙:** `.claude/rules/planning.md`(규칙 A·B), `.claude/rules/docs-tracking.md`
+
+---
+
+## 현재 상태 (2026-05-29 기준, 규칙 A)
+
+### 관련 코드·DB·UI 진입점
+- 필터·목록 로직: `dev/js/admin-deliverables.js`
+  - `renderDeliverablesList()` 65~370줄 — 필터 수집·그룹화·카운트·정렬·렌더
+  - `resetDelivFiltersAndSort()` 40~50줄 — 필터/정렬 초기화
+  - `passesFilters(g, opts)` 215~234줄 — 「자기 자신 필터 제외 + 나머지 AND」 카운트 패턴
+  - `result_status_repr` 계산 190~208줄 — 다중채널 대표 상태(우선순위 반려>검수대기>승인>미제출)
+- 검색형 콤보박스(참고 대상): `admin-deliverables.js` 1396~1562줄 — 대리등록의 캠페인/인플 **단일 선택** 콤보박스(`_renderAdminProxyCampList`/`selectAdminProxyCamp` 등). `matchSearchTokens` 기반 실시간 필터.
+- 공용 멀티필터 헬퍼: `dev/js/admin-core.js`
+  - `createMultiFilter(containerId, allLabel, options, onChange)` 451~512줄 — 체크박스 다중선택 드롭다운. **검색 입력 없음.**
+  - `syncMultiFilter` 420~441줄(옵션 변경 시 재생성·선택 보존), `getMultiFilterValues` 513~520줄, `resetMultiFilter` 401~410줄
+- 캠페인 멀티필터 어댑터: `dev/js/admin.js` `syncCampMultiFilter()` 94~102줄 — **결과물 관리(`delivCampMulti`)와 신청 관리(`appCampMulti`) 양쪽이 공유**
+- 필터 HTML: `dev/admin/index.html` 결과물 관리 페인 상단 (`delivCampMulti`/`delivRecruitTypeMulti`/`delivReceiptStatusMulti`/`delivResultStatusMulti`/`delivSearch`/`delivIncludeMissing`/`delivProxyOnly`)
+- CSS: `dev/css/admin.css` (`.mf-btn`/`.mf-drop`/`.mf-item` 멀티필터, 콤보박스 `.item`/`.empty`)
+
+### 현재 필터 동작 (확인된 사실)
+| 필터 | 방식 | 문제 |
+|---|---|---|
+| 캠페인 | 체크박스 다중선택 + 캠페인번호 부제 + 건수 | **검색 없음 → 목록 길면 못 찾음** |
+| 모집 타입 | 리뷰어/기프팅/방문형 다중 | — |
+| 영수증 상태 | 검수대기/승인/비승인/미제출, **모든 모집타입 일괄** | **기프팅·방문형은 영수증 없어 무조건 '미제출' 집계됨(버그)** |
+| 결과물 상태 | 검수대기/승인/비승인/채널미분류/미제출 | **다중채널을 대표상태 1개로 압축 → 반려+검수대기 섞이면 검수대기로 안 걸림** |
+| 채널 미분류(`legacy_no_channel`) | 항상 노출 | 채널·업로드 강제 이후 신규 0건. 단 **운영 레거시 385건 존재** |
+| 검색 | 인플(이름·가나·이메일) + 캠페인(명·브랜드·번호) 동시 | 캠페인 검색이 콤보박스로 빠지면 중복 |
+| 미제출 포함 | 승인됐는데 결과물 0건 신청 노출 | 다중채널 **부분 제출**은 안 잡힘(의미 모호) |
+| 대리등록만 | `submitted_by_admin` 있는 그룹 | 점 6 — 현행 유지 |
+
+### 이 제안과 충돌 가능성 있는 기존 동작
+- `createMultiFilter`는 **관리자 전역 공용 헬퍼**(캠페인/신청/인플루언서/기준데이터/관리자계정 등 다수 페인이 사용). 검색 기능 추가는 **opt-in 플래그**로만 — 기본 동작 변경 금지(회귀 위험).
+- `syncCampMultiFilter` 공유 → 캠페인 검색형 전환 시 **신청 관리(`appCampMulti`)에도 자동 적용**됨. 점 1 「모든 캠페인 드롭다운 통일」 의도와 일치하므로 **의도된 부수효과**(QA 시 신청 관리 화면도 확인).
+- 결과물 관리는 이미 운영 중(대리등록 출시 완료). 약관·DB 영향 없음(순수 관리자 UI/클라이언트 필터).
+- 동일 레이아웃 구조 일관성 규칙(`feedback_verify_structure_consistency`): 필터 줄 재배치가 `admin-pane-list`의 sticky-header→admin-card→table 구조·스크롤을 깨면 안 됨. 더보기 접이식이 sticky 높이를 바꾸므로 thead sticky·tbody 스크롤 회귀 점검 필수.
+
+### 미해결 백로그·관련 작업
+- 메모리 `project_admin_proxy_deliverable.md` — 대리등록 운영 출시 완료(점 6 기준선)
+- 메모리 `project_multichannel_deliverable.md` — monitor 채널별 결과물 분리(사양 2). 레거시 `post_channel=NULL` 385건이 채널 미분류의 원인
+- 메모리 `project_admin_server_pagination.md` — 관리자 목록 서버 페이지네이션(설계만, 미착수). 본 작업은 **클라이언트 전건 fetch 유지**(현행). 페이지네이션 전환 시 필터 로직 재이식 필요 — 별개 작업
+
+---
+
+## 의심·경우의 수 (규칙 B)
+
+### 1. 캠페인 검색형 다중선택 (점 1·7) — **결정: 검색 + 다중 선택**
+- 깨질 가능성 ① 대리등록 콤보박스는 단일 선택 → 「통일」을 단일로 받으면 다중 비교 능력 손실. **(해소: 필터는 다중 유지, 검색 UX만 통일. 폼은 1개 선택이 정상이라 단일 유지 — 동작 차이는 의미상 정당)**
+- ② (UX) 검색창이 인플 전용으로 바뀌면 기존에 "캠페인명으로 검색하던" 운영자가 잠깐 헷갈림 → placeholder를 「인플루언서명·이메일 검색」으로 명확히.
+- ③ (기술) 100건 초과 캠페인 시 콤보 목록 잘림 → 대리등록처럼 `slice(0,100)` + 검색 좁히기 안내.
+- **현재 구현 충돌점:** `syncCampMultiFilter` 공유 → 신청 관리에도 적용(의도됨, 확인 완료).
+
+### 2. 채널 필터 (점 2) — **결정: 별도 채널 드롭다운**
+- 깨질 가능성 ① 채널은 모집타입별 가용이 다름(LIPS·@cosme=리뷰어 전용) → 별도 드롭다운이라 조합 폭발은 회피. 단 모집타입 필터와 동시 적용 시 빈 교집합 0건 가능(카운트로 인지 가능).
+- ② 기프팅·방문형은 `post_channel` 자동판별 → **NULL(미상) 행은 특정 채널 필터에 안 걸림** → 채널 필터 활성 시 누락. **(처리 규칙 명시: 아래 §설계 3)**
+- ③ (UX) 채널 라벨은 `getLookupLabel('channel', code)` 필요 — 캐시 미보장 시 코드 노출(`renderDeliverablesList` 98줄에서 이미 `fetchLookups('channel')` 보장).
+
+### 3. 영수증 미제출 오류 (점 3) — **버그 수정 확정**
+- 의도 모호 없음. 기프팅·방문형은 영수증 단계 자체가 없음 → 영수증 상태 **카운트·필터 대상에서 완전 제외**.
+
+### 4. 다중채널 결과물 상태 (점 4·4-1) — **결정: 하나라도 해당(ANY)**
+- 깨질 가능성 ① ANY 매칭 시 한 신청이 검수대기·승인 양쪽에 **동시 집계** → 상태별 건수 합 ≠ 총건수. **(의도된 동작 — UI에 "다중채널은 채널 상태별 중복 집계" 안내 한 줄)**
+- ② 정렬의 「검수대기 우선」은 대표상태(repr) 기반 유지 → 필터는 ANY, 정렬은 repr. 두 로직이 공존해도 모순 없음(필터=노출 여부, 정렬=순서).
+- ③ 채널 미분류(레거시) 385건 존재 → 옵션 완전 삭제 불가. **건수>0일 때만 옵션 노출**.
+
+### 5. 미제출 포함 의미 (점 5) — **결정: 결과물 기준**
+- 모호 해소: 「미제출 포함」 토글 = **승인됐는데 결과물 0건인 신청**을 노출(현행 유지). 다중채널 **부분 미제출**은 그룹이 이미 목록에 있으므로, **결과물 상태='미제출'(ANY)** 필터로 잡음. 두 기능 역할 분리 → 토글 tooltip에 명시.
+
+### 6. 기간 필터·레이아웃 (점 8) — **결정: 최근 제출일만 + 기본줄/더보기 접이식**
+- 깨질 가능성 ① 구매기간·제출마감은 정렬(▲▼)과 중복 → 추가 안 함(필터 과밀 방지).
+- ② 더보기 접이식이 닫혀 있으면 적용된 필터가 안 보임 → **「필터 더보기 (N) ▾」 활성 개수 배지** 필수.
+- ③ (UX) 접이식 펼침/접힘으로 sticky-header 높이 변동 → thead sticky·tbody 스크롤 회귀 점검.
+
+---
+
+## 설계
+
+> DB 변경 없음. 전부 클라이언트 필터/렌더 + 공용 헬퍼 opt-in 확장. 영향 파일 4개: `admin-core.js`, `admin.js`(또는 `admin-deliverables.js`), `admin-deliverables.js`, `dev/admin/index.html`, `dev/css/admin.css`.
+
+### 1. 검색형 다중선택 캠페인 콤보박스 공용화 (점 1·7)
+- `createMultiFilter`에 **`searchable` opt-in 플래그** 추가(기본 false → 기존 전 페인 무영향).
+  - true면 `.mf-drop` 최상단에 검색 input 1개 삽입. 입력 시 `matchSearchTokens(q, [label, subLabel])`로 옵션 행 show/hide(체크 상태·`getMultiFilterValues` 결과 불변).
+  - 「전체」 항목은 항상 노출. 매칭 0건이면 "일치하는 캠페인 없음".
+- `syncMultiFilter`/`syncCampMultiFilter` 시그니처에 `searchable` 전달. `syncCampMultiFilter`만 `searchable:true`.
+- 결과 → `delivCampMulti` + `appCampMulti`(신청 관리) **양쪽 자동 검색형 통일**(점 1 의도).
+- 검색창 분리: `renderDeliverablesList` 검색 매칭에서 캠페인 필드 제거 → `matchSearchTokens(search, [inf.name, inf.name_kana, inf.email])`. HTML placeholder 「인플루언서명·이메일 검색」.
+
+### 2. 영수증 상태 — 리뷰어(monitor) 전용 (점 3)
+- `passesFilters` 영수증 분기: **monitor 그룹만** 대상. 기프팅·방문형은 영수증 필터·카운트에서 제외.
+- `receiptStatusCounts` 집계 루프에서 `g.campaign?.recruit_type === 'monitor'`인 그룹만 합산('none' 포함). 기프팅·방문형은 어떤 영수증 상태에도 안 들어감.
+- 영수증 상태 필터 활성 시 기프팅·방문형 그룹은 자동 비노출(영수증 없음). 셀 「—」 현행 유지.
+
+### 3. 채널 필터 신설 (점 2)
+- 신규 멀티필터 `delivChannelMulti`(더보기 영역). 옵션 = `fetchLookups('channel')` active 항목(value=code, label=`name_ko`, count).
+- 매칭 규칙(그룹 g):
+  - monitor: `campaign.channel` split에 선택 채널이 하나라도 포함되면 통과(캠페인 기준).
+  - gifting/visit: `g.result?.post_channel`이 선택 채널이면 통과.
+  - **채널 미상(post_channel NULL) 행**: 특정 채널 선택 시 비매칭(=숨김). 「전체」면 노출. → 채널 옵션에 **「채널 미상」 값(`__none__`)**을 건수>0일 때만 추가(영수증 처리와 동일 패턴).
+- 카운트·`passesFilters`에 `skipChannel` 추가(표준 패턴).
+
+### 4. 결과물 상태 ANY 매칭 + 채널 미분류 조건부 (점 4·4-1·5)
+- `passesFilters` 결과물 분기:
+  - monitor: 그룹의 채널별 상태 집합 `states`(미제출=none, 레거시=legacy_no_channel 포함) 중 **하나라도 선택값에 들면 통과**.
+  - gifting/visit: `g.result?.status`(없으면 none).
+- 카운트: 그룹이 가진 **각 상태마다** +1(중복 집계 허용). UI에 안내 문구 1줄.
+- 채널 미분류 옵션: `resultStatusCounts.legacy_no_channel > 0`일 때만 옵션 배열에 포함.
+- 미제출 포함 토글 tooltip: 「승인됐지만 결과물을 한 건도 제출하지 않은 신청을 함께 표시합니다. (다중채널 일부 미제출은 '결과물 상태=미제출'로 거르세요)」
+
+### 5. 최근 제출일 기간 필터 (점 8-1/8-2)
+- 더보기 영역에 flatpickr range 1개(`delivSubmittedRange`). 기준 = 그룹 `latest_submitted_at`.
+- 필터: 선택 범위 [start, end] 안의 그룹만(`latest_submitted_at` 날짜 비교, 양끝 포함).
+- `resetDelivFiltersAndSort`에 초기화 추가. 구매기간·제출마감은 정렬(▲▼) 유지(추가 안 함).
+
+### 6. 레이아웃 — 기본줄 + 더보기 접이식 (점 8-3)
+```
+┌─ 결과물 관리 ───────────────────────────────────┐
+│ [🔍 캠페인 검색·선택 ▾]  [결과물 상태 ▾]            │
+│ [🔍 인플루언서명·이메일 검색 ...............]        │
+│ [⚙ 필터 더보기 (N) ▾]              [초기화]        │  ← N = 더보기 영역 활성 필터 수
+│                                                  │
+│ ── 더보기 펼침(기본 닫힘) ──                        │
+│ [모집타입 ▾] [채널 ▾] [영수증 ▾] [최근 제출일 ▾]     │
+│ ☐ 미제출 포함   ☐ 대리등록만                        │
+└──────────────────────────────────────────────┘
+```
+- 「필터 더보기」 토글 버튼: 더보기 영역 show/hide. 닫혀 있어도 **활성 필터 수 배지**(모집타입·채널·영수증·기간·미제출·대리등록 중 적용된 개수) 표시.
+- 더보기 영역에 활성 필터가 1개라도 있으면 배지 강조(또는 자동 펼침은 하지 않고 배지만 — 사용자 수동 토글 존중).
+- sticky-header 안에 기본줄+더보기 모두 배치(접힘 시 높이 축소). thead sticky·tbody 스크롤 회귀 QA.
+
+---
+
+## PR 분할
+
+| PR | 제목 | 범위 | 의존 |
+|---|---|---|---|
+| PR 1 | 캠페인 검색형 다중선택 공용화 + 검색 인플 분리 | §설계 1 — `createMultiFilter` searchable opt-in, `syncCampMultiFilter` 적용(결과물+신청 양쪽), 검색 매칭 인플 전용 | 없음 |
+| PR 2 | 결과물 관리 필터 정확성 | §설계 2(영수증 monitor 전용)·4(결과물 ANY+채널미분류 조건부)·미제출 tooltip(5) | PR 1 |
+| PR 3 | 채널 필터 + 최근 제출일 기간 + 레이아웃 재배치 | §설계 3·5·6 — 신규 채널 필터, 기간 필터, 기본줄/더보기 접이식 + CSS | PR 1·2 |
+
+- 각 PR: `bash dev/build.sh` → reverb-reviewer GO → dev 머지. QA는 **Light(관리자 페인 — 컬럼·필터·모달)**. PR 3 머지 후 신청 관리 화면(캠페인 검색형 부수효과)도 함께 확인.
+- 운영 배포: 약관·DB 영향 없음. dev 검증 후 운영 배포 여부는 사용자 확인(`.claude/rules/git.md`).
+- `createMultiFilter` 변경(PR 1)은 전역 공용 헬퍼 → reviewer가 **모든 호출처 무영향(searchable 기본 false)** 확인 의무.
+
+## 사용자 확인 필요 (확정 완료)
+- 캠페인 필터 = 검색 + **다중 선택** ✅
+- 채널 = **별도 드롭다운** ✅
+- 다중채널 결과물 상태 = **하나라도 해당(ANY)** ✅
+- 기간 필터 = **최근 제출일만** ✅
+- 레이아웃 = **기본줄 + 더보기 접이식** ✅
+- (권고 반영) 점 3 영수증 monitor 전용 / 점 4-1 채널미분류 건수>0만 / 점 5 미제출=결과물 기준 / 점 7 검색=인플 전용
+
+## 구현 결과 (개발 세션이 채울 것)
+
+### PR 1 — 캠페인 검색형 다중선택 공용화 + 검색 인플 분리 (구현 완료)
+**구현일:** 2026-05-29
+**브랜치:** `feature/deliv-filter-redesign`
+
+#### 초안 대비 변경 사항
+- **추가된 것:** 신청 관리(`appSearch`) 검색창도 인플루언서 전용으로 통일(사용자 확인 — 「같이 통일」 선택). 사양서 초안 §설계 1은 결과물 관리 검색창만 명시했으나, `syncCampMultiFilter` 공용 전환으로 `appCampMulti`도 검색형이 되어 일관성 위해 신청 관리 검색에서도 캠페인 필드(`title/brand/brand_ko/product/product_ko/campaign_no`) 제거 + placeholder 변경.
+- **빠진 것:** 없음.
+- **달라진 것:** 검색창 placeholder를 결과물·신청 양쪽 「인플루언서명 · 이메일 검색」으로 통일.
+
+#### 구현 중 기술 결정 사항
+- `createMultiFilter`에 `opts.searchable`/`opts.searchPlaceholder` opt-in 추가(기본 false → 기존 전 페인 무영향). 검색형이면 `.mf-drop` 최상단에 sticky `.mf-search` input + `.mf-search-empty` 안내 삽입.
+- **회귀 차단:** 검색 input(`type=search`)이 필터 값에 섞이지 않도록 `getMultiFilterValues`/`resetMultiFilter`/`syncMultiFilter`/`createMultiFilter`의 옵션 셀렉터를 `input[type="checkbox"]:not([value="all"])`로 한정.
+- `syncMultiFilter` 옵션 캐시키(`optKey`)에 `'|__search'` 식별자 추가(검색형 컨테이너 재생성 보장, 비검색은 키 불변).
+- DB·RLS·약관 영향 없음(순수 관리자 클라이언트 UI).
+- reverb-reviewer GO(Warning 2건 반영 후 재검증 GO), qa-tester 권장 light.
+
+### PR 2 — 결과물 관리 필터 정확성 (예정)
+### PR 3 — 채널 필터 + 최근 제출일 + 레이아웃 재배치 (예정)


### PR DESCRIPTION
## 변경 요약
- 공용 멀티필터 헬퍼 `createMultiFilter`에 검색형 opt-in(`searchable`) 추가 — 캠페인 드롭다운에서 이름·번호 검색 가능
- `syncCampMultiFilter` 검색형 전환 → 결과물 관리(`delivCampMulti`)·신청 관리(`appCampMulti`) 양쪽 자동 통일
- 결과물·신청 관리 텍스트 검색창을 인플루언서 전용(이름·가나·이메일)으로 분리, placeholder 「인플루언서명 · 이메일 검색」

## 요청 외 추가 변경
- 신청 관리 검색창도 인플 전용으로 통일(사용자 확인 — 「같이 통일」 선택). PR1 범위 살짝 확장이나 캠페인 드롭다운 검색형 전환의 일관성 차원

## 관련 사양서
- docs/specs/2026-05-29-deliverables-filter-redesign.md (PR 1 구현 결과 기록)

## 검증
- reverb-reviewer GO (Warning 2건 반영 후 재검증)
- DB·RLS·약관 영향 없음 (순수 관리자 클라이언트 UI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)