### PR TITLE
fix: 일괄발송 캠페인 드롭다운 모달 클리핑 수정

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -12,7 +12,7 @@
 // 회귀(2026-05-12 PR #182 머지 직후 발생)를 방지하기 위한 자동 reload 가드.
 // sessionStorage 차단 환경(시크릿 모드 일부, 쿠키 차단)에서는 자연스럽게 skip.
 (function(){
-  var CURRENT_BUILD = 'v1780387153';
+  var CURRENT_BUILD = 'v1780388047';
   if (CURRENT_BUILD.indexOf('__') === 0) return; // 빌드 미적용 (dev/ 직접 열기) 시 skip
   try {
     var prev = sessionStorage.getItem('reverb.adminBuild');
@@ -1902,6 +1902,9 @@ textarea.form-input{resize:vertical;min-height:80px}
 .broadcast-recip-name { font-weight: 600; color: var(--ink); }
 .broadcast-recip-camp { flex: 1; font-size: 11px; color: var(--muted); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .broadcast-recip-status { font-size: 11px; color: var(--muted); }
+/* 일괄발송 캠페인 드롭다운 — 모달 body(overflow:auto)가 absolute 드롭을 자르는 문제 회피.
+   문서 흐름(static)으로 펼쳐 모달 자체 스크롤로 보이게 한다(포털 불필요, 이 드롭다운만 한정). */
+#bulkCampaignMulti .mf-drop { position: static; margin-top: 4px; min-width: 0; max-width: 100%; max-height: 240px; overflow-y: auto; box-shadow: none; border: 1px solid var(--line); }
 
 </style>
 </head>
@@ -1978,7 +1981,7 @@ textarea.form-input{resize:vertical;min-height:80px}
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-06-02 16:59 · dfc3820</span>
+          <span class="admin-build-text">2026-06-02 17:14 · 47ef73e</span>
         </div>
       </div>
     </aside>
@@ -4867,7 +4870,7 @@ textarea.form-input{resize:vertical;min-height:80px}
         <div id="bulkPresetInfo" style="display:none;font-size:13px;color:var(--muted);background:var(--bg);border-radius:10px;padding:10px 12px"></div>
         <div id="bulkCampaignPick">
           <div style="font-size:13px;color:var(--muted);margin-bottom:6px">캠페인 <span style="font-size:11px">(여러 개 선택 가능 · 이름·번호 검색)</span></div>
-          <div id="bulkCampaignMulti" class="mf-wrap" style="max-width:100%"><button type="button" class="mf-btn" style="width:100%;overflow:hidden;text-overflow:ellipsis">캠페인 선택</button><div class="mf-drop" style="min-width:300px;max-width:440px;max-height:300px;overflow-y:auto"></div></div>
+          <div id="bulkCampaignMulti" class="mf-wrap" style="max-width:100%"><button type="button" class="mf-btn" style="width:100%;overflow:hidden;text-overflow:ellipsis">캠페인 선택</button><div class="mf-drop"></div></div>
         </div>
         <div id="bulkFilters" style="display:none;flex-direction:column;gap:12px">
           <div>

--- a/dev/admin/index.html
+++ b/dev/admin/index.html
@@ -3023,7 +3023,7 @@
         <div id="bulkPresetInfo" style="display:none;font-size:13px;color:var(--muted);background:var(--bg);border-radius:10px;padding:10px 12px"></div>
         <div id="bulkCampaignPick">
           <div style="font-size:13px;color:var(--muted);margin-bottom:6px">캠페인 <span style="font-size:11px">(여러 개 선택 가능 · 이름·번호 검색)</span></div>
-          <div id="bulkCampaignMulti" class="mf-wrap" style="max-width:100%"><button type="button" class="mf-btn" style="width:100%;overflow:hidden;text-overflow:ellipsis">캠페인 선택</button><div class="mf-drop" style="min-width:300px;max-width:440px;max-height:300px;overflow-y:auto"></div></div>
+          <div id="bulkCampaignMulti" class="mf-wrap" style="max-width:100%"><button type="button" class="mf-btn" style="width:100%;overflow:hidden;text-overflow:ellipsis">캠페인 선택</button><div class="mf-drop"></div></div>
         </div>
         <div id="bulkFilters" style="display:none;flex-direction:column;gap:12px">
           <div>

--- a/dev/css/admin.css
+++ b/dev/css/admin.css
@@ -1452,3 +1452,6 @@
 .broadcast-recip-name { font-weight: 600; color: var(--ink); }
 .broadcast-recip-camp { flex: 1; font-size: 11px; color: var(--muted); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .broadcast-recip-status { font-size: 11px; color: var(--muted); }
+/* 일괄발송 캠페인 드롭다운 — 모달 body(overflow:auto)가 absolute 드롭을 자르는 문제 회피.
+   문서 흐름(static)으로 펼쳐 모달 자체 스크롤로 보이게 한다(포털 불필요, 이 드롭다운만 한정). */
+#bulkCampaignMulti .mf-drop { position: static; margin-top: 4px; min-width: 0; max-width: 100%; max-height: 240px; overflow-y: auto; box-shadow: none; border: 1px solid var(--line); }


### PR DESCRIPTION
qa가 발견한 드롭다운 클리핑 수정. .mf-drop(absolute)이 모달 overflow:auto에 잘려 검색창만 보이던 문제 → position:static 문서 흐름 펼침으로 전체 표시(모달 스크롤). 인라인 크기 제거하고 CSS로 제어.

🤖 Generated with [Claude Code](https://claude.com/claude-code)