### PR TITLE
fix(admin): 결과물 관리 초기화 시 미제출 포함 기본값(ON) 복원

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -12,7 +12,7 @@
 // 회귀(2026-05-12 PR #182 머지 직후 발생)를 방지하기 위한 자동 reload 가드.
 // sessionStorage 차단 환경(시크릿 모드 일부, 쿠키 차단)에서는 자연스럽게 skip.
 (function(){
-  var CURRENT_BUILD = 'v1780042120';
+  var CURRENT_BUILD = 'v1780042810';
   if (CURRENT_BUILD.indexOf('__') === 0) return; // 빌드 미적용 (dev/ 직접 열기) 시 skip
   try {
     var prev = sessionStorage.getItem('reverb.adminBuild');
@@ -1896,7 +1896,7 @@ textarea.form-input{resize:vertical;min-height:80px}
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-05-29 17:08 · e4d7d47</span>
+          <span class="admin-build-text">2026-05-29 17:20 · ad09491</span>
         </div>
       </div>
     </aside>
@@ -16857,7 +16857,8 @@ function resetDelivFiltersAndSort() {
   resetMultiFilter('delivResultStatusMulti', '전체');
   resetMultiFilter('delivCampMulti', '전체 캠페인');
   const q = $('delivSearch'); if (q) q.value = '';
-  const cb = $('delivIncludeMissing'); if (cb) cb.checked = false;
+  // 미제출 포함은 기본값 ON(HTML checked)과 일치하게 복원 — 초기화 후 전체 건수가 보이도록
+  const cb = $('delivIncludeMissing'); if (cb) cb.checked = true;
   const cb2 = $('delivProxyOnly'); if (cb2) cb2.checked = false;
   _delivSort = {col: null, dir: null};
   renderDeliverablesList();

--- a/dev/js/admin-deliverables.js
+++ b/dev/js/admin-deliverables.js
@@ -43,7 +43,8 @@ function resetDelivFiltersAndSort() {
   resetMultiFilter('delivResultStatusMulti', '전체');
   resetMultiFilter('delivCampMulti', '전체 캠페인');
   const q = $('delivSearch'); if (q) q.value = '';
-  const cb = $('delivIncludeMissing'); if (cb) cb.checked = false;
+  // 미제출 포함은 기본값 ON(HTML checked)과 일치하게 복원 — 초기화 후 전체 건수가 보이도록
+  const cb = $('delivIncludeMissing'); if (cb) cb.checked = true;
   const cb2 = $('delivProxyOnly'); if (cb2) cb2.checked = false;
   _delivSort = {col: null, dir: null};
   renderDeliverablesList();


### PR DESCRIPTION
## 변경 요약
- 결과물 관리 「초기화」 버튼이 「미제출 포함」을 OFF로 남겨 초기화 후 8건만 보이던 문제 수정. 기본값(ON)으로 복원해 전체 건수가 나오도록.

## 관련 사양서
- docs/specs/2026-05-29-deliverables-filter-redesign.md (PR2 QA 후속 fix)

## 검증
- reverb-reviewer GO, qa skip 권장(1줄 기본값 복원)

🤖 Generated with [Claude Code](https://claude.com/claude-code)