### PR TITLE
deploy: 사용자 앱 에러 수집 → 관리자 오류 로그 (마이그레이션 165)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -245,6 +245,13 @@
   - 관련 RPC: `get_promo_digest_targets(date)`(자격 매칭 인플)·`get_promo_digest_campaign_pool(date)`(관리자용 풀 전체, 개인화 제외)·`mark_promo_digest_sent`·`track_promo_click`(anon)·`unsubscribe_by_token`(anon 1-click 수신거부)·`resubscribe_marketing`(본인 재구독)
 - 헬퍼 함수 `_yesterday_kst_window()` STABLE — 어제 KST 윈도우 + 오늘 KST 날짜 반환 (SQL Editor 디버깅용)
 
+### 사용자 앱 에러 수집 (마이그레이션 165, 수집 기반 PR1·2 — 관리자 화면 PR3 예정)
+> 인플루언서 앱에서 발생한 에러를 관리자가 모아 보는 기능(실시간 아님). 수집은 백그라운드 무음, 개인정보 마스킹 필수.
+- `client_error_logs` — 에러 fingerprint 묶음 테이블. `fingerprint`+`status`(open/resolved/ignored) UNIQUE 로 같은 에러는 1행에 `occurrence_count` 누적. `source`(influencer/admin)·`kind`(unhandled/rejection/handled)·`message`/`stack`/`page_hash`(마스킹됨)·`error_code`·`user_id`(influencers FK, anon 은 NULL)·`first/last_seen_at`·`resolved_by/at/note`. RLS SELECT `is_admin()` 만, INSERT/UPDATE 는 RPC 경유
+- `report_client_error(...)` RPC — SECURITY DEFINER, **anon+authenticated** 호출. 빈값·범위 가드 + 길이 제한 + **서버측 2차 마스킹**(이메일·전화·우편번호 `\d{3}-\d{4}`·Bearer 토큰·PostgreSQL `(col)=(val)`) + open fingerprint UPSERT
+- `resolve_client_error(id, status, note)` RPC — `is_admin()` 가드, 상태 변경(resolved/ignored/open 되돌리기 시 resolved_* 초기화)
+- 클라: `dev/js/error-report.js`(전역 `window.onerror`·`unhandledrejection` 핸들러 + `friendlyErrorJa` 훅 + 1차 마스킹·fingerprint·노이즈필터·60초 디바운스·재진입가드·throw 안 함), `storage.js` `reportClientError()`. 사양서 `docs/specs/2026-06-02-client-error-reporting.md`
+
 ### RLS·인증·세션
 - 정책 요약: 캠페인 SELECT 공개, 나머지는 본인 데이터 or 관리자만 접근
 - `is_admin()` / `is_super_admin()` / `is_campaign_admin()` 함수: admins 테이블에서 auth.uid() 조회 (search_path 고정)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,7 +77,7 @@
 - 배포용: 루트 `index.html` (build.sh 로 생성)
 - 개발 폴더 구조:
   - `dev/js/` — 인플루언서: app, ui, campaign, application, auth, mypage, notifications, messaging
-    - 관리자(admin.js 페인 분리 완료, 2026-05-25): `admin.js`(캠페인 목록·폼만 잔류) + `admin-core.js`(공용 헬퍼: 페인 라우팅·다중필터·확인모달·라이트박스·태그입력) + `admin-notices.js` + `admin-faq.js` + `admin-influencers.js` + `admin-deliverables.js` + `admin-excel.js` + `admin-dashboard.js` + `admin-applications.js`(신청+신청자) + `admin-accounts.js`(내계정+관리자계정) + `admin-lookups.js`(기준데이터+번들3종+미니에디터) + `admin-brand.js`/`admin-company.js`/`admin-brand-ops.js`/`admin-messaging.js`(브랜드 서베이)
+    - 관리자(admin.js 페인 분리 완료, 2026-05-25): `admin.js`(캠페인 목록·폼만 잔류) + `admin-core.js`(공용 헬퍼: 페인 라우팅·다중필터·확인모달·라이트박스·태그입력) + `admin-notices.js` + `admin-faq.js` + `admin-influencers.js` + `admin-deliverables.js` + `admin-excel.js` + `admin-dashboard.js` + `admin-applications.js`(신청+신청자) + `admin-accounts.js`(내계정+관리자계정) + `admin-lookups.js`(기준데이터+번들3종+미니에디터) + `admin-errors.js`(오류 로그 페인 — 마이그레이션 165) + `admin-brand.js`/`admin-company.js`/`admin-brand-ops.js`/`admin-messaging.js`(브랜드 서베이)
     - 빌드는 ES 모듈이 아니라 단순 이어붙이기(concat) — 전역 스코프 1개. `admin-core.js`가 다른 admin-* 파일보다 앞, `admin.js`가 페인 파일들보다 뒤, `admin/app.js`가 맨 마지막 (build.sh `ADMIN_JS_FILES` 순서)
   - `dev/css/` — base, components, campaign, auth, mypage, admin
   - `dev/lib/` — supabase(설정), shared(전역변수), storage(DB/Storage API)
@@ -172,6 +172,7 @@
   - **삭제 2택**: `remove_admin_role` (권한만 해제, 인플루언서 계정 유지) / `delete_admin_completely` (auth/influencers/applications/receipts cascade). 자기 자신 삭제 불가
 - **메일 수신 설정**(`/admin#admin-accounts`): 각 행 「메일받기」 셀에 켜진 메일 종류 회색 칩 + 「설정」 버튼. 모달에서 메일 종류별 체크박스 일괄 on/off. `admin_email_subscriptions` 테이블 + `lookup_values(kind='admin_email_kind')` 카탈로그. super_admin 은 다른 관리자 설정도 편집, 그 외는 본인만. 신규 메일 종류 추가는 `lookup_values` 한 줄 추가만으로 가능
 - **내 계정**: 이름/비밀번호 변경
+- **오류 로그**(`/admin#errors`, 마이그레이션 165, `dev/js/admin-errors.js`): 사용자(인플루언서) 앱에서 발생한 오류를 모아 보는 페인. 사이드바 「오류 로그」(미해결 건수 빨강 배지). 목록(상태[기본 미해결]·앱·기간 필터 + 메시지/코드 검색 + lazy-load) + 상세 모달(전체 메시지·스택·발생정보 + 해결/무시/메모, `resolve_client_error` RPC). 개인정보는 수집 단계에서 마스킹됨. 수집은 인플 앱 `error-report.js`(전역 핸들러 + friendlyErrorJa 훅)
 - **에러 처리**: `friendlyError()` 한국어 메시지 + 에러 코드
 - **상태 뱃지**: `getStatusBadgeKo()` 한국어 상태 표시
 

