### PR TITLE
feat(admin): 결과물 관리 필터 재설계 PR3 — 채널 필터 + 기간 필터 + 더보기 접이식 레이아웃

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -12,7 +12,7 @@
 // 회귀(2026-05-12 PR #182 머지 직후 발생)를 방지하기 위한 자동 reload 가드.
 // sessionStorage 차단 환경(시크릿 모드 일부, 쿠키 차단)에서는 자연스럽게 skip.
 (function(){
-  var CURRENT_BUILD = 'v1780042810';
+  var CURRENT_BUILD = 'v1780043427';
   if (CURRENT_BUILD.indexOf('__') === 0) return; // 빌드 미적용 (dev/ 직접 열기) 시 skip
   try {
     var prev = sessionStorage.getItem('reverb.adminBuild');
@@ -498,6 +498,9 @@ textarea.form-input{resize:vertical;min-height:80px}
 .mf-search{width:100%;box-sizing:border-box;padding:6px 8px;font-size:12px;border:1px solid var(--outline);border-radius:6px;color:var(--ink);outline:none}
 .mf-search:focus{border-color:var(--primary)}
 .mf-search-empty{padding:10px 12px;font-size:12px;color:var(--muted);text-align:center}
+/* 결과물 관리 「필터 더보기」 토글 — 활성 필터 수 배지 + 기간 선택 활성 표시 */
+.deliv-more-badge{display:inline-flex;align-items:center;justify-content:center;min-width:16px;height:16px;padding:0 4px;margin-left:2px;background:var(--primary);color:#fff;border-radius:8px;font-size:10px;font-weight:700;line-height:1}
+.admin-filter-search.filter-active{border-color:var(--primary);color:var(--primary)}
 .admin-layout{display:grid;grid-template-columns:220px 1fr;height:100vh;transition:grid-template-columns .25s ease}
 .admin-layout.collapsed{grid-template-columns:56px 1fr}
 .admin-side{background:#1A0F18;padding:0;height:100%;overflow:hidden;flex-shrink:0;transition:width .25s ease;display:flex;flex-direction:column}
@@ -1896,7 +1899,7 @@ textarea.form-input{resize:vertical;min-height:80px}
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-05-29 17:20 · ad09491</span>
+          <span class="admin-build-text">2026-05-29 17:30 · 757eb5f</span>
         </div>
       </div>
     </aside>
@@ -2806,22 +2809,53 @@ textarea.form-input{resize:vertical;min-height:80px}
                 관리자 대리 등록
               </button>
             </div>
+            <!-- 기본줄: 자주 쓰는 필터 + 더보기 토글 -->
             <div style="display:flex;align-items:flex-end;gap:12px;flex-wrap:wrap">
               <div class="admin-filter-group">
                 <label>캠페인</label>
                 <div id="delivCampMulti" class="mf-wrap" style="max-width:260px"><button type="button" class="mf-btn" style="max-width:260px;overflow:hidden;text-overflow:ellipsis">전체 캠페인</button><div class="mf-drop" style="min-width:320px;max-width:420px"></div></div>
               </div>
               <div class="admin-filter-group">
+                <label>결과물 상태 <span class="material-icons-round notranslate" translate="no" title="다중채널 캠페인은 채널별 상태가 상태 종류마다 따로 집계됩니다. (예: 인스타 승인 + X 검수대기 → 승인·검수대기 양쪽 건수에 포함)" style="font-size:13px;cursor:help;color:var(--muted);vertical-align:middle">info_outline</span></label>
+                <div id="delivResultStatusMulti" class="mf-wrap"><button type="button" class="mf-btn">전체</button><div class="mf-drop"></div></div>
+              </div>
+              <div class="admin-filter-group" style="flex:1;min-width:200px">
+                <label>검색</label>
+                <div style="position:relative">
+                  <span class="material-icons-round" style="position:absolute;left:8px;top:50%;transform:translateY(-50%);font-size:16px;color:var(--muted)">search</span>
+                  <input type="search" id="delivSearch" class="admin-filter-search" autocomplete="off" data-lpignore="true" data-1p-ignore="true" readonly onfocus="this.removeAttribute('readonly')" placeholder="인플루언서명 · 이메일 검색" oninput="renderDeliverablesList()">
+                </div>
+              </div>
+              <div class="admin-filter-group" style="justify-content:flex-end">
+                <label>&nbsp;</label>
+                <button type="button" class="btn btn-ghost btn-sm deliv-more-btn" id="btnDelivMoreFilters" onclick="toggleDelivMoreFilters()">
+                  <span class="material-icons-round notranslate" translate="no" style="font-size:15px;vertical-align:middle">tune</span>
+                  <span>필터 더보기</span><span id="delivMoreFilterBadge" class="deliv-more-badge" style="display:none"></span>
+                  <span class="material-icons-round notranslate deliv-more-caret" translate="no" id="delivMoreCaret" style="font-size:16px;vertical-align:middle">expand_more</span>
+                </button>
+              </div>
+              <div class="admin-filter-group" style="justify-content:flex-end">
+                <label>&nbsp;</label>
+                <button class="btn btn-ghost btn-xs" id="btnDelivFilterReset" onclick="resetDelivFiltersAndSort()" style="display:none">초기화</button>
+              </div>
+            </div>
+            <!-- 더보기 영역 (기본 닫힘) -->
+            <div id="delivMoreFilters" style="display:none;align-items:flex-end;gap:12px;flex-wrap:wrap;margin-top:10px;padding-top:10px;border-top:1px dashed var(--outline)">
+              <div class="admin-filter-group">
                 <label>모집 타입</label>
                 <div id="delivRecruitTypeMulti" class="mf-wrap"><button type="button" class="mf-btn">전체 타입</button><div class="mf-drop"></div></div>
+              </div>
+              <div class="admin-filter-group">
+                <label>채널</label>
+                <div id="delivChannelMulti" class="mf-wrap"><button type="button" class="mf-btn">전체 채널</button><div class="mf-drop"></div></div>
               </div>
               <div class="admin-filter-group">
                 <label>영수증 상태 <span class="material-icons-round notranslate" translate="no" title="영수증은 리뷰어 캠페인 전용입니다. 영수증 상태로 거르면 기프팅·방문형은 표시되지 않습니다." style="font-size:13px;cursor:help;color:var(--muted);vertical-align:middle">info_outline</span></label>
                 <div id="delivReceiptStatusMulti" class="mf-wrap"><button type="button" class="mf-btn">전체</button><div class="mf-drop"></div></div>
               </div>
               <div class="admin-filter-group">
-                <label>결과물 상태 <span class="material-icons-round notranslate" translate="no" title="다중채널 캠페인은 채널별 상태가 상태 종류마다 따로 집계됩니다. (예: 인스타 승인 + X 검수대기 → 승인·검수대기 양쪽 건수에 포함)" style="font-size:13px;cursor:help;color:var(--muted);vertical-align:middle">info_outline</span></label>
-                <div id="delivResultStatusMulti" class="mf-wrap"><button type="button" class="mf-btn">전체</button><div class="mf-drop"></div></div>
+                <label>최근 제출일</label>
+                <input type="text" id="delivSubmittedRange" class="admin-filter-search" readonly placeholder="기간 선택" style="min-width:170px;cursor:pointer;background:#fff">
               </div>
               <div class="admin-filter-group" style="justify-content:flex-end">
                 <label>미제출</label>
@@ -2836,17 +2870,6 @@ textarea.form-input{resize:vertical;min-height:80px}
                   <input type="checkbox" id="delivProxyOnly" onchange="renderDeliverablesList()" style="margin:0">
                   <span>만 보기</span>
                 </label>
-              </div>
-              <div class="admin-filter-group" style="justify-content:flex-end">
-                <label>&nbsp;</label>
-                <button class="btn btn-ghost btn-xs" id="btnDelivFilterReset" onclick="resetDelivFiltersAndSort()" style="display:none">초기화</button>
-              </div>
-              <div class="admin-filter-group" style="flex:1;min-width:200px;margin-left:auto">
-                <label>검색</label>
-                <div style="position:relative">
-                  <span class="material-icons-round" style="position:absolute;left:8px;top:50%;transform:translateY(-50%);font-size:16px;color:var(--muted)">search</span>
-                  <input type="search" id="delivSearch" class="admin-filter-search" autocomplete="off" data-lpignore="true" data-1p-ignore="true" readonly onfocus="this.removeAttribute('readonly')" placeholder="인플루언서명 · 이메일 검색" oninput="renderDeliverablesList()">
-                </div>
               </div>
             </div>
           </div>
@@ -16855,11 +16878,16 @@ function resetDelivFiltersAndSort() {
   resetMultiFilter('delivRecruitTypeMulti', '전체 타입');
   resetMultiFilter('delivReceiptStatusMulti', '전체');
   resetMultiFilter('delivResultStatusMulti', '전체');
+  resetMultiFilter('delivChannelMulti', '전체 채널');
   resetMultiFilter('delivCampMulti', '전체 캠페인');
   const q = $('delivSearch'); if (q) q.value = '';
   // 미제출 포함은 기본값 ON(HTML checked)과 일치하게 복원 — 초기화 후 전체 건수가 보이도록
   const cb = $('delivIncludeMissing'); if (cb) cb.checked = true;
   const cb2 = $('delivProxyOnly'); if (cb2) cb2.checked = false;
+  // 최근 제출일 기간 초기화
+  _delivSubmittedFrom = ''; _delivSubmittedTo = '';
+  if (_delivSubmittedFp) _delivSubmittedFp.clear();
+  const dr = $('delivSubmittedRange'); if (dr) dr.classList.remove('filter-active');
   _delivSort = {col: null, dir: null};
   renderDeliverablesList();
 }
@@ -16904,13 +16932,85 @@ async function refreshApplySidebarBadge() {
 var delivLazy = null;
 const DELIV_PAGE_SIZE = 50;
 
+// 최근 제출일 기간 필터 상태 (브라우저 로컬 = 운영자 KST 기준 YYYY-MM-DD)
+var _delivSubmittedFrom = '';
+var _delivSubmittedTo = '';
+var _delivSubmittedFp = null;
+var _delivMoreOpen = false;
+
+// timestamptz ISO → 브라우저 로컬 날짜(YYYY-MM-DD). 기간 필터 비교용 (운영자 KST 기준)
+function delivLocalDate(iso) {
+  if (!iso) return '';
+  const d = new Date(iso);
+  if (isNaN(d.getTime())) return '';
+  return `${d.getFullYear()}-${String(d.getMonth()+1).padStart(2,'0')}-${String(d.getDate()).padStart(2,'0')}`;
+}
+
+// 결과물 그룹의 채널 매칭 — monitor=캠페인 채널 기준, gifting/visit=결과물 post_channel 기준.
+// 채널 미상(채널 미등록 monitor 캠페인 / post_channel 없는 gifting·visit)은 '__none__' 값에 매칭.
+function delivGroupMatchesChannel(g, channelVals) {
+  if (!channelVals || channelVals.length === 0) return true;
+  const rt = g.campaign?.recruit_type;
+  if (rt === 'monitor') {
+    const chans = (g.campaign?.channel || '').split(',').map(c => c.trim()).filter(Boolean);
+    if (chans.length === 0) return channelVals.includes('__none__');
+    return chans.some(c => channelVals.includes(c));
+  }
+  const pc = g.result?.post_channel;
+  return pc ? channelVals.includes(pc) : channelVals.includes('__none__');
+}
+
+// 최근 제출일 range picker mount (1회). 양끝 선택 완료 시에만 즉시 필터 반영.
+function setupDelivSubmittedRange() {
+  if (typeof flatpickr === 'undefined') return;
+  const el = $('delivSubmittedRange');
+  if (!el || _delivSubmittedFp) return;
+  const fmt = d => d ? `${d.getFullYear()}-${String(d.getMonth()+1).padStart(2,'0')}-${String(d.getDate()).padStart(2,'0')}` : '';
+  _delivSubmittedFp = flatpickr(el, {
+    mode: 'range',
+    dateFormat: 'Y-m-d',
+    locale: (flatpickr.l10ns && flatpickr.l10ns.ko) ? 'ko' : 'default',
+    showMonths: 1,
+    onChange: function(selectedDates) {
+      _delivSubmittedFrom = fmt(selectedDates[0]);
+      _delivSubmittedTo = fmt(selectedDates[1]);
+      el.classList.toggle('filter-active', !!(_delivSubmittedFrom || _delivSubmittedTo));
+      if (selectedDates.length === 0 || selectedDates.length === 2) renderDeliverablesList();
+    }
+  });
+}
+
+// 더보기 영역 펼침/접힘 토글
+function toggleDelivMoreFilters() {
+  _delivMoreOpen = !_delivMoreOpen;
+  const box = $('delivMoreFilters');
+  const caret = $('delivMoreCaret');
+  if (box) box.style.display = _delivMoreOpen ? 'flex' : 'none';
+  if (caret) caret.textContent = _delivMoreOpen ? 'expand_less' : 'expand_more';
+}
+
+// 더보기 영역에 적용된 필터 수 → 버튼 배지 (닫혀 있어도 적용 사실 인지)
+function updateDelivMoreFilterBadge() {
+  let n = 0;
+  if (getMultiFilterValues('delivRecruitTypeMulti').length > 0) n++;
+  if (getMultiFilterValues('delivChannelMulti').length > 0) n++;
+  if (getMultiFilterValues('delivReceiptStatusMulti').length > 0) n++;
+  if (_delivSubmittedFrom || _delivSubmittedTo) n++;
+  const im = $('delivIncludeMissing'); if (im && !im.checked) n++;   // 기본 ON → OFF면 사용자가 변경
+  const po = $('delivProxyOnly'); if (po && po.checked) n++;
+  const badge = $('delivMoreFilterBadge');
+  if (badge) { badge.textContent = n > 0 ? String(n) : ''; badge.style.display = n > 0 ? '' : 'none'; }
+}
+
 async function renderDeliverablesList() {
   const tbody = $('delivTableBody');
   if (!tbody) return;
   tbody.innerHTML = '<tr><td colspan="9" style="text-align:center;color:var(--muted);padding:24px"><span class="spinner" style="width:20px;height:20px;border-width:2px;border-color:rgba(200,120,163,.2);border-top-color:var(--pink)"></span></td></tr>';
   await loadApplicantMsgUnread();  // 응모건 메시지 본인 미열람 배지 맵
+  setupDelivSubmittedRange();  // 최근 제출일 range picker (1회 mount)
   // 채널 라벨 캐시 보장 — monitor 채널별 미니 행·검수 모달 패널 제목에서 getLookupLabel 사용. 캐시 없으면 코드 그대로 노출됨(예: 'qoo10' → 'Qoo10' 변환 실패).
-  try { await fetchLookups('channel'); } catch(e) { /* 캐시 실패해도 폴백 code 노출이라 화면 깨짐 없음 */ }
+  let channelLookup = [];
+  try { channelLookup = await fetchLookups('channel'); } catch(e) { /* 캐시 실패해도 폴백 code 노출이라 화면 깨짐 없음 */ }
 
   // 캠페인 리스트 로드 + 모집타입↔캠페인 캐스케이드
   const campsForFilter = await fetchCampaigns().catch(() => []);
@@ -16929,6 +17029,7 @@ async function renderDeliverablesList() {
 
   const receiptStatusVals = getMultiFilterValues('delivReceiptStatusMulti');
   const resultStatusVals = getMultiFilterValues('delivResultStatusMulti');
+  const channelVals = getMultiFilterValues('delivChannelMulti');
   const delivCampVals = getMultiFilterValues('delivCampMulti');
   const includeMissing = !!$('delivIncludeMissing')?.checked;
   const proxyOnly = !!$('delivProxyOnly')?.checked;
@@ -17058,6 +17159,13 @@ async function renderDeliverablesList() {
       const inf = g.influencer || {};
       if (!matchSearchTokens(search, [inf.name, inf.name_kana, inf.email])) return false;
     }
+    if (!opts.skipChannel && channelVals.length > 0 && !delivGroupMatchesChannel(g, channelVals)) return false;
+    if (_delivSubmittedFrom || _delivSubmittedTo) {
+      const d = delivLocalDate(g.latest_submitted_at);
+      if (!d) return false;  // 제출일 없는 그룹(미제출 포함)은 기간 필터 적용 시 제외
+      if (_delivSubmittedFrom && d < _delivSubmittedFrom) return false;
+      if (_delivSubmittedTo && d > _delivSubmittedTo) return false;
+    }
     return true;
   };
   const campCounts = {};
@@ -17065,6 +17173,7 @@ async function renderDeliverablesList() {
   const receiptStatusCounts = {pending:0, approved:0, rejected:0, none:0};
   // legacy_no_channel: 사양 2 전 post_channel NULL 인 review_image 행이 있는 monitor 신청 (385건, 2026-05-28)
   const resultStatusCounts = {pending:0, approved:0, rejected:0, none:0, legacy_no_channel:0};
+  const channelCounts = {};  // {channel_code: n} + '__none__': 채널 미상 n
   for (const g of allGroups) {
     // 캠페인 카운트: 자기 자신(캠페인 필터) 제외
     if (passesFilters(g, {skipCamp: true})) {
@@ -17090,6 +17199,18 @@ async function renderDeliverablesList() {
       } else {
         const xs = g.result ? g.result.status : 'none';
         if (xs in resultStatusCounts) resultStatusCounts[xs]++;
+      }
+    }
+    // 채널 카운트: 자기 자신(채널 필터) 제외 → monitor=캠페인 채널마다, gifting/visit=post_channel, 미상=__none__
+    if (passesFilters(g, {skipChannel: true})) {
+      const rt = g.campaign?.recruit_type;
+      if (rt === 'monitor') {
+        const chans = (g.campaign?.channel || '').split(',').map(c => c.trim()).filter(Boolean);
+        if (chans.length === 0) channelCounts['__none__'] = (channelCounts['__none__'] || 0) + 1;
+        else chans.forEach(c => { channelCounts[c] = (channelCounts[c] || 0) + 1; });
+      } else {
+        const key = g.result?.post_channel || '__none__';
+        channelCounts[key] = (channelCounts[key] || 0) + 1;
       }
     }
   }
@@ -17120,6 +17241,16 @@ async function renderDeliverablesList() {
   }
   delivResultOpts.push({value:'none', label:'미제출', count: resultStatusCounts.none});
   syncMultiFilter('delivResultStatusMulti', '전체', delivResultOpts, () => renderDeliverablesList());
+  // 채널 드롭다운 — lookup(channel) active 항목 + 채널 미상(__none__)은 건수>0일 때만
+  const delivChannelOpts = channelLookup.map(ch => ({
+    value: ch.code,
+    label: ch.name_ko || ch.code,
+    count: channelCounts[ch.code] || 0,
+  }));
+  if ((channelCounts['__none__'] || 0) > 0) {
+    delivChannelOpts.push({value:'__none__', label:'채널 미상', count: channelCounts['__none__']});
+  }
+  syncMultiFilter('delivChannelMulti', '전체 채널', delivChannelOpts, () => renderDeliverablesList());
 
   // 필터 적용
   let filtered = Array.from(groups.values());
@@ -17142,6 +17273,16 @@ async function renderDeliverablesList() {
     const s = g.result ? g.result.status : 'none';
     return resultStatusVals.includes(s);
   });
+  // 채널 필터 — monitor=캠페인 채널, gifting/visit=post_channel, 미상=__none__
+  if (channelVals.length > 0) filtered = filtered.filter(g => delivGroupMatchesChannel(g, channelVals));
+  // 최근 제출일 기간 필터 — 그룹의 latest_submitted_at(로컬 날짜)이 선택 범위 안 (양끝 포함, 제출일 없으면 제외)
+  if (_delivSubmittedFrom || _delivSubmittedTo) filtered = filtered.filter(g => {
+    const d = delivLocalDate(g.latest_submitted_at);
+    if (!d) return false;
+    if (_delivSubmittedFrom && d < _delivSubmittedFrom) return false;
+    if (_delivSubmittedTo && d > _delivSubmittedTo) return false;
+    return true;
+  });
   // 검색 필터 — 인플루언서 전용(단어 단위 AND, 전각/반각 공백 무관). 캠페인은 검색형 드롭다운으로 분리
   if (search) filtered = filtered.filter(g => {
     const inf = g.influencer || {};
@@ -17156,7 +17297,13 @@ async function renderDeliverablesList() {
     });
   }
 
-  updateFilterResetBtn('btnDelivFilterReset', ['delivRecruitTypeMulti','delivReceiptStatusMulti','delivResultStatusMulti','delivCampMulti'], 'delivSearch');
+  // 더보기 배지 갱신 + 초기화 버튼 노출 — 기본줄·더보기 필터(기간·미제출OFF·대리등록 포함) 중 하나라도 활성이면 노출
+  updateDelivMoreFilterBadge();
+  updateFilterResetBtn('btnDelivFilterReset', ['delivRecruitTypeMulti','delivReceiptStatusMulti','delivResultStatusMulti','delivChannelMulti','delivCampMulti'], 'delivSearch');
+  const _delivMoreActive = (_delivSubmittedFrom || _delivSubmittedTo)
+    || ($('delivIncludeMissing') && !$('delivIncludeMissing').checked)
+    || ($('delivProxyOnly') && $('delivProxyOnly').checked);
+  if (_delivMoreActive) { const rb = $('btnDelivFilterReset'); if (rb) rb.style.display = ''; }
 
   // 정렬: 수동 sort 있으면 그대로, 없으면 검수대기 우선 → 최근 제출일 내림차순
   if (_delivSort.col === 'submitted') {

--- a/dev/admin/index.html
+++ b/dev/admin/index.html
@@ -1041,22 +1041,53 @@
                 관리자 대리 등록
               </button>
             </div>
+            <!-- 기본줄: 자주 쓰는 필터 + 더보기 토글 -->
             <div style="display:flex;align-items:flex-end;gap:12px;flex-wrap:wrap">
               <div class="admin-filter-group">
                 <label>캠페인</label>
                 <div id="delivCampMulti" class="mf-wrap" style="max-width:260px"><button type="button" class="mf-btn" style="max-width:260px;overflow:hidden;text-overflow:ellipsis">전체 캠페인</button><div class="mf-drop" style="min-width:320px;max-width:420px"></div></div>
               </div>
               <div class="admin-filter-group">
+                <label>결과물 상태 <span class="material-icons-round notranslate" translate="no" title="다중채널 캠페인은 채널별 상태가 상태 종류마다 따로 집계됩니다. (예: 인스타 승인 + X 검수대기 → 승인·검수대기 양쪽 건수에 포함)" style="font-size:13px;cursor:help;color:var(--muted);vertical-align:middle">info_outline</span></label>
+                <div id="delivResultStatusMulti" class="mf-wrap"><button type="button" class="mf-btn">전체</button><div class="mf-drop"></div></div>
+              </div>
+              <div class="admin-filter-group" style="flex:1;min-width:200px">
+                <label>검색</label>
+                <div style="position:relative">
+                  <span class="material-icons-round" style="position:absolute;left:8px;top:50%;transform:translateY(-50%);font-size:16px;color:var(--muted)">search</span>
+                  <input type="search" id="delivSearch" class="admin-filter-search" autocomplete="off" data-lpignore="true" data-1p-ignore="true" readonly onfocus="this.removeAttribute('readonly')" placeholder="인플루언서명 · 이메일 검색" oninput="renderDeliverablesList()">
+                </div>
+              </div>
+              <div class="admin-filter-group" style="justify-content:flex-end">
+                <label>&nbsp;</label>
+                <button type="button" class="btn btn-ghost btn-sm deliv-more-btn" id="btnDelivMoreFilters" onclick="toggleDelivMoreFilters()">
+                  <span class="material-icons-round notranslate" translate="no" style="font-size:15px;vertical-align:middle">tune</span>
+                  <span>필터 더보기</span><span id="delivMoreFilterBadge" class="deliv-more-badge" style="display:none"></span>
+                  <span class="material-icons-round notranslate deliv-more-caret" translate="no" id="delivMoreCaret" style="font-size:16px;vertical-align:middle">expand_more</span>
+                </button>
+              </div>
+              <div class="admin-filter-group" style="justify-content:flex-end">
+                <label>&nbsp;</label>
+                <button class="btn btn-ghost btn-xs" id="btnDelivFilterReset" onclick="resetDelivFiltersAndSort()" style="display:none">초기화</button>
+              </div>
+            </div>
+            <!-- 더보기 영역 (기본 닫힘) -->
+            <div id="delivMoreFilters" style="display:none;align-items:flex-end;gap:12px;flex-wrap:wrap;margin-top:10px;padding-top:10px;border-top:1px dashed var(--outline)">
+              <div class="admin-filter-group">
                 <label>모집 타입</label>
                 <div id="delivRecruitTypeMulti" class="mf-wrap"><button type="button" class="mf-btn">전체 타입</button><div class="mf-drop"></div></div>
+              </div>
+              <div class="admin-filter-group">
+                <label>채널</label>
+                <div id="delivChannelMulti" class="mf-wrap"><button type="button" class="mf-btn">전체 채널</button><div class="mf-drop"></div></div>
               </div>
               <div class="admin-filter-group">
                 <label>영수증 상태 <span class="material-icons-round notranslate" translate="no" title="영수증은 리뷰어 캠페인 전용입니다. 영수증 상태로 거르면 기프팅·방문형은 표시되지 않습니다." style="font-size:13px;cursor:help;color:var(--muted);vertical-align:middle">info_outline</span></label>
                 <div id="delivReceiptStatusMulti" class="mf-wrap"><button type="button" class="mf-btn">전체</button><div class="mf-drop"></div></div>
               </div>
               <div class="admin-filter-group">
-                <label>결과물 상태 <span class="material-icons-round notranslate" translate="no" title="다중채널 캠페인은 채널별 상태가 상태 종류마다 따로 집계됩니다. (예: 인스타 승인 + X 검수대기 → 승인·검수대기 양쪽 건수에 포함)" style="font-size:13px;cursor:help;color:var(--muted);vertical-align:middle">info_outline</span></label>
-                <div id="delivResultStatusMulti" class="mf-wrap"><button type="button" class="mf-btn">전체</button><div class="mf-drop"></div></div>
+                <label>최근 제출일</label>
+                <input type="text" id="delivSubmittedRange" class="admin-filter-search" readonly placeholder="기간 선택" style="min-width:170px;cursor:pointer;background:#fff">
               </div>
               <div class="admin-filter-group" style="justify-content:flex-end">
                 <label>미제출</label>
@@ -1071,17 +1102,6 @@
                   <input type="checkbox" id="delivProxyOnly" onchange="renderDeliverablesList()" style="margin:0">
                   <span>만 보기</span>
                 </label>
-              </div>
-              <div class="admin-filter-group" style="justify-content:flex-end">
-                <label>&nbsp;</label>
-                <button class="btn btn-ghost btn-xs" id="btnDelivFilterReset" onclick="resetDelivFiltersAndSort()" style="display:none">초기화</button>
-              </div>
-              <div class="admin-filter-group" style="flex:1;min-width:200px;margin-left:auto">
-                <label>검색</label>
-                <div style="position:relative">
-                  <span class="material-icons-round" style="position:absolute;left:8px;top:50%;transform:translateY(-50%);font-size:16px;color:var(--muted)">search</span>
-                  <input type="search" id="delivSearch" class="admin-filter-search" autocomplete="off" data-lpignore="true" data-1p-ignore="true" readonly onfocus="this.removeAttribute('readonly')" placeholder="인플루언서명 · 이메일 검색" oninput="renderDeliverablesList()">
-                </div>
               </div>
             </div>
           </div>

--- a/dev/css/admin.css
+++ b/dev/css/admin.css
@@ -50,6 +50,9 @@
 .mf-search{width:100%;box-sizing:border-box;padding:6px 8px;font-size:12px;border:1px solid var(--outline);border-radius:6px;color:var(--ink);outline:none}
 .mf-search:focus{border-color:var(--primary)}
 .mf-search-empty{padding:10px 12px;font-size:12px;color:var(--muted);text-align:center}
+/* 결과물 관리 「필터 더보기」 토글 — 활성 필터 수 배지 + 기간 선택 활성 표시 */
+.deliv-more-badge{display:inline-flex;align-items:center;justify-content:center;min-width:16px;height:16px;padding:0 4px;margin-left:2px;background:var(--primary);color:#fff;border-radius:8px;font-size:10px;font-weight:700;line-height:1}
+.admin-filter-search.filter-active{border-color:var(--primary);color:var(--primary)}
 .admin-layout{display:grid;grid-template-columns:220px 1fr;height:100vh;transition:grid-template-columns .25s ease}
 .admin-layout.collapsed{grid-template-columns:56px 1fr}
 .admin-side{background:#1A0F18;padding:0;height:100%;overflow:hidden;flex-shrink:0;transition:width .25s ease;display:flex;flex-direction:column}

--- a/dev/js/admin-deliverables.js
+++ b/dev/js/admin-deliverables.js
@@ -41,11 +41,16 @@ function resetDelivFiltersAndSort() {
   resetMultiFilter('delivRecruitTypeMulti', '전체 타입');
   resetMultiFilter('delivReceiptStatusMulti', '전체');
   resetMultiFilter('delivResultStatusMulti', '전체');
+  resetMultiFilter('delivChannelMulti', '전체 채널');
   resetMultiFilter('delivCampMulti', '전체 캠페인');
   const q = $('delivSearch'); if (q) q.value = '';
   // 미제출 포함은 기본값 ON(HTML checked)과 일치하게 복원 — 초기화 후 전체 건수가 보이도록
   const cb = $('delivIncludeMissing'); if (cb) cb.checked = true;
   const cb2 = $('delivProxyOnly'); if (cb2) cb2.checked = false;
+  // 최근 제출일 기간 초기화
+  _delivSubmittedFrom = ''; _delivSubmittedTo = '';
+  if (_delivSubmittedFp) _delivSubmittedFp.clear();
+  const dr = $('delivSubmittedRange'); if (dr) dr.classList.remove('filter-active');
   _delivSort = {col: null, dir: null};
   renderDeliverablesList();
 }
@@ -90,13 +95,85 @@ async function refreshApplySidebarBadge() {
 var delivLazy = null;
 const DELIV_PAGE_SIZE = 50;
 
+// 최근 제출일 기간 필터 상태 (브라우저 로컬 = 운영자 KST 기준 YYYY-MM-DD)
+var _delivSubmittedFrom = '';
+var _delivSubmittedTo = '';
+var _delivSubmittedFp = null;
+var _delivMoreOpen = false;
+
+// timestamptz ISO → 브라우저 로컬 날짜(YYYY-MM-DD). 기간 필터 비교용 (운영자 KST 기준)
+function delivLocalDate(iso) {
+  if (!iso) return '';
+  const d = new Date(iso);
+  if (isNaN(d.getTime())) return '';
+  return `${d.getFullYear()}-${String(d.getMonth()+1).padStart(2,'0')}-${String(d.getDate()).padStart(2,'0')}`;
+}
+
+// 결과물 그룹의 채널 매칭 — monitor=캠페인 채널 기준, gifting/visit=결과물 post_channel 기준.
+// 채널 미상(채널 미등록 monitor 캠페인 / post_channel 없는 gifting·visit)은 '__none__' 값에 매칭.
+function delivGroupMatchesChannel(g, channelVals) {
+  if (!channelVals || channelVals.length === 0) return true;
+  const rt = g.campaign?.recruit_type;
+  if (rt === 'monitor') {
+    const chans = (g.campaign?.channel || '').split(',').map(c => c.trim()).filter(Boolean);
+    if (chans.length === 0) return channelVals.includes('__none__');
+    return chans.some(c => channelVals.includes(c));
+  }
+  const pc = g.result?.post_channel;
+  return pc ? channelVals.includes(pc) : channelVals.includes('__none__');
+}
+
+// 최근 제출일 range picker mount (1회). 양끝 선택 완료 시에만 즉시 필터 반영.
+function setupDelivSubmittedRange() {
+  if (typeof flatpickr === 'undefined') return;
+  const el = $('delivSubmittedRange');
+  if (!el || _delivSubmittedFp) return;
+  const fmt = d => d ? `${d.getFullYear()}-${String(d.getMonth()+1).padStart(2,'0')}-${String(d.getDate()).padStart(2,'0')}` : '';
+  _delivSubmittedFp = flatpickr(el, {
+    mode: 'range',
+    dateFormat: 'Y-m-d',
+    locale: (flatpickr.l10ns && flatpickr.l10ns.ko) ? 'ko' : 'default',
+    showMonths: 1,
+    onChange: function(selectedDates) {
+      _delivSubmittedFrom = fmt(selectedDates[0]);
+      _delivSubmittedTo = fmt(selectedDates[1]);
+      el.classList.toggle('filter-active', !!(_delivSubmittedFrom || _delivSubmittedTo));
+      if (selectedDates.length === 0 || selectedDates.length === 2) renderDeliverablesList();
+    }
+  });
+}
+
+// 더보기 영역 펼침/접힘 토글
+function toggleDelivMoreFilters() {
+  _delivMoreOpen = !_delivMoreOpen;
+  const box = $('delivMoreFilters');
+  const caret = $('delivMoreCaret');
+  if (box) box.style.display = _delivMoreOpen ? 'flex' : 'none';
+  if (caret) caret.textContent = _delivMoreOpen ? 'expand_less' : 'expand_more';
+}
+
+// 더보기 영역에 적용된 필터 수 → 버튼 배지 (닫혀 있어도 적용 사실 인지)
+function updateDelivMoreFilterBadge() {
+  let n = 0;
+  if (getMultiFilterValues('delivRecruitTypeMulti').length > 0) n++;
+  if (getMultiFilterValues('delivChannelMulti').length > 0) n++;
+  if (getMultiFilterValues('delivReceiptStatusMulti').length > 0) n++;
+  if (_delivSubmittedFrom || _delivSubmittedTo) n++;
+  const im = $('delivIncludeMissing'); if (im && !im.checked) n++;   // 기본 ON → OFF면 사용자가 변경
+  const po = $('delivProxyOnly'); if (po && po.checked) n++;
+  const badge = $('delivMoreFilterBadge');
+  if (badge) { badge.textContent = n > 0 ? String(n) : ''; badge.style.display = n > 0 ? '' : 'none'; }
+}
+
 async function renderDeliverablesList() {
   const tbody = $('delivTableBody');
   if (!tbody) return;
   tbody.innerHTML = '<tr><td colspan="9" style="text-align:center;color:var(--muted);padding:24px"><span class="spinner" style="width:20px;height:20px;border-width:2px;border-color:rgba(200,120,163,.2);border-top-color:var(--pink)"></span></td></tr>';
   await loadApplicantMsgUnread();  // 응모건 메시지 본인 미열람 배지 맵
+  setupDelivSubmittedRange();  // 최근 제출일 range picker (1회 mount)
   // 채널 라벨 캐시 보장 — monitor 채널별 미니 행·검수 모달 패널 제목에서 getLookupLabel 사용. 캐시 없으면 코드 그대로 노출됨(예: 'qoo10' → 'Qoo10' 변환 실패).
-  try { await fetchLookups('channel'); } catch(e) { /* 캐시 실패해도 폴백 code 노출이라 화면 깨짐 없음 */ }
+  let channelLookup = [];
+  try { channelLookup = await fetchLookups('channel'); } catch(e) { /* 캐시 실패해도 폴백 code 노출이라 화면 깨짐 없음 */ }
 
   // 캠페인 리스트 로드 + 모집타입↔캠페인 캐스케이드
   const campsForFilter = await fetchCampaigns().catch(() => []);
@@ -115,6 +192,7 @@ async function renderDeliverablesList() {
 
   const receiptStatusVals = getMultiFilterValues('delivReceiptStatusMulti');
   const resultStatusVals = getMultiFilterValues('delivResultStatusMulti');
+  const channelVals = getMultiFilterValues('delivChannelMulti');
   const delivCampVals = getMultiFilterValues('delivCampMulti');
   const includeMissing = !!$('delivIncludeMissing')?.checked;
   const proxyOnly = !!$('delivProxyOnly')?.checked;
@@ -244,6 +322,13 @@ async function renderDeliverablesList() {
       const inf = g.influencer || {};
       if (!matchSearchTokens(search, [inf.name, inf.name_kana, inf.email])) return false;
     }
+    if (!opts.skipChannel && channelVals.length > 0 && !delivGroupMatchesChannel(g, channelVals)) return false;
+    if (_delivSubmittedFrom || _delivSubmittedTo) {
+      const d = delivLocalDate(g.latest_submitted_at);
+      if (!d) return false;  // 제출일 없는 그룹(미제출 포함)은 기간 필터 적용 시 제외
+      if (_delivSubmittedFrom && d < _delivSubmittedFrom) return false;
+      if (_delivSubmittedTo && d > _delivSubmittedTo) return false;
+    }
     return true;
   };
   const campCounts = {};
@@ -251,6 +336,7 @@ async function renderDeliverablesList() {
   const receiptStatusCounts = {pending:0, approved:0, rejected:0, none:0};
   // legacy_no_channel: 사양 2 전 post_channel NULL 인 review_image 행이 있는 monitor 신청 (385건, 2026-05-28)
   const resultStatusCounts = {pending:0, approved:0, rejected:0, none:0, legacy_no_channel:0};
+  const channelCounts = {};  // {channel_code: n} + '__none__': 채널 미상 n
   for (const g of allGroups) {
     // 캠페인 카운트: 자기 자신(캠페인 필터) 제외
     if (passesFilters(g, {skipCamp: true})) {
@@ -276,6 +362,18 @@ async function renderDeliverablesList() {
       } else {
         const xs = g.result ? g.result.status : 'none';
         if (xs in resultStatusCounts) resultStatusCounts[xs]++;
+      }
+    }
+    // 채널 카운트: 자기 자신(채널 필터) 제외 → monitor=캠페인 채널마다, gifting/visit=post_channel, 미상=__none__
+    if (passesFilters(g, {skipChannel: true})) {
+      const rt = g.campaign?.recruit_type;
+      if (rt === 'monitor') {
+        const chans = (g.campaign?.channel || '').split(',').map(c => c.trim()).filter(Boolean);
+        if (chans.length === 0) channelCounts['__none__'] = (channelCounts['__none__'] || 0) + 1;
+        else chans.forEach(c => { channelCounts[c] = (channelCounts[c] || 0) + 1; });
+      } else {
+        const key = g.result?.post_channel || '__none__';
+        channelCounts[key] = (channelCounts[key] || 0) + 1;
       }
     }
   }
@@ -306,6 +404,16 @@ async function renderDeliverablesList() {
   }
   delivResultOpts.push({value:'none', label:'미제출', count: resultStatusCounts.none});
   syncMultiFilter('delivResultStatusMulti', '전체', delivResultOpts, () => renderDeliverablesList());
+  // 채널 드롭다운 — lookup(channel) active 항목 + 채널 미상(__none__)은 건수>0일 때만
+  const delivChannelOpts = channelLookup.map(ch => ({
+    value: ch.code,
+    label: ch.name_ko || ch.code,
+    count: channelCounts[ch.code] || 0,
+  }));
+  if ((channelCounts['__none__'] || 0) > 0) {
+    delivChannelOpts.push({value:'__none__', label:'채널 미상', count: channelCounts['__none__']});
+  }
+  syncMultiFilter('delivChannelMulti', '전체 채널', delivChannelOpts, () => renderDeliverablesList());
 
   // 필터 적용
   let filtered = Array.from(groups.values());
@@ -328,6 +436,16 @@ async function renderDeliverablesList() {
     const s = g.result ? g.result.status : 'none';
     return resultStatusVals.includes(s);
   });
+  // 채널 필터 — monitor=캠페인 채널, gifting/visit=post_channel, 미상=__none__
+  if (channelVals.length > 0) filtered = filtered.filter(g => delivGroupMatchesChannel(g, channelVals));
+  // 최근 제출일 기간 필터 — 그룹의 latest_submitted_at(로컬 날짜)이 선택 범위 안 (양끝 포함, 제출일 없으면 제외)
+  if (_delivSubmittedFrom || _delivSubmittedTo) filtered = filtered.filter(g => {
+    const d = delivLocalDate(g.latest_submitted_at);
+    if (!d) return false;
+    if (_delivSubmittedFrom && d < _delivSubmittedFrom) return false;
+    if (_delivSubmittedTo && d > _delivSubmittedTo) return false;
+    return true;
+  });
   // 검색 필터 — 인플루언서 전용(단어 단위 AND, 전각/반각 공백 무관). 캠페인은 검색형 드롭다운으로 분리
   if (search) filtered = filtered.filter(g => {
     const inf = g.influencer || {};
@@ -342,7 +460,13 @@ async function renderDeliverablesList() {
     });
   }
 
-  updateFilterResetBtn('btnDelivFilterReset', ['delivRecruitTypeMulti','delivReceiptStatusMulti','delivResultStatusMulti','delivCampMulti'], 'delivSearch');
+  // 더보기 배지 갱신 + 초기화 버튼 노출 — 기본줄·더보기 필터(기간·미제출OFF·대리등록 포함) 중 하나라도 활성이면 노출
+  updateDelivMoreFilterBadge();
+  updateFilterResetBtn('btnDelivFilterReset', ['delivRecruitTypeMulti','delivReceiptStatusMulti','delivResultStatusMulti','delivChannelMulti','delivCampMulti'], 'delivSearch');
+  const _delivMoreActive = (_delivSubmittedFrom || _delivSubmittedTo)
+    || ($('delivIncludeMissing') && !$('delivIncludeMissing').checked)
+    || ($('delivProxyOnly') && $('delivProxyOnly').checked);
+  if (_delivMoreActive) { const rb = $('btnDelivFilterReset'); if (rb) rb.style.display = ''; }
 
   // 정렬: 수동 sort 있으면 그대로, 없으면 검수대기 우선 → 최근 제출일 내림차순
   if (_delivSort.col === 'submitted') {

--- a/docs/specs/2026-05-29-deliverables-filter-redesign.md
+++ b/docs/specs/2026-05-29-deliverables-filter-redesign.md
@@ -172,5 +172,22 @@
 - DB·RLS·약관 영향 없음(순수 관리자 클라이언트 UI).
 - reverb-reviewer GO(Warning 2건 반영 후 재검증 GO), qa-tester 권장 light.
 
-### PR 2 — 결과물 관리 필터 정확성 (예정)
-### PR 3 — 채널 필터 + 최근 제출일 + 레이아웃 재배치 (예정)
+### PR 2 — 결과물 관리 필터 정확성 (구현 완료)
+**구현일:** 2026-05-29 · **브랜치:** `feature/deliv-filter-redesign`
+
+- **영수증 = 리뷰어(monitor) 전용**: 기프팅·방문형이 영수증 단계 없이 'none'(미제출)으로 오집계되던 버그를 필터·카운트·passesFilters 3곳에서 차단.
+- **결과물 ANY 매칭**: monitor 그룹에 `result_states`(채널별 상태 집합 + 레거시 legacy_no_channel) 추가. 필터·실제필터 모두 `states.some(...)`. 카운트는 상태 종류마다 +1(중복 집계). 정렬은 기존 `result_status_repr`(대표상태) 유지.
+- **채널 미분류 옵션**은 `resultStatusCounts.legacy_no_channel > 0`일 때만 노출.
+- 안내 문구 3종(영수증 리뷰어 전용 / 결과물 다중채널 중복집계 / 미제출 포함 tooltip), 모두 한국어.
+- **초안 대비:** QA에서 「초기화」가 미제출 포함을 기본값(ON)으로 복원 안 하던 기존 버그 발견 → 같은 사이클에서 fix.
+- reviewer GO(관리자 UI 일본어 혼입 1건 반영 후), qa light PASS(비승인·채널미분류 데이터는 개발서버 0건이라 운영 확인 권고).
+
+### PR 3 — 채널 필터 + 최근 제출일 기간 + 레이아웃 재배치 (구현 완료)
+**구현일:** 2026-05-29 · **브랜치:** `feature/deliv-filter-redesign`
+
+- **레이아웃**: 기본줄(캠페인·결과물 상태·검색·「필터 더보기」 토글·초기화) + 더보기 접이식(모집타입·채널·영수증·최근 제출일·미제출·대리등록). 닫혀 있어도 「필터 더보기」 버튼에 활성 필터 수 배지.
+- **채널 필터**: `delivChannelMulti` — `delivGroupMatchesChannel`(monitor=캠페인 채널 / gifting·visit=post_channel / 미상=`__none__`). 채널 미상 옵션은 건수>0일 때만. 카운트는 monitor 채널마다 +1.
+- **최근 제출일 기간 필터**: flatpickr range(`delivSubmittedRange`), 그룹 `latest_submitted_at` 로컬 날짜 비교(양끝 포함, 제출일 없으면 제외).
+- **초안 대비 변경:** 없음(§설계 3·5·6 그대로).
+- **구현 중 결정**: ① 기간/채널 날짜·매칭 모두 브라우저 로컬 기준(`delivLocalDate`)으로 통일해 UTC 혼선 차단. ② 기간 필터 활성 시 다른 드롭다운 카운트도 **기간 교집합 기준으로 집계됨**(passesFilters 내부 AND, skipDate 없음 — PR1·2 「나머지 AND」 원칙과 정합, 의도된 동작). ③ `delivChannelMulti`는 init 없이 sync 첫 호출로 생성(`delivCampMulti`와 동일 패턴).
+- reviewer GO(Warning 2건 모두 코드 문제 아님), qa 권장 light.


### PR DESCRIPTION
## 변경 요약
- **레이아웃 재배치**: 자주 쓰는 필터(캠페인·결과물 상태·검색)는 기본줄, 나머지는 「필터 더보기」 접이식. 닫혀 있어도 활성 필터 수 배지 표시
- **채널 필터 신설**: 리뷰어=캠페인 채널 / 기프팅·방문형=게시물 채널 기준, 채널 미상은 건수 있을 때만
- **최근 제출일 기간 필터**: 날짜 범위 선택기

## 요청 외 추가 변경
- 없음

## 관련 사양서
- docs/specs/2026-05-29-deliverables-filter-redesign.md §설계 3·5·6 (PR2·3 구현 결과 기록)

## 검증
- reverb-reviewer GO (Warning 2건 모두 코드 문제 아님)
- DB·RLS·약관 영향 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)