### PR TITLE
feat(admin): 결과물 필터 전체 노출 + 검색만 돋보기 버튼 토글 (PR3 후속)

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -12,7 +12,7 @@
 // 회귀(2026-05-12 PR #182 머지 직후 발생)를 방지하기 위한 자동 reload 가드.
 // sessionStorage 차단 환경(시크릿 모드 일부, 쿠키 차단)에서는 자연스럽게 skip.
 (function(){
-  var CURRENT_BUILD = 'v1780045143';
+  var CURRENT_BUILD = 'v1780046014';
   if (CURRENT_BUILD.indexOf('__') === 0) return; // 빌드 미적용 (dev/ 직접 열기) 시 skip
   try {
     var prev = sessionStorage.getItem('reverb.adminBuild');
@@ -498,8 +498,8 @@ textarea.form-input{resize:vertical;min-height:80px}
 .mf-search{width:100%;box-sizing:border-box;padding:6px 8px;font-size:12px;border:1px solid var(--outline);border-radius:6px;color:var(--ink);outline:none}
 .mf-search:focus{border-color:var(--primary)}
 .mf-search-empty{padding:10px 12px;font-size:12px;color:var(--muted);text-align:center}
-/* 결과물 관리 「필터 더보기」 토글 — 활성 필터 수 배지 + 기간 선택 활성 표시 */
-.deliv-more-badge{display:inline-flex;align-items:center;justify-content:center;min-width:16px;height:16px;padding:0 4px;margin-left:2px;background:var(--primary);color:#fff;border-radius:8px;font-size:10px;font-weight:700;line-height:1}
+/* 결과물 관리 — 검색 돋보기 버튼 활성 강조 + 기간 선택 활성 표시 */
+#btnDelivSearchToggle.active{color:var(--primary);border-color:var(--primary)}
 .admin-filter-search.filter-active{border-color:var(--primary);color:var(--primary)}
 .admin-layout{display:grid;grid-template-columns:220px 1fr;height:100vh;transition:grid-template-columns .25s ease}
 .admin-layout.collapsed{grid-template-columns:56px 1fr}
@@ -1899,7 +1899,7 @@ textarea.form-input{resize:vertical;min-height:80px}
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-05-29 17:59 · bc19834</span>
+          <span class="admin-build-text">2026-05-29 18:13 · 605d829</span>
         </div>
       </div>
     </aside>
@@ -2809,38 +2809,12 @@ textarea.form-input{resize:vertical;min-height:80px}
                 관리자 대리 등록
               </button>
             </div>
-            <!-- 기본줄: 자주 쓰는 필터 + 더보기 토글 -->
+            <!-- 모든 필터 항상 노출 (한 영역, 줄바꿈 허용). 텍스트 검색만 돋보기 버튼으로 토글 -->
             <div style="display:flex;align-items:flex-end;gap:12px;flex-wrap:wrap">
               <div class="admin-filter-group">
                 <label>캠페인</label>
                 <div id="delivCampMulti" class="mf-wrap" style="max-width:260px"><button type="button" class="mf-btn" style="max-width:260px;overflow:hidden;text-overflow:ellipsis">전체 캠페인</button><div class="mf-drop" style="min-width:320px;max-width:420px"></div></div>
               </div>
-              <div class="admin-filter-group">
-                <label>결과물 상태 <span class="material-icons-round notranslate" translate="no" title="다중채널 캠페인은 채널별 상태가 상태 종류마다 따로 집계됩니다. (예: 인스타 승인 + X 검수대기 → 승인·검수대기 양쪽 건수에 포함)" style="font-size:13px;cursor:help;color:var(--muted);vertical-align:middle">info_outline</span></label>
-                <div id="delivResultStatusMulti" class="mf-wrap"><button type="button" class="mf-btn">전체</button><div class="mf-drop"></div></div>
-              </div>
-              <div class="admin-filter-group" style="flex:1;min-width:200px">
-                <label>검색</label>
-                <div style="position:relative">
-                  <span class="material-icons-round" style="position:absolute;left:8px;top:50%;transform:translateY(-50%);font-size:16px;color:var(--muted)">search</span>
-                  <input type="search" id="delivSearch" class="admin-filter-search" autocomplete="off" data-lpignore="true" data-1p-ignore="true" readonly onfocus="this.removeAttribute('readonly')" placeholder="인플루언서명 · 이메일 검색" oninput="renderDeliverablesList()">
-                </div>
-              </div>
-              <div class="admin-filter-group" style="justify-content:flex-end">
-                <label>&nbsp;</label>
-                <button type="button" class="btn btn-ghost btn-sm deliv-more-btn" id="btnDelivMoreFilters" onclick="toggleDelivMoreFilters()">
-                  <span class="material-icons-round notranslate" translate="no" style="font-size:15px;vertical-align:middle">tune</span>
-                  <span>필터 더보기</span><span id="delivMoreFilterBadge" class="deliv-more-badge" style="display:none"></span>
-                  <span class="material-icons-round notranslate deliv-more-caret" translate="no" id="delivMoreCaret" style="font-size:16px;vertical-align:middle">expand_more</span>
-                </button>
-              </div>
-              <div class="admin-filter-group" style="justify-content:flex-end">
-                <label>&nbsp;</label>
-                <button class="btn btn-ghost btn-xs" id="btnDelivFilterReset" onclick="resetDelivFiltersAndSort()" style="display:none">초기화</button>
-              </div>
-            </div>
-            <!-- 더보기 영역 (기본 닫힘) -->
-            <div id="delivMoreFilters" style="display:none;align-items:flex-end;gap:12px;flex-wrap:wrap;margin-top:10px;padding-top:10px;border-top:1px dashed var(--outline)">
               <div class="admin-filter-group">
                 <label>모집 타입</label>
                 <div id="delivRecruitTypeMulti" class="mf-wrap"><button type="button" class="mf-btn">전체 타입</button><div class="mf-drop"></div></div>
@@ -2852,6 +2826,10 @@ textarea.form-input{resize:vertical;min-height:80px}
               <div class="admin-filter-group">
                 <label>영수증 상태 <span class="material-icons-round notranslate" translate="no" title="영수증은 리뷰어 캠페인 전용입니다. 영수증 상태로 거르면 기프팅·방문형은 표시되지 않습니다." style="font-size:13px;cursor:help;color:var(--muted);vertical-align:middle">info_outline</span></label>
                 <div id="delivReceiptStatusMulti" class="mf-wrap"><button type="button" class="mf-btn">전체</button><div class="mf-drop"></div></div>
+              </div>
+              <div class="admin-filter-group">
+                <label>결과물 상태 <span class="material-icons-round notranslate" translate="no" title="다중채널 캠페인은 채널별 상태가 상태 종류마다 따로 집계됩니다. (예: 인스타 승인 + X 검수대기 → 승인·검수대기 양쪽 건수에 포함)" style="font-size:13px;cursor:help;color:var(--muted);vertical-align:middle">info_outline</span></label>
+                <div id="delivResultStatusMulti" class="mf-wrap"><button type="button" class="mf-btn">전체</button><div class="mf-drop"></div></div>
               </div>
               <div class="admin-filter-group">
                 <label>최근 제출일</label>
@@ -2870,6 +2848,24 @@ textarea.form-input{resize:vertical;min-height:80px}
                   <input type="checkbox" id="delivProxyOnly" onchange="renderDeliverablesList()" style="margin:0">
                   <span>만 보기</span>
                 </label>
+              </div>
+              <div class="admin-filter-group" style="justify-content:flex-end">
+                <label>&nbsp;</label>
+                <button type="button" class="btn btn-ghost btn-sm" id="btnDelivSearchToggle" onclick="toggleDelivSearch()" title="인플루언서명 · 이메일 검색">
+                  <span class="material-icons-round notranslate" translate="no" style="font-size:16px;vertical-align:middle">search</span>
+                </button>
+              </div>
+              <div class="admin-filter-group" style="justify-content:flex-end">
+                <label>&nbsp;</label>
+                <button class="btn btn-ghost btn-xs" id="btnDelivFilterReset" onclick="resetDelivFiltersAndSort()" style="display:none">초기화</button>
+              </div>
+              <!-- 텍스트 검색 입력 (기본 숨김 — 돋보기 버튼으로 토글) -->
+              <div class="admin-filter-group" id="delivSearchBox" style="display:none;flex:1;min-width:220px">
+                <label>검색</label>
+                <div style="position:relative">
+                  <span class="material-icons-round notranslate" translate="no" style="position:absolute;left:8px;top:50%;transform:translateY(-50%);font-size:16px;color:var(--muted)">search</span>
+                  <input type="search" id="delivSearch" class="admin-filter-search" autocomplete="off" data-lpignore="true" data-1p-ignore="true" placeholder="인플루언서명 · 이메일 검색" oninput="renderDeliverablesList()">
+                </div>
               </div>
             </div>
           </div>
@@ -16881,6 +16877,9 @@ function resetDelivFiltersAndSort() {
   resetMultiFilter('delivChannelMulti', '전체 채널');
   resetMultiFilter('delivCampMulti', '전체 캠페인');
   const q = $('delivSearch'); if (q) q.value = '';
+  // 검색창 접기 + 돋보기 버튼 강조 해제
+  const sbox = $('delivSearchBox'); if (sbox) sbox.style.display = 'none';
+  const stb = $('btnDelivSearchToggle'); if (stb) stb.classList.remove('active');
   // 미제출 포함은 기본값 ON(HTML checked)과 일치하게 복원 — 초기화 후 전체 건수가 보이도록
   const cb = $('delivIncludeMissing'); if (cb) cb.checked = true;
   const cb2 = $('delivProxyOnly'); if (cb2) cb2.checked = false;
@@ -16936,7 +16935,6 @@ const DELIV_PAGE_SIZE = 50;
 var _delivSubmittedFrom = '';
 var _delivSubmittedTo = '';
 var _delivSubmittedFp = null;
-var _delivMoreOpen = false;
 
 // timestamptz ISO → 브라우저 로컬 날짜(YYYY-MM-DD). 기간 필터 비교용 (운영자 KST 기준)
 function delivLocalDate(iso) {
@@ -16980,26 +16978,15 @@ function setupDelivSubmittedRange() {
   });
 }
 
-// 더보기 영역 펼침/접힘 토글
-function toggleDelivMoreFilters() {
-  _delivMoreOpen = !_delivMoreOpen;
-  const box = $('delivMoreFilters');
-  const caret = $('delivMoreCaret');
-  if (box) box.style.display = _delivMoreOpen ? 'flex' : 'none';
-  if (caret) caret.textContent = _delivMoreOpen ? 'expand_less' : 'expand_more';
-}
-
-// 더보기 영역에 적용된 필터 수 → 버튼 배지 (닫혀 있어도 적용 사실 인지)
-function updateDelivMoreFilterBadge() {
-  let n = 0;
-  if (getMultiFilterValues('delivRecruitTypeMulti').length > 0) n++;
-  if (getMultiFilterValues('delivChannelMulti').length > 0) n++;
-  if (getMultiFilterValues('delivReceiptStatusMulti').length > 0) n++;
-  if (_delivSubmittedFrom || _delivSubmittedTo) n++;
-  const im = $('delivIncludeMissing'); if (im && !im.checked) n++;   // 기본 ON → OFF면 사용자가 변경
-  const po = $('delivProxyOnly'); if (po && po.checked) n++;
-  const badge = $('delivMoreFilterBadge');
-  if (badge) { badge.textContent = n > 0 ? String(n) : ''; badge.style.display = n > 0 ? '' : 'none'; }
+// 텍스트 검색창 토글 — 기본 숨김, 돋보기 버튼으로 펼침. 접을 때 검색어가 있으면 비우고 갱신.
+function toggleDelivSearch() {
+  const box = $('delivSearchBox');
+  const input = $('delivSearch');
+  if (!box) return;
+  const willShow = (box.style.display === 'none' || !box.style.display);
+  box.style.display = willShow ? 'flex' : 'none';
+  if (willShow) { setTimeout(() => { if (input) input.focus(); }, 0); }
+  else if (input && input.value) { input.value = ''; renderDeliverablesList(); }
 }
 
 async function renderDeliverablesList() {
@@ -17297,13 +17284,15 @@ async function renderDeliverablesList() {
     });
   }
 
-  // 더보기 배지 갱신 + 초기화 버튼 노출 — 기본줄·더보기 필터(기간·미제출OFF·대리등록 포함) 중 하나라도 활성이면 노출
-  updateDelivMoreFilterBadge();
+  // 초기화 버튼 노출 — 멀티필터·검색·기간·미제출OFF·대리등록 중 하나라도 활성이면 노출
   updateFilterResetBtn('btnDelivFilterReset', ['delivRecruitTypeMulti','delivReceiptStatusMulti','delivResultStatusMulti','delivChannelMulti','delivCampMulti'], 'delivSearch');
-  const _delivMoreActive = (_delivSubmittedFrom || _delivSubmittedTo)
+  const _delivExtraActive = (_delivSubmittedFrom || _delivSubmittedTo)
     || ($('delivIncludeMissing') && !$('delivIncludeMissing').checked)
     || ($('delivProxyOnly') && $('delivProxyOnly').checked);
-  if (_delivMoreActive) { const rb = $('btnDelivFilterReset'); if (rb) rb.style.display = ''; }
+  if (_delivExtraActive) { const rb = $('btnDelivFilterReset'); if (rb) rb.style.display = ''; }
+  // 검색어 있으면 돋보기 버튼 강조 + 검색창 펼친 상태 유지 (접힌 채 필터 적용 방지)
+  const _stb = $('btnDelivSearchToggle'); if (_stb) _stb.classList.toggle('active', !!search);
+  if (search) { const _sbox = $('delivSearchBox'); if (_sbox) _sbox.style.display = 'flex'; }
 
   // 정렬: 수동 sort 있으면 그대로, 없으면 검수대기 우선 → 최근 제출일 내림차순
   if (_delivSort.col === 'submitted') {

--- a/dev/admin/index.html
+++ b/dev/admin/index.html
@@ -1041,38 +1041,12 @@
                 관리자 대리 등록
               </button>
             </div>
-            <!-- 기본줄: 자주 쓰는 필터 + 더보기 토글 -->
+            <!-- 모든 필터 항상 노출 (한 영역, 줄바꿈 허용). 텍스트 검색만 돋보기 버튼으로 토글 -->
             <div style="display:flex;align-items:flex-end;gap:12px;flex-wrap:wrap">
               <div class="admin-filter-group">
                 <label>캠페인</label>
                 <div id="delivCampMulti" class="mf-wrap" style="max-width:260px"><button type="button" class="mf-btn" style="max-width:260px;overflow:hidden;text-overflow:ellipsis">전체 캠페인</button><div class="mf-drop" style="min-width:320px;max-width:420px"></div></div>
               </div>
-              <div class="admin-filter-group">
-                <label>결과물 상태 <span class="material-icons-round notranslate" translate="no" title="다중채널 캠페인은 채널별 상태가 상태 종류마다 따로 집계됩니다. (예: 인스타 승인 + X 검수대기 → 승인·검수대기 양쪽 건수에 포함)" style="font-size:13px;cursor:help;color:var(--muted);vertical-align:middle">info_outline</span></label>
-                <div id="delivResultStatusMulti" class="mf-wrap"><button type="button" class="mf-btn">전체</button><div class="mf-drop"></div></div>
-              </div>
-              <div class="admin-filter-group" style="flex:1;min-width:200px">
-                <label>검색</label>
-                <div style="position:relative">
-                  <span class="material-icons-round" style="position:absolute;left:8px;top:50%;transform:translateY(-50%);font-size:16px;color:var(--muted)">search</span>
-                  <input type="search" id="delivSearch" class="admin-filter-search" autocomplete="off" data-lpignore="true" data-1p-ignore="true" readonly onfocus="this.removeAttribute('readonly')" placeholder="인플루언서명 · 이메일 검색" oninput="renderDeliverablesList()">
-                </div>
-              </div>
-              <div class="admin-filter-group" style="justify-content:flex-end">
-                <label>&nbsp;</label>
-                <button type="button" class="btn btn-ghost btn-sm deliv-more-btn" id="btnDelivMoreFilters" onclick="toggleDelivMoreFilters()">
-                  <span class="material-icons-round notranslate" translate="no" style="font-size:15px;vertical-align:middle">tune</span>
-                  <span>필터 더보기</span><span id="delivMoreFilterBadge" class="deliv-more-badge" style="display:none"></span>
-                  <span class="material-icons-round notranslate deliv-more-caret" translate="no" id="delivMoreCaret" style="font-size:16px;vertical-align:middle">expand_more</span>
-                </button>
-              </div>
-              <div class="admin-filter-group" style="justify-content:flex-end">
-                <label>&nbsp;</label>
-                <button class="btn btn-ghost btn-xs" id="btnDelivFilterReset" onclick="resetDelivFiltersAndSort()" style="display:none">초기화</button>
-              </div>
-            </div>
-            <!-- 더보기 영역 (기본 닫힘) -->
-            <div id="delivMoreFilters" style="display:none;align-items:flex-end;gap:12px;flex-wrap:wrap;margin-top:10px;padding-top:10px;border-top:1px dashed var(--outline)">
               <div class="admin-filter-group">
                 <label>모집 타입</label>
                 <div id="delivRecruitTypeMulti" class="mf-wrap"><button type="button" class="mf-btn">전체 타입</button><div class="mf-drop"></div></div>
@@ -1084,6 +1058,10 @@
               <div class="admin-filter-group">
                 <label>영수증 상태 <span class="material-icons-round notranslate" translate="no" title="영수증은 리뷰어 캠페인 전용입니다. 영수증 상태로 거르면 기프팅·방문형은 표시되지 않습니다." style="font-size:13px;cursor:help;color:var(--muted);vertical-align:middle">info_outline</span></label>
                 <div id="delivReceiptStatusMulti" class="mf-wrap"><button type="button" class="mf-btn">전체</button><div class="mf-drop"></div></div>
+              </div>
+              <div class="admin-filter-group">
+                <label>결과물 상태 <span class="material-icons-round notranslate" translate="no" title="다중채널 캠페인은 채널별 상태가 상태 종류마다 따로 집계됩니다. (예: 인스타 승인 + X 검수대기 → 승인·검수대기 양쪽 건수에 포함)" style="font-size:13px;cursor:help;color:var(--muted);vertical-align:middle">info_outline</span></label>
+                <div id="delivResultStatusMulti" class="mf-wrap"><button type="button" class="mf-btn">전체</button><div class="mf-drop"></div></div>
               </div>
               <div class="admin-filter-group">
                 <label>최근 제출일</label>
@@ -1102,6 +1080,24 @@
                   <input type="checkbox" id="delivProxyOnly" onchange="renderDeliverablesList()" style="margin:0">
                   <span>만 보기</span>
                 </label>
+              </div>
+              <div class="admin-filter-group" style="justify-content:flex-end">
+                <label>&nbsp;</label>
+                <button type="button" class="btn btn-ghost btn-sm" id="btnDelivSearchToggle" onclick="toggleDelivSearch()" title="인플루언서명 · 이메일 검색">
+                  <span class="material-icons-round notranslate" translate="no" style="font-size:16px;vertical-align:middle">search</span>
+                </button>
+              </div>
+              <div class="admin-filter-group" style="justify-content:flex-end">
+                <label>&nbsp;</label>
+                <button class="btn btn-ghost btn-xs" id="btnDelivFilterReset" onclick="resetDelivFiltersAndSort()" style="display:none">초기화</button>
+              </div>
+              <!-- 텍스트 검색 입력 (기본 숨김 — 돋보기 버튼으로 토글) -->
+              <div class="admin-filter-group" id="delivSearchBox" style="display:none;flex:1;min-width:220px">
+                <label>검색</label>
+                <div style="position:relative">
+                  <span class="material-icons-round notranslate" translate="no" style="position:absolute;left:8px;top:50%;transform:translateY(-50%);font-size:16px;color:var(--muted)">search</span>
+                  <input type="search" id="delivSearch" class="admin-filter-search" autocomplete="off" data-lpignore="true" data-1p-ignore="true" placeholder="인플루언서명 · 이메일 검색" oninput="renderDeliverablesList()">
+                </div>
               </div>
             </div>
           </div>

--- a/dev/css/admin.css
+++ b/dev/css/admin.css
@@ -50,8 +50,8 @@
 .mf-search{width:100%;box-sizing:border-box;padding:6px 8px;font-size:12px;border:1px solid var(--outline);border-radius:6px;color:var(--ink);outline:none}
 .mf-search:focus{border-color:var(--primary)}
 .mf-search-empty{padding:10px 12px;font-size:12px;color:var(--muted);text-align:center}
-/* 결과물 관리 「필터 더보기」 토글 — 활성 필터 수 배지 + 기간 선택 활성 표시 */
-.deliv-more-badge{display:inline-flex;align-items:center;justify-content:center;min-width:16px;height:16px;padding:0 4px;margin-left:2px;background:var(--primary);color:#fff;border-radius:8px;font-size:10px;font-weight:700;line-height:1}
+/* 결과물 관리 — 검색 돋보기 버튼 활성 강조 + 기간 선택 활성 표시 */
+#btnDelivSearchToggle.active{color:var(--primary);border-color:var(--primary)}
 .admin-filter-search.filter-active{border-color:var(--primary);color:var(--primary)}
 .admin-layout{display:grid;grid-template-columns:220px 1fr;height:100vh;transition:grid-template-columns .25s ease}
 .admin-layout.collapsed{grid-template-columns:56px 1fr}

--- a/dev/js/admin-deliverables.js
+++ b/dev/js/admin-deliverables.js
@@ -44,6 +44,9 @@ function resetDelivFiltersAndSort() {
   resetMultiFilter('delivChannelMulti', '전체 채널');
   resetMultiFilter('delivCampMulti', '전체 캠페인');
   const q = $('delivSearch'); if (q) q.value = '';
+  // 검색창 접기 + 돋보기 버튼 강조 해제
+  const sbox = $('delivSearchBox'); if (sbox) sbox.style.display = 'none';
+  const stb = $('btnDelivSearchToggle'); if (stb) stb.classList.remove('active');
   // 미제출 포함은 기본값 ON(HTML checked)과 일치하게 복원 — 초기화 후 전체 건수가 보이도록
   const cb = $('delivIncludeMissing'); if (cb) cb.checked = true;
   const cb2 = $('delivProxyOnly'); if (cb2) cb2.checked = false;
@@ -99,7 +102,6 @@ const DELIV_PAGE_SIZE = 50;
 var _delivSubmittedFrom = '';
 var _delivSubmittedTo = '';
 var _delivSubmittedFp = null;
-var _delivMoreOpen = false;
 
 // timestamptz ISO → 브라우저 로컬 날짜(YYYY-MM-DD). 기간 필터 비교용 (운영자 KST 기준)
 function delivLocalDate(iso) {
@@ -143,26 +145,15 @@ function setupDelivSubmittedRange() {
   });
 }
 
-// 더보기 영역 펼침/접힘 토글
-function toggleDelivMoreFilters() {
-  _delivMoreOpen = !_delivMoreOpen;
-  const box = $('delivMoreFilters');
-  const caret = $('delivMoreCaret');
-  if (box) box.style.display = _delivMoreOpen ? 'flex' : 'none';
-  if (caret) caret.textContent = _delivMoreOpen ? 'expand_less' : 'expand_more';
-}
-
-// 더보기 영역에 적용된 필터 수 → 버튼 배지 (닫혀 있어도 적용 사실 인지)
-function updateDelivMoreFilterBadge() {
-  let n = 0;
-  if (getMultiFilterValues('delivRecruitTypeMulti').length > 0) n++;
-  if (getMultiFilterValues('delivChannelMulti').length > 0) n++;
-  if (getMultiFilterValues('delivReceiptStatusMulti').length > 0) n++;
-  if (_delivSubmittedFrom || _delivSubmittedTo) n++;
-  const im = $('delivIncludeMissing'); if (im && !im.checked) n++;   // 기본 ON → OFF면 사용자가 변경
-  const po = $('delivProxyOnly'); if (po && po.checked) n++;
-  const badge = $('delivMoreFilterBadge');
-  if (badge) { badge.textContent = n > 0 ? String(n) : ''; badge.style.display = n > 0 ? '' : 'none'; }
+// 텍스트 검색창 토글 — 기본 숨김, 돋보기 버튼으로 펼침. 접을 때 검색어가 있으면 비우고 갱신.
+function toggleDelivSearch() {
+  const box = $('delivSearchBox');
+  const input = $('delivSearch');
+  if (!box) return;
+  const willShow = (box.style.display === 'none' || !box.style.display);
+  box.style.display = willShow ? 'flex' : 'none';
+  if (willShow) { setTimeout(() => { if (input) input.focus(); }, 0); }
+  else if (input && input.value) { input.value = ''; renderDeliverablesList(); }
 }
 
 async function renderDeliverablesList() {
@@ -460,13 +451,15 @@ async function renderDeliverablesList() {
     });
   }
 
-  // 더보기 배지 갱신 + 초기화 버튼 노출 — 기본줄·더보기 필터(기간·미제출OFF·대리등록 포함) 중 하나라도 활성이면 노출
-  updateDelivMoreFilterBadge();
+  // 초기화 버튼 노출 — 멀티필터·검색·기간·미제출OFF·대리등록 중 하나라도 활성이면 노출
   updateFilterResetBtn('btnDelivFilterReset', ['delivRecruitTypeMulti','delivReceiptStatusMulti','delivResultStatusMulti','delivChannelMulti','delivCampMulti'], 'delivSearch');
-  const _delivMoreActive = (_delivSubmittedFrom || _delivSubmittedTo)
+  const _delivExtraActive = (_delivSubmittedFrom || _delivSubmittedTo)
     || ($('delivIncludeMissing') && !$('delivIncludeMissing').checked)
     || ($('delivProxyOnly') && $('delivProxyOnly').checked);
-  if (_delivMoreActive) { const rb = $('btnDelivFilterReset'); if (rb) rb.style.display = ''; }
+  if (_delivExtraActive) { const rb = $('btnDelivFilterReset'); if (rb) rb.style.display = ''; }
+  // 검색어 있으면 돋보기 버튼 강조 + 검색창 펼친 상태 유지 (접힌 채 필터 적용 방지)
+  const _stb = $('btnDelivSearchToggle'); if (_stb) _stb.classList.toggle('active', !!search);
+  if (search) { const _sbox = $('delivSearchBox'); if (_sbox) _sbox.style.display = 'flex'; }
 
   // 정렬: 수동 sort 있으면 그대로, 없으면 검수대기 우선 → 최근 제출일 내림차순
   if (_delivSort.col === 'submitted') {

--- a/docs/specs/2026-05-29-deliverables-filter-redesign.md
+++ b/docs/specs/2026-05-29-deliverables-filter-redesign.md
@@ -191,3 +191,10 @@
 - **초안 대비 변경:** 없음(§설계 3·5·6 그대로).
 - **구현 중 결정**: ① 기간/채널 날짜·매칭 모두 브라우저 로컬 기준(`delivLocalDate`)으로 통일해 UTC 혼선 차단. ② 기간 필터 활성 시 다른 드롭다운 카운트도 **기간 교집합 기준으로 집계됨**(passesFilters 내부 AND, skipDate 없음 — PR1·2 「나머지 AND」 원칙과 정합, 의도된 동작). ③ `delivChannelMulti`는 init 없이 sync 첫 호출로 생성(`delivCampMulti`와 동일 패턴).
 - reviewer GO(Warning 2건 모두 코드 문제 아님), qa 권장 light.
+
+### PR 3 후속 — 레이아웃 재변경 (사용자 요청, 구현 완료)
+**구현일:** 2026-05-29 · 사용자 요청: "필터들 기본 출력으로 다 보이게, 검색은 버튼 클릭 시 펼침. 가능하면 숨기지 않는 게 좋겠다."
+- §설계 6의 「기본줄 + 더보기 접이식」을 **폐지** → 모든 필터 드롭다운(캠페인·모집타입·채널·영수증·결과물상태·최근제출일·결과물미제출·대리등록)을 **단일 flex-wrap 영역에 항상 노출**(줄바꿈 허용).
+- 텍스트 검색창만 **돋보기 버튼(`btnDelivSearchToggle`) 토글**로 전환(`toggleDelivSearch`) — 평소 숨김, 클릭 시 펼침+focus, 접을 때 검색어 있으면 비우고 갱신. 검색어 있으면 버튼 강조(`.active`)+검색창 펼침 유지.
+- 제거: `toggleDelivMoreFilters`·`updateDelivMoreFilterBadge`·`_delivMoreOpen`·`#delivMoreFilters`·더보기 배지/caret·`.deliv-more-badge`.
+- reviewer GO(검색창 장식 아이콘 translate 누락 1건 반영 후), qa 권장 light.


### PR DESCRIPTION
## 변경 요약
- 사용자 요청: 필터를 숨기지 말고 전부 보이게, 검색만 버튼 클릭 시 펼치게
- 「필터 더보기」 접이식 폐지 → 모든 필터 드롭다운 한 영역에 항상 노출(줄바꿈 허용)
- 텍스트 검색창은 돋보기 버튼 토글(클릭 시 펼침+focus, 접으면 검색 해제, 검색 중엔 버튼 강조)

## 관련 사양서
- docs/specs/2026-05-29-deliverables-filter-redesign.md (PR3 후속 레이아웃 재변경 기록)

## 검증
- reverb-reviewer GO (검색 장식 아이콘 translate 누락 1건 반영)

🤖 Generated with [Claude Code](https://claude.com/claude-code)