### PR TITLE
fix(admin): 결과물 관리 '미제출' 라벨 → '결과물 미제출' 주어 명확화

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -12,7 +12,7 @@
 // 회귀(2026-05-12 PR #182 머지 직후 발생)를 방지하기 위한 자동 reload 가드.
 // sessionStorage 차단 환경(시크릿 모드 일부, 쿠키 차단)에서는 자연스럽게 skip.
 (function(){
-  var CURRENT_BUILD = 'v1780043427';
+  var CURRENT_BUILD = 'v1780045143';
   if (CURRENT_BUILD.indexOf('__') === 0) return; // 빌드 미적용 (dev/ 직접 열기) 시 skip
   try {
     var prev = sessionStorage.getItem('reverb.adminBuild');
@@ -1899,7 +1899,7 @@ textarea.form-input{resize:vertical;min-height:80px}
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-05-29 17:30 · 757eb5f</span>
+          <span class="admin-build-text">2026-05-29 17:59 · bc19834</span>
         </div>
       </div>
     </aside>
@@ -2858,7 +2858,7 @@ textarea.form-input{resize:vertical;min-height:80px}
                 <input type="text" id="delivSubmittedRange" class="admin-filter-search" readonly placeholder="기간 선택" style="min-width:170px;cursor:pointer;background:#fff">
               </div>
               <div class="admin-filter-group" style="justify-content:flex-end">
-                <label>미제출</label>
+                <label>결과물 미제출</label>
                 <label style="display:inline-flex;align-items:center;gap:4px;font-size:12px;cursor:pointer;height:32px" title="승인됐지만 결과물을 한 건도 제출하지 않은 신청을 함께 표시합니다. (다중채널에서 일부 채널만 미제출인 경우는 '결과물 상태=미제출'로 거르세요)">
                   <input type="checkbox" id="delivIncludeMissing" onchange="renderDeliverablesList()" checked style="margin:0">
                   <span>포함</span>

--- a/dev/admin/index.html
+++ b/dev/admin/index.html
@@ -1090,7 +1090,7 @@
                 <input type="text" id="delivSubmittedRange" class="admin-filter-search" readonly placeholder="기간 선택" style="min-width:170px;cursor:pointer;background:#fff">
               </div>
               <div class="admin-filter-group" style="justify-content:flex-end">
-                <label>미제출</label>
+                <label>결과물 미제출</label>
                 <label style="display:inline-flex;align-items:center;gap:4px;font-size:12px;cursor:pointer;height:32px" title="승인됐지만 결과물을 한 건도 제출하지 않은 신청을 함께 표시합니다. (다중채널에서 일부 채널만 미제출인 경우는 '결과물 상태=미제출'로 거르세요)">
                   <input type="checkbox" id="delivIncludeMissing" onchange="renderDeliverablesList()" checked style="margin:0">
                   <span>포함</span>


### PR DESCRIPTION
## 변경 요약
- 결과물 관리 상단 「미제출 · 포함」 체크박스 라벨이 주어가 없어 모호 → 「결과물 미제출 · 포함」으로 명확화 (영수증 미제출이 아닌 결과물 미제출임을 표기)

## 관련 사양서
- docs/specs/2026-05-29-deliverables-filter-redesign.md (필터 재설계 후속 문구 개선)

순수 라벨 1단어 변경 (로직·구조 무관).

🤖 Generated with [Claude Code](https://claude.com/claude-code)