### PR TITLE
feat(admin): PR5 — 대리 등록 증빙 파일 첨부 (마이그레이션 163)

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -12,7 +12,7 @@
 // 회귀(2026-05-12 PR #182 머지 직후 발생)를 방지하기 위한 자동 reload 가드.
 // sessionStorage 차단 환경(시크릿 모드 일부, 쿠키 차단)에서는 자연스럽게 skip.
 (function(){
-  var CURRENT_BUILD = 'v1780046014';
+  var CURRENT_BUILD = 'v1780279008';
   if (CURRENT_BUILD.indexOf('__') === 0) return; // 빌드 미적용 (dev/ 직접 열기) 시 skip
   try {
     var prev = sessionStorage.getItem('reverb.adminBuild');
@@ -198,6 +198,8 @@ textarea.form-input{resize:vertical;min-height:80px}
 #toast.show{transform:translateX(-50%) translateY(0);opacity:1}
 #toast.success{background:var(--green)}
 #toast.error{background:#B3261E}
+#toast.warning{background:#d97706}
+#toast.info{background:#1d4ed8}
 
 /* ── MODAL (Material Bottom Sheet) ── */
 .modal-overlay{display:none;position:fixed;inset:0;background:rgba(0,0,0,.4);z-index:500;align-items:flex-end;justify-content:center;padding:0}
@@ -1825,6 +1827,53 @@ textarea.form-input{resize:vertical;min-height:80px}
 }
 .modal-footer-aux{ margin-right:auto; }  /* 좌측 보조요소(상태 pill·삭제 버튼) 고정 */
 
+/* ── 대리 등록 증빙 파일 첨부 (마이그레이션 163) ── */
+.proxy-evidence-dropzone {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 10px 14px;
+  border: 1.5px dashed var(--line);
+  border-radius: 8px;
+  cursor: pointer;
+  background: var(--surface);
+  transition: border-color 0.15s, background 0.15s;
+  margin-bottom: 8px;
+}
+.proxy-evidence-dropzone:hover { border-color: var(--dark-pink); background: #fff5f8; }
+.proxy-evidence-preview-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  min-height: 0;
+}
+.proxy-evidence-item {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 8px;
+  background: #f7f7f7;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  font-size: 12px;
+  color: var(--ink);
+  max-width: 200px;
+  min-width: 100px;
+}
+.proxy-evidence-item img { width: 36px; height: 36px; object-fit: cover; border-radius: 4px; flex-shrink: 0; }
+.proxy-evidence-item .ev-name { flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.proxy-evidence-item .ev-remove {
+  flex-shrink: 0;
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--muted);
+  font-size: 14px;
+  line-height: 1;
+  padding: 0 2px;
+}
+.proxy-evidence-item .ev-remove:hover { color: #c00; }
+
 </style>
 </head>
 <body style="background:#F8F5F8">
@@ -1899,7 +1948,7 @@ textarea.form-input{resize:vertical;min-height:80px}
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-05-29 18:13 · 605d829</span>
+          <span class="admin-build-text">2026-06-01 10:56 · bdc5021</span>
         </div>
       </div>
     </aside>
@@ -4424,6 +4473,18 @@ textarea.form-input{resize:vertical;min-height:80px}
           <textarea id="adminProxyReason" placeholder="예: 6/12 도착 확인, 인플 LINE 협의 완료" maxlength="500"></textarea>
           <span class="form-help">운영 내부 메모. 인플루언서 화면에는 노출되지 않습니다.</span>
         </div>
+
+        <!-- 증빙 파일 첨부 (선택, 마이그레이션 163) -->
+        <div class="form-row" id="adminProxyEvidenceSection">
+          <label>증빙 첨부 <span style="font-weight:400;color:var(--muted)">(선택 · 최대 5장 · 장당 5MB)</span></label>
+          <input type="file" id="adminProxyEvidenceInput" accept="image/jpeg,image/png,image/webp,image/gif,application/pdf" multiple style="display:none" onchange="onAdminProxyEvidenceChange()">
+          <div id="adminProxyEvidenceDropzone" class="proxy-evidence-dropzone" onclick="document.getElementById('adminProxyEvidenceInput').click()" ondragover="event.preventDefault()" ondrop="onAdminProxyEvidenceDrop(event)">
+            <span class="material-icons-round notranslate" translate="no" style="font-size:20px;color:var(--muted)">attach_file</span>
+            <span style="font-size:13px;color:var(--muted);margin-left:6px">파일 선택 또는 드래그&amp;드롭 (이미지 / PDF)</span>
+          </div>
+          <div id="adminProxyEvidencePreview" class="proxy-evidence-preview-list"></div>
+          <span class="form-help">미첨부 시에도 대리 등록은 가능합니다. campaign_admin 이상만 열람 가능.</span>
+        </div>
       </div>
     </div>
     <div style="padding:14px 22px;border-top:1px solid var(--line);display:flex;gap:8px;justify-content:flex-end">
@@ -5792,6 +5853,41 @@ async function deleteFlagEvidenceFiles(paths) {
   if (error) throw error;
 }
 
+// ── 대리 등록 증빙 파일 업로드 (campaign_admin 이상, 마이그레이션 163) ──
+// file: File 객체
+// ref: deliverable_id 또는 'tmp/{timestamp}' 등 임시값
+// 반환: Storage 경로 문자열 (admin-proxy-evidence 버킷 기준)
+async function uploadProxyEvidence(file, ref) {
+  if (!db) throw new Error('DB 미연결');
+  const BUCKET = 'admin-proxy-evidence';
+  const ext = file.name ? file.name.split('.').pop().toLowerCase() : 'bin';
+  const uuid = crypto.randomUUID ? crypto.randomUUID() : (Date.now().toString(36) + Math.random().toString(36).substring(2));
+  const path = `${ref}/${uuid}.${ext}`;
+  const {error} = await db.storage.from(BUCKET).upload(path, file, {contentType: file.type, upsert: false, cacheControl: '86400'});
+  if (error) throw error;
+  return path;
+}
+
+// ── 대리 등록 증빙 signed URL 조회 (campaign_admin 이상, 마이그레이션 163) ──
+// path: uploadProxyEvidence() 반환값 (Storage 경로)
+// expiresIn: 초 단위, 기본 3600 (1시간)
+async function getProxyEvidenceSignedUrl(path, expiresIn = 3600) {
+  if (!db || !path) return null;
+  const BUCKET = 'admin-proxy-evidence';
+  const {data, error} = await db.storage.from(BUCKET).createSignedUrl(path, expiresIn);
+  if (error) throw error;
+  return data?.signedUrl || null;
+}
+
+// ── 대리 등록 증빙 파일 삭제 (super_admin 전용, 마이그레이션 163) ──
+// paths: Storage 경로 배열
+async function deleteProxyEvidenceFiles(paths) {
+  if (!db || !paths || paths.length === 0) return;
+  const BUCKET = 'admin-proxy-evidence';
+  const {error} = await db.storage.from(BUCKET).remove(paths);
+  if (error) throw error;
+}
+
 // 모든 인플루언서의 위반 건수 집계 — { [influencer_id]: count }
 async function fetchViolationCountsByInfluencer() {
   if (!db) return {};
@@ -5949,6 +6045,7 @@ async function fetchDeliverables(filters) {
         reviewed_by, reviewed_at, submitted_at, updated_at,
         application_id, user_id, campaign_id,
         submitted_by_admin, submitted_by_admin_reason_code, submitted_by_admin_reason, submitted_by_admin_at,
+        submitted_by_admin_evidence,
         campaigns:campaign_id (id, campaign_no, title, brand, recruit_type, channel, purchase_start, purchase_end, visit_start, visit_end, submission_end)
       `).neq('status', 'draft');
       if (filters?.status && filters.status !== 'all') q = q.eq('status', filters.status);
@@ -6135,7 +6232,7 @@ async function fetchDeliverablesByCampaign(campaignId) {
   if (!db) return [];
   try {
     const {data, error} = await db?.from('deliverables')
-      .select('id, application_id, user_id, kind, status, reviewed_at, submitted_at, updated_at, version, post_url, post_channel, receipt_url, purchase_date, purchase_amount, reject_reason, submitted_by_admin, submitted_by_admin_reason_code, submitted_by_admin_reason, submitted_by_admin_at')
+      .select('id, application_id, user_id, kind, status, reviewed_at, submitted_at, updated_at, version, post_url, post_channel, receipt_url, purchase_date, purchase_amount, reject_reason, submitted_by_admin, submitted_by_admin_reason_code, submitted_by_admin_reason, submitted_by_admin_at, submitted_by_admin_evidence')
       .eq('campaign_id', campaignId)
       .order('submitted_at', {ascending: false});
     if (error) throw error;
@@ -6263,7 +6360,8 @@ async function adminCreateDeliverableProxy(payload) {
       p_purchase_date:   payload.purchaseDate || null,
       p_purchase_amount: payload.purchaseAmount ?? null,
       p_reason_code:     payload.reasonCode,
-      p_reason:          payload.reason || null
+      p_reason:          payload.reason || null,
+      p_evidence_paths:  payload.evidencePaths || []  // 마이그레이션 163: 증빙 경로 배열 (기본 빈 배열)
     });
     if (error) throw error;
     newId = data;
@@ -6271,21 +6369,34 @@ async function adminCreateDeliverableProxy(payload) {
   return newId;
 }
 
-// 대리 등록 회수 (super_admin 전용, 마이그레이션 160).
+// 대리 등록 회수 (super_admin 전용, 마이그레이션 160·163).
 // 잘못 등록된 대리 등록 결과물을 삭제 + audit 1건 기록.
+// 마이그레이션 163: RPC가 삭제된 증빙 파일 경로 배열을 반환 → 클라이언트에서 Storage 파일 별도 삭제.
+// Storage 삭제 실패 시 회수 자체는 성공으로 처리 (경고 토스트만).
 async function adminRevokeProxyDeliverable(deliverableId, reason) {
   if (!db) throw new Error('DB 미연결');
   if (!deliverableId) throw new Error('deliverableId 누락');
-  let ok = false;
+  let evidencePaths = [];
   await retryWithRefresh(async () => {
-    const {error} = await db.rpc('admin_revoke_proxy_deliverable', {
+    const {data, error} = await db.rpc('admin_revoke_proxy_deliverable', {
       p_deliverable_id: deliverableId,
       p_reason:         reason || null
     });
     if (error) throw error;
-    ok = true;
+    // 마이그레이션 163: RPC 반환값 = text[] (증빙 경로 배열)
+    evidencePaths = Array.isArray(data) ? data : [];
   });
-  return ok;
+  // Storage 증빙 파일 삭제 — 실패해도 회수 자체는 성공 처리 (고아 파일 경고만)
+  if (evidencePaths.length > 0) {
+    try {
+      await deleteProxyEvidenceFiles(evidencePaths);
+    } catch (storageErr) {
+      console.warn('[admin-proxy] 증빙 파일 Storage 삭제 실패 (회수는 완료됨):', storageErr);
+      // 호출부에서 toast로 경고 표시 가능하도록 에러 정보 반환
+      return {ok: true, storageDeleteFailed: true};
+    }
+  }
+  return {ok: true, storageDeleteFailed: false};
 }
 
 // 채널 미지정 review_image 행에 채널 지정 / 해제 (마이그레이션 162)
@@ -18163,7 +18274,17 @@ function renderDelivPanelContent(d, events) {
     const reasonLabel = _proxyReasonLabelKo(d.submitted_by_admin_reason_code);
     const at = d.submitted_by_admin_at ? formatDate(d.submitted_by_admin_at) : '';
     const memo = d.submitted_by_admin_reason ? `<div class="deliv-proxy-meta">메모: ${esc(d.submitted_by_admin_reason)}</div>` : '';
-    html += `<div class="deliv-proxy-notice"><strong>관리자 대리 등록</strong> — 사유: ${esc(reasonLabel)}${at ? ' · ' + esc(at) : ''}${memo}<span class="deliv-proxy-cascade">회수 시 audit 로그도 함께 삭제됩니다 (영구 감사 미보존).</span></div>`;
+    // 마이그레이션 163: 증빙 파일 보기 버튼 (campaign_admin 이상, 비동기 signed URL)
+    const evidencePaths = Array.isArray(d.submitted_by_admin_evidence) ? d.submitted_by_admin_evidence : [];
+    const evidenceBtn = evidencePaths.length > 0
+      ? `<button class="btn btn-ghost btn-sm" style="font-size:11px;padding:3px 8px;margin-top:4px"
+           data-deliv-id="${esc(d.id)}"
+           data-evidence="${esc(JSON.stringify(evidencePaths))}"
+           onclick="openProxyEvidenceViewer(this.dataset.delivId, JSON.parse(this.dataset.evidence))">
+           증빙 ${evidencePaths.length}개 보기
+         </button>`
+      : '';
+    html += `<div class="deliv-proxy-notice"><strong>관리자 대리 등록</strong> — 사유: ${esc(reasonLabel)}${at ? ' · ' + esc(at) : ''}${memo}${evidenceBtn}<span class="deliv-proxy-cascade">회수 시 audit 로그도 함께 삭제됩니다 (영구 감사 미보존).</span></div>`;
   }
   if (d.kind === 'receipt' || d.kind === 'review_image') {
     html += `<div style="text-align:center;margin-bottom:12px">
@@ -18308,6 +18429,84 @@ function _resetAdminProxyForm() {
   });
   const kindSelect = $('adminProxyKind');
   if (kindSelect) { kindSelect.innerHTML = '<option value="">— 먼저 인플루언서를 선택하세요 —</option>'; kindSelect.disabled = true; }
+  // 마이그레이션 163: 증빙 파일 입력 + 미리보기 초기화
+  const evInput = $('adminProxyEvidenceInput');
+  if (evInput) evInput.value = '';
+  _renderProxyEvidencePreview([]);
+  // 내부 파일 목록 초기화
+  _proxyEvidenceFiles = [];
+}
+
+// 마이그레이션 163: 증빙 파일 목록 (File 객체 배열, 최대 5장)
+let _proxyEvidenceFiles = [];
+const _PROXY_EVIDENCE_MAX = 5;
+const _PROXY_EVIDENCE_MAX_SIZE = 5 * 1024 * 1024; // 5MB
+const _PROXY_EVIDENCE_ALLOWED_MIME = ['image/jpeg','image/png','image/webp','image/gif','application/pdf'];
+
+function _validateProxyEvidenceFiles(files) {
+  const candidates = Array.from(files);
+  const merged = [..._proxyEvidenceFiles, ...candidates];
+  if (merged.length > _PROXY_EVIDENCE_MAX) {
+    toast(`증빙 파일은 최대 ${_PROXY_EVIDENCE_MAX}장까지 첨부 가능합니다`, 'error');
+    return null;
+  }
+  for (const f of candidates) {
+    if (!_PROXY_EVIDENCE_ALLOWED_MIME.includes(f.type)) {
+      toast(`지원하지 않는 파일 형식입니다: ${f.name} (이미지 또는 PDF만 가능)`, 'error');
+      return null;
+    }
+    if (f.size > _PROXY_EVIDENCE_MAX_SIZE) {
+      toast(`파일 크기가 5MB를 초과합니다: ${f.name}`, 'error');
+      return null;
+    }
+  }
+  return merged;
+}
+
+function onAdminProxyEvidenceChange() {
+  const input = $('adminProxyEvidenceInput');
+  if (!input || !input.files || !input.files.length) return;
+  const merged = _validateProxyEvidenceFiles(input.files);
+  if (!merged) { input.value = ''; return; }
+  _proxyEvidenceFiles = merged;
+  _renderProxyEvidencePreview(_proxyEvidenceFiles);
+  input.value = '';
+}
+
+function onAdminProxyEvidenceDrop(e) {
+  e.preventDefault();
+  const files = e.dataTransfer?.files;
+  if (!files || !files.length) return;
+  const merged = _validateProxyEvidenceFiles(files);
+  if (!merged) return;
+  _proxyEvidenceFiles = merged;
+  _renderProxyEvidencePreview(_proxyEvidenceFiles);
+}
+
+function _renderProxyEvidencePreview(files) {
+  const container = $('adminProxyEvidencePreview');
+  if (!container) return;
+  // 기존 blob URL 해제 (메모리 누수 방지)
+  container.querySelectorAll('img[src^="blob:"]').forEach(img => URL.revokeObjectURL(img.src));
+  if (!files || !files.length) { container.innerHTML = ''; return; }
+  container.innerHTML = files.map((f, i) => {
+    const isPdf = f.type === 'application/pdf';
+    const thumb = isPdf
+      ? `<span class="material-icons-round notranslate" translate="no" style="font-size:32px;color:#e74c3c;flex-shrink:0">picture_as_pdf</span>`
+      : `<img src="${URL.createObjectURL(f)}" alt="">`;
+    return `<div class="proxy-evidence-item">
+      ${thumb}
+      <span class="ev-name" title="${esc(f.name)}">${esc(f.name)}</span>
+      <button class="ev-remove" type="button" onclick="_removeProxyEvidenceFile(${i})" title="삭제">
+        <span class="material-icons-round notranslate" translate="no" style="font-size:14px">close</span>
+      </button>
+    </div>`;
+  }).join('');
+}
+
+function _removeProxyEvidenceFile(index) {
+  _proxyEvidenceFiles.splice(index, 1);
+  _renderProxyEvidencePreview(_proxyEvidenceFiles);
 }
 
 async function _loadAdminProxyApprovedApps() {
@@ -18676,6 +18875,19 @@ async function submitAdminProxyDelivProxy() {
   const btn = $('adminProxySubmitBtn');
   if (btn) { btn.disabled = true; btn.textContent = '처리 중…'; }
   try {
+    // 마이그레이션 163: 증빙 파일 Storage 업로드 (있으면) → 경로 배열 수집
+    // 임시 참조 키는 타임스탬프 (RPC 성공 후 id를 알 수 있으므로 tmp 경로 사용)
+    let evidencePaths = [];
+    if (_proxyEvidenceFiles.length > 0) {
+      if (btn) btn.textContent = '증빙 업로드 중…';
+      const tmpRef = 'tmp-' + Date.now();
+      const uploads = await Promise.all(
+        _proxyEvidenceFiles.map(f => uploadProxyEvidence(f, tmpRef))
+      );
+      evidencePaths = uploads.filter(Boolean);
+    }
+    payload.evidencePaths = evidencePaths;
+
     const newId = await adminCreateDeliverableProxy(payload);
     toast('대리 등록·자동 승인 완료 (id ' + (newId || '').slice(0, 8) + ')', 'success');
     closeAdminProxyModal();
@@ -18708,14 +18920,49 @@ async function revokeAdminProxyDeliv(deliverableId) {
   if (!reason.trim()) return toast('회수 사유는 비워둘 수 없습니다', 'error');
   if (!confirm('대리 등록을 회수합니다. 결과물 행과 audit 로그가 삭제됩니다 (복구 불가). 진행할까요?')) return;
   try {
-    await adminRevokeProxyDeliverable(deliverableId, reason.trim());
-    toast('대리 등록 회수 완료', 'success');
+    // 마이그레이션 163: adminRevokeProxyDeliverable이 {ok, storageDeleteFailed} 반환
+    const result = await adminRevokeProxyDeliverable(deliverableId, reason.trim());
+    if (result?.storageDeleteFailed) {
+      toast('대리 등록 회수 완료 (증빙 파일 일부가 Storage에 남아있을 수 있습니다)', 'warning');
+    } else {
+      toast('대리 등록 회수 완료', 'success');
+    }
     closeDelivCombined();
     if (typeof refreshPane === 'function') await refreshPane('deliverables');
     else if (typeof renderDeliverablesList === 'function') await renderDeliverablesList();
   } catch (err) {
     console.error('[admin-proxy] 회수 실패', err);
     toast('회수 실패: ' + (err.message || err), 'error');
+  }
+}
+
+// 마이그레이션 163: 증빙 파일 보기 — 비동기 signed URL 생성 후 새 탭/라이트박스 열기
+async function openProxyEvidenceViewer(deliverableId, paths) {
+  if (!paths || !paths.length) return;
+  if (!Array.isArray(paths)) { try { paths = JSON.parse(paths); } catch(e) { return; } }
+
+  // campaign_admin 미만은 접근 불가 (Storage 정책에서도 차단됨)
+  const role = typeof currentAdminInfo !== 'undefined' ? currentAdminInfo?.role : null;
+  const allowedRoles = ['super_admin', 'campaign_admin'];
+  if (!role || !allowedRoles.includes(role)) {
+    return toast('증빙 파일은 campaign_admin 이상만 열람 가능합니다', 'error');
+  }
+
+  toast('증빙 파일 링크 생성 중…', 'info');
+  try {
+    const urls = await Promise.all(paths.map(p => getProxyEvidenceSignedUrl(p)));
+    const validUrls = urls.filter(Boolean);
+    if (!validUrls.length) return toast('증빙 파일 링크 생성에 실패했습니다', 'error');
+
+    // 이미지가 1개면 라이트박스, PDF이거나 여러 개면 새 탭 순차 오픈
+    if (validUrls.length === 1 && !paths[0].endsWith('.pdf')) {
+      openImageLightbox(validUrls[0]);
+    } else {
+      validUrls.forEach(url => window.open(url, '_blank', 'noopener'));
+    }
+  } catch (err) {
+    console.error('[proxy-evidence] signed URL 생성 실패', err);
+    toast('증빙 파일 링크 생성 실패: ' + (err.message || err), 'error');
   }
 }
 

--- a/dev/admin/index.html
+++ b/dev/admin/index.html
@@ -2658,6 +2658,18 @@
           <textarea id="adminProxyReason" placeholder="예: 6/12 도착 확인, 인플 LINE 협의 완료" maxlength="500"></textarea>
           <span class="form-help">운영 내부 메모. 인플루언서 화면에는 노출되지 않습니다.</span>
         </div>
+
+        <!-- 증빙 파일 첨부 (선택, 마이그레이션 163) -->
+        <div class="form-row" id="adminProxyEvidenceSection">
+          <label>증빙 첨부 <span style="font-weight:400;color:var(--muted)">(선택 · 최대 5장 · 장당 5MB)</span></label>
+          <input type="file" id="adminProxyEvidenceInput" accept="image/jpeg,image/png,image/webp,image/gif,application/pdf" multiple style="display:none" onchange="onAdminProxyEvidenceChange()">
+          <div id="adminProxyEvidenceDropzone" class="proxy-evidence-dropzone" onclick="document.getElementById('adminProxyEvidenceInput').click()" ondragover="event.preventDefault()" ondrop="onAdminProxyEvidenceDrop(event)">
+            <span class="material-icons-round notranslate" translate="no" style="font-size:20px;color:var(--muted)">attach_file</span>
+            <span style="font-size:13px;color:var(--muted);margin-left:6px">파일 선택 또는 드래그&amp;드롭 (이미지 / PDF)</span>
+          </div>
+          <div id="adminProxyEvidencePreview" class="proxy-evidence-preview-list"></div>
+          <span class="form-help">미첨부 시에도 대리 등록은 가능합니다. campaign_admin 이상만 열람 가능.</span>
+        </div>
       </div>
     </div>
     <div style="padding:14px 22px;border-top:1px solid var(--line);display:flex;gap:8px;justify-content:flex-end">

--- a/dev/css/admin.css
+++ b/dev/css/admin.css
@@ -1376,3 +1376,50 @@
   flex-shrink:0;
 }
 .modal-footer-aux{ margin-right:auto; }  /* 좌측 보조요소(상태 pill·삭제 버튼) 고정 */
+
+/* ── 대리 등록 증빙 파일 첨부 (마이그레이션 163) ── */
+.proxy-evidence-dropzone {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 10px 14px;
+  border: 1.5px dashed var(--line);
+  border-radius: 8px;
+  cursor: pointer;
+  background: var(--surface);
+  transition: border-color 0.15s, background 0.15s;
+  margin-bottom: 8px;
+}
+.proxy-evidence-dropzone:hover { border-color: var(--dark-pink); background: #fff5f8; }
+.proxy-evidence-preview-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  min-height: 0;
+}
+.proxy-evidence-item {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 8px;
+  background: #f7f7f7;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  font-size: 12px;
+  color: var(--ink);
+  max-width: 200px;
+  min-width: 100px;
+}
+.proxy-evidence-item img { width: 36px; height: 36px; object-fit: cover; border-radius: 4px; flex-shrink: 0; }
+.proxy-evidence-item .ev-name { flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.proxy-evidence-item .ev-remove {
+  flex-shrink: 0;
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--muted);
+  font-size: 14px;
+  line-height: 1;
+  padding: 0 2px;
+}
+.proxy-evidence-item .ev-remove:hover { color: #c00; }

--- a/dev/css/components.css
+++ b/dev/css/components.css
@@ -89,6 +89,8 @@ textarea.form-input{resize:vertical;min-height:80px}
 #toast.show{transform:translateX(-50%) translateY(0);opacity:1}
 #toast.success{background:var(--green)}
 #toast.error{background:#B3261E}
+#toast.warning{background:#d97706}
+#toast.info{background:#1d4ed8}
 
 /* ── MODAL (Material Bottom Sheet) ── */
 .modal-overlay{display:none;position:fixed;inset:0;background:rgba(0,0,0,.4);z-index:500;align-items:flex-end;justify-content:center;padding:0}

--- a/dev/js/admin-deliverables.js
+++ b/dev/js/admin-deliverables.js
@@ -1330,7 +1330,17 @@ function renderDelivPanelContent(d, events) {
     const reasonLabel = _proxyReasonLabelKo(d.submitted_by_admin_reason_code);
     const at = d.submitted_by_admin_at ? formatDate(d.submitted_by_admin_at) : '';
     const memo = d.submitted_by_admin_reason ? `<div class="deliv-proxy-meta">메모: ${esc(d.submitted_by_admin_reason)}</div>` : '';
-    html += `<div class="deliv-proxy-notice"><strong>관리자 대리 등록</strong> — 사유: ${esc(reasonLabel)}${at ? ' · ' + esc(at) : ''}${memo}<span class="deliv-proxy-cascade">회수 시 audit 로그도 함께 삭제됩니다 (영구 감사 미보존).</span></div>`;
+    // 마이그레이션 163: 증빙 파일 보기 버튼 (campaign_admin 이상, 비동기 signed URL)
+    const evidencePaths = Array.isArray(d.submitted_by_admin_evidence) ? d.submitted_by_admin_evidence : [];
+    const evidenceBtn = evidencePaths.length > 0
+      ? `<button class="btn btn-ghost btn-sm" style="font-size:11px;padding:3px 8px;margin-top:4px"
+           data-deliv-id="${esc(d.id)}"
+           data-evidence="${esc(JSON.stringify(evidencePaths))}"
+           onclick="openProxyEvidenceViewer(this.dataset.delivId, JSON.parse(this.dataset.evidence))">
+           증빙 ${evidencePaths.length}개 보기
+         </button>`
+      : '';
+    html += `<div class="deliv-proxy-notice"><strong>관리자 대리 등록</strong> — 사유: ${esc(reasonLabel)}${at ? ' · ' + esc(at) : ''}${memo}${evidenceBtn}<span class="deliv-proxy-cascade">회수 시 audit 로그도 함께 삭제됩니다 (영구 감사 미보존).</span></div>`;
   }
   if (d.kind === 'receipt' || d.kind === 'review_image') {
     html += `<div style="text-align:center;margin-bottom:12px">
@@ -1475,6 +1485,84 @@ function _resetAdminProxyForm() {
   });
   const kindSelect = $('adminProxyKind');
   if (kindSelect) { kindSelect.innerHTML = '<option value="">— 먼저 인플루언서를 선택하세요 —</option>'; kindSelect.disabled = true; }
+  // 마이그레이션 163: 증빙 파일 입력 + 미리보기 초기화
+  const evInput = $('adminProxyEvidenceInput');
+  if (evInput) evInput.value = '';
+  _renderProxyEvidencePreview([]);
+  // 내부 파일 목록 초기화
+  _proxyEvidenceFiles = [];
+}
+
+// 마이그레이션 163: 증빙 파일 목록 (File 객체 배열, 최대 5장)
+let _proxyEvidenceFiles = [];
+const _PROXY_EVIDENCE_MAX = 5;
+const _PROXY_EVIDENCE_MAX_SIZE = 5 * 1024 * 1024; // 5MB
+const _PROXY_EVIDENCE_ALLOWED_MIME = ['image/jpeg','image/png','image/webp','image/gif','application/pdf'];
+
+function _validateProxyEvidenceFiles(files) {
+  const candidates = Array.from(files);
+  const merged = [..._proxyEvidenceFiles, ...candidates];
+  if (merged.length > _PROXY_EVIDENCE_MAX) {
+    toast(`증빙 파일은 최대 ${_PROXY_EVIDENCE_MAX}장까지 첨부 가능합니다`, 'error');
+    return null;
+  }
+  for (const f of candidates) {
+    if (!_PROXY_EVIDENCE_ALLOWED_MIME.includes(f.type)) {
+      toast(`지원하지 않는 파일 형식입니다: ${f.name} (이미지 또는 PDF만 가능)`, 'error');
+      return null;
+    }
+    if (f.size > _PROXY_EVIDENCE_MAX_SIZE) {
+      toast(`파일 크기가 5MB를 초과합니다: ${f.name}`, 'error');
+      return null;
+    }
+  }
+  return merged;
+}
+
+function onAdminProxyEvidenceChange() {
+  const input = $('adminProxyEvidenceInput');
+  if (!input || !input.files || !input.files.length) return;
+  const merged = _validateProxyEvidenceFiles(input.files);
+  if (!merged) { input.value = ''; return; }
+  _proxyEvidenceFiles = merged;
+  _renderProxyEvidencePreview(_proxyEvidenceFiles);
+  input.value = '';
+}
+
+function onAdminProxyEvidenceDrop(e) {
+  e.preventDefault();
+  const files = e.dataTransfer?.files;
+  if (!files || !files.length) return;
+  const merged = _validateProxyEvidenceFiles(files);
+  if (!merged) return;
+  _proxyEvidenceFiles = merged;
+  _renderProxyEvidencePreview(_proxyEvidenceFiles);
+}
+
+function _renderProxyEvidencePreview(files) {
+  const container = $('adminProxyEvidencePreview');
+  if (!container) return;
+  // 기존 blob URL 해제 (메모리 누수 방지)
+  container.querySelectorAll('img[src^="blob:"]').forEach(img => URL.revokeObjectURL(img.src));
+  if (!files || !files.length) { container.innerHTML = ''; return; }
+  container.innerHTML = files.map((f, i) => {
+    const isPdf = f.type === 'application/pdf';
+    const thumb = isPdf
+      ? `<span class="material-icons-round notranslate" translate="no" style="font-size:32px;color:#e74c3c;flex-shrink:0">picture_as_pdf</span>`
+      : `<img src="${URL.createObjectURL(f)}" alt="">`;
+    return `<div class="proxy-evidence-item">
+      ${thumb}
+      <span class="ev-name" title="${esc(f.name)}">${esc(f.name)}</span>
+      <button class="ev-remove" type="button" onclick="_removeProxyEvidenceFile(${i})" title="삭제">
+        <span class="material-icons-round notranslate" translate="no" style="font-size:14px">close</span>
+      </button>
+    </div>`;
+  }).join('');
+}
+
+function _removeProxyEvidenceFile(index) {
+  _proxyEvidenceFiles.splice(index, 1);
+  _renderProxyEvidencePreview(_proxyEvidenceFiles);
 }
 
 async function _loadAdminProxyApprovedApps() {
@@ -1843,6 +1931,19 @@ async function submitAdminProxyDelivProxy() {
   const btn = $('adminProxySubmitBtn');
   if (btn) { btn.disabled = true; btn.textContent = '처리 중…'; }
   try {
+    // 마이그레이션 163: 증빙 파일 Storage 업로드 (있으면) → 경로 배열 수집
+    // 임시 참조 키는 타임스탬프 (RPC 성공 후 id를 알 수 있으므로 tmp 경로 사용)
+    let evidencePaths = [];
+    if (_proxyEvidenceFiles.length > 0) {
+      if (btn) btn.textContent = '증빙 업로드 중…';
+      const tmpRef = 'tmp-' + Date.now();
+      const uploads = await Promise.all(
+        _proxyEvidenceFiles.map(f => uploadProxyEvidence(f, tmpRef))
+      );
+      evidencePaths = uploads.filter(Boolean);
+    }
+    payload.evidencePaths = evidencePaths;
+
     const newId = await adminCreateDeliverableProxy(payload);
     toast('대리 등록·자동 승인 완료 (id ' + (newId || '').slice(0, 8) + ')', 'success');
     closeAdminProxyModal();
@@ -1875,14 +1976,49 @@ async function revokeAdminProxyDeliv(deliverableId) {
   if (!reason.trim()) return toast('회수 사유는 비워둘 수 없습니다', 'error');
   if (!confirm('대리 등록을 회수합니다. 결과물 행과 audit 로그가 삭제됩니다 (복구 불가). 진행할까요?')) return;
   try {
-    await adminRevokeProxyDeliverable(deliverableId, reason.trim());
-    toast('대리 등록 회수 완료', 'success');
+    // 마이그레이션 163: adminRevokeProxyDeliverable이 {ok, storageDeleteFailed} 반환
+    const result = await adminRevokeProxyDeliverable(deliverableId, reason.trim());
+    if (result?.storageDeleteFailed) {
+      toast('대리 등록 회수 완료 (증빙 파일 일부가 Storage에 남아있을 수 있습니다)', 'warning');
+    } else {
+      toast('대리 등록 회수 완료', 'success');
+    }
     closeDelivCombined();
     if (typeof refreshPane === 'function') await refreshPane('deliverables');
     else if (typeof renderDeliverablesList === 'function') await renderDeliverablesList();
   } catch (err) {
     console.error('[admin-proxy] 회수 실패', err);
     toast('회수 실패: ' + (err.message || err), 'error');
+  }
+}
+
+// 마이그레이션 163: 증빙 파일 보기 — 비동기 signed URL 생성 후 새 탭/라이트박스 열기
+async function openProxyEvidenceViewer(deliverableId, paths) {
+  if (!paths || !paths.length) return;
+  if (!Array.isArray(paths)) { try { paths = JSON.parse(paths); } catch(e) { return; } }
+
+  // campaign_admin 미만은 접근 불가 (Storage 정책에서도 차단됨)
+  const role = typeof currentAdminInfo !== 'undefined' ? currentAdminInfo?.role : null;
+  const allowedRoles = ['super_admin', 'campaign_admin'];
+  if (!role || !allowedRoles.includes(role)) {
+    return toast('증빙 파일은 campaign_admin 이상만 열람 가능합니다', 'error');
+  }
+
+  toast('증빙 파일 링크 생성 중…', 'info');
+  try {
+    const urls = await Promise.all(paths.map(p => getProxyEvidenceSignedUrl(p)));
+    const validUrls = urls.filter(Boolean);
+    if (!validUrls.length) return toast('증빙 파일 링크 생성에 실패했습니다', 'error');
+
+    // 이미지가 1개면 라이트박스, PDF이거나 여러 개면 새 탭 순차 오픈
+    if (validUrls.length === 1 && !paths[0].endsWith('.pdf')) {
+      openImageLightbox(validUrls[0]);
+    } else {
+      validUrls.forEach(url => window.open(url, '_blank', 'noopener'));
+    }
+  } catch (err) {
+    console.error('[proxy-evidence] signed URL 생성 실패', err);
+    toast('증빙 파일 링크 생성 실패: ' + (err.message || err), 'error');
   }
 }
 

--- a/dev/lib/storage.js
+++ b/dev/lib/storage.js
@@ -418,6 +418,41 @@ async function deleteFlagEvidenceFiles(paths) {
   if (error) throw error;
 }
 
+// ── 대리 등록 증빙 파일 업로드 (campaign_admin 이상, 마이그레이션 163) ──
+// file: File 객체
+// ref: deliverable_id 또는 'tmp/{timestamp}' 등 임시값
+// 반환: Storage 경로 문자열 (admin-proxy-evidence 버킷 기준)
+async function uploadProxyEvidence(file, ref) {
+  if (!db) throw new Error('DB 미연결');
+  const BUCKET = 'admin-proxy-evidence';
+  const ext = file.name ? file.name.split('.').pop().toLowerCase() : 'bin';
+  const uuid = crypto.randomUUID ? crypto.randomUUID() : (Date.now().toString(36) + Math.random().toString(36).substring(2));
+  const path = `${ref}/${uuid}.${ext}`;
+  const {error} = await db.storage.from(BUCKET).upload(path, file, {contentType: file.type, upsert: false, cacheControl: '86400'});
+  if (error) throw error;
+  return path;
+}
+
+// ── 대리 등록 증빙 signed URL 조회 (campaign_admin 이상, 마이그레이션 163) ──
+// path: uploadProxyEvidence() 반환값 (Storage 경로)
+// expiresIn: 초 단위, 기본 3600 (1시간)
+async function getProxyEvidenceSignedUrl(path, expiresIn = 3600) {
+  if (!db || !path) return null;
+  const BUCKET = 'admin-proxy-evidence';
+  const {data, error} = await db.storage.from(BUCKET).createSignedUrl(path, expiresIn);
+  if (error) throw error;
+  return data?.signedUrl || null;
+}
+
+// ── 대리 등록 증빙 파일 삭제 (super_admin 전용, 마이그레이션 163) ──
+// paths: Storage 경로 배열
+async function deleteProxyEvidenceFiles(paths) {
+  if (!db || !paths || paths.length === 0) return;
+  const BUCKET = 'admin-proxy-evidence';
+  const {error} = await db.storage.from(BUCKET).remove(paths);
+  if (error) throw error;
+}
+
 // 모든 인플루언서의 위반 건수 집계 — { [influencer_id]: count }
 async function fetchViolationCountsByInfluencer() {
   if (!db) return {};
@@ -575,6 +610,7 @@ async function fetchDeliverables(filters) {
         reviewed_by, reviewed_at, submitted_at, updated_at,
         application_id, user_id, campaign_id,
         submitted_by_admin, submitted_by_admin_reason_code, submitted_by_admin_reason, submitted_by_admin_at,
+        submitted_by_admin_evidence,
         campaigns:campaign_id (id, campaign_no, title, brand, recruit_type, channel, purchase_start, purchase_end, visit_start, visit_end, submission_end)
       `).neq('status', 'draft');
       if (filters?.status && filters.status !== 'all') q = q.eq('status', filters.status);
@@ -761,7 +797,7 @@ async function fetchDeliverablesByCampaign(campaignId) {
   if (!db) return [];
   try {
     const {data, error} = await db?.from('deliverables')
-      .select('id, application_id, user_id, kind, status, reviewed_at, submitted_at, updated_at, version, post_url, post_channel, receipt_url, purchase_date, purchase_amount, reject_reason, submitted_by_admin, submitted_by_admin_reason_code, submitted_by_admin_reason, submitted_by_admin_at')
+      .select('id, application_id, user_id, kind, status, reviewed_at, submitted_at, updated_at, version, post_url, post_channel, receipt_url, purchase_date, purchase_amount, reject_reason, submitted_by_admin, submitted_by_admin_reason_code, submitted_by_admin_reason, submitted_by_admin_at, submitted_by_admin_evidence')
       .eq('campaign_id', campaignId)
       .order('submitted_at', {ascending: false});
     if (error) throw error;
@@ -889,7 +925,8 @@ async function adminCreateDeliverableProxy(payload) {
       p_purchase_date:   payload.purchaseDate || null,
       p_purchase_amount: payload.purchaseAmount ?? null,
       p_reason_code:     payload.reasonCode,
-      p_reason:          payload.reason || null
+      p_reason:          payload.reason || null,
+      p_evidence_paths:  payload.evidencePaths || []  // 마이그레이션 163: 증빙 경로 배열 (기본 빈 배열)
     });
     if (error) throw error;
     newId = data;
@@ -897,21 +934,34 @@ async function adminCreateDeliverableProxy(payload) {
   return newId;
 }
 
-// 대리 등록 회수 (super_admin 전용, 마이그레이션 160).
+// 대리 등록 회수 (super_admin 전용, 마이그레이션 160·163).
 // 잘못 등록된 대리 등록 결과물을 삭제 + audit 1건 기록.
+// 마이그레이션 163: RPC가 삭제된 증빙 파일 경로 배열을 반환 → 클라이언트에서 Storage 파일 별도 삭제.
+// Storage 삭제 실패 시 회수 자체는 성공으로 처리 (경고 토스트만).
 async function adminRevokeProxyDeliverable(deliverableId, reason) {
   if (!db) throw new Error('DB 미연결');
   if (!deliverableId) throw new Error('deliverableId 누락');
-  let ok = false;
+  let evidencePaths = [];
   await retryWithRefresh(async () => {
-    const {error} = await db.rpc('admin_revoke_proxy_deliverable', {
+    const {data, error} = await db.rpc('admin_revoke_proxy_deliverable', {
       p_deliverable_id: deliverableId,
       p_reason:         reason || null
     });
     if (error) throw error;
-    ok = true;
+    // 마이그레이션 163: RPC 반환값 = text[] (증빙 경로 배열)
+    evidencePaths = Array.isArray(data) ? data : [];
   });
-  return ok;
+  // Storage 증빙 파일 삭제 — 실패해도 회수 자체는 성공 처리 (고아 파일 경고만)
+  if (evidencePaths.length > 0) {
+    try {
+      await deleteProxyEvidenceFiles(evidencePaths);
+    } catch (storageErr) {
+      console.warn('[admin-proxy] 증빙 파일 Storage 삭제 실패 (회수는 완료됨):', storageErr);
+      // 호출부에서 toast로 경고 표시 가능하도록 에러 정보 반환
+      return {ok: true, storageDeleteFailed: true};
+    }
+  }
+  return {ok: true, storageDeleteFailed: false};
 }
 
 // 채널 미지정 review_image 행에 채널 지정 / 해제 (마이그레이션 162)

--- a/index.html
+++ b/index.html
@@ -177,6 +177,8 @@ textarea.form-input{resize:vertical;min-height:80px}
 #toast.show{transform:translateX(-50%) translateY(0);opacity:1}
 #toast.success{background:var(--green)}
 #toast.error{background:#B3261E}
+#toast.warning{background:#d97706}
+#toast.info{background:#1d4ed8}
 
 /* ── MODAL (Material Bottom Sheet) ── */
 .modal-overlay{display:none;position:fixed;inset:0;background:rgba(0,0,0,.4);z-index:500;align-items:flex-end;justify-content:center;padding:0}
@@ -4405,6 +4407,41 @@ async function deleteFlagEvidenceFiles(paths) {
   if (error) throw error;
 }
 
+// ── 대리 등록 증빙 파일 업로드 (campaign_admin 이상, 마이그레이션 163) ──
+// file: File 객체
+// ref: deliverable_id 또는 'tmp/{timestamp}' 등 임시값
+// 반환: Storage 경로 문자열 (admin-proxy-evidence 버킷 기준)
+async function uploadProxyEvidence(file, ref) {
+  if (!db) throw new Error('DB 미연결');
+  const BUCKET = 'admin-proxy-evidence';
+  const ext = file.name ? file.name.split('.').pop().toLowerCase() : 'bin';
+  const uuid = crypto.randomUUID ? crypto.randomUUID() : (Date.now().toString(36) + Math.random().toString(36).substring(2));
+  const path = `${ref}/${uuid}.${ext}`;
+  const {error} = await db.storage.from(BUCKET).upload(path, file, {contentType: file.type, upsert: false, cacheControl: '86400'});
+  if (error) throw error;
+  return path;
+}
+
+// ── 대리 등록 증빙 signed URL 조회 (campaign_admin 이상, 마이그레이션 163) ──
+// path: uploadProxyEvidence() 반환값 (Storage 경로)
+// expiresIn: 초 단위, 기본 3600 (1시간)
+async function getProxyEvidenceSignedUrl(path, expiresIn = 3600) {
+  if (!db || !path) return null;
+  const BUCKET = 'admin-proxy-evidence';
+  const {data, error} = await db.storage.from(BUCKET).createSignedUrl(path, expiresIn);
+  if (error) throw error;
+  return data?.signedUrl || null;
+}
+
+// ── 대리 등록 증빙 파일 삭제 (super_admin 전용, 마이그레이션 163) ──
+// paths: Storage 경로 배열
+async function deleteProxyEvidenceFiles(paths) {
+  if (!db || !paths || paths.length === 0) return;
+  const BUCKET = 'admin-proxy-evidence';
+  const {error} = await db.storage.from(BUCKET).remove(paths);
+  if (error) throw error;
+}
+
 // 모든 인플루언서의 위반 건수 집계 — { [influencer_id]: count }
 async function fetchViolationCountsByInfluencer() {
   if (!db) return {};
@@ -4562,6 +4599,7 @@ async function fetchDeliverables(filters) {
         reviewed_by, reviewed_at, submitted_at, updated_at,
         application_id, user_id, campaign_id,
         submitted_by_admin, submitted_by_admin_reason_code, submitted_by_admin_reason, submitted_by_admin_at,
+        submitted_by_admin_evidence,
         campaigns:campaign_id (id, campaign_no, title, brand, recruit_type, channel, purchase_start, purchase_end, visit_start, visit_end, submission_end)
       `).neq('status', 'draft');
       if (filters?.status && filters.status !== 'all') q = q.eq('status', filters.status);
@@ -4748,7 +4786,7 @@ async function fetchDeliverablesByCampaign(campaignId) {
   if (!db) return [];
   try {
     const {data, error} = await db?.from('deliverables')
-      .select('id, application_id, user_id, kind, status, reviewed_at, submitted_at, updated_at, version, post_url, post_channel, receipt_url, purchase_date, purchase_amount, reject_reason, submitted_by_admin, submitted_by_admin_reason_code, submitted_by_admin_reason, submitted_by_admin_at')
+      .select('id, application_id, user_id, kind, status, reviewed_at, submitted_at, updated_at, version, post_url, post_channel, receipt_url, purchase_date, purchase_amount, reject_reason, submitted_by_admin, submitted_by_admin_reason_code, submitted_by_admin_reason, submitted_by_admin_at, submitted_by_admin_evidence')
       .eq('campaign_id', campaignId)
       .order('submitted_at', {ascending: false});
     if (error) throw error;
@@ -4876,7 +4914,8 @@ async function adminCreateDeliverableProxy(payload) {
       p_purchase_date:   payload.purchaseDate || null,
       p_purchase_amount: payload.purchaseAmount ?? null,
       p_reason_code:     payload.reasonCode,
-      p_reason:          payload.reason || null
+      p_reason:          payload.reason || null,
+      p_evidence_paths:  payload.evidencePaths || []  // 마이그레이션 163: 증빙 경로 배열 (기본 빈 배열)
     });
     if (error) throw error;
     newId = data;
@@ -4884,21 +4923,34 @@ async function adminCreateDeliverableProxy(payload) {
   return newId;
 }
 
-// 대리 등록 회수 (super_admin 전용, 마이그레이션 160).
+// 대리 등록 회수 (super_admin 전용, 마이그레이션 160·163).
 // 잘못 등록된 대리 등록 결과물을 삭제 + audit 1건 기록.
+// 마이그레이션 163: RPC가 삭제된 증빙 파일 경로 배열을 반환 → 클라이언트에서 Storage 파일 별도 삭제.
+// Storage 삭제 실패 시 회수 자체는 성공으로 처리 (경고 토스트만).
 async function adminRevokeProxyDeliverable(deliverableId, reason) {
   if (!db) throw new Error('DB 미연결');
   if (!deliverableId) throw new Error('deliverableId 누락');
-  let ok = false;
+  let evidencePaths = [];
   await retryWithRefresh(async () => {
-    const {error} = await db.rpc('admin_revoke_proxy_deliverable', {
+    const {data, error} = await db.rpc('admin_revoke_proxy_deliverable', {
       p_deliverable_id: deliverableId,
       p_reason:         reason || null
     });
     if (error) throw error;
-    ok = true;
+    // 마이그레이션 163: RPC 반환값 = text[] (증빙 경로 배열)
+    evidencePaths = Array.isArray(data) ? data : [];
   });
-  return ok;
+  // Storage 증빙 파일 삭제 — 실패해도 회수 자체는 성공 처리 (고아 파일 경고만)
+  if (evidencePaths.length > 0) {
+    try {
+      await deleteProxyEvidenceFiles(evidencePaths);
+    } catch (storageErr) {
+      console.warn('[admin-proxy] 증빙 파일 Storage 삭제 실패 (회수는 완료됨):', storageErr);
+      // 호출부에서 toast로 경고 표시 가능하도록 에러 정보 반환
+      return {ok: true, storageDeleteFailed: true};
+    }
+  }
+  return {ok: true, storageDeleteFailed: false};
 }
 
 // 채널 미지정 review_image 행에 채널 지정 / 해제 (마이그레이션 162)

--- a/supabase/migrations/163_admin_proxy_evidence.sql
+++ b/supabase/migrations/163_admin_proxy_evidence.sql
@@ -1,0 +1,541 @@
+-- =============================================================================
+-- 마이그레이션 163: 관리자 대리 등록 증빙 파일 첨부
+-- 제목    : admin proxy deliverable — 증빙 파일 경로 배열 컬럼 추가 + RPC 확장
+-- 의존    : 160 (admin_create_deliverable_proxy 원본)
+--           161 (admin_create_deliverable_proxy 본문 정정 — 사유 라벨 노출)
+--           162 (review_image 채널 지정)
+-- 대상    : 개발서버 + 운영서버
+-- 날짜    : 2026-06-01
+-- PR      : PR 5 — 관리자 결과물 대리 등록 증빙 첨부
+-- 위험도  : 낮음
+--           - 컬럼 추가 (DEFAULT '{}', 기존 행 영향 없음)
+--           - RPC 재생성 (DROP + CREATE — 인자 수 변경으로 오버로드 충돌 방지)
+--           - Storage 버킷 정책 추가 (신규 버킷 `admin-proxy-evidence` 전제)
+-- 멱등성  : ADD COLUMN IF NOT EXISTS, DROP FUNCTION IF EXISTS (시그니처 명시),
+--           CREATE OR REPLACE FUNCTION, DROP POLICY IF EXISTS + CREATE POLICY
+--
+-- 변경 요약:
+--   deliverables.submitted_by_admin_evidence text[] DEFAULT '{}'
+--     → 대리 등록 시 첨부한 증빙 파일의 Storage 경로 배열
+--       (`admin-proxy-evidence` 버킷 기준 경로)
+--
+--   admin_create_deliverable_proxy (10인자 → 11인자)
+--     → p_evidence_paths text[] DEFAULT '{}' 파라미터 추가
+--     → INSERT 시 submitted_by_admin_evidence 컬럼에 값 주입
+--     → 기존 10인자 함수 DROP 후 11인자 버전 재생성 (오버로드 충돌 방지)
+--
+--   admin_revoke_proxy_deliverable (반환 타입 void → text[])
+--     → DELETE 전에 submitted_by_admin_evidence 조회해서 반환
+--     → 클라이언트가 반환된 경로 배열로 Storage 파일 별도 삭제 처리
+--     → 기존 void 반환 함수 DROP 후 text[] 반환 버전 재생성
+--
+--   Storage 행 단위 보안 정책 (`admin-proxy-evidence` 버킷):
+--     SELECT / INSERT : is_campaign_admin() 이상 (campaign_manager 제외)
+--     DELETE         : is_super_admin() 전용 (회수 흐름과 일치)
+--     ※ 버킷 자체는 Supabase 대시보드에서 수동 생성 필요
+--        (비공개 버킷, 파일 크기 10MB, MIME: image/*, application/pdf)
+--
+-- 롤백 방법 (주석):
+--   -- 1. 11인자 함수 제거
+--   DROP FUNCTION IF EXISTS public.admin_create_deliverable_proxy(uuid,text,text,text,text,text,date,numeric,text,text,text[]);
+--
+--   -- 2. 161 버전(10인자)으로 복원 — 마이그레이션 161 본문 그대로 재실행
+--
+--   -- 3. text[] 반환 함수 제거
+--   DROP FUNCTION IF EXISTS public.admin_revoke_proxy_deliverable(uuid,text);
+--
+--   -- 4. 160 버전(void 반환)으로 복원 — 마이그레이션 160 §섹션7 본문 재실행
+--
+--   -- 5. Storage 정책 제거
+--   DROP POLICY IF EXISTS "admin_proxy_evidence_select" ON storage.objects;
+--   DROP POLICY IF EXISTS "admin_proxy_evidence_insert" ON storage.objects;
+--   DROP POLICY IF EXISTS "admin_proxy_evidence_delete" ON storage.objects;
+--
+--   -- 6. 컬럼 제거 (데이터 소실 주의 — 운영 적용 전 반드시 Storage 파일 백업)
+--   ALTER TABLE public.deliverables
+--     DROP COLUMN IF EXISTS submitted_by_admin_evidence;
+-- =============================================================================
+
+BEGIN;
+
+-- ============================================================
+-- 섹션 1: deliverables 컬럼 추가 — submitted_by_admin_evidence
+--
+--   타입  : text[] (Storage 경로 문자열 배열)
+--   DEFAULT: '{}' (기존 행은 빈 배열, 백필 불필요)
+--   NULL  : 허용 (증빙 미첨부 시 NULL도 허용 — 클라이언트는 빈 배열 전송)
+--   패턴  : influencer_flags.evidence_paths 와 동일 구조
+-- ============================================================
+
+ALTER TABLE public.deliverables
+  ADD COLUMN IF NOT EXISTS submitted_by_admin_evidence text[] DEFAULT '{}';
+
+COMMENT ON COLUMN public.deliverables.submitted_by_admin_evidence IS
+  '관리자 대리 등록 시 첨부한 증빙 파일 경로 배열. '
+  '`admin-proxy-evidence` Storage 버킷 기준 상대 경로. '
+  'NULL 또는 빈 배열이면 증빙 미첨부. '
+  'influencer_flags.evidence_paths 와 동일 패턴.';
+
+
+-- ============================================================
+-- 섹션 2: admin_create_deliverable_proxy — 10인자 DROP 후 11인자 재생성
+--
+--   DROP 대상 시그니처 (마이그레이션 160·161의 공통 시그니처):
+--     (uuid, text, text, text, text, text, date, numeric, text, text)
+--   신규 시그니처 (163):
+--     (uuid, text, text, text, text, text, date, numeric, text, text, text[])
+--
+--   p_evidence_paths 는 DEFAULT '{}' 로 선언하여
+--   기존 클라이언트 코드가 인자를 생략해도 빈 배열로 동작 (하위 호환).
+--   단, PostgreSQL 함수 오버로드는 인자 수 기준이므로
+--   10인자 버전을 명시 DROP 하지 않으면 동일 이름 다른 인자 수로 공존 가능하나
+--   REVOKE/GRANT 및 클라이언트 호출 시 혼동 방지를 위해 명시 DROP 권장.
+-- ============================================================
+
+DROP FUNCTION IF EXISTS public.admin_create_deliverable_proxy(
+  uuid, text, text, text, text, text, date, numeric, text, text
+);
+
+CREATE OR REPLACE FUNCTION public.admin_create_deliverable_proxy(
+  p_application_id         uuid,
+  p_kind                   text,           -- 'receipt' | 'post' | 'review_image'
+  p_post_channel           text,           -- post / review_image 일 때 필수
+  p_image_url              text,           -- receipt / review_image 일 때 필수 (Storage URL)
+  p_post_url               text,           -- post 일 때 필수
+  p_order_number           text,           -- receipt 일 때 필수
+  p_purchase_date          date,           -- receipt 일 때 필수
+  p_purchase_amount        numeric,        -- receipt 일 때 필수
+  p_reason_code            text,           -- 사유 코드 (필수, admin_proxy_reason.code)
+  p_reason                 text,           -- 사유 자유 메모 (선택, 운영 내부 — 인플 알림 미포함)
+  p_evidence_paths         text[] DEFAULT '{}'  -- 163 신규: 증빙 파일 경로 배열
+)
+RETURNS uuid
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_admin_id        uuid;
+  v_app_status      text;
+  v_app_user_id     uuid;
+  v_app_campaign_id uuid;
+  v_deliverable_id  uuid;
+  v_reason_label    text;   -- 161에서 추가: 인플 알림용 사유 라벨 (lookup_values.name_ja)
+BEGIN
+
+  -- ① 권한 가드: campaign_admin 이상만 허용
+  IF NOT public.is_campaign_admin() THEN
+    RAISE EXCEPTION '권한이 없습니다. campaign_admin 이상 권한이 필요합니다.'
+      USING ERRCODE = '42501';
+  END IF;
+
+  -- ② 호출 관리자의 admins.id 조회
+  SELECT id
+    INTO v_admin_id
+    FROM public.admins
+   WHERE auth_id = auth.uid();
+
+  IF v_admin_id IS NULL THEN
+    RAISE EXCEPTION '관리자 계정 정보를 찾을 수 없습니다. 관리자 목록을 확인해 주세요.'
+      USING ERRCODE = 'P0002';
+  END IF;
+
+  -- ③ 사유 코드 필수 검증
+  IF p_reason_code IS NULL OR trim(p_reason_code) = '' THEN
+    RAISE EXCEPTION '사유 코드는 필수 입력 항목입니다.'
+      USING ERRCODE = '22023';
+  END IF;
+
+  -- ③-b 사유 코드가 실제 활성 lookup에 존재하는지 확인 + 일본어 라벨 동시 조회 (161 정책 유지)
+  SELECT name_ja
+    INTO v_reason_label
+    FROM public.lookup_values
+   WHERE kind = 'admin_proxy_reason'
+     AND code = p_reason_code
+     AND active = true
+   LIMIT 1;
+
+  IF v_reason_label IS NULL THEN
+    RAISE EXCEPTION '유효하지 않은 사유 코드입니다: %', p_reason_code
+      USING ERRCODE = '22023';
+  END IF;
+
+  -- ④ 신청 검증 (행 잠금 — 동시 대리 등록 충돌 방지)
+  SELECT status, user_id, campaign_id
+    INTO v_app_status, v_app_user_id, v_app_campaign_id
+    FROM public.applications
+   WHERE id = p_application_id
+   FOR UPDATE;
+
+  IF v_app_status IS NULL THEN
+    RAISE EXCEPTION '신청 정보를 찾을 수 없습니다.'
+      USING ERRCODE = 'P0002';
+  END IF;
+
+  IF v_app_status <> 'approved' THEN
+    RAISE EXCEPTION '승인된 신청에만 대리 등록이 가능합니다. 현재 신청 상태: %', v_app_status
+      USING ERRCODE = 'P0001';
+  END IF;
+
+  -- ⑤ kind 값 유효성 검증
+  IF p_kind NOT IN ('receipt', 'post', 'review_image') THEN
+    RAISE EXCEPTION '유효하지 않은 결과물 종류입니다: %. receipt, post, review_image 중 하나를 선택해 주세요.', p_kind
+      USING ERRCODE = '22023';
+  END IF;
+
+  -- ⑥ kind별 필수 필드 검증
+  IF p_kind = 'receipt' THEN
+    IF p_image_url IS NULL OR trim(p_image_url) = '' THEN
+      RAISE EXCEPTION '영수증 이미지 URL은 필수 입력 항목입니다.'
+        USING ERRCODE = '22023';
+    END IF;
+    IF p_order_number IS NULL OR trim(p_order_number) = '' THEN
+      RAISE EXCEPTION '주문번호는 필수 입력 항목입니다.'
+        USING ERRCODE = '22023';
+    END IF;
+    IF p_purchase_date IS NULL THEN
+      RAISE EXCEPTION '구매일은 필수 입력 항목입니다.'
+        USING ERRCODE = '22023';
+    END IF;
+    IF p_purchase_amount IS NULL OR p_purchase_amount <= 0 THEN
+      RAISE EXCEPTION '구매금액은 0보다 큰 값이어야 합니다.'
+        USING ERRCODE = '22023';
+    END IF;
+
+  ELSIF p_kind = 'post' THEN
+    IF p_post_url IS NULL OR trim(p_post_url) = '' THEN
+      RAISE EXCEPTION '게시물 URL은 필수 입력 항목입니다.'
+        USING ERRCODE = '22023';
+    END IF;
+    IF p_post_channel IS NULL OR trim(p_post_channel) = '' THEN
+      RAISE EXCEPTION '채널 정보는 필수 입력 항목입니다.'
+        USING ERRCODE = '22023';
+    END IF;
+
+    -- post URL 중복 사전 체크 (uidx_deliverables_post_url 위반 전 친화적 에러)
+    IF EXISTS (
+      SELECT 1
+        FROM public.deliverables
+       WHERE application_id = p_application_id
+         AND kind = 'post'
+         AND post_url = p_post_url
+    ) THEN
+      RAISE EXCEPTION '같은 게시물 URL이 이미 등록되어 있습니다.'
+        USING ERRCODE = '23505';
+    END IF;
+
+  ELSIF p_kind = 'review_image' THEN
+    IF p_image_url IS NULL OR trim(p_image_url) = '' THEN
+      RAISE EXCEPTION '리뷰 이미지 URL은 필수 입력 항목입니다.'
+        USING ERRCODE = '22023';
+    END IF;
+    IF p_post_channel IS NULL OR trim(p_post_channel) = '' THEN
+      RAISE EXCEPTION '채널 정보는 필수 입력 항목입니다.'
+        USING ERRCODE = '22023';
+    END IF;
+
+    -- 채널 중복 사전 체크 (deliverables_review_image_app_channel_uniq 위반 전 친화적 에러)
+    IF EXISTS (
+      SELECT 1
+        FROM public.deliverables
+       WHERE application_id = p_application_id
+         AND kind = 'review_image'
+         AND post_channel = p_post_channel
+    ) THEN
+      RAISE EXCEPTION '해당 채널(%)의 리뷰 이미지가 이미 등록되어 있습니다.', p_post_channel
+        USING ERRCODE = '23505';
+    END IF;
+  END IF;
+
+  -- ⑦ deliverables INSERT — status='approved', 대리 등록 필드 + 증빙 경로 배열 동시 기록
+  --    p_reason (자유 메모)는 deliverables 컬럼에만 저장 (운영 내부, 관리자 검수 모달 노출)
+  --    인플 알림 body에는 v_reason_label (사유 라벨)만 노출 (161 정책 유지)
+  --    submitted_by_admin_evidence: NULL 방지를 위해 COALESCE로 빈 배열 보장
+  INSERT INTO public.deliverables (
+    application_id,
+    campaign_id,
+    user_id,
+    kind,
+    post_channel,
+    receipt_url,
+    post_url,
+    order_number,
+    purchase_date,
+    purchase_amount,
+    status,
+    reviewed_by,
+    reviewed_at,
+    submitted_at,
+    submitted_by_admin,
+    submitted_by_admin_reason_code,
+    submitted_by_admin_reason,
+    submitted_by_admin_at,
+    submitted_by_admin_evidence
+  )
+  VALUES (
+    p_application_id,
+    v_app_campaign_id,
+    v_app_user_id,
+    p_kind,
+    CASE WHEN p_kind IN ('post', 'review_image') THEN p_post_channel ELSE NULL END,
+    CASE WHEN p_kind IN ('receipt', 'review_image') THEN p_image_url ELSE NULL END,
+    CASE WHEN p_kind = 'post' THEN p_post_url ELSE NULL END,
+    CASE WHEN p_kind = 'receipt' THEN p_order_number ELSE NULL END,
+    CASE WHEN p_kind = 'receipt' THEN p_purchase_date ELSE NULL END,
+    CASE WHEN p_kind = 'receipt' THEN p_purchase_amount ELSE NULL END,
+    'approved',       -- 대리 등록은 즉시 승인 상태
+    auth.uid(),       -- reviewed_by: 호출 관리자 auth.uid()
+    now(),
+    now(),
+    v_admin_id,       -- submitted_by_admin: 호출 관리자 admins.id
+    p_reason_code,
+    p_reason,         -- 운영 내부 메모 (인플 미노출)
+    now(),
+    COALESCE(p_evidence_paths, '{}')  -- 163 신규: 증빙 경로 배열, NULL 보호
+  )
+  RETURNING id INTO v_deliverable_id;
+
+  -- ⑧ 감사(audit) 로그 — deliverable_events에 admin_proxy_submit 기록
+  --    actor_id: auth.uid() (auth.users.id, admins 아님)
+  INSERT INTO public.deliverable_events (
+    deliverable_id,
+    actor_id,
+    action,
+    from_status,
+    to_status
+  )
+  VALUES (
+    v_deliverable_id,
+    auth.uid(),
+    'admin_proxy_submit',
+    NULL,        -- 신규 생성이므로 이전 상태 없음
+    'approved'
+  );
+
+  -- ⑨ 인플루언서 알림 INSERT — 사유 라벨만 노출 (161 정책 유지)
+  --    kind='deliverable_proxy_submitted' — 앱에서 활동관리로 이동
+  INSERT INTO public.notifications (
+    user_id,
+    kind,
+    ref_table,
+    ref_id,
+    title,
+    body
+  )
+  VALUES (
+    v_app_user_id,
+    'deliverable_proxy_submitted',
+    'deliverables',
+    v_deliverable_id,
+    '結果物が登録されました',
+    '運営側で結果物を登録・承認しました。理由: ' || v_reason_label
+  );
+
+  RETURN v_deliverable_id;
+
+END;
+$$;
+
+-- GRANT: authenticated(관리자)만 실행 가능. 내부에서 is_campaign_admin() 재검증.
+REVOKE ALL ON FUNCTION public.admin_create_deliverable_proxy(
+  uuid, text, text, text, text, text, date, numeric, text, text, text[]
+) FROM PUBLIC;
+
+GRANT EXECUTE ON FUNCTION public.admin_create_deliverable_proxy(
+  uuid, text, text, text, text, text, date, numeric, text, text, text[]
+) TO authenticated;
+
+
+-- ============================================================
+-- 섹션 3: admin_revoke_proxy_deliverable — void 반환 DROP 후 text[] 반환 재생성
+--
+--   반환 타입 변경: void → text[]
+--     DELETE 전에 submitted_by_admin_evidence 를 SELECT 해서 반환.
+--     클라이언트가 반환된 경로 배열로 Storage 파일을 별도 삭제.
+--     증빙이 없었으면 빈 배열('{}') 반환.
+--
+--   PostgreSQL에서 반환 타입 변경은 CREATE OR REPLACE 로 불가 (타입 불일치 오류).
+--   따라서 기존 void 반환 함수를 명시 DROP 후 text[] 반환으로 재생성.
+--
+--   기존 void 반환 시그니처 (160):
+--     admin_revoke_proxy_deliverable(uuid, text) RETURNS void
+--   신규 text[] 반환 시그니처 (163):
+--     admin_revoke_proxy_deliverable(uuid, text) RETURNS text[]
+--   → 인자 시그니처 동일하므로 반드시 DROP 먼저.
+-- ============================================================
+
+DROP FUNCTION IF EXISTS public.admin_revoke_proxy_deliverable(uuid, text);
+
+CREATE OR REPLACE FUNCTION public.admin_revoke_proxy_deliverable(
+  p_deliverable_id  uuid,
+  p_reason          text    -- 회수 사유 (기록용, NULL 허용)
+)
+RETURNS text[]              -- 163 신규: 삭제된 증빙 파일 경로 배열 반환 (없으면 '{}')
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_submitted_by_admin      uuid;
+  v_user_id                 uuid;
+  v_kind                    text;
+  v_post_channel            text;
+  v_evidence_paths          text[];   -- 163 신규: 삭제 전 증빙 경로 배열 보존용
+BEGIN
+
+  -- ① 권한 가드: super_admin 전용
+  IF NOT public.is_super_admin() THEN
+    RAISE EXCEPTION '권한이 없습니다. super_admin 권한이 필요합니다.'
+      USING ERRCODE = '42501';
+  END IF;
+
+  -- ② 대상 행 검증 + 행 잠금 + 증빙 경로 배열 동시 조회 (163 신규)
+  SELECT submitted_by_admin, user_id, kind, post_channel,
+         COALESCE(submitted_by_admin_evidence, '{}')
+    INTO v_submitted_by_admin, v_user_id, v_kind, v_post_channel,
+         v_evidence_paths
+    FROM public.deliverables
+   WHERE id = p_deliverable_id
+   FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION '결과물 정보를 찾을 수 없습니다.'
+      USING ERRCODE = 'P0002';
+  END IF;
+
+  -- ③ 대리 등록 행만 회수 가능
+  IF v_submitted_by_admin IS NULL THEN
+    RAISE EXCEPTION '대리 등록된 결과물만 회수할 수 있습니다. 인플루언서 본인이 제출한 결과물은 회수 대상이 아닙니다.'
+      USING ERRCODE = 'P0001';
+  END IF;
+
+  -- ④ 감사 로그 먼저 기록 (DELETE 후에는 deliverable_id 참조 불가)
+  --    deliverable_events.deliverable_id FK는 ON DELETE CASCADE이므로
+  --    deliverable 삭제 시 이 이벤트 행도 함께 삭제됨에 유의.
+  --    영구 감사가 필요하다면 별도 audit 테이블 분리를 권장.
+  INSERT INTO public.deliverable_events (
+    deliverable_id,
+    actor_id,
+    action,
+    from_status,
+    to_status,
+    reason
+  )
+  VALUES (
+    p_deliverable_id,
+    auth.uid(),
+    'admin_proxy_revoke',
+    'approved',   -- 대리 등록 행은 항상 approved 상태
+    NULL,         -- 회수 후 상태 없음 (행 삭제)
+    p_reason
+  );
+
+  -- ⑤ 결과물 행 삭제 (CASCADE로 deliverable_events도 삭제됨)
+  DELETE FROM public.deliverables
+   WHERE id = p_deliverable_id;
+
+  -- ⑥ 인플루언서 알림은 발송하지 않음 (160 정책 유지)
+  --    회수는 운영 내부 처리 빈도가 낮고, 인플에게 혼란을 줄 수 있음.
+
+  -- ⑦ 삭제된 증빙 파일 경로 배열 반환 — 클라이언트가 Storage 파일 별도 삭제
+  --    증빙이 없었으면 빈 배열('{}') 반환
+  RETURN v_evidence_paths;
+
+END;
+$$;
+
+-- GRANT: authenticated(관리자) 실행 허용. 내부에서 is_super_admin() 재검증.
+REVOKE ALL ON FUNCTION public.admin_revoke_proxy_deliverable(uuid, text) FROM PUBLIC;
+
+GRANT EXECUTE ON FUNCTION public.admin_revoke_proxy_deliverable(uuid, text)
+  TO authenticated;
+
+
+COMMIT;
+
+
+-- ============================================================
+-- 섹션 4: Storage 버킷 행 단위 보안 정책 — admin-proxy-evidence
+--
+--   ※ 버킷 생성은 Supabase 대시보드에서 수동으로 수행 필요:
+--     - 버킷 이름: admin-proxy-evidence
+--     - 공개 여부: 비공개 (Private)
+--     - 허용 MIME 타입: image/jpeg, image/png, image/webp, image/gif, application/pdf
+--     - 파일 크기 제한: 10MB
+--
+--   정책 설계:
+--     SELECT / INSERT : is_campaign_admin() 이상 (campaign_manager 접근 불가)
+--     DELETE          : is_super_admin() 전용 (회수 흐름과 권한 일치)
+--     UPDATE          : 미부여 (덮어쓰기 방지 — 증거 변조 차단, 수정은 삭제 후 재업로드)
+--
+--   참고: influencer-flag-evidence 버킷 정책 패턴을 기반으로
+--         권한 함수만 is_super_admin() → is_campaign_admin() 으로 조정
+--
+--   멱등성: DROP POLICY IF EXISTS → CREATE POLICY 패턴
+-- ============================================================
+
+-- SELECT 정책: campaign_admin 이상 — 증빙 파일 다운로드·미리보기
+DROP POLICY IF EXISTS "admin_proxy_evidence_select" ON storage.objects;
+CREATE POLICY "admin_proxy_evidence_select"
+  ON storage.objects FOR SELECT
+  TO authenticated
+  USING (
+    bucket_id = 'admin-proxy-evidence'
+    AND public.is_campaign_admin()
+  );
+
+-- INSERT 정책: campaign_admin 이상 — 증빙 파일 업로드
+DROP POLICY IF EXISTS "admin_proxy_evidence_insert" ON storage.objects;
+CREATE POLICY "admin_proxy_evidence_insert"
+  ON storage.objects FOR INSERT
+  TO authenticated
+  WITH CHECK (
+    bucket_id = 'admin-proxy-evidence'
+    AND public.is_campaign_admin()
+  );
+
+-- DELETE 정책: super_admin 전용 — 회수 시 Storage 파일 삭제
+DROP POLICY IF EXISTS "admin_proxy_evidence_delete" ON storage.objects;
+CREATE POLICY "admin_proxy_evidence_delete"
+  ON storage.objects FOR DELETE
+  TO authenticated
+  USING (
+    bucket_id = 'admin-proxy-evidence'
+    AND public.is_super_admin()
+  );
+
+
+-- =============================================================================
+-- 검증 SQL (SQL Editor에서 1단계씩 순차 실행)
+--
+-- [1단계] 컬럼 추가 확인
+-- SELECT column_name, data_type, column_default, is_nullable
+--   FROM information_schema.columns
+--  WHERE table_schema = 'public'
+--    AND table_name   = 'deliverables'
+--    AND column_name  = 'submitted_by_admin_evidence';
+-- 기대: 1행 — data_type='ARRAY', column_default="'{}'::text[]", is_nullable='YES'
+--
+-- [2단계] 11인자 RPC 시그니처 확인 (1단계 확인 후 실행)
+-- SELECT proname, pg_get_function_arguments(oid) AS args, pg_get_function_result(oid) AS ret
+--   FROM pg_proc
+--  WHERE proname = 'admin_create_deliverable_proxy'
+--    AND pronamespace = 'public'::regnamespace;
+-- 기대: 1행 — args에 'p_evidence_paths text[] DEFAULT ...' 포함, ret='uuid'
+-- (10인자 버전이 추가로 조회되면 DROP이 실패한 것 — 수동 DROP 필요)
+--
+-- [3단계] text[] 반환 RPC 시그니처 확인 (2단계 확인 후 실행)
+-- SELECT proname, pg_get_function_arguments(oid) AS args, pg_get_function_result(oid) AS ret
+--   FROM pg_proc
+--  WHERE proname = 'admin_revoke_proxy_deliverable'
+--    AND pronamespace = 'public'::regnamespace;
+-- 기대: 1행 — ret='text[]' (void이면 DROP 실패 — 수동 DROP 필요)
+--
+-- [4단계] Storage 정책 확인 (3단계 확인 후 실행)
+-- SELECT policyname, cmd, roles, qual
+--   FROM pg_policies
+--  WHERE schemaname = 'storage'
+--    AND tablename  = 'objects'
+--    AND policyname LIKE 'admin_proxy_evidence_%';
+-- 기대: 3행 — select(campaign_admin) / insert(campaign_admin) / delete(super_admin)
+-- =============================================================================


### PR DESCRIPTION
## 변경 요약

- 관리자 결과물 대리 등록 시 증빙 파일(이미지/PDF) 최대 5장 첨부 기능 추가
- 마이그레이션 163: `deliverables.submitted_by_admin_evidence text[]` 컬럼 + RPC 2종 확장 + Storage 행 단위 보안 정책 3종
- 검수 모달에서 「증빙 N개 보기」 버튼 클릭 시 signed URL로 파일 조회 (campaign_admin 이상)
- 회수 시 Storage 파일 자동 삭제 (실패 시 경고 토스트만, 회수 자체는 성공 처리)

## 수동 작업 필요 (배포 전)

**Supabase 대시보드 Storage에서 `admin-proxy-evidence` 버킷 생성 필요:**
- 공개 여부: 비공개 (Private)
- 허용 MIME: image/jpeg, image/png, image/webp, image/gif, application/pdf
- 파일 크기 제한: 10MB

**개발서버 DB SQL Editor에서 마이그레이션 163 적용:**
```
supabase/migrations/163_admin_proxy_evidence.sql
```

## 요청 외 추가 변경

- `dev/css/components.css`: `#toast.warning`, `#toast.info` 색상 스타일 추가

## 관련 사양서

- `docs/specs/2026-05-28-admin-proxy-deliverable.md` §9 PR5

🤖 Generated with [Claude Code](https://claude.com/claude-code)