### PR TITLE
feat(admin): 결과물 관리 필터 재설계 PR2 — 영수증 리뷰어 전용 + 결과물 ANY 매칭

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -12,7 +12,7 @@
 // 회귀(2026-05-12 PR #182 머지 직후 발생)를 방지하기 위한 자동 reload 가드.
 // sessionStorage 차단 환경(시크릿 모드 일부, 쿠키 차단)에서는 자연스럽게 skip.
 (function(){
-  var CURRENT_BUILD = 'v1780040903';
+  var CURRENT_BUILD = 'v1780042120';
   if (CURRENT_BUILD.indexOf('__') === 0) return; // 빌드 미적용 (dev/ 직접 열기) 시 skip
   try {
     var prev = sessionStorage.getItem('reverb.adminBuild');
@@ -1896,7 +1896,7 @@ textarea.form-input{resize:vertical;min-height:80px}
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-05-29 16:48 · 942a6ec</span>
+          <span class="admin-build-text">2026-05-29 17:08 · e4d7d47</span>
         </div>
       </div>
     </aside>
@@ -2816,16 +2816,16 @@ textarea.form-input{resize:vertical;min-height:80px}
                 <div id="delivRecruitTypeMulti" class="mf-wrap"><button type="button" class="mf-btn">전체 타입</button><div class="mf-drop"></div></div>
               </div>
               <div class="admin-filter-group">
-                <label>영수증 상태</label>
+                <label>영수증 상태 <span class="material-icons-round notranslate" translate="no" title="영수증은 리뷰어 캠페인 전용입니다. 영수증 상태로 거르면 기프팅·방문형은 표시되지 않습니다." style="font-size:13px;cursor:help;color:var(--muted);vertical-align:middle">info_outline</span></label>
                 <div id="delivReceiptStatusMulti" class="mf-wrap"><button type="button" class="mf-btn">전체</button><div class="mf-drop"></div></div>
               </div>
               <div class="admin-filter-group">
-                <label>결과물 상태</label>
+                <label>결과물 상태 <span class="material-icons-round notranslate" translate="no" title="다중채널 캠페인은 채널별 상태가 상태 종류마다 따로 집계됩니다. (예: 인스타 승인 + X 검수대기 → 승인·검수대기 양쪽 건수에 포함)" style="font-size:13px;cursor:help;color:var(--muted);vertical-align:middle">info_outline</span></label>
                 <div id="delivResultStatusMulti" class="mf-wrap"><button type="button" class="mf-btn">전체</button><div class="mf-drop"></div></div>
               </div>
               <div class="admin-filter-group" style="justify-content:flex-end">
                 <label>미제출</label>
-                <label style="display:inline-flex;align-items:center;gap:4px;font-size:12px;cursor:pointer;height:32px">
+                <label style="display:inline-flex;align-items:center;gap:4px;font-size:12px;cursor:pointer;height:32px" title="승인됐지만 결과물을 한 건도 제출하지 않은 신청을 함께 표시합니다. (다중채널에서 일부 채널만 미제출인 경우는 '결과물 상태=미제출'로 거르세요)">
                   <input type="checkbox" id="delivIncludeMissing" onchange="renderDeliverablesList()" checked style="margin:0">
                   <span>포함</span>
                 </label>
@@ -17008,6 +17008,7 @@ async function renderDeliverablesList() {
     if (channels.length === 0) {
       // 채널 미등록 monitor 캠페인 — 레거시 행 있으면 legacy 표시
       g.result_status_repr = g.hasLegacyReviewImage ? 'legacy_no_channel' : 'none';
+      g.result_states = [g.result_status_repr];
       continue;
     }
     const states = channels.map(ch => (g.reviewByChannel[ch]?.status) || 'none');
@@ -17019,6 +17020,10 @@ async function renderDeliverablesList() {
       repr = g.hasLegacyReviewImage ? 'legacy_no_channel' : 'none';
     }
     g.result_status_repr = repr;
+    // 필터 ANY 매칭용 상태 집합 — 채널별 상태(미제출=none) + 레거시 NULL channel 행 있으면 legacy_no_channel
+    const stateSet = new Set(states);
+    if (g.hasLegacyReviewImage) stateSet.add('legacy_no_channel');
+    g.result_states = [...stateSet];
   }
 
   // 옵션별 카운트 — 표준 multi-filter 패턴: 「자기 자신 필터 제외 + 다른 모든 필터 적용」 후 그룹 수.
@@ -17031,13 +17036,21 @@ async function renderDeliverablesList() {
     if (!opts.skipRecruit && recruitTypeVals.length > 0 && !recruitTypeVals.includes(g.campaign?.recruit_type)) return false;
     if (!opts.skipCamp && delivCampVals.length > 0 && !delivCampVals.includes(g.campaign?.id)) return false;
     if (!opts.skipReceipt && receiptStatusVals.length > 0) {
+      // 영수증은 리뷰어(monitor) 전용 — 기프팅·방문형은 영수증 단계가 없음
+      if (g.campaign?.recruit_type !== 'monitor') return false;
       const s = g.receipt ? g.receipt.status : 'none';
       if (!receiptStatusVals.includes(s)) return false;
     }
     if (!opts.skipResult && resultStatusVals.length > 0) {
       const rt2 = g.campaign?.recruit_type;
-      const s = (rt2 === 'monitor') ? (g.result_status_repr || 'none') : (g.result ? g.result.status : 'none');
-      if (!resultStatusVals.includes(s)) return false;
+      if (rt2 === 'monitor') {
+        // 다중채널: 채널별 상태 중 하나라도 선택값에 들면 통과 (ANY)
+        const states = g.result_states || ['none'];
+        if (!states.some(s => resultStatusVals.includes(s))) return false;
+      } else {
+        const s = g.result ? g.result.status : 'none';
+        if (!resultStatusVals.includes(s)) return false;
+      }
     }
     if (search) {
       // 검색은 인플루언서 전용 (캠페인은 검색형 캠페인 드롭다운으로 분리)
@@ -17062,16 +17075,21 @@ async function renderDeliverablesList() {
       const rt = g.campaign?.recruit_type;
       if (rt && (rt in recruitTypeCounts)) recruitTypeCounts[rt]++;
     }
-    // 영수증 상태 카운트: 자기 자신(영수증 필터) 제외 → 결과물·캠페인·모집타입·검색 모두 적용
-    if (passesFilters(g, {skipReceipt: true})) {
+    // 영수증 상태 카운트: 리뷰어(monitor) 그룹만 합산 (기프팅·방문형 'none' 오집계 차단)
+    if (passesFilters(g, {skipReceipt: true}) && g.campaign?.recruit_type === 'monitor') {
       const rs = g.receipt ? g.receipt.status : 'none';
       if (rs in receiptStatusCounts) receiptStatusCounts[rs]++;
     }
     // 결과물 상태 카운트: 자기 자신(결과물 필터) 제외 → 영수증·캠페인·모집타입·검색 모두 적용
     if (passesFilters(g, {skipResult: true})) {
       const rt = g.campaign?.recruit_type;
-      const xs = (rt === 'monitor') ? (g.result_status_repr || 'none') : (g.result ? g.result.status : 'none');
-      if (xs in resultStatusCounts) resultStatusCounts[xs]++;
+      if (rt === 'monitor') {
+        // 다중채널: 그룹이 가진 상태 종류마다 +1 (ANY 매칭과 정합 — 중복 집계 허용)
+        [...new Set(g.result_states || ['none'])].forEach(s => { if (s in resultStatusCounts) resultStatusCounts[s]++; });
+      } else {
+        const xs = g.result ? g.result.status : 'none';
+        if (xs in resultStatusCounts) resultStatusCounts[xs]++;
+      }
     }
   }
 
@@ -17090,28 +17108,37 @@ async function renderDeliverablesList() {
     {value:'rejected', label:'비승인',  count: receiptStatusCounts.rejected},
     {value:'none',     label:'미제출',  count: receiptStatusCounts.none},
   ], () => renderDeliverablesList());
-  syncMultiFilter('delivResultStatusMulti', '전체', [
-    {value:'pending',           label:'검수대기',   count: resultStatusCounts.pending},
-    {value:'approved',          label:'승인',       count: resultStatusCounts.approved},
-    {value:'rejected',          label:'비승인',     count: resultStatusCounts.rejected},
-    {value:'legacy_no_channel', label:'채널 미분류', count: resultStatusCounts.legacy_no_channel},
-    {value:'none',              label:'미제출',     count: resultStatusCounts.none},
-  ], () => renderDeliverablesList());
+  const delivResultOpts = [
+    {value:'pending',  label:'검수대기', count: resultStatusCounts.pending},
+    {value:'approved', label:'승인',    count: resultStatusCounts.approved},
+    {value:'rejected', label:'비승인',  count: resultStatusCounts.rejected},
+  ];
+  // 채널 미분류(레거시 NULL channel)는 건수>0일 때만 노출 — 채널 강제 이후 신규 0건
+  if (resultStatusCounts.legacy_no_channel > 0) {
+    delivResultOpts.push({value:'legacy_no_channel', label:'채널 미분류', count: resultStatusCounts.legacy_no_channel});
+  }
+  delivResultOpts.push({value:'none', label:'미제출', count: resultStatusCounts.none});
+  syncMultiFilter('delivResultStatusMulti', '전체', delivResultOpts, () => renderDeliverablesList());
 
   // 필터 적용
   let filtered = Array.from(groups.values());
   if (recruitTypeVals.length > 0) filtered = filtered.filter(g => g.campaign && recruitTypeVals.includes(g.campaign.recruit_type));
   if (delivCampVals.length > 0) filtered = filtered.filter(g => g.campaign && delivCampVals.includes(g.campaign.id));
   if (receiptStatusVals.length > 0) filtered = filtered.filter(g => {
+    // 영수증은 리뷰어(monitor) 전용 — 기프팅·방문형은 표시 안 함
+    if (g.campaign?.recruit_type !== 'monitor') return false;
     const s = g.receipt ? g.receipt.status : 'none';
     return receiptStatusVals.includes(s);
   });
   if (resultStatusVals.length > 0) filtered = filtered.filter(g => {
-    // monitor: reviewByChannel 종합 대표 상태(g.result_status_repr) / gifting·visit: g.result(post)
     const rt = g.campaign?.recruit_type;
-    const s = (rt === 'monitor')
-      ? (g.result_status_repr || 'none')
-      : (g.result ? g.result.status : 'none');
+    if (rt === 'monitor') {
+      // 다중채널: 채널별 상태 중 하나라도 선택값에 들면 통과 (ANY)
+      const states = g.result_states || ['none'];
+      return states.some(s => resultStatusVals.includes(s));
+    }
+    // gifting·visit: g.result(post)
+    const s = g.result ? g.result.status : 'none';
     return resultStatusVals.includes(s);
   });
   // 검색 필터 — 인플루언서 전용(단어 단위 AND, 전각/반각 공백 무관). 캠페인은 검색형 드롭다운으로 분리

--- a/dev/admin/index.html
+++ b/dev/admin/index.html
@@ -1051,16 +1051,16 @@
                 <div id="delivRecruitTypeMulti" class="mf-wrap"><button type="button" class="mf-btn">전체 타입</button><div class="mf-drop"></div></div>
               </div>
               <div class="admin-filter-group">
-                <label>영수증 상태</label>
+                <label>영수증 상태 <span class="material-icons-round notranslate" translate="no" title="영수증은 리뷰어 캠페인 전용입니다. 영수증 상태로 거르면 기프팅·방문형은 표시되지 않습니다." style="font-size:13px;cursor:help;color:var(--muted);vertical-align:middle">info_outline</span></label>
                 <div id="delivReceiptStatusMulti" class="mf-wrap"><button type="button" class="mf-btn">전체</button><div class="mf-drop"></div></div>
               </div>
               <div class="admin-filter-group">
-                <label>결과물 상태</label>
+                <label>결과물 상태 <span class="material-icons-round notranslate" translate="no" title="다중채널 캠페인은 채널별 상태가 상태 종류마다 따로 집계됩니다. (예: 인스타 승인 + X 검수대기 → 승인·검수대기 양쪽 건수에 포함)" style="font-size:13px;cursor:help;color:var(--muted);vertical-align:middle">info_outline</span></label>
                 <div id="delivResultStatusMulti" class="mf-wrap"><button type="button" class="mf-btn">전체</button><div class="mf-drop"></div></div>
               </div>
               <div class="admin-filter-group" style="justify-content:flex-end">
                 <label>미제출</label>
-                <label style="display:inline-flex;align-items:center;gap:4px;font-size:12px;cursor:pointer;height:32px">
+                <label style="display:inline-flex;align-items:center;gap:4px;font-size:12px;cursor:pointer;height:32px" title="승인됐지만 결과물을 한 건도 제출하지 않은 신청을 함께 표시합니다. (다중채널에서 일부 채널만 미제출인 경우는 '결과물 상태=미제출'로 거르세요)">
                   <input type="checkbox" id="delivIncludeMissing" onchange="renderDeliverablesList()" checked style="margin:0">
                   <span>포함</span>
                 </label>

--- a/dev/js/admin-deliverables.js
+++ b/dev/js/admin-deliverables.js
@@ -194,6 +194,7 @@ async function renderDeliverablesList() {
     if (channels.length === 0) {
       // 채널 미등록 monitor 캠페인 — 레거시 행 있으면 legacy 표시
       g.result_status_repr = g.hasLegacyReviewImage ? 'legacy_no_channel' : 'none';
+      g.result_states = [g.result_status_repr];
       continue;
     }
     const states = channels.map(ch => (g.reviewByChannel[ch]?.status) || 'none');
@@ -205,6 +206,10 @@ async function renderDeliverablesList() {
       repr = g.hasLegacyReviewImage ? 'legacy_no_channel' : 'none';
     }
     g.result_status_repr = repr;
+    // 필터 ANY 매칭용 상태 집합 — 채널별 상태(미제출=none) + 레거시 NULL channel 행 있으면 legacy_no_channel
+    const stateSet = new Set(states);
+    if (g.hasLegacyReviewImage) stateSet.add('legacy_no_channel');
+    g.result_states = [...stateSet];
   }
 
   // 옵션별 카운트 — 표준 multi-filter 패턴: 「자기 자신 필터 제외 + 다른 모든 필터 적용」 후 그룹 수.
@@ -217,13 +222,21 @@ async function renderDeliverablesList() {
     if (!opts.skipRecruit && recruitTypeVals.length > 0 && !recruitTypeVals.includes(g.campaign?.recruit_type)) return false;
     if (!opts.skipCamp && delivCampVals.length > 0 && !delivCampVals.includes(g.campaign?.id)) return false;
     if (!opts.skipReceipt && receiptStatusVals.length > 0) {
+      // 영수증은 리뷰어(monitor) 전용 — 기프팅·방문형은 영수증 단계가 없음
+      if (g.campaign?.recruit_type !== 'monitor') return false;
       const s = g.receipt ? g.receipt.status : 'none';
       if (!receiptStatusVals.includes(s)) return false;
     }
     if (!opts.skipResult && resultStatusVals.length > 0) {
       const rt2 = g.campaign?.recruit_type;
-      const s = (rt2 === 'monitor') ? (g.result_status_repr || 'none') : (g.result ? g.result.status : 'none');
-      if (!resultStatusVals.includes(s)) return false;
+      if (rt2 === 'monitor') {
+        // 다중채널: 채널별 상태 중 하나라도 선택값에 들면 통과 (ANY)
+        const states = g.result_states || ['none'];
+        if (!states.some(s => resultStatusVals.includes(s))) return false;
+      } else {
+        const s = g.result ? g.result.status : 'none';
+        if (!resultStatusVals.includes(s)) return false;
+      }
     }
     if (search) {
       // 검색은 인플루언서 전용 (캠페인은 검색형 캠페인 드롭다운으로 분리)
@@ -248,16 +261,21 @@ async function renderDeliverablesList() {
       const rt = g.campaign?.recruit_type;
       if (rt && (rt in recruitTypeCounts)) recruitTypeCounts[rt]++;
     }
-    // 영수증 상태 카운트: 자기 자신(영수증 필터) 제외 → 결과물·캠페인·모집타입·검색 모두 적용
-    if (passesFilters(g, {skipReceipt: true})) {
+    // 영수증 상태 카운트: 리뷰어(monitor) 그룹만 합산 (기프팅·방문형 'none' 오집계 차단)
+    if (passesFilters(g, {skipReceipt: true}) && g.campaign?.recruit_type === 'monitor') {
       const rs = g.receipt ? g.receipt.status : 'none';
       if (rs in receiptStatusCounts) receiptStatusCounts[rs]++;
     }
     // 결과물 상태 카운트: 자기 자신(결과물 필터) 제외 → 영수증·캠페인·모집타입·검색 모두 적용
     if (passesFilters(g, {skipResult: true})) {
       const rt = g.campaign?.recruit_type;
-      const xs = (rt === 'monitor') ? (g.result_status_repr || 'none') : (g.result ? g.result.status : 'none');
-      if (xs in resultStatusCounts) resultStatusCounts[xs]++;
+      if (rt === 'monitor') {
+        // 다중채널: 그룹이 가진 상태 종류마다 +1 (ANY 매칭과 정합 — 중복 집계 허용)
+        [...new Set(g.result_states || ['none'])].forEach(s => { if (s in resultStatusCounts) resultStatusCounts[s]++; });
+      } else {
+        const xs = g.result ? g.result.status : 'none';
+        if (xs in resultStatusCounts) resultStatusCounts[xs]++;
+      }
     }
   }
 
@@ -276,28 +294,37 @@ async function renderDeliverablesList() {
     {value:'rejected', label:'비승인',  count: receiptStatusCounts.rejected},
     {value:'none',     label:'미제출',  count: receiptStatusCounts.none},
   ], () => renderDeliverablesList());
-  syncMultiFilter('delivResultStatusMulti', '전체', [
-    {value:'pending',           label:'검수대기',   count: resultStatusCounts.pending},
-    {value:'approved',          label:'승인',       count: resultStatusCounts.approved},
-    {value:'rejected',          label:'비승인',     count: resultStatusCounts.rejected},
-    {value:'legacy_no_channel', label:'채널 미분류', count: resultStatusCounts.legacy_no_channel},
-    {value:'none',              label:'미제출',     count: resultStatusCounts.none},
-  ], () => renderDeliverablesList());
+  const delivResultOpts = [
+    {value:'pending',  label:'검수대기', count: resultStatusCounts.pending},
+    {value:'approved', label:'승인',    count: resultStatusCounts.approved},
+    {value:'rejected', label:'비승인',  count: resultStatusCounts.rejected},
+  ];
+  // 채널 미분류(레거시 NULL channel)는 건수>0일 때만 노출 — 채널 강제 이후 신규 0건
+  if (resultStatusCounts.legacy_no_channel > 0) {
+    delivResultOpts.push({value:'legacy_no_channel', label:'채널 미분류', count: resultStatusCounts.legacy_no_channel});
+  }
+  delivResultOpts.push({value:'none', label:'미제출', count: resultStatusCounts.none});
+  syncMultiFilter('delivResultStatusMulti', '전체', delivResultOpts, () => renderDeliverablesList());
 
   // 필터 적용
   let filtered = Array.from(groups.values());
   if (recruitTypeVals.length > 0) filtered = filtered.filter(g => g.campaign && recruitTypeVals.includes(g.campaign.recruit_type));
   if (delivCampVals.length > 0) filtered = filtered.filter(g => g.campaign && delivCampVals.includes(g.campaign.id));
   if (receiptStatusVals.length > 0) filtered = filtered.filter(g => {
+    // 영수증은 리뷰어(monitor) 전용 — 기프팅·방문형은 표시 안 함
+    if (g.campaign?.recruit_type !== 'monitor') return false;
     const s = g.receipt ? g.receipt.status : 'none';
     return receiptStatusVals.includes(s);
   });
   if (resultStatusVals.length > 0) filtered = filtered.filter(g => {
-    // monitor: reviewByChannel 종합 대표 상태(g.result_status_repr) / gifting·visit: g.result(post)
     const rt = g.campaign?.recruit_type;
-    const s = (rt === 'monitor')
-      ? (g.result_status_repr || 'none')
-      : (g.result ? g.result.status : 'none');
+    if (rt === 'monitor') {
+      // 다중채널: 채널별 상태 중 하나라도 선택값에 들면 통과 (ANY)
+      const states = g.result_states || ['none'];
+      return states.some(s => resultStatusVals.includes(s));
+    }
+    // gifting·visit: g.result(post)
+    const s = g.result ? g.result.status : 'none';
     return resultStatusVals.includes(s);
   });
   // 검색 필터 — 인플루언서 전용(단어 단위 AND, 전각/반각 공백 무관). 캠페인은 검색형 드롭다운으로 분리


### PR DESCRIPTION
## 변경 요약
- **영수증 상태 = 리뷰어(monitor) 전용**: 기프팅·방문형이 영수증 단계 없이 '미제출'로 오집계되던 버그 수정 (필터·카운트·내부판정 3곳)
- **결과물 상태 ANY 매칭**: 다중채널 캠페인은 채널별 상태 중 하나라도 선택값에 해당하면 통과(반려+검수대기 섞여도 양쪽에서 검색). 카운트도 상태 종류마다 집계
- **채널 미분류 옵션**은 해당 건수>0일 때만 노출
- 안내 문구 3종(영수증 리뷰어 전용 / 결과물 다중채널 중복집계 / 미제출 포함 tooltip)

## 요청 외 추가 변경
- 없음

## 관련 사양서
- docs/specs/2026-05-29-deliverables-filter-redesign.md §설계 2·4·5

## 검증
- reverb-reviewer GO (관리자 UI 일본어 혼입 경고 1건 반영 후)
- DB·RLS·약관 영향 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)