### PR TITLE
deploy: 관리자 메일 항목 통합 — 일일 통합 메일 (PR1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,7 @@
 
 ### 가동 중인 메일 파이프라인 (세부 구현은 `supabase/functions/*` + 사양서가 source of truth)
 - **광고주 신청 접수 알림** (`notify-brand-application`): `brand_applications` INSERT 직후 호출. 수신자 = `get_subscribed_admin_emails('brand_notify')` + env `NOTIFY_ADMIN_EMAILS`
-- **관리자 일일 통합 다이제스트** (`notify-admin-daily-digest`): pg_cron 매일 KST 09:00. 4섹션 1통(신청 접수·응모 취소·결과물 제출·재처리), 캠페인별 그룹 표. 인플 표시 4종(한자·가나·이메일·SNS링크) 통일. `admin_daily_digest_runs.digest_date UNIQUE` mutex
+- **관리자 일일 통합 다이제스트** (`notify-admin-daily-digest`): pg_cron 매일 KST 09:00. 4섹션 1통(신청 접수·응모 취소·결과물 제출·재처리), 캠페인별 그룹 표. 인플 표시 4종(한자·가나·이메일·SNS링크) 통일. `admin_daily_digest_runs.digest_date UNIQUE` mutex. 수신자 = `get_subscribed_admin_emails('daily_digest')` + env `NOTIFY_ADMIN_EMAILS` (마이그레이션 164 에서 구 `application_cancel`·`application_received` 2종 구독 → `daily_digest` 단일 구독으로 통합)
 - **인플루언서 일일 다이제스트** (`notify-influencer-daily-digest`): pg_cron 매일 KST 09:00. 어제 신청·승인·반려 + 오늘 D-5/D-1 마감 4섹션. `deadline_reminder_email_sent` 4-tuple UNIQUE 재발송 차단. marketing_opt_in 무시(트랜잭션)
 - **캠페인 홍보 메일** (`notify-campaign-promo-digest`): pg_cron 매주 월·목 KST 09:00. 신규+D-1 임박 캠페인, `marketing_opt_in=true`+자격 매칭 인플(1통씩 분리, 노출 최대 2회·클릭 시 제외). 첫 배치에서 `campaign_promo` 토글 관리자에게도 동시 발송. 사양서 `docs/specs/2026-05-27-admin-promo-email-subscription.md`
 - **공통 패턴**: ①인플 대상 메일은 **4줄 푸터 필수**(自動送信 안내·LINE @reverb.jp·© JFUN·사이트 URL, 글자색 #999) — 신규 인플 메일 추가 시 의무 ②관리자 일괄 발송은 **1명당 1통 분리**(To 헤더 노출 차단) ③부분 실패는 `status='sent'`+실패 명단 누적(전원 실패만 `failed`)
@@ -209,7 +209,7 @@
 ### 인플루언서·관리자
 - `influencers` — 인플루언서 프로필. `name`, SNS 계정+팔로워, 주소, `paypal_email`, `primary_sns`, `terms_agreed_at`, `privacy_agreed_at`, `marketing_opt_in` 등. 홍보 메일 PR 1 추가 컬럼: `unsubscribe_token uuid NOT NULL DEFAULT gen_random_uuid() UNIQUE`(영구 1개 토큰, 메일 수신거부·클릭 추적 익명 호출 식별자), `marketing_unsubscribed_at timestamptz NULL`(수신거부 시각 감사 — 재구독 시 NULL 초기화). 기존 인플 1,398행 백필 완료 (마이그레이션 140)
 - `admins` — 관리자 계정. `auth_id`, `email`, `name`, `role`(super_admin/campaign_admin/campaign_manager)
-- `admin_email_subscriptions` — 관리자별 메일 수신 구독. `(admin_id, mail_kind)` UNIQUE. `mail_kind` 는 `lookup_values(kind='admin_email_kind')` code 참조 (시드 `brand_notify`/`application_cancel`/`application_received`). RLS SELECT 관리자 전체, CUD 본인 또는 super_admin. 헬퍼 `get_subscribed_admin_emails(p_mail_kind)`
+- `admin_email_subscriptions` — 관리자별 메일 수신 구독. `(admin_id, mail_kind)` UNIQUE. `mail_kind` 는 `lookup_values(kind='admin_email_kind')` code 참조 (활성 항목 `brand_notify`/`daily_digest`/`campaign_promo`). 구 `application_cancel`·`application_received` 는 마이그레이션 164 에서 `daily_digest`(일일 통합 메일) 단일 항목으로 통합·비활성(soft, 행·구독 이력 보존). RLS SELECT 관리자 전체, CUD 본인 또는 super_admin. 헬퍼 `get_subscribed_admin_emails(p_mail_kind)`
 - `admin_notices` — 관리자 공지. `category`(system_update/release/warning/general), `pin`(bool), `title`, `body_html`(Quill rich), `created_by`/`created_at`/`updated_at`, `status CHECK(draft|published)`, `published_at`/`published_by`/`published_by_name`. SELECT RLS 는 published OR `is_super_admin()` OR `created_by=auth.uid()` (draft 는 작성자/super 한정). XSS 방어는 저장+렌더 이중 sanitize
 - `admin_notice_reads` — 관리자별 읽음 기록. `(admin_id, notice_id, read_at)` UNIQUE. `upsert_admin_notice_read` RPC. 미읽음 카운트 = published - reads(by admin)
 - `influencer_flags` — 인플루언서 관리자 마킹 이력. `influencer_id`, `action`(verify/violation/blacklist/clear), `reasons text[]` (blacklist_reason ∪ violation_reason lookup), `memo`, `evidence_paths text[]`, `updated_at/by/by_name`. 위반 행만 UPDATE RLS

--- a/admin/index.html
+++ b/admin/index.html
@@ -12,7 +12,7 @@
 // 회귀(2026-05-12 PR #182 머지 직후 발생)를 방지하기 위한 자동 reload 가드.
 // sessionStorage 차단 환경(시크릿 모드 일부, 쿠키 차단)에서는 자연스럽게 skip.
 (function(){
-  var CURRENT_BUILD = 'v1780300422';
+  var CURRENT_BUILD = 'v1780366533';
   if (CURRENT_BUILD.indexOf('__') === 0) return; // 빌드 미적용 (dev/ 직접 열기) 시 skip
   try {
     var prev = sessionStorage.getItem('reverb.adminBuild');
@@ -1948,7 +1948,7 @@ textarea.form-input{resize:vertical;min-height:80px}
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-06-01 16:53 · 4a56409</span>
+          <span class="admin-build-text">2026-06-02 11:15 · c87bdcd</span>
         </div>
       </div>
     </aside>
@@ -21505,6 +21505,8 @@ async function openAdminEmailSubsModal(adminId, adminName, adminEmail) {
 function _adminEmailKindDesc(code) {
   const map = {
     'brand_notify':       '광고주(브랜드)가 sales 페이지에서 신청 폼을 제출했을 때 접수 알림',
+    'daily_digest':       '신청 접수·응모 취소·결과물 제출·재처리 내역을 하루 한 통으로 묶어 매일 아침 발송',
+    'campaign_promo':     '신규·마감임박 캠페인 홍보 메일 (주 2회, 월·목 발송)',
     'application_cancel': '인플루언서가 구매기간 이후에 응모를 취소했을 때 알림'
   };
   return map[code] || '';

--- a/dev/js/admin-accounts.js
+++ b/dev/js/admin-accounts.js
@@ -151,6 +151,8 @@ async function openAdminEmailSubsModal(adminId, adminName, adminEmail) {
 function _adminEmailKindDesc(code) {
   const map = {
     'brand_notify':       '광고주(브랜드)가 sales 페이지에서 신청 폼을 제출했을 때 접수 알림',
+    'daily_digest':       '신청 접수·응모 취소·결과물 제출·재처리 내역을 하루 한 통으로 묶어 매일 아침 발송',
+    'campaign_promo':     '신규·마감임박 캠페인 홍보 메일 (주 2회, 월·목 발송)',
     'application_cancel': '인플루언서가 구매기간 이후에 응모를 취소했을 때 알림'
   };
   return map[code] || '';

--- a/docs/specs/2026-06-02-admin-email-consolidation.md
+++ b/docs/specs/2026-06-02-admin-email-consolidation.md
@@ -1,0 +1,160 @@
+# 관리자 메일 수신 항목 통합 (application_cancel + application_received → daily_digest)
+**작성일:** 2026-06-02
+**작성:** reverb-planner (기획)
+**방향 확정:** 사용자 — "합치기 + 죽은 코드까지 제거"
+
+## 현재 상태 (작성일 2026-06-02 기준, planning.md 규칙 A)
+
+### 관련 코드·DB·UI 진입점
+- **lookup `admin_email_kind` 현재 4항목**:
+  | code | name_ko / name_ja | sort | 추가 | 발송 주체 | 처리 |
+  |---|---|---|---|---|---|
+  | `brand_notify` | 브랜드 서베이 접수 / ブランドサーベイ受付 | 10 | 마이그레이션 103 | `notify-brand-application` (INSERT 즉시) | **독립·유지** |
+  | `application_cancel` | 응모 취소 알림 / 応募取消通知 | 20 | 마이그레이션 103 | (지금은) `notify-admin-daily-digest` 수신 스위치 | **흡수 대상** |
+  | `application_received` | 캠페인 신청 접수 / キャンペーン応募受付 | 30 | 마이그레이션 130 | (지금은) `notify-admin-daily-digest` 수신 스위치 | **흡수 대상** |
+  | `campaign_promo` | 캠페인 홍보 메일 / キャンペーン宣伝メール | 40 | 마이그레이션 152 | `notify-campaign-promo-digest` (주2회) | **독립·유지** |
+- **실제 도는 일일 통합 함수**: `supabase/functions/notify-admin-daily-digest/index.ts`. 수신자 = `resolveAdminEmails()` (index.ts 263~291): `get_subscribed_admin_emails('application_cancel')` ∪ `get_subscribed_admin_emails('application_received')` ∪ env `NOTIFY_ADMIN_EMAILS`. **두 mail_kind가 같은 통합 메일 1통의 수신 스위치로 중복** → 둘 중 하나만 ON 이어도 통합 메일 전체(4섹션)가 발송됨.
+- **헬퍼 함수**: `get_subscribed_admin_emails(p_mail_kind text)` (마이그레이션 103, SECURITY DEFINER, search_path 고정). `subscribed=true` 행만 조인.
+- **구독 테이블**: `admin_email_subscriptions (admin_id, mail_kind)` UNIQUE, `subscribed boolean`. RLS SELECT 관리자 전체 / CUD 본인 또는 super_admin.
+- **화면**: `dev/js/admin-accounts.js`
+  - 모달 체크박스 목록은 `fetchAdminEmailKinds()`(storage.js 2363) → `lookup_values(kind='admin_email_kind', active=true)` order by sort_order 로 **완전 동적 렌더**. 하드코딩된 mail_kind 분기 **없음**.
+  - 단 `_adminEmailKindDesc(code)` (admin-accounts.js 151~157)에 `brand_notify`·`application_cancel` 2개 code 의 **보조 설명 카피만 하드코딩**. (없으면 빈 문자열 — 동작엔 지장 없으나 신규 `daily_digest` 설명 추가 권장)
+  - 목록 칩: `fetchAdminEmailSubscriptions()` (storage.js 2346) — **`subscribed=true` 인 모든 행을 lookup active 여부와 무관하게 가져옴**. ⚠️ 후술 충돌점.
+  - 저장: `saveAdminEmailSubscriptions(adminId, subscribedKinds, allKinds)` (storage.js 2425) — `allKinds`(현재 active lookup 전체)에 대해서만 행을 UPSERT. **비활성 lookup 행은 건드리지 않음**.
+- **죽은 Edge Function 2개** (cron 없음 = 호출 안 됨, 코드만 잔존):
+  - `supabase/functions/notify-application-cancelled-daily/` — 로그 테이블 `application_cancel_digest_runs` (마이그레이션 113) 사용
+  - `supabase/functions/notify-application-received-admin-daily/` — 로그 테이블 `application_received_admin_digest_runs` (마이그레이션 130) 사용
+- **cron 상태** (2026-05-18 통합 사양서 §13·§14-3 확정):
+  - `application-cancel-daily-digest` cron → **해제됨** (관리자 통합으로 흡수)
+  - `notify-application-received-admin-daily` cron → **마이그레이션 130 시점부터 양 DB 모두 미등록**
+  - 가동 중: `notify-admin-daily-digest` cron + `notify-influencer-daily-digest` cron
+- **마이그레이션 최신 163**. 이번 작업은 **164** 사용. (에러 수집 마이그레이션은 다른 브랜치에서 165로 재배치 예정)
+
+### 이 제안과 충돌 가능성 있는 기존 동작
+1. **칩 표시 잔존 (가장 중요)** — `fetchAdminEmailSubscriptions()`는 lookup active 무관하게 `subscribed=true` 행을 칩으로 노출한다. lookup 만 비활성화하고 구독 행을 안 치우면 관리자 계정 목록 칩에 라벨 매핑 안 되는 code(또는 깨진 칩)가 계속 보인다. → **마이그레이션 164에서 기존 두 mail_kind 구독 행을 반드시 정리(subscribed=false)** 해야 화면이 깨끗해진다.
+2. **저장 시 stale 행 미정리** — `saveAdminEmailSubscriptions`는 active lookup(`allKinds`)만 UPSERT 하므로, 비활성 lookup 의 기존 행은 영원히 `subscribed=true` 로 남는다. 위 1번과 동일 뿌리.
+3. **env NOTIFY_ADMIN_EMAILS** — `resolveAdminEmails()`는 lookup·구독과 무관하게 env 관리자를 **항상** 합집합에 포함. 통합 후에도 동일하게 유지되어야 한다(수신 누락 0 보장).
+
+### 미해결 백로그·관련 작업
+- `docs/specs/2026-05-18-mail-pipeline-consolidation.md` §6-1 — "deprecated Edge Function 2종 정리는 운영 2주 안정화 후 별도 PR". **본 작업이 그 미처리 백로그를 닫는다.** (통합 가동 2026-05-18~19, 2주 안정화 충족)
+
+## 의심·경우의 수 (planning.md 규칙 B — 반대론자)
+
+### 1. 깨질 수 있는 경우의 수
+
+**[데이터] ① 한쪽만 구독한 관리자 이전 누락/중복**
+관리자별로 두 항목을 각각 ON/OFF 가능. 통합 규칙 "둘 중 하나라도 ON → daily_digest ON". 이전 쿼리는 `OR`(distinct admin_id) + `(admin_id, daily_digest)` UNIQUE 충돌을 `ON CONFLICT DO UPDATE SET subscribed=true` 로 흡수해야 함. `DO NOTHING` 이면 기존 daily_digest=false 행이 우연히 있을 때 안 켜짐 → **DO UPDATE 필수**.
+
+**[데이터] ② 기존 구독 행 미정리로 칩 깨짐 (충돌점 1번)**
+이전 후 두 mail_kind 구독 행을 **반드시 정리**(권장: subscribed=false UPDATE — DELETE 보다 명시적 끄기 흔적 보존).
+
+**[기술] ③ 죽은 함수 운영 잔존**
+Edge Function 은 repo 삭제만으론 운영에서 안 사라짐. 배포본이 Dashboard 에 남아 URL 직접 호출 시 실행 가능. → repo 삭제 + **양 서버 `supabase functions delete` 수동 절차 필요**. (cron 없어 자동 호출 위험 0)
+
+**[기술] ④ resolveAdminEmails 부분 실패 폴백 회귀**
+2 RPC → 1 RPC 로 줄일 때, 단일 RPC error 시에도 빈 배열 + env 폴백 처리 유지 확인.
+
+**[UX] ⑤ (필수) 관리자 의도 손실 — "취소만 받고 접수는 끄기"가 원래 불가능했음**
+통합 메일은 1통에 4섹션. **현재도 섹션별 수신 선택 불가**(둘 중 하나만 켜도 통합 메일 전체). 즉 "응모취소만 받기"는 이미 작동 안 하던 환상 옵션. 통합은 UI 를 정직하게 만드는 개선. 단 daily_digest 보조 설명에 **"신청 접수·응모 취소·결과물 제출·재처리를 하루 1통으로 묶어 보냅니다"** 명시. 둘 다 OFF 였던 관리자는 통합 후 daily_digest OFF 유지(이전 쿼리 "하나라도 ON" 조건이라 제외) → 의도 보존.
+
+**[권한] ⑥ campaign_manager** — 통합 후 권한 변화 없음(본인 daily_digest 토글 가능). 충돌 없음.
+
+### 2. 현재 구현 충돌점
+- **충돌 있음 (2건, 같은 뿌리)**: `fetchAdminEmailSubscriptions`가 active 무관 칩 렌더 + `saveAdminEmailSubscriptions`가 active lookup 만 UPSERT. → **마이그레이션 164에서 기존 구독 행 subscribed=false 정리하면 화면 자동 정상화**(코드 수정 불필요).
+- 그 외 영역(brand_notify·campaign_promo 발송, RLS, env 폴백): **확인 완료, 충돌 없음**.
+
+### 3. 의도 모호점
+- "죽은 코드 제거" 범위 = ① repo 디렉토리 2개 삭제 ② 양 서버 functions delete ③ 로그 테이블 2개 DROP vs 보존 ④ 카탈로그 카드 정리. → ②③④ 사용자 확인.
+- lookup 비활성화 vs 완전 삭제 → 권고: soft(active=false).
+- 로그 테이블 보존 여부 → 권고: 보존(COMMENT deprecated 표기).
+
+## 제안 / 설계
+
+### 변경 요지
+1. 신규 lookup `daily_digest` 1건 추가 ("일일 통합 메일").
+2. 기존 `application_cancel`·`application_received` lookup 을 active=false (soft, 행 보존).
+3. `admin_email_subscriptions`: 둘 중 하나라도 ON 이던 관리자를 daily_digest ON 으로 이전(멱등) → 그 후 두 mail_kind 구독 행 subscribed=false 정리.
+4. `notify-admin-daily-digest`: resolveAdminEmails() 의 2 RPC → daily_digest 단일 RPC.
+5. 죽은 Edge Function 2개 repo 삭제 + 양 서버 functions delete (수동).
+6. 카탈로그·CLAUDE.md·문서 갱신.
+
+### 마이그레이션 164 SQL 초안
+
+```sql
+-- 164_admin_email_consolidation.sql  (2026-06-02)
+-- application_cancel + application_received → daily_digest 단일 항목
+-- 멱등: 재실행 안전
+BEGIN;
+
+-- [1] 신규 lookup 'daily_digest' (sort 20)
+INSERT INTO public.lookup_values (kind, code, name_ko, name_ja, sort_order, active)
+VALUES ('admin_email_kind', 'daily_digest', '일일 통합 메일', '日次まとめメール', 20, true)
+ON CONFLICT (kind, code) DO UPDATE
+  SET name_ko=EXCLUDED.name_ko, name_ja=EXCLUDED.name_ja,
+      sort_order=EXCLUDED.sort_order, active=true;
+
+-- [2] 구독 이전: 둘 중 하나라도 ON 이던 관리자 → daily_digest ON
+INSERT INTO public.admin_email_subscriptions (admin_id, mail_kind, subscribed)
+SELECT DISTINCT s.admin_id, 'daily_digest', true
+FROM public.admin_email_subscriptions s
+WHERE s.mail_kind IN ('application_cancel','application_received') AND s.subscribed = true
+ON CONFLICT (admin_id, mail_kind) DO UPDATE SET subscribed=true, updated_at=now();
+
+-- [3] 기존 두 mail_kind 구독 행 정리 (칩 잔존 방지)
+UPDATE public.admin_email_subscriptions
+   SET subscribed=false, updated_at=now()
+ WHERE mail_kind IN ('application_cancel','application_received') AND subscribed=true;
+
+-- [4] 기존 두 lookup 비활성화 (soft)
+UPDATE public.lookup_values SET active=false
+ WHERE kind='admin_email_kind' AND code IN ('application_cancel','application_received');
+
+-- [5] 로그 테이블 deprecated 표기 (보존 — 선택지 확정 후 확정)
+COMMENT ON TABLE public.application_cancel_digest_runs IS
+  'DEPRECATED (2026-06-02, migration 164). 함수 통합으로 미사용. 과거 이력 보존용.';
+COMMENT ON TABLE public.application_received_admin_digest_runs IS
+  'DEPRECATED (2026-06-02, migration 164). 함수 통합으로 미사용. 과거 이력 보존용.';
+
+COMMIT;
+```
+
+검증 쿼리 / 롤백 SQL 은 기획 보고 본문 참조(롤백은 어느 쪽이 원래 ON 이었는지 정보 손실 → 사실상 비가역, 단 발송 동작은 동일하므로 실질 위험 낮음).
+
+### Edge Function 변경
+| 파일 | 변경 |
+|---|---|
+| `notify-admin-daily-digest/index.ts` (resolveAdminEmails 263~291) | 2 RPC → 1 RPC(`daily_digest`). 주석 갱신. env·single-RPC error 폴백 유지 |
+| `notify-application-cancelled-daily/` | 디렉토리 삭제 |
+| `notify-application-received-admin-daily/` | 디렉토리 삭제 |
+수동 절차: 양 서버 `supabase functions delete <fn>` (운영 twofagomeizrtkwlhsuv / 개발 qysmxtipobomefudyixw) + `notify-admin-daily-digest` 양 서버 재배포.
+
+### 화면 확인 결과
+- 모달 체크박스: lookup 동적 → 자동 반영. 코드 수정 불필요.
+- `_adminEmailKindDesc(code)`: daily_digest 보조 설명 한 줄 추가 권장.
+- 칩: 마이그레이션 [3]으로 자동 정상화.
+- **화면 코드 변경은 `_adminEmailKindDesc` 한 줄(권장)뿐.**
+
+### 약관 판정
+- **PRIVACY/TERMS 무영향** — 관리자 내부 수신 설정 명칭 변경, 개인정보 수집·처리 변화 없음.
+
+## PR 분할
+| PR | 내용 | 의존 |
+|---|---|---|
+| **PR 1 — 메일 항목 통합** | 마이그레이션 164 + notify-admin-daily-digest 1 RPC 화 + _adminEmailKindDesc 설명 | 없음 |
+| **PR 2 — 죽은 함수 정리** | repo 디렉토리 2개 삭제 + 카탈로그 카드 제거 + 문서 정리. 양 서버 functions delete 는 수동 | PR 1 안정화 후 권장(또는 동시) |
+
+## 사용자 확인 필요 (4가지)
+- Q1 항목 처리: 비활성화(행 보존, 추천) vs 완전 삭제
+- Q2 로그 테이블: 보존+deprecated 표기(추천) vs DROP
+- Q3 PR 분할: 분리(추천) vs 한 PR
+- Q4 명칭: "일일 통합 메일"(추천) vs 직접 입력
+
+## 구현 결과 (개발 세션이 채울 것)
+**구현일:** (미정)
+**관련 커밋/PR:** (미정)
+### 초안 대비 변경 사항
+- 추가된 것:
+- 빠진 것:
+- 달라진 것:
+### 구현 중 기술 결정 사항
+-

--- a/supabase/functions/notify-admin-daily-digest/index.ts
+++ b/supabase/functions/notify-admin-daily-digest/index.ts
@@ -26,9 +26,9 @@
 //   - 부분 0건 → 발송, 0건 섹션은 본문에서 생략
 //
 // 수신자:
-//   get_subscribed_admin_emails('application_cancel')
-//     ∪ get_subscribed_admin_emails('application_received')
+//   get_subscribed_admin_emails('daily_digest')
 //     ∪ env.NOTIFY_ADMIN_EMAILS
+//   (migration 164: application_cancel + application_received → daily_digest 통합)
 //
 // 환경변수:
 //   SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY (자동 주입)
@@ -260,7 +260,8 @@ function render(html: string, data: Record<string, string>): string {
   return html.replace(/\{\{(\w+)\}\}/g, (_m, key) => data[key] ?? "");
 }
 
-// 수신자 — 두 구독 종류 합집합 + env (개별 try-catch + env 폴백)
+// 수신자 — daily_digest 구독자 + env (try-catch + env 폴백)
+// migration 164: application_cancel + application_received → daily_digest 단일 RPC
 async function resolveAdminEmails(
   sb: ReturnType<typeof createClient>,
 ): Promise<string[]> {
@@ -270,21 +271,15 @@ async function resolveAdminEmails(
     .filter(Boolean);
 
   try {
-    const [cancelRes, receivedRes] = await Promise.all([
-      sb.rpc("get_subscribed_admin_emails", { p_mail_kind: "application_cancel" }),
-      sb.rpc("get_subscribed_admin_emails", { p_mail_kind: "application_received" }),
-    ]);
-    const cancelEmails = cancelRes.error
+    const digestRes = await sb.rpc("get_subscribed_admin_emails", {
+      p_mail_kind: "daily_digest",
+    });
+    const digestEmails = digestRes.error
       ? []
-      : (cancelRes.data || [])
+      : (digestRes.data || [])
           .map((r: { email: string | null }) => (r.email || "").trim())
           .filter(Boolean);
-    const receivedEmails = receivedRes.error
-      ? []
-      : (receivedRes.data || [])
-          .map((r: { email: string | null }) => (r.email || "").trim())
-          .filter(Boolean);
-    return [...new Set([...cancelEmails, ...receivedEmails, ...fromEnv])];
+    return [...new Set([...digestEmails, ...fromEnv])];
   } catch (_e) {
     return [...new Set(fromEnv)];
   }

--- a/supabase/functions/notify-admin-daily-digest/templates.ts
+++ b/supabase/functions/notify-admin-daily-digest/templates.ts
@@ -9,8 +9,8 @@ export const TEMPLATES: Record<string, string> = {
   Mail: 관리자 일일 통합 다이제스트 (admin daily digest)
   Trigger: pg_cron 매일 UTC 00:00 (= 한국시간 오전 9시) → Edge Function notify-admin-daily-digest
   Window:  전일 한국시간 0시~24시
-  To:      get_subscribed_admin_emails('application_cancel') ∪
-           get_subscribed_admin_emails('application_received') ∪ env.NOTIFY_ADMIN_EMAILS
+  To:      get_subscribed_admin_emails('daily_digest') ∪ env.NOTIFY_ADMIN_EMAILS
+           (migration 164: application_cancel + application_received → daily_digest 통합)
   Lang:    KO
   Skip:    4섹션 모두 0건이면 메일 미발송 + 발송 로그 status='skipped_no_data'
 

--- a/supabase/migrations/164_admin_email_consolidation.sql
+++ b/supabase/migrations/164_admin_email_consolidation.sql
@@ -1,0 +1,141 @@
+-- ════════════════════════════════════════════════════════════════════
+-- migration 164: 관리자 메일 수신 항목 통합
+--   application_cancel + application_received → daily_digest 단일 항목
+-- ════════════════════════════════════════════════════════════════════
+--
+-- 사양서: docs/specs/2026-06-02-admin-email-consolidation.md
+--
+-- 배경:
+--   notify-admin-daily-digest 는 4섹션을 1통으로 묶어 발송한다.
+--   그런데 수신 on/off 스위치가 application_cancel / application_received
+--   두 항목으로 나뉘어 있어 관리자 메일 설정 화면에서 동일 메일을
+--   두 곳에서 제어하는 혼란이 있었다.
+--   (실제로 둘 중 하나만 ON 이어도 통합 메일 전체 4섹션이 발송됨)
+--   → 단일 항목 'daily_digest'("일일 통합 메일")로 통합한다.
+--
+-- 변경 요약:
+--   [1] lookup 'daily_digest' 신규 추가 (sort_order=20)
+--   [2] 구독 이전: 기존 두 항목 중 하나라도 ON 이던 관리자 → daily_digest ON
+--       (ON CONFLICT DO UPDATE — 기존 daily_digest=false 행도 켜짐 보장)
+--   [3] 기존 두 mail_kind 구독 행 subscribed=false 정리 (칩 잔존 방지)
+--   [4] 기존 두 lookup active=false (soft 비활성화, 행 보존)
+--   [5] 죽은 로그 테이블 2개 COMMENT deprecated 표기 (보존)
+--
+-- 멱등: 재실행 안전 (ON CONFLICT DO UPDATE / UPDATE WHERE)
+--
+-- 롤백 방법 (롤백은 "누가 원래 어떤 항목을 ON 이었는가"를 정확히 복원 불가 — 비가역):
+--   -- lookup 비활성화 원복
+--   UPDATE public.lookup_values SET active=true
+--    WHERE kind='admin_email_kind' AND code IN ('application_cancel','application_received');
+--   UPDATE public.lookup_values SET active=false
+--    WHERE kind='admin_email_kind' AND code='daily_digest';
+--   -- (구독 행 원복 필요 시 마이그레이션 130 의 시드 INSERT 문을 재실행)
+-- ════════════════════════════════════════════════════════════════════
+
+BEGIN;
+
+-- ── [1] 신규 lookup 'daily_digest' ────────────────────────────────
+-- sort_order=20: 기존 brand_notify(10) 바로 다음, campaign_promo(40) 앞
+INSERT INTO public.lookup_values (kind, code, name_ko, name_ja, sort_order, active)
+VALUES (
+  'admin_email_kind',
+  'daily_digest',
+  '일일 통합 메일',
+  '日次まとめメール',
+  20,
+  true
+)
+ON CONFLICT (kind, code) DO UPDATE
+  SET name_ko    = EXCLUDED.name_ko,
+      name_ja    = EXCLUDED.name_ja,
+      sort_order = EXCLUDED.sort_order,
+      active     = true;
+
+-- ── [2] 구독 이전: 하나라도 ON 이던 관리자 → daily_digest ON ───────
+-- DISTINCT admin_id: 두 항목 모두 ON 이어도 1행만 삽입
+-- ON CONFLICT DO UPDATE SET subscribed=true:
+--   daily_digest 행이 이미 있어도(false 포함) 반드시 true 로 갱신
+INSERT INTO public.admin_email_subscriptions (admin_id, mail_kind, subscribed)
+SELECT DISTINCT s.admin_id, 'daily_digest', true
+  FROM public.admin_email_subscriptions s
+ WHERE s.mail_kind IN ('application_cancel', 'application_received')
+   AND s.subscribed = true
+ON CONFLICT (admin_id, mail_kind) DO UPDATE
+  SET subscribed  = true,
+      updated_at  = now();
+
+-- ── [3] 기존 두 mail_kind 구독 행 정리 (칩 잔존 방지) ──────────────
+-- DELETE 대신 UPDATE: 명시적 끄기 흔적 보존
+UPDATE public.admin_email_subscriptions
+   SET subscribed  = false,
+       updated_at  = now()
+ WHERE mail_kind IN ('application_cancel', 'application_received')
+   AND subscribed  = true;
+
+-- ── [4] 기존 두 lookup active=false (soft 비활성화) ─────────────────
+-- 행 보존: 기존 참조·이력용으로 남겨둠
+UPDATE public.lookup_values
+   SET active = false
+ WHERE kind = 'admin_email_kind'
+   AND code IN ('application_cancel', 'application_received');
+
+-- ── [5] 죽은 로그 테이블 deprecated 표기 (보존) ──────────────────────
+-- 두 테이블을 사용하던 Edge Function 은 cron 이 해제된 상태이며
+-- 이번 통합으로 더 이상 호출되지 않는다. 테이블 자체는 과거 이력 보존용.
+COMMENT ON TABLE public.application_cancel_digest_runs IS
+  'DEPRECATED (2026-06-02, migration 164). '
+  'notify-application-cancelled-daily Edge Function 전용 발송 로그. '
+  'cron 해제 및 기능 통합(notify-admin-daily-digest)으로 미사용. '
+  '과거 이력 보존용으로 행 보존.';
+
+COMMENT ON TABLE public.application_received_admin_digest_runs IS
+  'DEPRECATED (2026-06-02, migration 164). '
+  'notify-application-received-admin-daily Edge Function 전용 발송 로그. '
+  'cron 미등록 및 기능 통합(notify-admin-daily-digest)으로 미사용. '
+  '과거 이력 보존용으로 행 보존.';
+
+COMMIT;
+
+-- ════════════════════════════════════════════════════════════════════
+-- 검증 쿼리 (개발/운영 SQL Editor에서 마이그레이션 직후 실행)
+-- ════════════════════════════════════════════════════════════════════
+
+-- [검증 1] daily_digest lookup 생성 + 기존 두 항목 비활성화 확인
+-- 기대값: daily_digest active=true, application_cancel/received active=false
+/*
+SELECT code, name_ko, sort_order, active
+  FROM public.lookup_values
+ WHERE kind = 'admin_email_kind'
+ ORDER BY sort_order;
+*/
+
+-- [검증 2] 구독 이전 결과 — daily_digest ON 인 관리자 수 확인
+-- 기대값: 마이그레이션 전 application_cancel OR application_received 가 subscribed=true 이던 관리자 수와 일치
+/*
+SELECT mail_kind, COUNT(*) AS cnt
+  FROM public.admin_email_subscriptions
+ WHERE mail_kind IN ('application_cancel', 'application_received', 'daily_digest')
+   AND subscribed = true
+ GROUP BY mail_kind
+ ORDER BY mail_kind;
+-- 기대: daily_digest 행만 N건, 나머지 0건
+*/
+
+-- [검증 3] 로그 테이블 COMMENT 확인
+/*
+SELECT relname, obj_description(oid, 'pg_class') AS comment
+  FROM pg_class
+ WHERE relname IN ('application_cancel_digest_runs', 'application_received_admin_digest_runs')
+ ORDER BY relname;
+*/
+
+-- ════════════════════════════════════════════════════════════════════
+-- 스모크 호출 (검증 완료 후 실행 — notify-admin-daily-digest 수신자 확인)
+-- ════════════════════════════════════════════════════════════════════
+-- get_subscribed_admin_emails('daily_digest') 를 직접 호출해
+-- 구독자 이메일 목록이 정상적으로 반환되는지 확인한다.
+/*
+SELECT email
+  FROM public.get_subscribed_admin_emails('daily_digest');
+-- 기대: 마이그레이션 전 두 항목 구독자의 합집합(DISTINCT)
+*/


### PR DESCRIPTION
## 변경 요약
관리자 「메일받기」의 「응모 취소 알림」+「캠페인 신청 접수」를 「일일 통합 메일」(daily_digest) 하나로 통합. 개발서버 검증 3/3 PASS.

- 마이그레이션 164: lookup 통합 + 구독 이전 + 옛 항목 비활성/구독 정리
- notify-admin-daily-digest: 수신자 2 RPC → 1 RPC
- admin-accounts.js: 보조 설명 추가, CLAUDE.md 갱신

## DB 변경
- 마이그레이션 164 (운영 DB 적용 필요 — 도쿄 nrwtujmlbktxjgdwlpjj)
- Edge Function notify-admin-daily-digest 운영 재배포 필요

## 검증
- 개발서버 qa light 3/3 PASS (모달 항목·칩 잔존 없음·저장 동작)
- reviewer GO

## 관련 사양서
- docs/specs/2026-06-02-admin-email-consolidation.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)