### PR TITLE
약관·정책 보강 (허위리뷰·정정요구·환수·위반기록 3년 보관)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -273,6 +273,7 @@
 - 페이지 전환: 관리자/인플루언서 화면 같은 탭에서 이동 (새 탭 열기 금지)
 - 깜빡임 방지: visibility:hidden cloak 기법 (인플루언서+관리자 양쪽)
 - 마이페이지 서브해시: `#mypage-applications` 등 URL 해시로 서브페이지 복원
+- 약관/정책 수정: `docs/{TERMS,PRIVACY}_{kr,ja}.md` 가 source of truth. 인플루언서 앱 푸터 약관은 `dev/lib/legal.js` 가 이 4개 md 를 **런타임 fetch + 마크다운 렌더링** — 별도 복사본 없음, 문서만 고치면 앱 반영(빌드 무관). 변경 시 한·일 동시 수정 + 부칙 갱신 (`.claude/rules/policy.md`)
 
 ## Conventions
 - 인플루언서 페이지 UI 텍스트: 일본어


### PR DESCRIPTION
## 변경 요약
- 약관 4종(`TERMS_{kr,ja}`·`PRIVACY_{kr,ja}`) 문구 보강 — 사양서 `2026-05-27-terms-policy-reinforcement.md` B·C·D·F
  - 제11조 5번(광고 표기 정정 요구권)·제13조 4번(리워드 부정 수령 환수)·제16조 9·10번(허위·도용 리뷰 금지)
  - 개인정보처리방침 §6.1 보유기간 표에 「부정 이용·위반 기록 3년」 추가
  - 부칙 개정 이력: 공고 2026-06-02 / 시행 2026-06-09 (공고 후 7일, 중대 변경 아님)
- 마이그레이션 166 — `influencer_flags` 3년 경과 행 자동 삭제(`purge_old_influencer_flags()` + pg_cron 매일 KST 04:00). 위 「3년 보관」 정책 실제 집행

## 요청 외 추가 변경
- 사용자 결정으로 보관기간 정합화 방식 확정: `influencer_flags` 는 자동삭제 로직이 없어 사실상 영구 보관이었음 → 「3년 명시 + 자동삭제 cron 추가」(옵션 2) 채택
- CLAUDE.md: `influencer_flags` 정리 cron + 약관 fetch 방식(legal.js 런타임 fetch) 기록

## 관련 사양서
- docs/specs/2026-05-27-terms-policy-reinforcement.md (구현 결과 섹션 작성 완료)

## 배포 주의 (운영)
- 마이그레이션 166 을 개발 DB → 운영 DB SQL Editor 순차 적용 (cron 등록 확인)
- 앱 공지 게시일이 2026-06-02 아니면 부칙 공고·시행일(게시+7일) 4종 재조정
- reviewer GO (Critical 0). qa-tester: skip (문서·마이그레이션 전용)

🤖 Generated with [Claude Code](https://claude.com/claude-code)