### PR TITLE
docs: 정산 지연 단체 메일 기록 + QA 스크린샷 ignore 보강

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,11 @@ memo-*.png
 more-menu-*.png
 faq-*.png
 msg-*.png
+admin-*.png
+errors-*.png
+toast-*.png
+inf-*.png
+regression-*.png
 
 # Sales 정적 이미지 assets는 QA 패턴에서 제외
 !dev/sales/images/

--- a/docs/notices/2026-06-02-payment-delay-notice.html
+++ b/docs/notices/2026-06-02-payment-delay-notice.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<!--
+  Mail: サーバー障害による精算システムの不具合について (정산 지연 사과 단체 공지)
+  발송: Brevo 단체 메일링 (일회성, 수동)
+  대상: 리뷰어/시딩 결과물 승인 모두 완료된 인플루언서
+        (Qoo10·@cosme 채널 중 하나라도 검수대기/미제출이면 제외)
+  성격: 트랜잭션(정산 안내) — marketing_opt_in 무관
+  Lang: JA
+  스타일: policy-change-notice.html 기반 + 인플 메일 4줄 푸터 (CLAUDE.md 규칙)
+-->
+<div style="font-family:'Hiragino Sans','Noto Sans JP',Arial,sans-serif;color:#222;max-width:600px;margin:0 auto;font-size:14px;line-height:1.7">
+  <h2 style="color:#5B6BBF;margin:0 0 6px;font-size:19px">サーバー障害による精算システムの不具合について</h2>
+  <p style="margin:0 0 18px;color:#666;font-size:13px">REVERB JP からの大切なお知らせです</p>
+
+  <p style="margin:0 0 16px">
+    現在、サーバー障害の影響により精算システムに不具合が発生しており、お支払いに遅延が生じております。<br>
+    ご利用の皆様には多大なるご迷惑とご不便をおかけしておりますこと、心よりお詫び申し上げます。
+  </p>
+
+  <div style="margin:0 0 16px;padding:12px 14px;background:#F4F6FF;border-radius:8px">
+    <div style="font-weight:700;color:#5B6BBF;margin-bottom:4px">■ お支払い予定</div>
+    <div style="font-size:15px;color:#222">6月15日より順次対応・実施させていただく予定です。</div>
+  </div>
+
+  <p style="margin:0 0 16px">
+    本件に関してご不明な点がございましたら、Global Reverb へログインのうえ、ご参加いただいたキャンペーンの「お問い合わせ」よりメッセージをお送りください。<br>
+    内容を確認次第、迅速にご対応させていただきます。
+  </p>
+
+  <p style="margin:0 0 16px">
+    何卒ご理解賜りますようお願い申し上げます。
+  </p>
+
+  <p style="margin:24px 0 0;color:#999;font-size:11px;line-height:1.6">
+    REVERB JP のメンバーシップに紐づいて自動送信されています。<br>
+    <br>
+    © JFUN Corp. · 株式会社ジェイファン<br>
+    <a href="https://globalreverb.com" style="color:#999;text-decoration:underline">https://globalreverb.com</a>
+  </p>
+</div>


### PR DESCRIPTION
## 변경 요약
- 정산 지연 사과 단체 메일 HTML 기록(`docs/notices/2026-06-02-payment-delay-notice.html`) — Brevo로 48명(결과물 승인 완료자)에게 발송 완료한 메일 본문
- `.gitignore`에 QA 스크린샷 패턴(admin-/errors-/toast-/inf-/regression-) 추가

## 요청 외 추가 변경
- 없음

## 영향
- 발송 완료 기록물 + ignore 규칙. 코드/빌드/DB/약관 무영향