### PR TITLE
[P0] fix: 게시물 URL 재제출 유니크 제약 위반 버그 수정

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -12,7 +12,7 @@
 // 회귀(2026-05-12 PR #182 머지 직후 발생)를 방지하기 위한 자동 reload 가드.
 // sessionStorage 차단 환경(시크릿 모드 일부, 쿠키 차단)에서는 자연스럽게 skip.
 (function(){
-  var CURRENT_BUILD = 'v1780388047';
+  var CURRENT_BUILD = 'v1780388808';
   if (CURRENT_BUILD.indexOf('__') === 0) return; // 빌드 미적용 (dev/ 직접 열기) 시 skip
   try {
     var prev = sessionStorage.getItem('reverb.adminBuild');
@@ -1981,7 +1981,7 @@ textarea.form-input{resize:vertical;min-height:80px}
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-06-02 17:14 · 47ef73e</span>
+          <span class="admin-build-text">2026-06-02 17:26 · f989d7b</span>
         </div>
       </div>
     </aside>
@@ -6512,6 +6512,44 @@ async function insertDraftDeliverable(payload) {
         return;  // 기존 행 갱신 완료 — INSERT 스킵
       }
     }
+    // post(게시물 URL) 재제출: uidx_deliverables_post_url(application_id, kind='post', post_url) UNIQUE 충돌 방지.
+    //   탐색은 application_id + kind='post' + post_url 3개 모두 일치(다른 게시물 덮어쓰기 방지).
+    //   기존 행이 approved(승인)면 되돌리지 않고 차단(승인 결과물 draft 추락 방지),
+    //   그 외(rejected/pending/draft)면 status='draft' 로 되돌리고 반려사유 초기화 + post_submissions append + 채널 갱신.
+    //   (사양서 docs/specs/2026-06-02-deliverable-post-url-duplicate-fix.md 경우의 수 ①·③)
+    if (payload.kind === 'post' && payload.post_url) {
+      const {data: existing, error: selErr} = await db?.from('deliverables')
+        .select('id, status, post_submissions')
+        .eq('application_id', payload.application_id)
+        .eq('kind', 'post')
+        .eq('post_url', payload.post_url)
+        .maybeSingle();
+      if (selErr) throw selErr;
+      if (existing?.id) {
+        if (existing.status === 'approved') {
+          // 승인된 게시물은 재제출로 덮어쓰지 않음 (경우의 수 ①)
+          const apErr = new Error('この投稿は既に承認済みです。');
+          apErr.code = 'post_already_approved';
+          throw apErr;
+        }
+        const prevSubs = Array.isArray(existing.post_submissions) ? existing.post_submissions : [];
+        const {error: upErr} = await db?.from('deliverables')
+          .update({
+            status: 'draft',
+            // 채널이 명시 전달된 경우만 갱신 — 빈값/undefined 면 기존 채널 보존
+            ...(payload.post_channel ? { post_channel: payload.post_channel } : {}),
+            reject_reason: null,
+            reject_template_code: null,
+            reviewed_by: null,
+            reviewed_at: null,
+            post_submissions: [...prevSubs, {url: payload.post_url, channel: payload.post_channel, submitted_at: new Date().toISOString()}]
+          })
+          .eq('id', existing.id);
+        if (upErr) throw upErr;
+        id = existing.id;
+        return;  // 기존 행 갱신 완료 — INSERT 스킵
+      }
+    }
     const row = {
       application_id: payload.application_id,
       user_id: payload.user_id,
@@ -8738,7 +8776,9 @@ const _ERR_DICT = {
     auth: 'セッションの有効期限が切れました。再ログインしてください',
     emailUnverified: 'メールアドレスの認証が完了していません',
     credentials: 'メールアドレスまたはパスワードが正しくありません',
-    slotsFull: '募集定員に達したため、応募を受け付けておりません'
+    slotsFull: '募集定員に達したため、応募を受け付けておりません',
+    postApproved: 'この投稿は既に承認済みのため、再提出できません',
+    postDuplicate: '同じURLは既に提出済みです'
   },
   ko: {
     unknown: '오류가 발생했습니다',
@@ -8753,7 +8793,9 @@ const _ERR_DICT = {
     auth: '인증이 만료되었습니다. 다시 로그인해주세요',
     emailUnverified: '이메일 인증이 완료되지 않았습니다',
     credentials: '이메일 또는 비밀번호가 올바르지 않습니다',
-    slotsFull: '모집 정원에 도달하여 신청이 마감되었습니다'
+    slotsFull: '모집 정원에 도달하여 신청이 마감되었습니다',
+    postApproved: '이미 승인된 게시물이라 다시 제출할 수 없습니다',
+    postDuplicate: '같은 URL은 이미 제출되었습니다'
   }
 };
 
@@ -8764,6 +8806,9 @@ function friendlyErrorJa(e) {
   const t = _ERR_DICT[lang];
   const s = String(e?.message || e || '');
   if (!s) return t.unknown;
+  // 게시물 URL 결과물 — 승인 차단·중복 URL 전용 안내 (일반 duplicate 보다 먼저 매칭)
+  if (e?.code === 'post_already_approved' || /既に承認済み/.test(s)) return t.postApproved;
+  if (/uidx_deliverables_post_url/.test(s)) return t.postDuplicate;
   if (/duplicate key|unique constraint|already exists/.test(s)) return t.duplicate;
   if (/permission denied|Permission denied|violates row-level security/.test(s)) return t.permission;
   if (/violates foreign key/.test(s)) return t.fk;

--- a/dev/js/ui.js
+++ b/dev/js/ui.js
@@ -89,7 +89,9 @@ const _ERR_DICT = {
     auth: 'セッションの有効期限が切れました。再ログインしてください',
     emailUnverified: 'メールアドレスの認証が完了していません',
     credentials: 'メールアドレスまたはパスワードが正しくありません',
-    slotsFull: '募集定員に達したため、応募を受け付けておりません'
+    slotsFull: '募集定員に達したため、応募を受け付けておりません',
+    postApproved: 'この投稿は既に承認済みのため、再提出できません',
+    postDuplicate: '同じURLは既に提出済みです'
   },
   ko: {
     unknown: '오류가 발생했습니다',
@@ -104,7 +106,9 @@ const _ERR_DICT = {
     auth: '인증이 만료되었습니다. 다시 로그인해주세요',
     emailUnverified: '이메일 인증이 완료되지 않았습니다',
     credentials: '이메일 또는 비밀번호가 올바르지 않습니다',
-    slotsFull: '모집 정원에 도달하여 신청이 마감되었습니다'
+    slotsFull: '모집 정원에 도달하여 신청이 마감되었습니다',
+    postApproved: '이미 승인된 게시물이라 다시 제출할 수 없습니다',
+    postDuplicate: '같은 URL은 이미 제출되었습니다'
   }
 };
 
@@ -115,6 +119,9 @@ function friendlyErrorJa(e) {
   const t = _ERR_DICT[lang];
   const s = String(e?.message || e || '');
   if (!s) return t.unknown;
+  // 게시물 URL 결과물 — 승인 차단·중복 URL 전용 안내 (일반 duplicate 보다 먼저 매칭)
+  if (e?.code === 'post_already_approved' || /既に承認済み/.test(s)) return t.postApproved;
+  if (/uidx_deliverables_post_url/.test(s)) return t.postDuplicate;
   if (/duplicate key|unique constraint|already exists/.test(s)) return t.duplicate;
   if (/permission denied|Permission denied|violates row-level security/.test(s)) return t.permission;
   if (/violates foreign key/.test(s)) return t.fk;

--- a/dev/lib/storage.js
+++ b/dev/lib/storage.js
@@ -858,6 +858,44 @@ async function insertDraftDeliverable(payload) {
         return;  // 기존 행 갱신 완료 — INSERT 스킵
       }
     }
+    // post(게시물 URL) 재제출: uidx_deliverables_post_url(application_id, kind='post', post_url) UNIQUE 충돌 방지.
+    //   탐색은 application_id + kind='post' + post_url 3개 모두 일치(다른 게시물 덮어쓰기 방지).
+    //   기존 행이 approved(승인)면 되돌리지 않고 차단(승인 결과물 draft 추락 방지),
+    //   그 외(rejected/pending/draft)면 status='draft' 로 되돌리고 반려사유 초기화 + post_submissions append + 채널 갱신.
+    //   (사양서 docs/specs/2026-06-02-deliverable-post-url-duplicate-fix.md 경우의 수 ①·③)
+    if (payload.kind === 'post' && payload.post_url) {
+      const {data: existing, error: selErr} = await db?.from('deliverables')
+        .select('id, status, post_submissions')
+        .eq('application_id', payload.application_id)
+        .eq('kind', 'post')
+        .eq('post_url', payload.post_url)
+        .maybeSingle();
+      if (selErr) throw selErr;
+      if (existing?.id) {
+        if (existing.status === 'approved') {
+          // 승인된 게시물은 재제출로 덮어쓰지 않음 (경우의 수 ①)
+          const apErr = new Error('この投稿は既に承認済みです。');
+          apErr.code = 'post_already_approved';
+          throw apErr;
+        }
+        const prevSubs = Array.isArray(existing.post_submissions) ? existing.post_submissions : [];
+        const {error: upErr} = await db?.from('deliverables')
+          .update({
+            status: 'draft',
+            // 채널이 명시 전달된 경우만 갱신 — 빈값/undefined 면 기존 채널 보존
+            ...(payload.post_channel ? { post_channel: payload.post_channel } : {}),
+            reject_reason: null,
+            reject_template_code: null,
+            reviewed_by: null,
+            reviewed_at: null,
+            post_submissions: [...prevSubs, {url: payload.post_url, channel: payload.post_channel, submitted_at: new Date().toISOString()}]
+          })
+          .eq('id', existing.id);
+        if (upErr) throw upErr;
+        id = existing.id;
+        return;  // 기존 행 갱신 완료 — INSERT 스킵
+      }
+    }
     const row = {
       application_id: payload.application_id,
       user_id: payload.user_id,

--- a/docs/specs/2026-06-02-deliverable-post-url-duplicate-fix.md
+++ b/docs/specs/2026-06-02-deliverable-post-url-duplicate-fix.md
@@ -1,0 +1,85 @@
+# [P0·최우선] 게시물 URL 재제출 시 유니크 제약 위반 버그 수정
+
+**작성일:** 2026-06-02
+**우선순위:** 🔴 **P0 (최우선)** — 운영 중 인플루언서가 결과물 제출에 막히는 실사용 차단 버그
+**상태:** 기획 초안 (개발 세션 즉시 착수 권장)
+**작성 세션:** 기획/설계 세션 (코드 직접 검증 완료)
+**제보:** 운영 오류 로그 — `duplicate key value violates unique constraint "uidx_deliverables_post_url"`, 화면 `#activity`, 2026-06-02 16:18, iPhone Safari
+
+---
+
+## 1. 증상
+
+인플루언서가 기프팅/방문형 캠페인 활동관리(`#activity`)에서 SNS 게시물 링크(URL)를 제출할 때, **같은 신청건에 같은 링크가 이미 있으면** 데이터베이스 유니크 제약 위반으로 제출이 실패한다. 친화적 일본어 에러로 변환되지 않아 날것의 제약 위반 메시지가 노출됐을 가능성이 크다.
+
+## 2. 현재 상태 (planning.md 규칙 A — 2026-06-02 코드 직접 검증)
+
+### 유니크 제약 정의
+`supabase/migrations/035_create_deliverables.sql:98`
+```sql
+CREATE UNIQUE INDEX uidx_deliverables_post_url
+  ON deliverables(application_id, kind, post_url)
+  WHERE kind = 'post' AND post_url IS NOT NULL;
+```
+→ **같은 신청(application_id) 안에서 kind='post'인 같은 post_url은 1건만.**
+
+### 근본 원인 — 결과물 저장 함수의 비대칭 누락
+`dev/lib/storage.js` `insertDraftDeliverable(payload)` (828행~):
+
+| 결과물 종류 | 기존 행 탐색 → UPDATE 분기 | 결과 |
+|---|---|---|
+| `review_image` (리뷰어 채널별 사진) | ✅ **있음** — 마이그레이션 158(리뷰어 채널 유니크 인덱스) 충돌 방지로 명시 추가. 같은 `application_id`+`kind='review_image'`+`post_channel` 행 있으면 `status='draft'`로 UPDATE 후 return(INSERT 스킵) | 재제출 안전 |
+| `post` (기프팅/방문형 게시물 URL) | ❌ **없음** — 무조건 `db.from('deliverables').insert(row)` | **같은 URL 재제출 시 유니크 위반** |
+
+게시물 URL 제출 진입점: `dev/js/application.js` `addDraftUrl()` (1164행~) → `insertDraftDeliverable({kind:'post', post_url, post_channel})`. 주석에 "마감 후라도 반려 이력 있으면 재제출 허용"이라 동일 URL 재제출 경로가 열려 있음.
+
+### 문서 불일치 (부가)
+`CLAUDE.md` "활동관리" 항목: **"동일 URL은 `post_submissions` 배열에 날짜 누적"** 이라 기재돼 있으나, 실제 클라이언트 코드엔 그 누적 분기가 **없다**. 문서가 의도한 동작이 미구현 상태.
+
+### 충돌 가능성 있는 기존 동작
+- `review_image` 분기는 이미 UPDATE 패턴을 쓰므로, `post`도 같은 패턴을 미러링하면 구조적으로 일관. 충돌 없음.
+
+## 3. 의심·경우의 수 (planning.md 규칙 B — 수정 시 반드시 고려)
+
+| # | 시나리오 | 위험 | 대응 |
+|---|---|---|---|
+| ① | **기존 post 행이 `approved`(승인) 상태인데 같은 URL 재제출** | `review_image`처럼 무조건 `status='draft'`로 되돌리면 **승인된 결과물이 draft로 떨어지는 사고** | 기존 행이 `approved`면 되돌리지 말고 **차단**(친화 안내). `rejected`/`pending`/`draft`일 때만 재제출 허용 |
+| ② | 같은 URL인데 **다른 채널**로 제출 | post는 URL별 1행(채널 무관 유니크)이라 같은 URL은 무조건 1건 | UPDATE 시 channel도 갱신, 혹은 안내 |
+| ③ | 한 신청에 **여러 다른 게시물(다른 URL)** 제출 | post는 URL별 1행이라 정상 — 탐색을 반드시 `post_url`까지 일치로 해야 함. `application_id`만으로 탐색하면 다른 URL 게시물을 덮어쓰는 사고 | 탐색 조건 = `application_id` + `kind='post'` + `post_url` 3개 모두 일치 |
+| ④ | `post_submissions` 누적 시 중복 날짜 | 같은 URL 여러 번이면 배열이 비대해짐 | 누적은 의도된 동작(이력). 무한 증가 아님 |
+| ⑤ | 친화 에러 미변환 | 사용자가 날것 제약명을 봄 | `friendlyErrorJa`에 매핑 병행 |
+
+### 의도 모호점
+- "재제출 허용"의 범위 — `rejected`만인지 `pending`도인지. **승인(`approved`)은 절대 재제출로 덮어쓰면 안 됨**(경우의 수 ①). 구현 시 status 가드 필수.
+
+## 4. 제안 — 수정 설계
+
+### 4-1. 근본 수정 (필수)
+`insertDraftDeliverable`의 `kind === 'post'` 경우에도 `review_image`와 동일한 "기존 행 탐색 → 분기" 추가:
+
+1. `application_id` + `kind='post'` + `post_url` **3개 모두 일치**하는 기존 행 조회(`.maybeSingle()`)
+2. 기존 행이 있으면:
+   - `status === 'approved'` → **차단**, 친화 안내("이미 승인된 게시물입니다") — 경우의 수 ①
+   - 그 외(`rejected`/`pending`/`draft`) → `status='draft'`로 되돌리고 `reject_reason` 등 초기화 + `post_submissions`에 `{url, channel, submitted_at}` **append**(CLAUDE.md 의도대로) + `post_channel` 갱신 → return(INSERT 스킵)
+3. 기존 행 없으면 → 현행 INSERT 진행
+
+`review_image` 분기(840~858행)를 패턴 참조하되 **status 가드(경우의 수 ①)와 post_url 일치 탐색(경우의 수 ③)을 반드시 포함**.
+
+### 4-2. 친화 에러 매핑 (병행 권장)
+`friendlyErrorJa`(또는 `friendlyError`)에 `uidx_deliverables_post_url` / `duplicate key` → "同じURLは既に提出済みです" 류 안내 추가. 근본 수정 후에도 만일의 동시성(다중 탭 동시 제출) 대비 안전망.
+
+### 4-3. 문서 정합
+- `CLAUDE.md` "활동관리"의 "동일 URL은 post_submissions 누적"이 실제 구현과 일치하게 됨 — 수정 후 한 줄 확인.
+
+## 5. 검증 (개발 세션)
+- 개발서버에서 기프팅/방문형 캠페인 결과물:
+  1. 같은 URL 두 번 제출 → 두 번째가 에러 없이 기존 행 갱신 + `post_submissions` 누적되는지
+  2. 승인된 게시물 같은 URL 재제출 → 차단되고 draft로 안 떨어지는지 (경우의 수 ①)
+  3. 다른 URL 게시물 추가 제출 → 별도 행으로 정상 생성(기존 게시물 안 덮어쓰는지, 경우의 수 ③)
+- `reverb-reviewer` + `reverb-qa-tester`(응모/결과물 플로우 변경이라 Full 또는 활동관리 시나리오)
+
+## 6. 배포
+- DB 변경 없음(클라이언트 로직 수정만) → `bash dev/build.sh` 재빌드 필요
+- 운영 핫픽스 성격(실사용 차단). dev 검증 후 운영 배포 여부는 사용자 확인. 보류 기능과 얽히면 메모리 `project_prod_hotfix_rebuild` 패턴(소스 diff apply + 재빌드)
+
+## 7. 구현 결과 (개발 세션이 채울 것)

--- a/index.html
+++ b/index.html
@@ -4862,6 +4862,44 @@ async function insertDraftDeliverable(payload) {
         return;  // 기존 행 갱신 완료 — INSERT 스킵
       }
     }
+    // post(게시물 URL) 재제출: uidx_deliverables_post_url(application_id, kind='post', post_url) UNIQUE 충돌 방지.
+    //   탐색은 application_id + kind='post' + post_url 3개 모두 일치(다른 게시물 덮어쓰기 방지).
+    //   기존 행이 approved(승인)면 되돌리지 않고 차단(승인 결과물 draft 추락 방지),
+    //   그 외(rejected/pending/draft)면 status='draft' 로 되돌리고 반려사유 초기화 + post_submissions append + 채널 갱신.
+    //   (사양서 docs/specs/2026-06-02-deliverable-post-url-duplicate-fix.md 경우의 수 ①·③)
+    if (payload.kind === 'post' && payload.post_url) {
+      const {data: existing, error: selErr} = await db?.from('deliverables')
+        .select('id, status, post_submissions')
+        .eq('application_id', payload.application_id)
+        .eq('kind', 'post')
+        .eq('post_url', payload.post_url)
+        .maybeSingle();
+      if (selErr) throw selErr;
+      if (existing?.id) {
+        if (existing.status === 'approved') {
+          // 승인된 게시물은 재제출로 덮어쓰지 않음 (경우의 수 ①)
+          const apErr = new Error('この投稿は既に承認済みです。');
+          apErr.code = 'post_already_approved';
+          throw apErr;
+        }
+        const prevSubs = Array.isArray(existing.post_submissions) ? existing.post_submissions : [];
+        const {error: upErr} = await db?.from('deliverables')
+          .update({
+            status: 'draft',
+            // 채널이 명시 전달된 경우만 갱신 — 빈값/undefined 면 기존 채널 보존
+            ...(payload.post_channel ? { post_channel: payload.post_channel } : {}),
+            reject_reason: null,
+            reject_template_code: null,
+            reviewed_by: null,
+            reviewed_at: null,
+            post_submissions: [...prevSubs, {url: payload.post_url, channel: payload.post_channel, submitted_at: new Date().toISOString()}]
+          })
+          .eq('id', existing.id);
+        if (upErr) throw upErr;
+        id = existing.id;
+        return;  // 기존 행 갱신 완료 — INSERT 스킵
+      }
+    }
     const row = {
       application_id: payload.application_id,
       user_id: payload.user_id,
@@ -7367,7 +7405,9 @@ const _ERR_DICT = {
     auth: 'セッションの有効期限が切れました。再ログインしてください',
     emailUnverified: 'メールアドレスの認証が完了していません',
     credentials: 'メールアドレスまたはパスワードが正しくありません',
-    slotsFull: '募集定員に達したため、応募を受け付けておりません'
+    slotsFull: '募集定員に達したため、応募を受け付けておりません',
+    postApproved: 'この投稿は既に承認済みのため、再提出できません',
+    postDuplicate: '同じURLは既に提出済みです'
   },
   ko: {
     unknown: '오류가 발생했습니다',
@@ -7382,7 +7422,9 @@ const _ERR_DICT = {
     auth: '인증이 만료되었습니다. 다시 로그인해주세요',
     emailUnverified: '이메일 인증이 완료되지 않았습니다',
     credentials: '이메일 또는 비밀번호가 올바르지 않습니다',
-    slotsFull: '모집 정원에 도달하여 신청이 마감되었습니다'
+    slotsFull: '모집 정원에 도달하여 신청이 마감되었습니다',
+    postApproved: '이미 승인된 게시물이라 다시 제출할 수 없습니다',
+    postDuplicate: '같은 URL은 이미 제출되었습니다'
   }
 };
 
@@ -7393,6 +7435,9 @@ function friendlyErrorJa(e) {
   const t = _ERR_DICT[lang];
   const s = String(e?.message || e || '');
   if (!s) return t.unknown;
+  // 게시물 URL 결과물 — 승인 차단·중복 URL 전용 안내 (일반 duplicate 보다 먼저 매칭)
+  if (e?.code === 'post_already_approved' || /既に承認済み/.test(s)) return t.postApproved;
+  if (/uidx_deliverables_post_url/.test(s)) return t.postDuplicate;
   if (/duplicate key|unique constraint|already exists/.test(s)) return t.duplicate;
   if (/permission denied|Permission denied|violates row-level security/.test(s)) return t.permission;
   if (/violates foreign key/.test(s)) return t.fk;


### PR DESCRIPTION
## 변경 요약
운영 P0 — 인플루언서가 같은 게시물 URL 재제출 시 `uidx_deliverables_post_url` 위반으로 제출 실패. `insertDraftDeliverable` 가 review_image엔 UPDATE 분기 있으나 post엔 없어 무조건 INSERT.
- post 분기 추가(review_image 패턴): application_id+kind=post+post_url 3개 일치 탐색, 기존 행 갱신+post_submissions 누적
- 가드: 승인(approved) 게시물은 차단(되돌리지 않음 — 승인 결과물 draft 추락 방지), 그 외만 재제출 허용
- friendlyErrorJa 친화 메시지(승인됨/중복 URL, 한·일)

## 요청 외 추가 변경
- 없음

## 관련 사양서
- docs/specs/2026-06-02-deliverable-post-url-duplicate-fix.md

reviewer GO(Critical 0). DB 변경 없음. 운영 핫픽스 — dev 검증 후 운영 배포 여부 사용자 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)