--- a/admin/index.html
+++ b/admin/index.html
@@ -12,7 +12,7 @@
 // 회귀(2026-05-12 PR #182 머지 직후 발생)를 방지하기 위한 자동 reload 가드.
 // sessionStorage 차단 환경(시크릿 모드 일부, 쿠키 차단)에서는 자연스럽게 skip.
 (function(){
-  var CURRENT_BUILD = 'v1780366533';
+  var CURRENT_BUILD = 'v1780374404';
   if (CURRENT_BUILD.indexOf('__') === 0) return; // 빌드 미적용 (dev/ 직접 열기) 시 skip
   try {
     var prev = sessionStorage.getItem('reverb.adminBuild');
@@ -1948,7 +1948,7 @@ textarea.form-input{resize:vertical;min-height:80px}
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-06-02 11:15 · c87bdcd</span>
+          <span class="admin-build-text">2026-06-02 13:26 · 9a838b4</span>
         </div>
       </div>
     </aside>
@@ -8301,6 +8301,15 @@ async function fetchFaqInteractionsForApp(applicationId) {
   } catch (e) { console.error('[fetchFaqInteractionsForApp]', e); return []; }
 }
 
+// ── 사용자 앱 에러 수집 (마이그레이션 165) ──
+// error-report.js 의 collectClientError 가 마스킹·디바운스 후 호출.
+// 실패는 완전 무음 (보고 실패가 앱 동작을 막으면 안 됨).
+async function reportClientError(payload) {
+  if (!db) return;
+  try { await db.rpc('report_client_error', payload); }
+  catch (e) { /* 무음 — 에러 보고 실패는 삼킨다 */ }
+}
+
 
 // ══════════════════════════════════════
 // UI — 알림 팝업, 로딩, 모달, 슬라이더
@@ -8413,6 +8422,8 @@ const _ERR_DICT = {
 };
 
 function friendlyErrorJa(e) {
+  // 처리된 에러도 관리자 오류 로그로 수집 (마이그레이션 165) — 수집 실패는 무음
+  if (typeof collectClientError === 'function') { try { collectClientError(e, 'handled'); } catch(_){} }
   const lang = (typeof getLang === 'function' ? getLang() : 'ja') === 'ko' ? 'ko' : 'ja';
   const t = _ERR_DICT[lang];
   const s = String(e?.message || e || '');

--- a/admin/index.html
+++ b/admin/index.html
@@ -12,7 +12,7 @@
 // 회귀(2026-05-12 PR #182 머지 직후 발생)를 방지하기 위한 자동 reload 가드.
 // sessionStorage 차단 환경(시크릿 모드 일부, 쿠키 차단)에서는 자연스럽게 skip.
 (function(){
-  var CURRENT_BUILD = 'v1780374404';
+  var CURRENT_BUILD = 'v1780375454';
   if (CURRENT_BUILD.indexOf('__') === 0) return; // 빌드 미적용 (dev/ 직접 열기) 시 skip
   try {
     var prev = sessionStorage.getItem('reverb.adminBuild');
@@ -1874,6 +1874,13 @@ textarea.form-input{resize:vertical;min-height:80px}
 }
 .proxy-evidence-item .ev-remove:hover { color: #c00; }
 
+/* 오류 로그 상세 모달 (admin-errors) — 상세 행 + 입력 (마이그레이션 165) */
+.admin-detail-row { display: flex; gap: 10px; padding: 7px 0; border-bottom: 1px solid var(--line); font-size: 13px; }
+.admin-detail-row:last-child { border-bottom: none; }
+.admin-detail-label { flex-shrink: 0; width: 84px; color: var(--muted); font-weight: 600; }
+.admin-input { padding: 8px 10px; border: 1px solid var(--line); border-radius: 8px; font-size: 13px; color: var(--ink); background: #fff; }
+.admin-input:focus { outline: none; border-color: var(--pink); }
+
 </style>
 </head>
 <body style="background:#F8F5F8">
@@ -1933,6 +1940,7 @@ textarea.form-input{resize:vertical;min-height:80px}
         <div class="admin-si" data-pane="lookups" id="adminLookupsSi" onclick="navAdminPaneReload('lookups')" style="display:none"><span class="si-icon material-icons-round">tune</span><span class="si-text">기준 데이터</span></div>
         <div class="admin-si" data-pane="faq" id="adminFaqSi" onclick="navAdminPaneReload('faq')" style="display:none"><span class="si-icon material-icons-round notranslate" translate="no">quiz</span><span class="si-text">자주 묻는 질문</span></div>
         <div class="admin-si" data-pane="admin-accounts" id="adminAccountSi" onclick="navAdminPaneReload('admin-accounts')"><span class="si-icon material-icons-round">admin_panel_settings</span><span class="si-text">관리자 계정</span></div>
+        <div class="admin-si" data-pane="errors" id="adminErrorsSi" onclick="navAdminPaneReload('errors')"><span class="si-icon material-icons-round notranslate" translate="no">bug_report</span><span class="si-text">오류 로그</span><span id="adminErrorsBadge" class="admin-si-badge" style="display:none">0</span></div>
         <div id="sidebarAdminProfile" class="admin-si" data-pane="my-account" onclick="navAdminPaneReload('my-account')">
           <div style="width:24px;height:24px;border-radius:50%;background:var(--pink);display:flex;align-items:center;justify-content:center;font-size:10px;font-weight:700;color:#fff;flex-shrink:0" id="sidebarAdminAvatar">A</div>
           <span class="si-text" id="sidebarAdminName">관리자</span>
@@ -1948,7 +1956,7 @@ textarea.form-input{resize:vertical;min-height:80px}
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-06-02 13:26 · 9a838b4</span>
+          <span class="admin-build-text">2026-06-02 13:44 · 6db118d</span>
         </div>
       </div>
     </aside>
@@ -2941,6 +2949,61 @@ textarea.form-input{resize:vertical;min-height:80px}
           </div>
         </div>
 
+        <!-- CLIENT ERROR LOGS (오류 로그) PANE — 마이그레이션 165 -->
+        <div id="adminPane-errors" class="admin-pane admin-pane-list">
+          <div class="admin-sticky-header">
+            <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:12px">
+              <div style="font-size:16px;font-weight:700;color:var(--ink)">오류 로그</div>
+              <div style="font-size:12px;color:var(--muted)">사용자 앱에서 발생한 오류 (개인정보는 자동 마스킹)</div>
+            </div>
+            <div style="display:flex;align-items:flex-end;gap:12px;flex-wrap:wrap">
+              <div class="admin-filter-group">
+                <label>상태</label>
+                <select id="errFilterStatus" class="form-input" style="padding:4px 28px 4px 10px;font-size:12px;border-radius:6px;width:auto" onchange="loadClientErrors()">
+                  <option value="open">미해결</option>
+                  <option value="resolved">해결됨</option>
+                  <option value="ignored">무시</option>
+                  <option value="">전체</option>
+                </select>
+              </div>
+              <div class="admin-filter-group">
+                <label>앱</label>
+                <select id="errFilterSource" class="form-input" style="padding:4px 28px 4px 10px;font-size:12px;border-radius:6px;width:auto" onchange="loadClientErrors()">
+                  <option value="">전체</option>
+                  <option value="influencer">인플루언서</option>
+                  <option value="admin">관리자</option>
+                </select>
+              </div>
+              <div class="admin-filter-group">
+                <label>기간</label>
+                <select id="errFilterDays" class="form-input" style="padding:4px 28px 4px 10px;font-size:12px;border-radius:6px;width:auto" onchange="loadClientErrors()">
+                  <option value="">전체</option>
+                  <option value="7">최근 7일</option>
+                  <option value="30">최근 30일</option>
+                </select>
+              </div>
+              <div class="admin-filter-group" style="flex:1;min-width:200px;margin-left:auto">
+                <label>검색</label>
+                <div style="position:relative">
+                  <span class="material-icons-round" style="position:absolute;left:8px;top:50%;transform:translateY(-50%);font-size:16px;color:var(--muted)">search</span>
+                  <input type="search" id="errSearch" class="admin-filter-search" autocomplete="off" data-lpignore="true" data-1p-ignore="true" readonly onfocus="this.removeAttribute('readonly')" placeholder="메시지 · 코드 검색" oninput="loadClientErrors()">
+                </div>
+              </div>
+            </div>
+          </div>
+          <div class="admin-card">
+            <div class="admin-card-header">
+              <div style="display:flex;align-items:center;gap:8px"><span class="admin-card-title">오류 목록</span><span id="errTotalCount" style="font-size:12px;color:var(--muted)"></span></div>
+            </div>
+            <div class="admin-table-wrap">
+              <table class="data-table">
+                <thead><tr><th style="width:80px">상태</th><th>메시지</th><th style="width:120px">코드</th><th style="width:60px;text-align:center">횟수</th><th style="width:140px">최근 발생</th><th style="width:70px">상세</th></tr></thead>
+                <tbody id="errTableBody"><tr><td colspan="6" style="text-align:center;color:var(--muted);padding:24px"><span class="spinner" style="width:20px;height:20px;border-width:2px;border-color:rgba(200,120,163,.2);border-top-color:var(--pink)"></span></td></tr></tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+
         <!-- BRAND DASHBOARD (광고주 서베이 현황) PANE -->
         <!-- 메시지 받은편지함 (3단: 캠페인 / 대화 상대 / 대화 내용) -->
         <div id="adminPane-messages" class="admin-pane">
@@ -3276,6 +3339,18 @@ textarea.form-input{resize:vertical;min-height:80px}
               <button class="btn btn-ghost btn-sm" onclick="closeCompanyModal()">닫기</button>
               <button id="companySaveBtn" class="btn btn-primary btn-sm" onclick="saveCompany()">저장</button>
             </div>
+          </div>
+        </div>
+
+        <!-- CLIENT ERROR DETAIL MODAL (오류 로그 상세) — 마이그레이션 165 -->
+        <div class="modal-overlay" id="clientErrorDetailModal" style="z-index:616">
+          <div class="modal" style="max-width:600px;width:94vw;border-radius:16px;margin:auto;max-height:88vh;display:flex;flex-direction:column">
+            <div class="modal-header" style="padding:16px 20px 12px;border-bottom:1px solid var(--line);display:flex;align-items:center;justify-content:space-between">
+              <div style="font-size:14px;font-weight:700;color:var(--ink)">오류 상세</div>
+              <button class="btn btn-ghost btn-xs" onclick="closeModal('clientErrorDetailModal')" style="padding:4px 10px">✕</button>
+            </div>
+            <div class="modal-body" style="padding:20px;overflow-y:auto;flex:1" id="clientErrorDetailBody"></div>
+            <div class="modal-footer" id="clientErrorDetailActions" style="padding:12px 20px;border-top:1px solid var(--line);display:flex;gap:8px;justify-content:flex-end"></div>
           </div>
         </div>
 
@@ -5241,6 +5316,9 @@ function faqComputeStatus(status, delivs, camp) {
 // 호출하면 등록된 갱신 함수가 실행된다. 새 페인 추가 시 PANE_REFRESHERS 에만
 // 한 행을 더한다 (.claude/rules/quality.md 「관리자 모달 페인 갱신」 룰 참조).
 const PANE_REFRESHERS = {
+  'errors': async () => {
+    if (typeof loadClientErrors === 'function') await loadClientErrors();
+  },
   'influencers': async () => {
     if (typeof rerenderInfluencersFromCache === 'function') rerenderInfluencersFromCache();
     else if (typeof loadAdminInfluencers === 'function') await loadAdminInfluencers();
@@ -8310,6 +8388,44 @@ async function reportClientError(payload) {
   catch (e) { /* 무음 — 에러 보고 실패는 삼킨다 */ }
 }
 
+// 관리자 오류 로그 조회 (RLS: is_admin() 만). 1000행 캡 대응 pagination.
+async function fetchClientErrors(filters = {}) {
+  if (!db) return [];
+  try {
+    return await fetchAllPaged(() => {
+      let q = db.from('client_error_logs').select('*');
+      if (filters.status) q = q.eq('status', filters.status);
+      if (filters.source) q = q.eq('source', filters.source);
+      if (filters.since)  q = q.gte('last_seen_at', filters.since);
+      return q.order('last_seen_at', { ascending: false });
+    });
+  } catch (e) { console.error('[fetchClientErrors]', e); return []; }
+}
+
+// 미해결(open) 오류 건수 — 사이드바 배지용
+async function fetchClientErrorOpenCount() {
+  if (!db) return 0;
+  try {
+    const { count, error } = await db.from('client_error_logs')
+      .select('id', { count: 'exact', head: true })
+      .eq('status', 'open');
+    if (error) throw error;
+    return count || 0;
+  } catch (e) { console.error('[fetchClientErrorOpenCount]', e); return 0; }
+}
+
+// 관리자 상태 변경 (resolved / ignored / open 되돌리기). resolve_client_error RPC.
+async function resolveClientError(id, status, note) {
+  if (!db) return false;
+  try {
+    await retryWithRefresh(async () => {
+      const { error } = await db.rpc('resolve_client_error', { p_id: id, p_status: status, p_note: note || null });
+      if (error) throw error;
+    });
+    return true;
+  } catch (e) { console.error('[resolveClientError]', e); return false; }
+}
+
 
 // ══════════════════════════════════════
 // UI — 알림 팝업, 로딩, 모달, 슬라이더
@@ -9380,7 +9496,8 @@ function switchAdminPane(pane, el, pushHistory) {
     'companies': loadCompanies,
     'brands': loadBrandsPane,
     'admin-notices': loadAdminNotices,
-    'messages': loadMessagesInbox
+    'messages': loadMessagesInbox,
+    'errors': loadClientErrors
   };
   // 브라우저 히스토리 기록 (뒤로가기 지원)
   if (pushHistory !== false) {
@@ -22969,6 +23086,160 @@ async function saveNgSetEdit() {
   } catch(e) {
     show('저장 실패: ' + (e.message||String(e)));
   }
+}
+
+// ═════════════════════════════════════════════════════════════════
+// REVERB ADMIN — dev/js/admin-errors.js
+// ═════════════════════════════════════════════════════════════════
+//   사용자(인플루언서) 앱 오류 로그 페인 (#adminPane-errors, 마이그레이션 165).
+//   · 목록: 상태/앱/기간 필터 + 검색 + lazy-load (loadClientErrors)
+//   · 상세 모달: 전체 메시지·스택·발생 정보 + 해결/무시/메모 (openClientErrorDetail)
+//   · 사이드바 미해결(open) 건수 배지 (updateClientErrorBadge)
+//   loadClientErrors 는 switchAdminPane(admin-core.js) loaders 가 호출 → 전역 유지.
+//   상세는 표시용 마스킹된 데이터만 다룸(개인정보는 수집 단계에서 이미 마스킹).
+// ═════════════════════════════════════════════════════════════════
+
+var clientErrorsLazy = null;
+const CLIENT_ERRORS_PAGE_SIZE = 50;
+var _clientErrorsCache = [];   // 현재 목록 (상세 모달이 id로 조회)
+var _currentClientErrorId = null;  // 상세 모달이 처리 중인 오류 id
+
+// 상태 한국어 라벨 + 색
+const CLIENT_ERR_STATUS = {
+  open:     { ko: '미해결', color: '#C33',     bg: '#FFF5F5' },
+  resolved: { ko: '해결됨', color: '#2D7A3E',  bg: '#E4F5E8' },
+  ignored:  { ko: '무시',   color: 'var(--muted)', bg: 'var(--surface-dim)' },
+};
+const CLIENT_ERR_KIND_KO = { unhandled: '미처리 예외', rejection: '비동기 거부', handled: '처리된 오류' };
+const CLIENT_ERR_SOURCE_KO = { influencer: '인플루언서', admin: '관리자' };
+
+function _clientErrStatusBadge(status) {
+  const s = CLIENT_ERR_STATUS[status] || CLIENT_ERR_STATUS.open;
+  return `<span style="display:inline-block;background:${s.bg};color:${s.color};font-size:11px;font-weight:700;padding:2px 8px;border-radius:4px">${s.ko}</span>`;
+}
+
+async function loadClientErrors() {
+  const status = $('errFilterStatus') ? $('errFilterStatus').value : 'open';
+  const source = $('errFilterSource') ? $('errFilterSource').value : '';
+  const days   = $('errFilterDays') ? $('errFilterDays').value : '';
+  const searchQ = ($('errSearch') ? $('errSearch').value : '').trim().toLowerCase();
+
+  const filters = {};
+  if (status) filters.status = status;
+  if (source) filters.source = source;
+  if (days) {
+    const d = new Date();
+    d.setDate(d.getDate() - parseInt(days, 10));
+    filters.since = d.toISOString();
+  }
+
+  let rows = await fetchClientErrors(filters);
+  _clientErrorsCache = rows;
+  if (searchQ) {
+    rows = rows.filter(r => matchSearchTokens(searchQ, [r.message, r.error_code, r.page_hash, r.context]));
+  }
+
+  const countEl = $('errTotalCount');
+  if (countEl) countEl.textContent = `총 ${rows.length}건`;
+
+  updateClientErrorBadge();
+
+  const body = $('errTableBody');
+  if (!body) return;
+
+  const renderRow = (r) => {
+    const kindKo = CLIENT_ERR_KIND_KO[r.kind] || r.kind || '';
+    const srcKo = CLIENT_ERR_SOURCE_KO[r.source] || r.source || '';
+    const msgShort = (r.message || '').length > 90 ? (r.message || '').slice(0, 90) + '…' : (r.message || '');
+    return `<tr data-id="${esc(r.id)}">
+      <td>${_clientErrStatusBadge(r.status)}</td>
+      <td style="max-width:380px">
+        <div style="font-size:13px;color:var(--ink);word-break:break-word;cursor:pointer" onclick="openClientErrorDetail('${esc(r.id)}')">${esc(msgShort) || '—'}</div>
+        <div style="font-size:10px;color:var(--muted);margin-top:2px">${esc(kindKo)} · ${esc(srcKo)}${r.page_hash ? ' · ' + esc(r.page_hash) : ''}</div>
+      </td>
+      <td style="font-size:11px;color:var(--muted)">${r.error_code ? esc(r.error_code) : '—'}</td>
+      <td style="text-align:center;font-weight:700;color:${r.occurrence_count > 10 ? 'var(--red)' : 'var(--ink)'}">${r.occurrence_count || 1}</td>
+      <td style="font-size:12px;color:var(--muted);white-space:nowrap">${formatDateTime(r.last_seen_at)}</td>
+      <td><button class="btn btn-ghost btn-xs" onclick="openClientErrorDetail('${esc(r.id)}')">상세</button></td>
+    </tr>`;
+  };
+
+  if (clientErrorsLazy) clientErrorsLazy.destroy();
+  clientErrorsLazy = mountLazyList({
+    tbody: body,
+    scrollRoot: body.closest('.admin-table-wrap'),
+    rows,
+    renderRow,
+    pageSize: CLIENT_ERRORS_PAGE_SIZE,
+    emptyHtml: '<tr><td colspan="6" style="text-align:center;color:var(--muted);padding:32px">최근 보고된 오류가 없습니다</td></tr>',
+  });
+}
+
+// 사이드바 미해결(open) 건수 배지
+async function updateClientErrorBadge() {
+  const badge = $('adminErrorsBadge');
+  if (!badge) return;
+  const n = await fetchClientErrorOpenCount();
+  if (n > 0) { badge.textContent = n > 99 ? '99+' : String(n); badge.style.display = ''; }
+  else { badge.style.display = 'none'; }
+}
+
+// 상세 모달
+function openClientErrorDetail(id) {
+  const r = _clientErrorsCache.find(x => x.id === id);
+  if (!r) { toast('오류 정보를 찾을 수 없습니다', 'warn'); return; }
+  _currentClientErrorId = id;
+  const kindKo = CLIENT_ERR_KIND_KO[r.kind] || r.kind || '';
+  const srcKo = CLIENT_ERR_SOURCE_KO[r.source] || r.source || '';
+  const body = $('clientErrorDetailBody');
+  if (body) {
+    body.innerHTML = `
+      <div style="display:flex;align-items:center;gap:8px;margin-bottom:12px">
+        ${_clientErrStatusBadge(r.status)}
+        <span style="font-size:12px;color:var(--muted)">${esc(kindKo)} · ${esc(srcKo)} · ${r.occurrence_count || 1}회 발생</span>
+      </div>
+      <div class="admin-detail-row"><div class="admin-detail-label">메시지</div><div style="word-break:break-word;color:var(--ink)">${esc(r.message) || '—'}</div></div>
+      ${r.error_code ? `<div class="admin-detail-row"><div class="admin-detail-label">코드</div><div>${esc(r.error_code)}</div></div>` : ''}
+      ${r.page_hash ? `<div class="admin-detail-row"><div class="admin-detail-label">발생 화면</div><div>${esc(r.page_hash)}</div></div>` : ''}
+      ${r.context ? `<div class="admin-detail-row"><div class="admin-detail-label">맥락</div><div>${esc(r.context)}</div></div>` : ''}
+      <div class="admin-detail-row"><div class="admin-detail-label">최초 발생</div><div>${formatDateTime(r.first_seen_at)}</div></div>
+      <div class="admin-detail-row"><div class="admin-detail-label">최근 발생</div><div>${formatDateTime(r.last_seen_at)}</div></div>
+      ${r.user_agent ? `<div class="admin-detail-row"><div class="admin-detail-label">브라우저</div><div style="font-size:11px;color:var(--muted);word-break:break-all">${esc(r.user_agent)}</div></div>` : ''}
+      ${r.stack ? `<div class="admin-detail-row"><div class="admin-detail-label">스택</div><pre style="white-space:pre-wrap;word-break:break-word;font-size:11px;color:var(--muted);background:var(--surface-dim);padding:8px;border-radius:6px;max-height:240px;overflow:auto;margin:0">${esc(r.stack)}</pre></div>` : ''}
+      ${r.resolved_by ? `<div class="admin-detail-row"><div class="admin-detail-label">처리</div><div style="font-size:12px;color:var(--muted)">${formatDateTime(r.resolved_at)}${r.resolve_note ? ' · ' + esc(r.resolve_note) : ''}</div></div>` : ''}
+      <div style="margin-top:8px">
+        <label style="font-size:12px;color:var(--muted);display:block;margin-bottom:4px">처리 메모 (선택)</label>
+        <input type="text" id="clientErrorNote" class="admin-input" placeholder="예: 재현 확인 후 수정 완료" value="${esc(r.resolve_note || '')}" style="width:100%">
+      </div>
+    `;
+  }
+  // 상태에 따라 버튼 노출 (open → 해결/무시, 그 외 → 미해결로 되돌리기)
+  const actions = $('clientErrorDetailActions');
+  if (actions) {
+    if (r.status === 'open') {
+      actions.innerHTML = `
+        <button class="btn btn-ghost" onclick="closeModal('clientErrorDetailModal')">닫기</button>
+        <button class="btn btn-ghost" style="color:var(--muted)" onclick="resolveClientErrorAction('ignored')">무시</button>
+        <button class="btn btn-green" onclick="resolveClientErrorAction('resolved')">해결됨</button>`;
+    } else {
+      actions.innerHTML = `
+        <button class="btn btn-ghost" onclick="closeModal('clientErrorDetailModal')">닫기</button>
+        <button class="btn btn-primary" onclick="resolveClientErrorAction('open')">미해결로 되돌리기</button>`;
+    }
+  }
+  openModal('clientErrorDetailModal');
+}
+
+async function resolveClientErrorAction(status) {
+  if (!_currentClientErrorId) return;
+  const note = $('clientErrorNote') ? $('clientErrorNote').value.trim() : '';
+  const ok = await resolveClientError(_currentClientErrorId, status, note);
+  if (!ok) { toast('처리에 실패했습니다', 'error'); return; }
+  const msgs = { resolved: '해결됨으로 처리했습니다', ignored: '무시 처리했습니다', open: '미해결로 되돌렸습니다' };
+  toast(msgs[status] || '처리했습니다', status === 'resolved' ? 'success' : '');
+  closeModal('clientErrorDetailModal');
+  _currentClientErrorId = null;
+  await refreshPane('errors');
 }
 
 // ════════════════════════════════════════════════════════════════════

--- a/dev/admin/index.html
+++ b/dev/admin/index.html
@@ -116,6 +116,7 @@
         <div class="admin-si" data-pane="lookups" id="adminLookupsSi" onclick="navAdminPaneReload('lookups')" style="display:none"><span class="si-icon material-icons-round">tune</span><span class="si-text">기준 데이터</span></div>
         <div class="admin-si" data-pane="faq" id="adminFaqSi" onclick="navAdminPaneReload('faq')" style="display:none"><span class="si-icon material-icons-round notranslate" translate="no">quiz</span><span class="si-text">자주 묻는 질문</span></div>
         <div class="admin-si" data-pane="admin-accounts" id="adminAccountSi" onclick="navAdminPaneReload('admin-accounts')"><span class="si-icon material-icons-round">admin_panel_settings</span><span class="si-text">관리자 계정</span></div>
+        <div class="admin-si" data-pane="errors" id="adminErrorsSi" onclick="navAdminPaneReload('errors')"><span class="si-icon material-icons-round notranslate" translate="no">bug_report</span><span class="si-text">오류 로그</span><span id="adminErrorsBadge" class="admin-si-badge" style="display:none">0</span></div>
         <div id="sidebarAdminProfile" class="admin-si" data-pane="my-account" onclick="navAdminPaneReload('my-account')">
           <div style="width:24px;height:24px;border-radius:50%;background:var(--pink);display:flex;align-items:center;justify-content:center;font-size:10px;font-weight:700;color:#fff;flex-shrink:0" id="sidebarAdminAvatar">A</div>
           <span class="si-text" id="sidebarAdminName">관리자</span>
@@ -1124,6 +1125,61 @@
           </div>
         </div>
 
+        <!-- CLIENT ERROR LOGS (오류 로그) PANE — 마이그레이션 165 -->
+        <div id="adminPane-errors" class="admin-pane admin-pane-list">
+          <div class="admin-sticky-header">
+            <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:12px">
+              <div style="font-size:16px;font-weight:700;color:var(--ink)">오류 로그</div>
+              <div style="font-size:12px;color:var(--muted)">사용자 앱에서 발생한 오류 (개인정보는 자동 마스킹)</div>
+            </div>
+            <div style="display:flex;align-items:flex-end;gap:12px;flex-wrap:wrap">
+              <div class="admin-filter-group">
+                <label>상태</label>
+                <select id="errFilterStatus" class="form-input" style="padding:4px 28px 4px 10px;font-size:12px;border-radius:6px;width:auto" onchange="loadClientErrors()">
+                  <option value="open">미해결</option>
+                  <option value="resolved">해결됨</option>
+                  <option value="ignored">무시</option>
+                  <option value="">전체</option>
+                </select>
+              </div>
+              <div class="admin-filter-group">
+                <label>앱</label>
+                <select id="errFilterSource" class="form-input" style="padding:4px 28px 4px 10px;font-size:12px;border-radius:6px;width:auto" onchange="loadClientErrors()">
+                  <option value="">전체</option>
+                  <option value="influencer">인플루언서</option>
+                  <option value="admin">관리자</option>
+                </select>
+              </div>
+              <div class="admin-filter-group">
+                <label>기간</label>
+                <select id="errFilterDays" class="form-input" style="padding:4px 28px 4px 10px;font-size:12px;border-radius:6px;width:auto" onchange="loadClientErrors()">
+                  <option value="">전체</option>
+                  <option value="7">최근 7일</option>
+                  <option value="30">최근 30일</option>
+                </select>
+              </div>
+              <div class="admin-filter-group" style="flex:1;min-width:200px;margin-left:auto">
+                <label>검색</label>
+                <div style="position:relative">
+                  <span class="material-icons-round" style="position:absolute;left:8px;top:50%;transform:translateY(-50%);font-size:16px;color:var(--muted)">search</span>
+                  <input type="search" id="errSearch" class="admin-filter-search" autocomplete="off" data-lpignore="true" data-1p-ignore="true" readonly onfocus="this.removeAttribute('readonly')" placeholder="메시지 · 코드 검색" oninput="loadClientErrors()">
+                </div>
+              </div>
+            </div>
+          </div>
+          <div class="admin-card">
+            <div class="admin-card-header">
+              <div style="display:flex;align-items:center;gap:8px"><span class="admin-card-title">오류 목록</span><span id="errTotalCount" style="font-size:12px;color:var(--muted)"></span></div>
+            </div>
+            <div class="admin-table-wrap">
+              <table class="data-table">
+                <thead><tr><th style="width:80px">상태</th><th>메시지</th><th style="width:120px">코드</th><th style="width:60px;text-align:center">횟수</th><th style="width:140px">최근 발생</th><th style="width:70px">상세</th></tr></thead>
+                <tbody id="errTableBody"><tr><td colspan="6" style="text-align:center;color:var(--muted);padding:24px"><span class="spinner" style="width:20px;height:20px;border-width:2px;border-color:rgba(200,120,163,.2);border-top-color:var(--pink)"></span></td></tr></tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+
         <!-- BRAND DASHBOARD (광고주 서베이 현황) PANE -->
         <!-- 메시지 받은편지함 (3단: 캠페인 / 대화 상대 / 대화 내용) -->
         <div id="adminPane-messages" class="admin-pane">
@@ -1459,6 +1515,18 @@
               <button class="btn btn-ghost btn-sm" onclick="closeCompanyModal()">닫기</button>
               <button id="companySaveBtn" class="btn btn-primary btn-sm" onclick="saveCompany()">저장</button>
             </div>
+          </div>
+        </div>
+
+        <!-- CLIENT ERROR DETAIL MODAL (오류 로그 상세) — 마이그레이션 165 -->
+        <div class="modal-overlay" id="clientErrorDetailModal" style="z-index:616">
+          <div class="modal" style="max-width:600px;width:94vw;border-radius:16px;margin:auto;max-height:88vh;display:flex;flex-direction:column">
+            <div class="modal-header" style="padding:16px 20px 12px;border-bottom:1px solid var(--line);display:flex;align-items:center;justify-content:space-between">
+              <div style="font-size:14px;font-weight:700;color:var(--ink)">오류 상세</div>
+              <button class="btn btn-ghost btn-xs" onclick="closeModal('clientErrorDetailModal')" style="padding:4px 10px">✕</button>
+            </div>
+            <div class="modal-body" style="padding:20px;overflow-y:auto;flex:1" id="clientErrorDetailBody"></div>
+            <div class="modal-footer" id="clientErrorDetailActions" style="padding:12px 20px;border-top:1px solid var(--line);display:flex;gap:8px;justify-content:flex-end"></div>
           </div>
         </div>
 

--- a/dev/build.sh
+++ b/dev/build.sh
@@ -24,7 +24,7 @@ echo "🔨 REVERB JP 빌드 시작..."
 # 1. CLIENT 빌드 → ../index.html
 # ══════════════════════════════════════
 CLIENT_CSS_FILES=("css/base.css" "css/components.css" "css/campaign.css" "css/auth.css" "css/mypage.css")
-CLIENT_JS_FILES=("lib/supabase.js" "lib/shared.js" "lib/i18n/ja.js" "lib/i18n/ko.js" "lib/i18n/index.js" "lib/image-compress.js" "lib/storage.js" "lib/legal.js" "js/ui.js" "js/campaign.js" "js/auth.js" "js/application.js" "js/notifications.js" "js/mypage.js" "js/messaging.js" "js/app.js")
+CLIENT_JS_FILES=("lib/supabase.js" "lib/shared.js" "lib/i18n/ja.js" "lib/i18n/ko.js" "lib/i18n/index.js" "lib/image-compress.js" "lib/storage.js" "lib/legal.js" "js/error-report.js" "js/ui.js" "js/campaign.js" "js/auth.js" "js/application.js" "js/notifications.js" "js/mypage.js" "js/messaging.js" "js/app.js")
 
 : > "$BUILD_TMP/client.css"
 for f in "${CLIENT_CSS_FILES[@]}"; do

--- a/dev/build.sh
+++ b/dev/build.sh
@@ -75,7 +75,7 @@ PYTHON_SCRIPT
 mkdir -p ../admin
 
 ADMIN_CSS_FILES=("css/base.css" "css/components.css" "css/admin.css")
-ADMIN_JS_FILES=("lib/supabase.js" "lib/shared.js" "lib/storage.js" "js/ui.js" "js/admin-core.js" "js/admin-brand.js" "js/admin-company.js" "js/admin-brand-ops.js" "js/admin-messaging.js" "js/admin-notices.js" "js/admin-faq.js" "js/admin-influencers.js" "js/admin-deliverables.js" "js/admin-excel.js" "js/admin-dashboard.js" "js/admin-applications.js" "js/admin-accounts.js" "js/admin-lookups.js" "js/admin.js" "admin/app.js")
+ADMIN_JS_FILES=("lib/supabase.js" "lib/shared.js" "lib/storage.js" "js/ui.js" "js/admin-core.js" "js/admin-brand.js" "js/admin-company.js" "js/admin-brand-ops.js" "js/admin-messaging.js" "js/admin-notices.js" "js/admin-faq.js" "js/admin-influencers.js" "js/admin-deliverables.js" "js/admin-excel.js" "js/admin-dashboard.js" "js/admin-applications.js" "js/admin-accounts.js" "js/admin-lookups.js" "js/admin-errors.js" "js/admin.js" "admin/app.js")
 
 : > "$BUILD_TMP/admin.css"
 for f in "${ADMIN_CSS_FILES[@]}"; do

--- a/dev/css/admin.css
+++ b/dev/css/admin.css
@@ -1423,3 +1423,10 @@
   padding: 0 2px;
 }
 .proxy-evidence-item .ev-remove:hover { color: #c00; }
+
+/* 오류 로그 상세 모달 (admin-errors) — 상세 행 + 입력 (마이그레이션 165) */
+.admin-detail-row { display: flex; gap: 10px; padding: 7px 0; border-bottom: 1px solid var(--line); font-size: 13px; }
+.admin-detail-row:last-child { border-bottom: none; }
+.admin-detail-label { flex-shrink: 0; width: 84px; color: var(--muted); font-weight: 600; }
+.admin-input { padding: 8px 10px; border: 1px solid var(--line); border-radius: 8px; font-size: 13px; color: var(--ink); background: #fff; }
+.admin-input:focus { outline: none; border-color: var(--pink); }

--- a/dev/index.html
+++ b/dev/index.html
@@ -1156,6 +1156,7 @@ window._supabaseLoaded = false;
 <script src="lib/image-compress.js"></script>
 <script src="lib/storage.js"></script>
 <script src="lib/legal.js"></script>
+<script src="js/error-report.js"></script>
 <script src="js/ui.js"></script>
 <script src="js/campaign.js"></script>
 <script src="js/auth.js"></script>

--- a/dev/js/admin-core.js
+++ b/dev/js/admin-core.js
@@ -170,7 +170,8 @@ function switchAdminPane(pane, el, pushHistory) {
     'companies': loadCompanies,
     'brands': loadBrandsPane,
     'admin-notices': loadAdminNotices,
-    'messages': loadMessagesInbox
+    'messages': loadMessagesInbox,
+    'errors': loadClientErrors
   };
   // 브라우저 히스토리 기록 (뒤로가기 지원)
   if (pushHistory !== false) {

--- a/dev/js/admin-errors.js
+++ b/dev/js/admin-errors.js
@@ -1,0 +1,153 @@
+// ═════════════════════════════════════════════════════════════════
+// REVERB ADMIN — dev/js/admin-errors.js
+// ═════════════════════════════════════════════════════════════════
+//   사용자(인플루언서) 앱 오류 로그 페인 (#adminPane-errors, 마이그레이션 165).
+//   · 목록: 상태/앱/기간 필터 + 검색 + lazy-load (loadClientErrors)
+//   · 상세 모달: 전체 메시지·스택·발생 정보 + 해결/무시/메모 (openClientErrorDetail)
+//   · 사이드바 미해결(open) 건수 배지 (updateClientErrorBadge)
+//   loadClientErrors 는 switchAdminPane(admin-core.js) loaders 가 호출 → 전역 유지.
+//   상세는 표시용 마스킹된 데이터만 다룸(개인정보는 수집 단계에서 이미 마스킹).
+// ═════════════════════════════════════════════════════════════════
+
+var clientErrorsLazy = null;
+const CLIENT_ERRORS_PAGE_SIZE = 50;
+var _clientErrorsCache = [];   // 현재 목록 (상세 모달이 id로 조회)
+var _currentClientErrorId = null;  // 상세 모달이 처리 중인 오류 id
+
+// 상태 한국어 라벨 + 색
+const CLIENT_ERR_STATUS = {
+  open:     { ko: '미해결', color: '#C33',     bg: '#FFF5F5' },
+  resolved: { ko: '해결됨', color: '#2D7A3E',  bg: '#E4F5E8' },
+  ignored:  { ko: '무시',   color: 'var(--muted)', bg: 'var(--surface-dim)' },
+};
+const CLIENT_ERR_KIND_KO = { unhandled: '미처리 예외', rejection: '비동기 거부', handled: '처리된 오류' };
+const CLIENT_ERR_SOURCE_KO = { influencer: '인플루언서', admin: '관리자' };
+
+function _clientErrStatusBadge(status) {
+  const s = CLIENT_ERR_STATUS[status] || CLIENT_ERR_STATUS.open;
+  return `<span style="display:inline-block;background:${s.bg};color:${s.color};font-size:11px;font-weight:700;padding:2px 8px;border-radius:4px">${s.ko}</span>`;
+}
+
+async function loadClientErrors() {
+  const status = $('errFilterStatus') ? $('errFilterStatus').value : 'open';
+  const source = $('errFilterSource') ? $('errFilterSource').value : '';
+  const days   = $('errFilterDays') ? $('errFilterDays').value : '';
+  const searchQ = ($('errSearch') ? $('errSearch').value : '').trim().toLowerCase();
+
+  const filters = {};
+  if (status) filters.status = status;
+  if (source) filters.source = source;
+  if (days) {
+    const d = new Date();
+    d.setDate(d.getDate() - parseInt(days, 10));
+    filters.since = d.toISOString();
+  }
+
+  let rows = await fetchClientErrors(filters);
+  _clientErrorsCache = rows;
+  if (searchQ) {
+    rows = rows.filter(r => matchSearchTokens(searchQ, [r.message, r.error_code, r.page_hash, r.context]));
+  }
+
+  const countEl = $('errTotalCount');
+  if (countEl) countEl.textContent = `총 ${rows.length}건`;
+
+  updateClientErrorBadge();
+
+  const body = $('errTableBody');
+  if (!body) return;
+
+  const renderRow = (r) => {
+    const kindKo = CLIENT_ERR_KIND_KO[r.kind] || r.kind || '';
+    const srcKo = CLIENT_ERR_SOURCE_KO[r.source] || r.source || '';
+    const msgShort = (r.message || '').length > 90 ? (r.message || '').slice(0, 90) + '…' : (r.message || '');
+    return `<tr data-id="${esc(r.id)}">
+      <td>${_clientErrStatusBadge(r.status)}</td>
+      <td style="max-width:380px">
+        <div style="font-size:13px;color:var(--ink);word-break:break-word;cursor:pointer" onclick="openClientErrorDetail('${esc(r.id)}')">${esc(msgShort) || '—'}</div>
+        <div style="font-size:10px;color:var(--muted);margin-top:2px">${esc(kindKo)} · ${esc(srcKo)}${r.page_hash ? ' · ' + esc(r.page_hash) : ''}</div>
+      </td>
+      <td style="font-size:11px;color:var(--muted)">${r.error_code ? esc(r.error_code) : '—'}</td>
+      <td style="text-align:center;font-weight:700;color:${r.occurrence_count > 10 ? 'var(--red)' : 'var(--ink)'}">${r.occurrence_count || 1}</td>
+      <td style="font-size:12px;color:var(--muted);white-space:nowrap">${formatDateTime(r.last_seen_at)}</td>
+      <td><button class="btn btn-ghost btn-xs" onclick="openClientErrorDetail('${esc(r.id)}')">상세</button></td>
+    </tr>`;
+  };
+
+  if (clientErrorsLazy) clientErrorsLazy.destroy();
+  clientErrorsLazy = mountLazyList({
+    tbody: body,
+    scrollRoot: body.closest('.admin-table-wrap'),
+    rows,
+    renderRow,
+    pageSize: CLIENT_ERRORS_PAGE_SIZE,
+    emptyHtml: '<tr><td colspan="6" style="text-align:center;color:var(--muted);padding:32px">최근 보고된 오류가 없습니다</td></tr>',
+  });
+}
+
+// 사이드바 미해결(open) 건수 배지
+async function updateClientErrorBadge() {
+  const badge = $('adminErrorsBadge');
+  if (!badge) return;
+  const n = await fetchClientErrorOpenCount();
+  if (n > 0) { badge.textContent = n > 99 ? '99+' : String(n); badge.style.display = ''; }
+  else { badge.style.display = 'none'; }
+}
+
+// 상세 모달
+function openClientErrorDetail(id) {
+  const r = _clientErrorsCache.find(x => x.id === id);
+  if (!r) { toast('오류 정보를 찾을 수 없습니다', 'warn'); return; }
+  _currentClientErrorId = id;
+  const kindKo = CLIENT_ERR_KIND_KO[r.kind] || r.kind || '';
+  const srcKo = CLIENT_ERR_SOURCE_KO[r.source] || r.source || '';
+  const body = $('clientErrorDetailBody');
+  if (body) {
+    body.innerHTML = `
+      <div style="display:flex;align-items:center;gap:8px;margin-bottom:12px">
+        ${_clientErrStatusBadge(r.status)}
+        <span style="font-size:12px;color:var(--muted)">${esc(kindKo)} · ${esc(srcKo)} · ${r.occurrence_count || 1}회 발생</span>
+      </div>
+      <div class="admin-detail-row"><div class="admin-detail-label">메시지</div><div style="word-break:break-word;color:var(--ink)">${esc(r.message) || '—'}</div></div>
+      ${r.error_code ? `<div class="admin-detail-row"><div class="admin-detail-label">코드</div><div>${esc(r.error_code)}</div></div>` : ''}
+      ${r.page_hash ? `<div class="admin-detail-row"><div class="admin-detail-label">발생 화면</div><div>${esc(r.page_hash)}</div></div>` : ''}
+      ${r.context ? `<div class="admin-detail-row"><div class="admin-detail-label">맥락</div><div>${esc(r.context)}</div></div>` : ''}
+      <div class="admin-detail-row"><div class="admin-detail-label">최초 발생</div><div>${formatDateTime(r.first_seen_at)}</div></div>
+      <div class="admin-detail-row"><div class="admin-detail-label">최근 발생</div><div>${formatDateTime(r.last_seen_at)}</div></div>
+      ${r.user_agent ? `<div class="admin-detail-row"><div class="admin-detail-label">브라우저</div><div style="font-size:11px;color:var(--muted);word-break:break-all">${esc(r.user_agent)}</div></div>` : ''}
+      ${r.stack ? `<div class="admin-detail-row"><div class="admin-detail-label">스택</div><pre style="white-space:pre-wrap;word-break:break-word;font-size:11px;color:var(--muted);background:var(--surface-dim);padding:8px;border-radius:6px;max-height:240px;overflow:auto;margin:0">${esc(r.stack)}</pre></div>` : ''}
+      ${r.resolved_by ? `<div class="admin-detail-row"><div class="admin-detail-label">처리</div><div style="font-size:12px;color:var(--muted)">${formatDateTime(r.resolved_at)}${r.resolve_note ? ' · ' + esc(r.resolve_note) : ''}</div></div>` : ''}
+      <div style="margin-top:8px">
+        <label style="font-size:12px;color:var(--muted);display:block;margin-bottom:4px">처리 메모 (선택)</label>
+        <input type="text" id="clientErrorNote" class="admin-input" placeholder="예: 재현 확인 후 수정 완료" value="${esc(r.resolve_note || '')}" style="width:100%">
+      </div>
+    `;
+  }
+  // 상태에 따라 버튼 노출 (open → 해결/무시, 그 외 → 미해결로 되돌리기)
+  const actions = $('clientErrorDetailActions');
+  if (actions) {
+    if (r.status === 'open') {
+      actions.innerHTML = `
+        <button class="btn btn-ghost" onclick="closeModal('clientErrorDetailModal')">닫기</button>
+        <button class="btn btn-ghost" style="color:var(--muted)" onclick="resolveClientErrorAction('ignored')">무시</button>
+        <button class="btn btn-green" onclick="resolveClientErrorAction('resolved')">해결됨</button>`;
+    } else {
+      actions.innerHTML = `
+        <button class="btn btn-ghost" onclick="closeModal('clientErrorDetailModal')">닫기</button>
+        <button class="btn btn-primary" onclick="resolveClientErrorAction('open')">미해결로 되돌리기</button>`;
+    }
+  }
+  openModal('clientErrorDetailModal');
+}
+
+async function resolveClientErrorAction(status) {
+  if (!_currentClientErrorId) return;
+  const note = $('clientErrorNote') ? $('clientErrorNote').value.trim() : '';
+  const ok = await resolveClientError(_currentClientErrorId, status, note);
+  if (!ok) { toast('처리에 실패했습니다', 'error'); return; }
+  const msgs = { resolved: '해결됨으로 처리했습니다', ignored: '무시 처리했습니다', open: '미해결로 되돌렸습니다' };
+  toast(msgs[status] || '처리했습니다', status === 'resolved' ? 'success' : '');
+  closeModal('clientErrorDetailModal');
+  _currentClientErrorId = null;
+  await refreshPane('errors');
+}

--- a/dev/js/app.js
+++ b/dev/js/app.js
@@ -439,6 +439,8 @@ async function init() {
 }
 
 document.addEventListener('DOMContentLoaded', async function() {
+  // 전역 에러 수집 핸들러 등록 (가능한 일찍 — 마이그레이션 165)
+  if (typeof initErrorReporting === 'function') { try { initErrorReporting(); } catch(_){} }
   // recovery 진행 중이면 home 대신 reset-pw 페이지 활성화
   let inRecovery = false;
   try { inRecovery = sessionStorage.getItem('reverb.recovery') === '1'; } catch(e) {}

--- a/dev/js/error-report.js
+++ b/dev/js/error-report.js
@@ -1,0 +1,125 @@
+// =============================================================================
+// 사용자(인플루언서) 앱 에러 수집 — 관리자 오류 로그 전송 (실시간 아님, 백그라운드 무음)
+//   사양서: docs/specs/2026-06-02-client-error-reporting.md
+//   - 전역 미처리 예외(window.onerror·unhandledrejection) + 처리된 에러(friendlyErrorJa) 수집
+//   - 클라 1차 마스킹(이메일·전화·우편번호·토큰) 후 report_client_error RPC 로 전송
+//   - 서버에서 2차 마스킹 + fingerprint 묶음 (마이그레이션 165)
+//   - 절대 throw 안 함(보고 실패가 앱을 막지 않음), 재진입·디바운스 가드
+// =============================================================================
+(function () {
+  let _reporting = false;              // 재진입 가드 (보고 중 발생한 에러로 무한루프 방지)
+  const _recentFp = new Map();         // fingerprint → 마지막 전송 시각 (디바운스)
+  const DEBOUNCE_MS = 60000;           // 같은 fingerprint 60초 내 1회만 전송
+
+  // 우리 책임이 아닌/무의미한 에러 (네트워크 끊김·브라우저 확장·CORS 가림 등) — 수집 제외
+  const NOISE = [
+    /ResizeObserver loop/i,
+    /^Script error\.?$/i,              // CORS 로 가려진 외부 스크립트 에러
+    /AbortError/i,
+    /Load failed/i,
+    /NetworkError|Failed to fetch/i,   // 사용자 네트워크 끊김
+    /Non-Error promise rejection/i,
+    /chrome-extension|moz-extension|safari-extension/i,
+  ];
+
+  function _toMessage(v) {
+    try {
+      if (typeof v === 'string') return v;
+      if (v && v.message) return String(v.message);
+      return String(v);
+    } catch (_) { return ''; }
+  }
+
+  // 클라 1차 마스킹 (서버 RPC 가 2차로 한 번 더 가림)
+  function _mask(s) {
+    if (!s) return s;
+    return String(s)
+      .replace(/[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}/g, '[email]')
+      .replace(/(\+81|\+82|0)\d[\d\-]{8,12}/g, '[phone]')
+      .replace(/\d{3}-\d{4}/g, '[zip]')                 // 하이픈 필수 (7자리 ID 과마스킹 방지)
+      .replace(/Bearer\s+\S+/g, 'Bearer [token]');
+  }
+
+  // 32bit 해시 (외부 의존 없는 간단 해시)
+  function _hash(s) {
+    let h = 0;
+    for (let i = 0; i < s.length; i++) { h = ((h << 5) - h + s.charCodeAt(i)) | 0; }
+    return 'fp' + (h >>> 0).toString(36);
+  }
+
+  // fingerprint: 메시지 정규화(숫자·UUID 제거) + 스택 첫 위치
+  function _fingerprint(msg, stack) {
+    const norm = (msg || '')
+      .replace(/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/gi, '#uuid#')
+      .replace(/\d+/g, '#')
+      .slice(0, 200);
+    const loc = ((stack || '').split('\n')[1] || '')
+      .replace(/:\d+:\d+/g, '')
+      .replace(/\d+/g, '#')
+      .slice(0, 120);
+    return _hash(norm + '|' + loc);
+  }
+
+  function _isNoise(msg, stack) {
+    const t = (msg || '') + ' ' + (stack || '');
+    return NOISE.some((re) => re.test(t));
+  }
+
+  // 에러 1건 수집 → 마스킹 → reportClientError RPC. 절대 throw 안 함.
+  async function collectClientError(err, kind) {
+    if (_reporting) return;
+    try {
+      const msg = _toMessage(err);
+      if (!msg) return;
+      const stack = (err && err.stack) ? String(err.stack) : '';
+      if (_isNoise(msg, stack)) return;
+
+      const fp = _fingerprint(msg, stack);
+      const now = Date.now();
+      const last = _recentFp.get(fp);
+      if (last && (now - last) < DEBOUNCE_MS) return;   // 디바운스
+      _recentFp.set(fp, now);
+      // 메모리 누수 방지 — 디바운스 맵이 커지면 오래된 항목 정리
+      if (_recentFp.size > 200) {
+        for (const [k, ts] of _recentFp) { if (now - ts > DEBOUNCE_MS) _recentFp.delete(k); }
+      }
+
+      const codeMatch = msg.match(/\[(ERR_[A-Z]+_\d+)\]/);
+      const payload = {
+        p_fingerprint: fp,
+        p_source: 'influencer',
+        p_kind: kind,
+        p_message: _mask(msg).slice(0, 1000),
+        p_error_code: codeMatch ? codeMatch[1] : null,
+        p_stack: _mask(stack).slice(0, 4000),
+        p_page_hash: _mask((location.hash || '').replace(/\d+/g, '#')).slice(0, 200),
+        p_context: null,
+        p_user_agent: (navigator.userAgent || '').slice(0, 512),
+      };
+
+      _reporting = true;
+      try {
+        if (typeof reportClientError === 'function') await reportClientError(payload);
+      } finally {
+        _reporting = false;
+      }
+    } catch (_) {
+      // 보고 자체가 실패해도 완전 무음 — 앱 동작을 절대 막지 않는다
+      _reporting = false;
+    }
+  }
+
+  // 전역 미처리 예외 핸들러 등록 (앱 부트 시 1회)
+  function initErrorReporting() {
+    window.addEventListener('error', function (e) {
+      collectClientError(e.error || e.message, 'unhandled');
+    });
+    window.addEventListener('unhandledrejection', function (e) {
+      collectClientError(e.reason, 'rejection');
+    });
+  }
+
+  // 전역 노출 (concat 빌드 — 다른 파일에서 호출)
+  window.collectClientError = collectClientError;
+  window.initErrorReporting = initErrorReporting;
+})();

--- a/dev/js/ui.js
+++ b/dev/js/ui.js
@@ -109,6 +109,8 @@ const _ERR_DICT = {
 };
 
 function friendlyErrorJa(e) {
+  // 처리된 에러도 관리자 오류 로그로 수집 (마이그레이션 165) — 수집 실패는 무음
+  if (typeof collectClientError === 'function') { try { collectClientError(e, 'handled'); } catch(_){} }
   const lang = (typeof getLang === 'function' ? getLang() : 'ja') === 'ko' ? 'ko' : 'ja';
   const t = _ERR_DICT[lang];
   const s = String(e?.message || e || '');

--- a/dev/lib/shared.js
+++ b/dev/lib/shared.js
@@ -447,6 +447,9 @@ function faqComputeStatus(status, delivs, camp) {
 // 호출하면 등록된 갱신 함수가 실행된다. 새 페인 추가 시 PANE_REFRESHERS 에만
 // 한 행을 더한다 (.claude/rules/quality.md 「관리자 모달 페인 갱신」 룰 참조).
 const PANE_REFRESHERS = {
+  'errors': async () => {
+    if (typeof loadClientErrors === 'function') await loadClientErrors();
+  },
   'influencers': async () => {
     if (typeof rerenderInfluencersFromCache === 'function') rerenderInfluencersFromCache();
     else if (typeof loadAdminInfluencers === 'function') await loadAdminInfluencers();

--- a/dev/lib/storage.js
+++ b/dev/lib/storage.js
@@ -2866,3 +2866,12 @@ async function fetchFaqInteractionsForApp(applicationId) {
   } catch (e) { console.error('[fetchFaqInteractionsForApp]', e); return []; }
 }
 
+// ── 사용자 앱 에러 수집 (마이그레이션 165) ──
+// error-report.js 의 collectClientError 가 마스킹·디바운스 후 호출.
+// 실패는 완전 무음 (보고 실패가 앱 동작을 막으면 안 됨).
+async function reportClientError(payload) {
+  if (!db) return;
+  try { await db.rpc('report_client_error', payload); }
+  catch (e) { /* 무음 — 에러 보고 실패는 삼킨다 */ }
+}
+

--- a/dev/lib/storage.js
+++ b/dev/lib/storage.js
@@ -2875,3 +2875,41 @@ async function reportClientError(payload) {
   catch (e) { /* 무음 — 에러 보고 실패는 삼킨다 */ }
 }
 
+// 관리자 오류 로그 조회 (RLS: is_admin() 만). 1000행 캡 대응 pagination.
+async function fetchClientErrors(filters = {}) {
+  if (!db) return [];
+  try {
+    return await fetchAllPaged(() => {
+      let q = db.from('client_error_logs').select('*');
+      if (filters.status) q = q.eq('status', filters.status);
+      if (filters.source) q = q.eq('source', filters.source);
+      if (filters.since)  q = q.gte('last_seen_at', filters.since);
+      return q.order('last_seen_at', { ascending: false });
+    });
+  } catch (e) { console.error('[fetchClientErrors]', e); return []; }
+}
+
+// 미해결(open) 오류 건수 — 사이드바 배지용
+async function fetchClientErrorOpenCount() {
+  if (!db) return 0;
+  try {
+    const { count, error } = await db.from('client_error_logs')
+      .select('id', { count: 'exact', head: true })
+      .eq('status', 'open');
+    if (error) throw error;
+    return count || 0;
+  } catch (e) { console.error('[fetchClientErrorOpenCount]', e); return 0; }
+}
+
+// 관리자 상태 변경 (resolved / ignored / open 되돌리기). resolve_client_error RPC.
+async function resolveClientError(id, status, note) {
+  if (!db) return false;
+  try {
+    await retryWithRefresh(async () => {
+      const { error } = await db.rpc('resolve_client_error', { p_id: id, p_status: status, p_note: note || null });
+      if (error) throw error;
+    });
+    return true;
+  } catch (e) { console.error('[resolveClientError]', e); return false; }
+}
+

--- a/docs/specs/2026-06-02-client-error-reporting.md
+++ b/docs/specs/2026-06-02-client-error-reporting.md
@@ -1,0 +1,253 @@
+# 사용자(인플루언서) 앱 에러를 관리자가 볼 수 있게 하는 기능
+**작성일:** 2026-06-02
+**작성:** reverb-planner (기획 세션)
+**상태:** 설계 — 사용자 결정 대기 (미착수)
+
+> 사용자 요청 원문: "사용자들이 사용하면서 에러코드가 뜨는 걸 관리자에게 알릴 수 있나? 실시간이 아니더라도."
+
+---
+
+## 현재 상태 (작성일 2026-06-02 기준, planning.md 규칙 A)
+
+### 관련 코드·DB·UI 진입점
+- **에러 표시 변환기 2종** (관리자에게 전송하는 곳 아님, 사용자 화면 표시용):
+  - `friendlyErrorJa(e)` — `dev/js/ui.js:111`. 인플루언서 일본어/한국어 i18n 분기. 정규식 12종 매칭 후 사전 문구 반환. **호출처는 단 8곳** (`mypage.js` 3 · `application.js` 4 · `ui.js` 1). 즉 인플 앱 에러의 극히 일부만 이 함수를 거침.
+  - `friendlyError(msg)` — `dev/js/admin-core.js:99`. 관리자 한국어. `[ERR_XXX_NNNNN]` 코드 부착.
+- **`console.error` 101곳** (`dev` 전체): `storage.js` 65 · `admin-messaging.js` 11 · `admin-deliverables.js` 7 · `messaging.js` 6 · `admin-excel.js` 4 · 기타. **현재 이 로그는 사용자 본인 브라우저 콘솔에만 출력 — 관리자는 절대 못 봄.**
+- **전역 에러 핸들러 없음**: `window.onerror` / `unhandledrejection` / `addEventListener('error')` grep 0건. 미처리 예외·Promise reject는 어디에도 잡히지 않음.
+- **외부 에러 추적 도구 없음**: Sentry·LogRocket 등 미연동. 에러 로그 테이블 없음.
+- **앱 부트**: `dev/js/app.js:441` `DOMContentLoaded` 핸들러 — 여기가 전역 핸들러를 달 유일한 진입점.
+- **DB 함수 집중**: `dev/lib/storage.js` (CLAUDE.md Rules — 다른 파일 직접 쿼리 금지). 세션 만료 재시도 `retryWithRefresh()` (storage.js:8).
+
+### 활용 가능한 기존 인프라
+- `notifications` (인플루언서 알림 — 관리자용 아님). 관리자 알림은 `admin_notices` 테이블 별도.
+- `admin_email_subscriptions` (마이그레이션 103) + lookup `admin_email_kind` (시드 `brand_notify`/`application_cancel`/`application_received`). 신규 메일 종류는 lookup 한 줄 추가로 확장 가능. 헬퍼 `get_subscribed_admin_emails(p_mail_kind)`.
+- **관리자 일일 통합 다이제스트** `notify-admin-daily-digest` (pg_cron 매일 KST 09:00, 4섹션 1통). **5번째 섹션 추가 가능.**
+- 익명 INSERT 패턴: 반드시 SECURITY DEFINER RPC (RLS WITH CHECK + RETURNING 충돌 42501 사례 — `.claude/rules/supabase.md`).
+- 관리자 목록 페인 패턴: IntersectionObserver lazy-load · `refreshPane` · sticky-header · `admin-pane-list` 클래스 · PostgREST 1000행 cap → `fetchAllPaged`.
+- 약관 문서: `docs/PRIVACY_{ja,kr}.md`, `docs/TERMS_{ja,kr}.md` 존재.
+- 마이그레이션 현재 최신 **164**(관리자 메일 항목 통합). 신규는 **165**.
+
+### 이 제안과 충돌 가능성 있는 기존 동작
+- **확인 완료 — 직접적 코드 충돌 없음** (에러 로그 인프라가 전무하므로 신규 추가).
+- 단 **약관(PRIVACY) 충돌 위험 있음**: 에러 메시지·스택에 사용자 개인정보가 섞여 들어가면 「수집하는 개인정보」에 빠진 채 수집하는 셈이 됨 → §의심 2 참조. 이건 코드 충돌이 아니라 법적 충돌.
+- `notify-admin-daily-digest` 다이제스트에 섹션을 추가하면 기존 4섹션 메일 레이아웃·`sections_summary jsonb`(`{received, cancelled, submitted, reprocessed}`) 구조를 건드림 → 5번째 키 추가 필요.
+
+### 미해결 백로그·관련 작업
+- 관련 백로그 없음 (신규 영역). 메모리·specs에 에러 수집 관련 항목 없음.
+- 참고: 관리자 일일 다이제스트는 이미 운영 중 (`feedback_dev_no_mail_test.md` — 메일 발송 테스트는 운영에서만).
+
+---
+
+## 의심·경우의 수 (planning.md 규칙 B — 반대론자 모드)
+
+### 1. 깨질 수 있는 경우의 수 (UX 포함 의무)
+
+**[기술] 수집 자체 실패로 무한 루프**
+에러 보고 INSERT(또는 RPC)가 또 실패하면(네트워크 끊김·RLS 오류) 그 실패가 다시 에러로 잡혀 또 보고를 시도 → 재귀·폭주. 특히 `window.onerror` 전역 훅에서 보고 로직이 던지는 예외는 다시 `window.onerror`로 들어옴. **반드시 보고 경로 자체는 try/catch로 완전히 삼키고(절대 throw 안 함), 보고 중 플래그(`_reporting`)로 재진입 차단.**
+
+**[기술] 폭증 — 한 사용자 한 버그가 수천 건 INSERT**
+무한 스크롤·렌더 루프 안에서 같은 에러가 나면 초당 수십 건 발생. 매 건 INSERT 하면 DB 폭증 + Brevo·다이제스트 노이즈. **fingerprint(메시지+위치 정규화 해시)로 묶어 `occurrence_count` 증가 + 클라이언트 측 동일 fingerprint 디바운스(예: 같은 fingerprint 60초 내 1회만 전송).**
+
+**[데이터/법률] 개인정보가 에러 메시지·스택에 섞임 (가장 중요)**
+DB 에러 메시지에 입력값이 그대로 나올 수 있음(예: `duplicate key value ... (email)=(user@x.com)`), 스택·URL 쿼리에 토큰·이메일·전화·PayPal·주소가 섞일 수 있음. 이걸 그대로 저장하면 PRIVACY에 없는 개인정보를 새로 수집·국외이전(Supabase 도쿄)하는 셈 → APPI·PIPA 위반 소지. **저장 전 마스킹 필수**(이메일·전화·우편번호·토큰·`(...)=(...)` PostgreSQL 상세값 정규식 치환) + PRIVACY 반영 검토.
+
+**[권한/환경] anon·비로그인 사용자 에러**
+회원가입 전·로그인 화면·캠페인 목록 열람은 비로그인(anon). 이 단계 에러도 받고 싶으면 `user_id` NULL 허용 + anon이 호출 가능한 SECURITY DEFINER RPC 필요. anon에게 INSERT 권한을 직접 주면 스팸 INSERT 벡터(누구나 임의 로그 주입) → **RPC 안에서 rate limit + 페이로드 크기 제한.**
+
+**[UX — 관리자] 노이즈에 파묻혀 진짜 버그를 놓침**
+사용자 네트워크 끊김·브라우저 확장 충돌·`ResizeObserver loop` 같은 무해 에러·취소된 요청(`AbortError`)이 대량 유입되면, 관리자 화면이 의미 없는 빨강으로 가득 차 정작 봐야 할 신규 버그를 못 봄. **수집 단계 노이즈 필터(블록리스트) + 관리자 화면에서 「해결됨/무시」 상태 + 「미해결만」 기본 필터** 필수. 빈 상태(에러 0건)일 때는 "최근 보고된 오류가 없습니다" 안내.
+
+**[UX — 인플루언서] 보고 동작이 사용자 경험을 방해하면 안 됨**
+에러 보고는 100% 백그라운드·무음이어야 함. 사용자에게 "오류를 보고하시겠습니까?" 팝업·로딩 스피너·토스트 절대 금지(인플은 일본어, 초등학생 눈높이 — 영문 에러코드 노출도 금지). 기존 `friendlyErrorJa` 일본어 표시는 그대로 두고, 보고는 그 뒤에서 조용히.
+
+### 2. 현재 구현과 어긋나는 지점
+- **확인 완료 — 코드 충돌 없음** (신규 인프라). 단 다음 2가지는 기존 구조에 "끼워 넣는" 작업이라 주의:
+  - DB 함수는 `storage.js` 집중 규칙 → 보고 함수 `reportClientError()`도 `storage.js`에 추가.
+  - 다이제스트 메일 섹션 추가 시 `sections_summary jsonb` 키 1개 추가 + `notify-admin-daily-digest/templates.ts` 레이아웃 수정.
+
+### 3. 사용자 의도와 다르게 해석될 수 있는 부분
+- **"에러코드가 뜨는 걸"** = ① 사용자 화면에 토스트로 보인 에러만(`friendlyErrorJa` 통과분, 8곳뿐)인지 ② 콘솔에만 찍힌 `console.error` 101곳인지 ③ 코드에 아예 안 잡힌 미처리 예외(흰 화면·앱 멈춤)까지인지 — **세 범위가 완전히 다름.** 사용자가 말한 "에러코드"는 보통 ①(화면에 보이는 것)이지만, 운영상 정작 중요한 건 ③(앱이 멈추는 치명적 버그). → 결정 필요.
+- **"관리자에게 알릴 수 있나"** = ① 관리자 화면에 쌓이는 목록(보러 가는 방식)인지 ② 메일로 밀어주는 방식(받는 방식)인지 ③ 둘 다인지. "실시간 아니어도 된다"는 단서는 ②(일일 다이제스트 메일) 또는 ①(목록)이면 충분하다는 뜻. → 결정 필요.
+- **인플 앱만? 관리자 앱도?** 관리자 앱 에러는 운영자 본인이 보는 화면이라 보고 의미가 다름(스스로 콘솔 확인 가능). 우선 인플 앱만 권장. → 결정 필요.
+
+### 권고 (한두 문장)
+실시간 불필요·운영 부담 최소 전제에서, **수집 범위는 「전역 미처리 예외(window.onerror·unhandledrejection) + friendlyErrorJa를 거친 처리된 에러」 둘 다**, 저장은 **fingerprint 묶음 + 강한 마스킹**, 관리자 노출은 **(a) 관리자 「오류 로그」 페인 목록(상태 관리 가능) + (c) 사이드바 미해결 배지**를 기본으로 하고, 일일 다이제스트 메일 섹션(b)은 선택 옵션으로 둔다(메일 노이즈 우려). 인플 앱만 먼저, 관리자 앱은 후순위.
+
+---
+
+## 제안 / 설계
+
+### 전체 흐름
+```
+인플 앱에서 에러 발생
+  ├─ window.onerror / unhandledrejection (전역 미처리 예외)
+  └─ friendlyErrorJa() 통과 (처리된 에러, 토스트로 표시된 것)
+        ↓ (둘 다 collectClientError로 모임)
+  noise 필터 통과? ── no ──▶ 버림
+        │ yes
+  fingerprint 계산 + 60초 디바운스 (같은 fp 중복 억제)
+        ↓
+  마스킹 (이메일/전화/우편번호/토큰/PG 상세값 제거)
+        ↓
+  reportClientError() → SECURITY DEFINER RPC `report_client_error()`
+        ↓
+  client_error_logs 테이블 (같은 fingerprint면 occurrence_count++ , 아니면 신규 INSERT)
+        ↓
+  [관리자] (a) #adminPane-errors 목록 페인 + (c) 사이드바 미해결 배지
+           (b 옵션) 일일 다이제스트 메일 5번째 섹션
+```
+
+### DB 스키마 초안 (마이그레이션 165)
+
+```sql
+-- ── 테이블 ──────────────────────────────────────────────
+CREATE TABLE public.client_error_logs (
+  id            uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  fingerprint   text NOT NULL,            -- 메시지+위치 정규화 해시 (묶음 키)
+  source        text NOT NULL DEFAULT 'influencer'  -- influencer | admin (앱 구분)
+                  CHECK (source IN ('influencer','admin')),
+  kind          text NOT NULL             -- unhandled | rejection | handled (수집 경로)
+                  CHECK (kind IN ('unhandled','rejection','handled')),
+  message       text NOT NULL,            -- 마스킹된 에러 메시지
+  error_code    text,                     -- friendlyError의 [ERR_XXX] 코드 (있으면)
+  stack         text,                     -- 마스킹된 스택 (선택, 길이 제한)
+  page_hash     text,                     -- location.hash (#detail-123 등, id는 마스킹)
+  context       text,                     -- 발생 맥락 (어떤 동작 중 — 화이트리스트 라벨만)
+  user_agent    text,                     -- 브라우저/OS (개인식별 아님)
+  user_id       uuid REFERENCES public.influencers(id) ON DELETE SET NULL, -- 로그인 시만, NULL=anon
+  occurrence_count integer NOT NULL DEFAULT 1,   -- 같은 fingerprint 누적 횟수
+  first_seen_at timestamptz NOT NULL DEFAULT now(),
+  last_seen_at  timestamptz NOT NULL DEFAULT now(),
+  -- 관리자 처리 상태
+  status        text NOT NULL DEFAULT 'open'     -- open | resolved | ignored
+                  CHECK (status IN ('open','resolved','ignored')),
+  resolved_by   uuid REFERENCES auth.users(id) ON DELETE SET NULL,
+  resolved_at   timestamptz,
+  resolve_note  text,
+  UNIQUE (fingerprint, status)   -- open 상태 같은 fp는 1행으로 묶임 (resolved 후 재발하면 새 open)
+);
+
+CREATE INDEX client_error_logs_status_lastseen_idx
+  ON public.client_error_logs (status, last_seen_at DESC);
+CREATE INDEX client_error_logs_fingerprint_idx
+  ON public.client_error_logs (fingerprint);
+
+-- ── RLS ─────────────────────────────────────────────────
+ALTER TABLE public.client_error_logs ENABLE ROW LEVEL SECURITY;
+-- SELECT: 관리자만 (사용자는 자기 에러 로그 볼 필요 없음)
+CREATE POLICY cel_select_admin ON public.client_error_logs
+  FOR SELECT USING (public.is_admin());
+-- INSERT/UPDATE 직접 금지 — 전부 RPC 경유 (정책 미생성 = service_role/SECURITY DEFINER만)
+-- 단 관리자 상태변경(resolve/ignore)은 별도 RPC 또는 UPDATE 정책:
+CREATE POLICY cel_update_admin ON public.client_error_logs
+  FOR UPDATE USING (public.is_admin()) WITH CHECK (public.is_admin());
+```
+
+### 보고 RPC 초안 (SECURITY DEFINER — anon·authenticated 양쪽 호출)
+
+```sql
+CREATE OR REPLACE FUNCTION public.report_client_error(
+  p_fingerprint text,
+  p_source      text,
+  p_kind        text,
+  p_message     text,
+  p_error_code  text DEFAULT NULL,
+  p_stack       text DEFAULT NULL,
+  p_page_hash   text DEFAULT NULL,
+  p_context     text DEFAULT NULL,
+  p_user_agent  text DEFAULT NULL
+) RETURNS void
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = ''
+AS $$
+DECLARE
+  v_uid uuid := auth.uid();   -- 로그인 시 채워짐, anon이면 NULL
+BEGIN
+  -- 페이로드 길이 가드 (폭주·거대 스택 방지)
+  p_message := left(coalesce(p_message,''), 1000);
+  p_stack   := left(coalesce(p_stack,''), 4000);
+  IF length(p_fingerprint) = 0 OR length(p_message) = 0 THEN RETURN; END IF;
+
+  -- 같은 open fingerprint 있으면 카운트++ , 없으면 신규
+  UPDATE public.client_error_logs
+     SET occurrence_count = occurrence_count + 1, last_seen_at = now()
+   WHERE fingerprint = p_fingerprint AND status = 'open';
+  IF NOT FOUND THEN
+    INSERT INTO public.client_error_logs
+      (fingerprint, source, kind, message, error_code, stack, page_hash,
+       context, user_agent, user_id)
+    VALUES
+      (p_fingerprint, coalesce(p_source,'influencer'), p_kind, p_message,
+       p_error_code, p_stack, p_page_hash, p_context, p_user_agent, v_uid)
+    ON CONFLICT (fingerprint, status) DO UPDATE
+      SET occurrence_count = public.client_error_logs.occurrence_count + 1,
+          last_seen_at = now();
+  END IF;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.report_client_error(...) TO anon, authenticated;
+```
+
+> **서버측 추가 마스킹**: 클라이언트 마스킹을 1차 방어로 두되, RPC 안에서 `(...)=(...)` PostgreSQL 상세값·이메일 정규식을 한 번 더 치환하는 2차 방어 권장(클라 우회·신규 누락 대비).
+
+### 클라이언트 수집 로직 (신규 `dev/js/error-report.js` + storage.js 함수)
+
+1. **전역 핸들러** (app.js 부트에 1회 등록):
+   ```js
+   window.addEventListener('error', (e) => collectClientError(e.error || e.message, 'unhandled'));
+   window.addEventListener('unhandledrejection', (e) => collectClientError(e.reason, 'rejection'));
+   ```
+2. **처리된 에러 훅**: `friendlyErrorJa` 내부 끝에서 `collectClientError(e, 'handled')` 호출 (호출처 8곳 자동 커버). 추가로 `storage.js` 주요 catch에서 선택적 호출.
+3. **`collectClientError(err, kind)`** (error-report.js):
+   - 재진입 가드 `if (_reporting) return;`
+   - 노이즈 블록리스트 매칭 시 return (`ResizeObserver loop`, `AbortError`, `Failed to fetch`(네트워크 끊김 — 옵션), 브라우저 확장 스택 등)
+   - fingerprint = `hash(정규화된 메시지 + 파일:라인)` (숫자 id·UUID 제거 후)
+   - 60초 디바운스 (메모리 Set, 같은 fp 최근 전송이면 skip)
+   - 마스킹: 이메일·전화·우편번호·`Bearer xxx`·`(col)=(val)` 치환
+   - `_reporting=true` → `reportClientError(payload)` → finally `_reporting=false`
+   - **절대 throw 안 함** (catch로 전부 삼킴)
+4. **`reportClientError(payload)`** (storage.js): `db?.rpc('report_client_error', {...})`. `if(!db) return` (DEMO 폴백).
+
+### 관리자 화면 와이어 (텍스트)
+
+신규 페인 `#adminPane-errors` (사이드바 「관리자설정」 그룹 아래 또는 「대시보드」 하단). `admin-pane-list` 패턴.
+
+```
+┌─ 오류 로그 ───────────────────────────────────────────────┐
+│ [상태 ▾ 미해결] [앱 ▾ 인플/관리자] [기간 ▾ 7일] [검색 메시지/코드] │
+├──────────────────────────────────────────────────────────┤
+│ 상태 │ 메시지(마스킹)        │ 코드        │ 횟수 │ 최근발생   │ │
+│ ●open│ 네트워크 오류…         │ ERR_NETWORK│ 142 │ 2분 전     │⋯│
+│ ●open│ 결과물 제출 실패…      │ ERR_NULL   │  7  │ 1시간 전   │⋯│
+│ ✓done│ JWT 만료…             │ ERR_AUTH   │  3  │ 어제       │⋯│
+└──────────────────────────────────────────────────────────┘
+  (행 클릭 → 상세 모달: 전체 메시지·스택·page_hash·user_agent·
+   발생 사용자 수·타임라인 + [해결됨 표시][무시][메모])
+  빈 상태: "최근 보고된 오류가 없습니다"
+```
+- **사이드바 배지**: 미해결(open) 건수 빨강 배지 (pending 배지 패턴 재사용).
+- **모달 저장 후** `refreshPane('errors')` 의무 (`.claude/rules/quality.md`). → `PANE_REFRESHERS`에 `errors` 등록.
+
+### 약관(PRIVACY) 영향 판단
+- **마스킹이 완전하면**: 개인정보를 수집하지 않으므로 PRIVACY 개정 불필요 가능. 단 `user_id`(로그인 사용자 식별)·`user_agent`를 저장하면 「자동 수집 정보」에 해당할 수 있음.
+- **보수적 권장**: PRIVACY `_ja`/`_kr` 「자동으로 수집되는 정보」 항목에 "서비스 오류 진단을 위한 오류 메시지·발생 화면·브라우저 정보(개인 식별 정보는 마스킹 처리)"를 1줄 추가. 중대 변경(수집항목 신설)이지만 개인 식별 없는 진단 정보라 사전 통지로 충분(재동의 불요)한지 `/약관확인`으로 별도 판정. → **결정 필요**.
+
+---
+
+## PR 분할
+
+- **PR 1 — DB·RPC**: 마이그레이션 165 (테이블 + RLS + `report_client_error` RPC + 서버측 2차 마스킹). 스모크 호출 1회(`feedback_db_function_smoke_test.md`).
+- **PR 2 — 클라이언트 수집**: `dev/js/error-report.js` 신규(전역 핸들러·노이즈 필터·fingerprint·마스킹·디바운스) + `friendlyErrorJa` 훅 + `storage.js` `reportClientError()` + build.sh 등록 + app.js 부트 1줄. 인플 앱만.
+- **PR 3 — 관리자 화면**: `#adminPane-errors` 페인 + 목록(lazy-load·필터·검색) + 상세 모달(해결/무시/메모) + 사이드바 미해결 배지 + `PANE_REFRESHERS` 등록. `dev/js/admin-errors.js` 신규.
+- **PR 4 (선택) — 다이제스트 메일 섹션**: `notify-admin-daily-digest` 5번째 섹션(어제 신규 미해결 오류 Top N) + `sections_summary` 키 추가. 메일 노이즈 우려로 사용자 확인 후.
+- **PR 5 (선택) — 관리자 앱 에러 수집**: source='admin' 으로 관리자 앱에도 동일 수집 적용.
+- **PR 6 (선택) — 보관 정리**: pg_cron 으로 90일·resolved/ignored 오래된 행 자동 삭제.
+
+의존성: PR 1 → PR 2 → PR 3. PR 4·5·6은 독립(1·2·3 운영 안정화 후).
+
+## 사용자 확인 필요
+(아래 4개 결정 — AskUserQuestion으로 변환: 수집 범위 / 알림 방식 / 대상 앱 / 개인정보·약관)
+
+## 구현 결과
+(개발 세션이 채울 것)

--- a/index.html
+++ b/index.html
@@ -2307,6 +2307,9 @@ function faqComputeStatus(status, delivs, camp) {
 // 호출하면 등록된 갱신 함수가 실행된다. 새 페인 추가 시 PANE_REFRESHERS 에만
 // 한 행을 더한다 (.claude/rules/quality.md 「관리자 모달 페인 갱신」 룰 참조).
 const PANE_REFRESHERS = {
+  'errors': async () => {
+    if (typeof loadClientErrors === 'function') await loadClientErrors();
+  },
   'influencers': async () => {
     if (typeof rerenderInfluencersFromCache === 'function') rerenderInfluencersFromCache();
     else if (typeof loadAdminInfluencers === 'function') await loadAdminInfluencers();
@@ -6874,6 +6877,44 @@ async function reportClientError(payload) {
   if (!db) return;
   try { await db.rpc('report_client_error', payload); }
   catch (e) { /* 무음 — 에러 보고 실패는 삼킨다 */ }
+}
+
+// 관리자 오류 로그 조회 (RLS: is_admin() 만). 1000행 캡 대응 pagination.
+async function fetchClientErrors(filters = {}) {
+  if (!db) return [];
+  try {
+    return await fetchAllPaged(() => {
+      let q = db.from('client_error_logs').select('*');
+      if (filters.status) q = q.eq('status', filters.status);
+      if (filters.source) q = q.eq('source', filters.source);
+      if (filters.since)  q = q.gte('last_seen_at', filters.since);
+      return q.order('last_seen_at', { ascending: false });
+    });
+  } catch (e) { console.error('[fetchClientErrors]', e); return []; }
+}
+
+// 미해결(open) 오류 건수 — 사이드바 배지용
+async function fetchClientErrorOpenCount() {
+  if (!db) return 0;
+  try {
+    const { count, error } = await db.from('client_error_logs')
+      .select('id', { count: 'exact', head: true })
+      .eq('status', 'open');
+    if (error) throw error;
+    return count || 0;
+  } catch (e) { console.error('[fetchClientErrorOpenCount]', e); return 0; }
+}
+
+// 관리자 상태 변경 (resolved / ignored / open 되돌리기). resolve_client_error RPC.
+async function resolveClientError(id, status, note) {
+  if (!db) return false;
+  try {
+    await retryWithRefresh(async () => {
+      const { error } = await db.rpc('resolve_client_error', { p_id: id, p_status: status, p_note: note || null });
+      if (error) throw error;
+    });
+    return true;
+  } catch (e) { console.error('[resolveClientError]', e); return false; }
 }
 
 

--- a/index.html
+++ b/index.html
@@ -6867,6 +6867,15 @@ async function fetchFaqInteractionsForApp(applicationId) {
   } catch (e) { console.error('[fetchFaqInteractionsForApp]', e); return []; }
 }
 
+// ── 사용자 앱 에러 수집 (마이그레이션 165) ──
+// error-report.js 의 collectClientError 가 마스킹·디바운스 후 호출.
+// 실패는 완전 무음 (보고 실패가 앱 동작을 막으면 안 됨).
+async function reportClientError(payload) {
+  if (!db) return;
+  try { await db.rpc('report_client_error', payload); }
+  catch (e) { /* 무음 — 에러 보고 실패는 삼킨다 */ }
+}
+
 
 // ══════════════════════════════════════
 // LEGAL — 약관/개인정보 페이지 마크다운 렌더링
@@ -7021,6 +7030,132 @@ async function renderLegalPage() {
   }
 }
 
+// =============================================================================
+// 사용자(인플루언서) 앱 에러 수집 — 관리자 오류 로그 전송 (실시간 아님, 백그라운드 무음)
+//   사양서: docs/specs/2026-06-02-client-error-reporting.md
+//   - 전역 미처리 예외(window.onerror·unhandledrejection) + 처리된 에러(friendlyErrorJa) 수집
+//   - 클라 1차 마스킹(이메일·전화·우편번호·토큰) 후 report_client_error RPC 로 전송
+//   - 서버에서 2차 마스킹 + fingerprint 묶음 (마이그레이션 165)
+//   - 절대 throw 안 함(보고 실패가 앱을 막지 않음), 재진입·디바운스 가드
+// =============================================================================
+(function () {
+  let _reporting = false;              // 재진입 가드 (보고 중 발생한 에러로 무한루프 방지)
+  const _recentFp = new Map();         // fingerprint → 마지막 전송 시각 (디바운스)
+  const DEBOUNCE_MS = 60000;           // 같은 fingerprint 60초 내 1회만 전송
+
+  // 우리 책임이 아닌/무의미한 에러 (네트워크 끊김·브라우저 확장·CORS 가림 등) — 수집 제외
+  const NOISE = [
+    /ResizeObserver loop/i,
+    /^Script error\.?$/i,              // CORS 로 가려진 외부 스크립트 에러
+    /AbortError/i,
+    /Load failed/i,
+    /NetworkError|Failed to fetch/i,   // 사용자 네트워크 끊김
+    /Non-Error promise rejection/i,
+    /chrome-extension|moz-extension|safari-extension/i,
+  ];
+
+  function _toMessage(v) {
+    try {
+      if (typeof v === 'string') return v;
+      if (v && v.message) return String(v.message);
+      return String(v);
+    } catch (_) { return ''; }
+  }
+
+  // 클라 1차 마스킹 (서버 RPC 가 2차로 한 번 더 가림)
+  function _mask(s) {
+    if (!s) return s;
+    return String(s)
+      .replace(/[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}/g, '[email]')
+      .replace(/(\+81|\+82|0)\d[\d\-]{8,12}/g, '[phone]')
+      .replace(/\d{3}-\d{4}/g, '[zip]')                 // 하이픈 필수 (7자리 ID 과마스킹 방지)
+      .replace(/Bearer\s+\S+/g, 'Bearer [token]');
+  }
+
+  // 32bit 해시 (외부 의존 없는 간단 해시)
+  function _hash(s) {
+    let h = 0;
+    for (let i = 0; i < s.length; i++) { h = ((h << 5) - h + s.charCodeAt(i)) | 0; }
+    return 'fp' + (h >>> 0).toString(36);
+  }
+
+  // fingerprint: 메시지 정규화(숫자·UUID 제거) + 스택 첫 위치
+  function _fingerprint(msg, stack) {
+    const norm = (msg || '')
+      .replace(/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/gi, '#uuid#')
+      .replace(/\d+/g, '#')
+      .slice(0, 200);
+    const loc = ((stack || '').split('\n')[1] || '')
+      .replace(/:\d+:\d+/g, '')
+      .replace(/\d+/g, '#')
+      .slice(0, 120);
+    return _hash(norm + '|' + loc);
+  }
+
+  function _isNoise(msg, stack) {
+    const t = (msg || '') + ' ' + (stack || '');
+    return NOISE.some((re) => re.test(t));
+  }
+
+  // 에러 1건 수집 → 마스킹 → reportClientError RPC. 절대 throw 안 함.
+  async function collectClientError(err, kind) {
+    if (_reporting) return;
+    try {
+      const msg = _toMessage(err);
+      if (!msg) return;
+      const stack = (err && err.stack) ? String(err.stack) : '';
+      if (_isNoise(msg, stack)) return;
+
+      const fp = _fingerprint(msg, stack);
+      const now = Date.now();
+      const last = _recentFp.get(fp);
+      if (last && (now - last) < DEBOUNCE_MS) return;   // 디바운스
+      _recentFp.set(fp, now);
+      // 메모리 누수 방지 — 디바운스 맵이 커지면 오래된 항목 정리
+      if (_recentFp.size > 200) {
+        for (const [k, ts] of _recentFp) { if (now - ts > DEBOUNCE_MS) _recentFp.delete(k); }
+      }
+
+      const codeMatch = msg.match(/\[(ERR_[A-Z]+_\d+)\]/);
+      const payload = {
+        p_fingerprint: fp,
+        p_source: 'influencer',
+        p_kind: kind,
+        p_message: _mask(msg).slice(0, 1000),
+        p_error_code: codeMatch ? codeMatch[1] : null,
+        p_stack: _mask(stack).slice(0, 4000),
+        p_page_hash: _mask((location.hash || '').replace(/\d+/g, '#')).slice(0, 200),
+        p_context: null,
+        p_user_agent: (navigator.userAgent || '').slice(0, 512),
+      };
+
+      _reporting = true;
+      try {
+        if (typeof reportClientError === 'function') await reportClientError(payload);
+      } finally {
+        _reporting = false;
+      }
+    } catch (_) {
+      // 보고 자체가 실패해도 완전 무음 — 앱 동작을 절대 막지 않는다
+      _reporting = false;
+    }
+  }
+
+  // 전역 미처리 예외 핸들러 등록 (앱 부트 시 1회)
+  function initErrorReporting() {
+    window.addEventListener('error', function (e) {
+      collectClientError(e.error || e.message, 'unhandled');
+    });
+    window.addEventListener('unhandledrejection', function (e) {
+      collectClientError(e.reason, 'rejection');
+    });
+  }
+
+  // 전역 노출 (concat 빌드 — 다른 파일에서 호출)
+  window.collectClientError = collectClientError;
+  window.initErrorReporting = initErrorReporting;
+})();
+
 // ══════════════════════════════════════
 // UI — 알림 팝업, 로딩, 모달, 슬라이더
 // ══════════════════════════════════════
@@ -7132,6 +7267,8 @@ const _ERR_DICT = {
 };
 
 function friendlyErrorJa(e) {
+  // 처리된 에러도 관리자 오류 로그로 수집 (마이그레이션 165) — 수집 실패는 무음
+  if (typeof collectClientError === 'function') { try { collectClientError(e, 'handled'); } catch(_){} }
   const lang = (typeof getLang === 'function' ? getLang() : 'ja') === 'ko' ? 'ko' : 'ja';
   const t = _ERR_DICT[lang];
   const s = String(e?.message || e || '');
@@ -12159,6 +12296,8 @@ async function init() {
 }
 
 document.addEventListener('DOMContentLoaded', async function() {
+  // 전역 에러 수집 핸들러 등록 (가능한 일찍 — 마이그레이션 165)
+  if (typeof initErrorReporting === 'function') { try { initErrorReporting(); } catch(_){} }
   // recovery 진행 중이면 home 대신 reset-pw 페이지 활성화
   let inRecovery = false;
   try { inRecovery = sessionStorage.getItem('reverb.recovery') === '1'; } catch(e) {}

--- a/supabase/migrations/165_client_error_logs.sql
+++ b/supabase/migrations/165_client_error_logs.sql
@@ -1,0 +1,287 @@
+-- =============================================================================
+-- 마이그레이션 165: 사용자(인플루언서) 앱 에러 수집
+-- 제목    : client error logs — 에러 수집 테이블 + RPC 2종
+-- 의존    : 없음 (신규 인프라, 기존 테이블과 독립)
+-- 대상    : 개발서버 + 운영서버
+-- 날짜    : 2026-06-02
+-- 사양서  : docs/specs/2026-06-02-client-error-reporting.md
+-- 위험도  : 낮음 — 신규 테이블/RPC, 기존 행·정책·트리거 무변경
+-- 멱등성  : CREATE TABLE IF NOT EXISTS, CREATE INDEX IF NOT EXISTS,
+--           DROP FUNCTION IF EXISTS (시그니처 명시), CREATE OR REPLACE FUNCTION,
+--           DROP POLICY IF EXISTS + CREATE POLICY
+--
+-- 변경 요약:
+--   [신규] public.client_error_logs  — 에러 fingerprint 묶음 테이블
+--   [신규] RPC report_client_error() — anon+authenticated 호출, 서버측 2차 마스킹
+--   [신규] RPC resolve_client_error()— 관리자 상태 변경(resolved/ignored/open)
+--
+-- 설계 결정 — UPDATE 정책 vs resolve RPC:
+--   사양서 초안은 "UPDATE 정책 또는 RPC" 양쪽을 허용했으나,
+--   ① 관리자 상태변경에 `resolved_by`·`resolved_at`·`resolve_note` 3개 필드를
+--      한 트랜잭션에서 원자적으로 기록해야 감사 일관성이 보장되며,
+--   ② UPDATE 정책으로 두면 클라이언트가 직접 `status='open'`으로 되돌리는 등
+--      임의 조작이 가능해지므로
+--   → 상태변경 경로는 resolve_client_error() RPC로 단일화.
+--      RLS UPDATE 정책은 생성하지 않음.
+--
+-- 마스킹 설계 — 2차 방어 정규식:
+--   클라이언트 1차 마스킹 이후 서버 RPC에서 아래 패턴을 다시 치환:
+--   1) 이메일: \S+@\S+\.\S{2,}  → [email]
+--   2) 전화번호: \b0\d{9,10}\b | \+81\d{9,10} | \+82\d{9,10} → [phone]
+--   3) 우편번호: \d{3}-\d{4} (하이픈 필수, 7자리 ID 과마스킹 방지)  → [zip]
+--   4) Bearer 토큰: Bearer\s+\S+  → Bearer [token]
+--   5) PostgreSQL 상세값: \(\w+\)=\([^)]*\)  → [col]=[masked]
+--   대상 컬럼: message, stack, page_hash
+--
+-- 롤백 방법:
+--   DROP FUNCTION IF EXISTS public.resolve_client_error(uuid, text, text);
+--   DROP FUNCTION IF EXISTS public.report_client_error(text, text, text, text, text, text, text, text, text);
+--   DROP TABLE IF EXISTS public.client_error_logs CASCADE;
+-- =============================================================================
+
+-- ── 테이블 ──────────────────────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS public.client_error_logs (
+  id               uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+
+  -- 묶음 키: 메시지+위치 정규화 후 클라이언트가 계산한 해시 문자열
+  fingerprint      text        NOT NULL,
+
+  -- 발생 앱 구분 (현재 인플루언서 앱만 사용, admin은 향후 PR 5)
+  source           text        NOT NULL DEFAULT 'influencer'
+                                CHECK (source IN ('influencer', 'admin')),
+
+  -- 수집 경로: 미처리 예외(window.onerror) / Promise reject / 처리된 에러(friendlyErrorJa)
+  kind             text        NOT NULL
+                                CHECK (kind IN ('unhandled', 'rejection', 'handled')),
+
+  -- 마스킹된 에러 메시지 (최대 1000자 — RPC 내부에서 자름)
+  message          text        NOT NULL,
+
+  -- friendlyError의 [ERR_XXX_NNNNN] 코드 (있는 경우만)
+  error_code       text,
+
+  -- 마스킹된 스택 트레이스 (최대 4000자 — RPC 내부에서 자름)
+  stack            text,
+
+  -- 발생 화면 해시 (#page-mypage, #detail-xxx 등. UUID 등 개인 식별자는 클라에서 마스킹)
+  page_hash        text,
+
+  -- 발생 맥락 라벨 (화이트리스트 문자열만 — 예: 'application_submit', 'auth_login')
+  context          text,
+
+  -- 브라우저/OS 식별 문자열 (개인 식별 안 됨)
+  user_agent       text,
+
+  -- 로그인 사용자 참조 (NULL = anon 또는 인플루언서 탈퇴로 삭제됨)
+  user_id          uuid        REFERENCES public.influencers(id) ON DELETE SET NULL,
+
+  -- 같은 fingerprint+status 조합의 누적 발생 횟수
+  occurrence_count integer     NOT NULL DEFAULT 1,
+
+  -- 처음 발생 시각 (open 행 기준; resolved 후 재발하면 새 open 행의 first_seen_at이 갱신됨)
+  first_seen_at    timestamptz NOT NULL DEFAULT now(),
+  last_seen_at     timestamptz NOT NULL DEFAULT now(),
+
+  -- 관리자 처리 상태
+  status           text        NOT NULL DEFAULT 'open'
+                                CHECK (status IN ('open', 'resolved', 'ignored')),
+
+  -- 처리한 관리자 정보 (resolved/ignored 전환 시 RPC가 채움)
+  resolved_by      uuid        REFERENCES auth.users(id) ON DELETE SET NULL,
+  resolved_at      timestamptz,
+  resolve_note     text,
+
+  -- open 상태에서 같은 fingerprint는 1행으로 묶음.
+  -- resolved/ignored 된 뒤 재발하면 새로운 open 행이 생성됨.
+  UNIQUE (fingerprint, status)
+);
+
+-- 관리자 목록 페인 기본 정렬(미해결 오래된 것 먼저)
+CREATE INDEX IF NOT EXISTS client_error_logs_status_lastseen_idx
+  ON public.client_error_logs (status, last_seen_at DESC);
+
+-- fingerprint 조회 (RPC의 open 행 UPDATE WHERE 절)
+CREATE INDEX IF NOT EXISTS client_error_logs_fingerprint_idx
+  ON public.client_error_logs (fingerprint);
+
+-- ── 행 단위 보안 정책(RLS) ────────────────────────────────────────────────────
+
+ALTER TABLE public.client_error_logs ENABLE ROW LEVEL SECURITY;
+
+-- SELECT: 관리자만 (인플루언서는 자기 에러 로그를 볼 필요 없음)
+DROP POLICY IF EXISTS cel_select_admin ON public.client_error_logs;
+CREATE POLICY cel_select_admin ON public.client_error_logs
+  FOR SELECT USING (public.is_admin());
+
+-- INSERT/UPDATE 직접 정책 없음 → report_client_error / resolve_client_error RPC 경유만 허용
+-- (SECURITY DEFINER RPC는 정책을 우회(BYPASSRLS 아님)하는 게 아니라
+--  함수 소유자(postgres)의 권한으로 실행되므로 별도 RPC-only 정책 불필요)
+
+-- ── RPC: report_client_error ─────────────────────────────────────────────────
+-- anon + authenticated 양쪽 호출 가능.
+-- 클라이언트 1차 마스킹 이후 서버측 2차 마스킹을 적용하고
+-- open fingerprint가 있으면 occurrence_count 증가, 없으면 신규 INSERT.
+
+DROP FUNCTION IF EXISTS public.report_client_error(text, text, text, text, text, text, text, text, text);
+
+CREATE OR REPLACE FUNCTION public.report_client_error(
+  p_fingerprint  text,
+  p_source       text    DEFAULT 'influencer',
+  p_kind         text    DEFAULT 'unhandled',
+  p_message      text    DEFAULT '',
+  p_error_code   text    DEFAULT NULL,
+  p_stack        text    DEFAULT NULL,
+  p_page_hash    text    DEFAULT NULL,
+  p_context      text    DEFAULT NULL,
+  p_user_agent   text    DEFAULT NULL
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_uid      uuid := auth.uid();  -- 로그인 사용자이면 채워짐, anon이면 NULL
+  v_message  text;
+  v_stack    text;
+  v_pagehash text;
+BEGIN
+  -- ── 1. 빈값 가드 ──────────────────────────────────────────────────────────
+  -- fingerprint 또는 message가 비어 있으면 의미 없는 로그 → 조용히 종료
+  IF coalesce(trim(p_fingerprint), '') = '' OR coalesce(trim(p_message), '') = '' THEN
+    RETURN;
+  END IF;
+
+  -- source / kind 범위 가드 (CHECK 제약과 이중 방어)
+  IF p_source NOT IN ('influencer', 'admin') THEN
+    RETURN;
+  END IF;
+  IF p_kind NOT IN ('unhandled', 'rejection', 'handled') THEN
+    RETURN;
+  END IF;
+
+  -- ── 2. 길이 제한 ─────────────────────────────────────────────────────────
+  v_message  := left(p_message,  1000);
+  v_stack    := left(p_stack,    4000);
+  v_pagehash := left(p_page_hash, 512);
+
+  -- ── 3. 서버측 2차 마스킹 ─────────────────────────────────────────────────
+  -- 클라이언트 1차 마스킹을 통과한 잔존 개인정보를 정규식으로 제거.
+  -- 적용 대상: message, stack, page_hash
+
+  -- (a) 이메일 패턴: something@domain.tld
+  v_message  := regexp_replace(v_message,  '[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}', '[email]', 'g');
+  v_stack    := regexp_replace(v_stack,    '[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}', '[email]', 'g');
+  v_pagehash := regexp_replace(v_pagehash, '[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}', '[email]', 'g');
+
+  -- (b) 전화번호 패턴: 010-xxxx-xxxx / 0xx-xxxx-xxxx / +81xxxxxxxxx / +82xxxxxxxxx
+  v_message  := regexp_replace(v_message,  '(\+81|\+82|0)\d[\d\-]{8,12}', '[phone]', 'g');
+  v_stack    := regexp_replace(v_stack,    '(\+81|\+82|0)\d[\d\-]{8,12}', '[phone]', 'g');
+  v_pagehash := regexp_replace(v_pagehash, '(\+81|\+82|0)\d[\d\-]{8,12}', '[phone]', 'g');
+
+  -- (c) 우편번호 패턴: 123-4567 (하이픈 필수 — 일본 우편번호는 항상 〒123-4567 형태.
+  --     하이픈 없는 7자리 연속 숫자는 주문번호·신청번호 등 ID라 과마스킹 방지 위해 제외)
+  v_message  := regexp_replace(v_message,  '\d{3}-\d{4}', '[zip]', 'g');
+  v_stack    := regexp_replace(v_stack,    '\d{3}-\d{4}', '[zip]', 'g');
+  v_pagehash := regexp_replace(v_pagehash, '\d{3}-\d{4}', '[zip]', 'g');
+
+  -- (d) Bearer 토큰: "Bearer eyJxxx..." 형태
+  v_message  := regexp_replace(v_message,  'Bearer\s+\S+', 'Bearer [token]', 'g');
+  v_stack    := regexp_replace(v_stack,    'Bearer\s+\S+', 'Bearer [token]', 'g');
+  v_pagehash := regexp_replace(v_pagehash, 'Bearer\s+\S+', 'Bearer [token]', 'g');
+
+  -- (e) PostgreSQL 상세 오류값: (column)=(value) 패턴
+  --     예: "duplicate key value ... (email)=(user@x.com)"
+  v_message  := regexp_replace(v_message,  '\(\w+\)=\([^)]*\)', '[col]=[masked]', 'g');
+  v_stack    := regexp_replace(v_stack,    '\(\w+\)=\([^)]*\)', '[col]=[masked]', 'g');
+  v_pagehash := regexp_replace(v_pagehash, '\(\w+\)=\([^)]*\)', '[col]=[masked]', 'g');
+
+  -- ── 4. open fingerprint가 있으면 카운트 증가, 없으면 신규 INSERT ──────────
+  UPDATE public.client_error_logs
+     SET occurrence_count = occurrence_count + 1,
+         last_seen_at     = now()
+   WHERE fingerprint = p_fingerprint
+     AND status      = 'open';
+
+  IF NOT FOUND THEN
+    -- ON CONFLICT: UPDATE 시점과 INSERT 시점 사이에 다른 세션이 먼저 INSERT 하는
+    -- 극히 드문 경합을 UNIQUE(fingerprint, status) 제약으로 안전하게 처리
+    INSERT INTO public.client_error_logs
+      (fingerprint, source, kind, message, error_code,
+       stack, page_hash, context, user_agent, user_id)
+    VALUES
+      (p_fingerprint,
+       p_source,
+       p_kind,
+       v_message,
+       p_error_code,
+       v_stack,
+       v_pagehash,
+       left(p_context,    200),
+       left(p_user_agent, 512),
+       v_uid)
+    ON CONFLICT (fingerprint, status) DO UPDATE
+      SET occurrence_count = public.client_error_logs.occurrence_count + 1,
+          last_seen_at     = now();
+  END IF;
+
+END;
+$$;
+
+-- anon(비로그인)과 인증 사용자 모두 호출 가능
+GRANT EXECUTE ON FUNCTION public.report_client_error(text, text, text, text, text, text, text, text, text)
+  TO anon, authenticated;
+
+-- ── RPC: resolve_client_error ────────────────────────────────────────────────
+-- 관리자가 에러 행의 상태를 resolved / ignored / open(되돌리기)으로 변경.
+-- 설계 결정: UPDATE 정책 대신 RPC로 단일화
+--   - resolved_by·resolved_at·resolve_note 3개 필드를 원자적으로 기록
+--   - 클라이언트가 직접 status를 임의 조작하는 경로 차단
+--   - open으로 되돌릴 때도 resolved_* 필드를 초기화해 감사 일관성 보장
+
+DROP FUNCTION IF EXISTS public.resolve_client_error(uuid, text, text);
+
+CREATE OR REPLACE FUNCTION public.resolve_client_error(
+  p_id     uuid,
+  p_status text,
+  p_note   text DEFAULT NULL
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+BEGIN
+  -- 관리자 권한 가드
+  IF NOT public.is_admin() THEN
+    RAISE EXCEPTION 'permission denied';
+  END IF;
+
+  -- 허용 status 가드
+  IF p_status NOT IN ('open', 'resolved', 'ignored') THEN
+    RAISE EXCEPTION 'invalid status: %', p_status;
+  END IF;
+
+  UPDATE public.client_error_logs
+     SET status      = p_status,
+         resolved_by = CASE WHEN p_status = 'open' THEN NULL ELSE auth.uid() END,
+         resolved_at = CASE WHEN p_status = 'open' THEN NULL ELSE now()      END,
+         resolve_note = CASE WHEN p_status = 'open' THEN NULL ELSE p_note    END
+   WHERE id = p_id;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'client_error_log not found: %', p_id;
+  END IF;
+END;
+$$;
+
+-- 관리자만 호출 가능 (is_admin() 내부 가드와 이중 방어)
+GRANT EXECUTE ON FUNCTION public.resolve_client_error(uuid, text, text)
+  TO authenticated;
+
+-- =============================================================================
+-- 스모크 테스트 (개발 DB 적용 후 SQL Editor에서 실행)
+-- SELECT public.report_client_error('fp-smoke-test-001', 'influencer', 'handled', 'smoke test error');
+-- SELECT id, fingerprint, source, kind, message, status, occurrence_count FROM public.client_error_logs WHERE fingerprint = 'fp-smoke-test-001';
+-- =============================================================================


### PR DESCRIPTION
## 변경 요약
인플루언서 앱 오류를 관리자가 보는 기능(PR1 DB + PR2 수집 + PR3 관리자 화면). 개발서버 검증 완료(qa light 5/5 PASS).

- 마이그레이션 165: client_error_logs + report_client_error/resolve_client_error RPC
- 클라 수집(error-report.js): 전역 핸들러 + friendlyErrorJa 훅, 마스킹·디바운스·무음
- 관리자 「오류 로그」 페인 + 상세 모달 + 사이드바 배지

## DB 변경
- 마이그레이션 165 운영 DB 적용 필요 (도쿄 nrwtujmlbktxjgdwlpjj). Edge Function 변경 없음(RPC만)

## 검증
- 개발 qa light 5/5 PASS (진입·필터·검색·상세·해결·배지), 콘솔 에러 0
- planner/supabase-expert/reviewer 게이트 전부 통과

## ⚠️ 약관 후속
- 개인정보처리방침 "오류 진단 정보 수집(개인정보 마스킹)" 1줄 추가 검토 권고 — 운영 배포 후 /약관확인

## 관련 사양서
- docs/specs/2026-06-02-client-error-reporting.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)