### PR TITLE
fix: 일괄발송 이력 탭명 변경

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -12,7 +12,7 @@
 // 회귀(2026-05-12 PR #182 머지 직후 발생)를 방지하기 위한 자동 reload 가드.
 // sessionStorage 차단 환경(시크릿 모드 일부, 쿠키 차단)에서는 자연스럽게 skip.
 (function(){
-  var CURRENT_BUILD = 'v1780383936';
+  var CURRENT_BUILD = 'v1780386284';
   if (CURRENT_BUILD.indexOf('__') === 0) return; // 빌드 미적용 (dev/ 직접 열기) 시 skip
   try {
     var prev = sessionStorage.getItem('reverb.adminBuild');
@@ -1978,7 +1978,7 @@ textarea.form-input{resize:vertical;min-height:80px}
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-06-02 16:05 · ab9e508</span>
+          <span class="admin-build-text">2026-06-02 16:44 · a6a2678</span>
         </div>
       </div>
     </aside>
@@ -3035,7 +3035,7 @@ textarea.form-input{resize:vertical;min-height:80px}
                 <div style="font-size:16px;font-weight:700;color:var(--ink)">메시지</div>
                 <div class="inbox-tabs" style="display:flex;gap:4px">
                   <button class="inbox-tab is-active" id="inboxTabInbox" onclick="switchInboxTab('inbox')">받은편지함</button>
-                  <button class="inbox-tab" id="inboxTabBroadcasts" onclick="switchInboxTab('broadcasts')">발송 이력</button>
+                  <button class="inbox-tab" id="inboxTabBroadcasts" onclick="switchInboxTab('broadcasts')">일괄발송 이력</button>
                 </div>
               </div>
               <button class="btn btn-primary btn-sm" id="bulkMsgOpenBtn" onclick="openBulkMessageModal()" style="display:none;align-items:center;gap:4px">

--- a/dev/admin/index.html
+++ b/dev/admin/index.html
@@ -1189,7 +1189,7 @@
                 <div style="font-size:16px;font-weight:700;color:var(--ink)">메시지</div>
                 <div class="inbox-tabs" style="display:flex;gap:4px">
                   <button class="inbox-tab is-active" id="inboxTabInbox" onclick="switchInboxTab('inbox')">받은편지함</button>
-                  <button class="inbox-tab" id="inboxTabBroadcasts" onclick="switchInboxTab('broadcasts')">발송 이력</button>
+                  <button class="inbox-tab" id="inboxTabBroadcasts" onclick="switchInboxTab('broadcasts')">일괄발송 이력</button>
                 </div>
               </div>
               <button class="btn btn-primary btn-sm" id="bulkMsgOpenBtn" onclick="openBulkMessageModal()" style="display:none;align-items:center;gap:4px">


### PR DESCRIPTION
메시지 페인 헤더 「발송 이력」 → 「일괄발송 이력」 라벨 변경 (단순 문구).

🤖 Generated with [Claude Code](https://claude.com/claude-code)