### PR TITLE
[P0 정정] fix: 게시물은 채널별 1건, 재제출 시 교체

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -12,7 +12,7 @@
 // 회귀(2026-05-12 PR #182 머지 직후 발생)를 방지하기 위한 자동 reload 가드.
 // sessionStorage 차단 환경(시크릿 모드 일부, 쿠키 차단)에서는 자연스럽게 skip.
 (function(){
-  var CURRENT_BUILD = 'v1780388808';
+  var CURRENT_BUILD = 'v1780390526';
   if (CURRENT_BUILD.indexOf('__') === 0) return; // 빌드 미적용 (dev/ 직접 열기) 시 skip
   try {
     var prev = sessionStorage.getItem('reverb.adminBuild');
@@ -1981,7 +1981,7 @@ textarea.form-input{resize:vertical;min-height:80px}
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-06-02 17:26 · f989d7b</span>
+          <span class="admin-build-text">2026-06-02 17:55 · 60ff85e</span>
         </div>
       </div>
     </aside>
@@ -6512,22 +6512,25 @@ async function insertDraftDeliverable(payload) {
         return;  // 기존 행 갱신 완료 — INSERT 스킵
       }
     }
-    // post(게시물 URL) 재제출: uidx_deliverables_post_url(application_id, kind='post', post_url) UNIQUE 충돌 방지.
-    //   탐색은 application_id + kind='post' + post_url 3개 모두 일치(다른 게시물 덮어쓰기 방지).
-    //   기존 행이 approved(승인)면 되돌리지 않고 차단(승인 결과물 draft 추락 방지),
-    //   그 외(rejected/pending/draft)면 status='draft' 로 되돌리고 반려사유 초기화 + post_submissions append + 채널 갱신.
-    //   (사양서 docs/specs/2026-06-02-deliverable-post-url-duplicate-fix.md 경우의 수 ①·③)
-    if (payload.kind === 'post' && payload.post_url) {
-      const {data: existing, error: selErr} = await db?.from('deliverables')
+    // post(게시물 URL) 제출: 채널마다 게시물 1건(교체). review_image 패턴과 동일하게 post_channel 기준 탐색.
+    //   (2026-06-02 사용자 결정: 기프팅/방문형 게시물은 채널별 1건 — 같은 채널 재제출은 같은 URL/다른 URL 모두 교체)
+    //   같은 채널의 기존 post 행이 있으면 그 행을 새 URL 로 교체(post_submissions 누적), 없으면 INSERT.
+    //   기존 행이 approved(승인)면 되돌리지 않고 차단(승인 결과물 draft 추락 방지).
+    //   ⚠️ 과거 버그(URL별 별도 행)로 같은 채널 post 가 여러 행일 수 있어 maybeSingle 대신 가장 오래된 1건 교체.
+    //   사양서 docs/specs/2026-06-02-deliverable-post-url-duplicate-fix.md (채널별 1건으로 정정)
+    if (payload.kind === 'post' && payload.post_channel) {
+      const {data: existRows, error: selErr} = await db?.from('deliverables')
         .select('id, status, post_submissions')
         .eq('application_id', payload.application_id)
         .eq('kind', 'post')
-        .eq('post_url', payload.post_url)
-        .maybeSingle();
+        .eq('post_channel', payload.post_channel)
+        .order('created_at', { ascending: true })
+        .limit(1);
       if (selErr) throw selErr;
+      const existing = existRows && existRows[0];
       if (existing?.id) {
         if (existing.status === 'approved') {
-          // 승인된 게시물은 재제출로 덮어쓰지 않음 (경우의 수 ①)
+          // 승인된 게시물은 재제출로 덮어쓰지 않음
           const apErr = new Error('この投稿は既に承認済みです。');
           apErr.code = 'post_already_approved';
           throw apErr;
@@ -6536,8 +6539,7 @@ async function insertDraftDeliverable(payload) {
         const {error: upErr} = await db?.from('deliverables')
           .update({
             status: 'draft',
-            // 채널이 명시 전달된 경우만 갱신 — 빈값/undefined 면 기존 채널 보존
-            ...(payload.post_channel ? { post_channel: payload.post_channel } : {}),
+            post_url: payload.post_url || null,   // 채널별 교체 — 새 URL 로 갱신
             reject_reason: null,
             reject_template_code: null,
             reviewed_by: null,

--- a/dev/lib/storage.js
+++ b/dev/lib/storage.js
@@ -858,22 +858,25 @@ async function insertDraftDeliverable(payload) {
         return;  // 기존 행 갱신 완료 — INSERT 스킵
       }
     }
-    // post(게시물 URL) 재제출: uidx_deliverables_post_url(application_id, kind='post', post_url) UNIQUE 충돌 방지.
-    //   탐색은 application_id + kind='post' + post_url 3개 모두 일치(다른 게시물 덮어쓰기 방지).
-    //   기존 행이 approved(승인)면 되돌리지 않고 차단(승인 결과물 draft 추락 방지),
-    //   그 외(rejected/pending/draft)면 status='draft' 로 되돌리고 반려사유 초기화 + post_submissions append + 채널 갱신.
-    //   (사양서 docs/specs/2026-06-02-deliverable-post-url-duplicate-fix.md 경우의 수 ①·③)
-    if (payload.kind === 'post' && payload.post_url) {
-      const {data: existing, error: selErr} = await db?.from('deliverables')
+    // post(게시물 URL) 제출: 채널마다 게시물 1건(교체). review_image 패턴과 동일하게 post_channel 기준 탐색.
+    //   (2026-06-02 사용자 결정: 기프팅/방문형 게시물은 채널별 1건 — 같은 채널 재제출은 같은 URL/다른 URL 모두 교체)
+    //   같은 채널의 기존 post 행이 있으면 그 행을 새 URL 로 교체(post_submissions 누적), 없으면 INSERT.
+    //   기존 행이 approved(승인)면 되돌리지 않고 차단(승인 결과물 draft 추락 방지).
+    //   ⚠️ 과거 버그(URL별 별도 행)로 같은 채널 post 가 여러 행일 수 있어 maybeSingle 대신 가장 오래된 1건 교체.
+    //   사양서 docs/specs/2026-06-02-deliverable-post-url-duplicate-fix.md (채널별 1건으로 정정)
+    if (payload.kind === 'post' && payload.post_channel) {
+      const {data: existRows, error: selErr} = await db?.from('deliverables')
         .select('id, status, post_submissions')
         .eq('application_id', payload.application_id)
         .eq('kind', 'post')
-        .eq('post_url', payload.post_url)
-        .maybeSingle();
+        .eq('post_channel', payload.post_channel)
+        .order('created_at', { ascending: true })
+        .limit(1);
       if (selErr) throw selErr;
+      const existing = existRows && existRows[0];
       if (existing?.id) {
         if (existing.status === 'approved') {
-          // 승인된 게시물은 재제출로 덮어쓰지 않음 (경우의 수 ①)
+          // 승인된 게시물은 재제출로 덮어쓰지 않음
           const apErr = new Error('この投稿は既に承認済みです。');
           apErr.code = 'post_already_approved';
           throw apErr;
@@ -882,8 +885,7 @@ async function insertDraftDeliverable(payload) {
         const {error: upErr} = await db?.from('deliverables')
           .update({
             status: 'draft',
-            // 채널이 명시 전달된 경우만 갱신 — 빈값/undefined 면 기존 채널 보존
-            ...(payload.post_channel ? { post_channel: payload.post_channel } : {}),
+            post_url: payload.post_url || null,   // 채널별 교체 — 새 URL 로 갱신
             reject_reason: null,
             reject_template_code: null,
             reviewed_by: null,

--- a/docs/specs/2026-06-02-deliverable-post-url-duplicate-fix.md
+++ b/docs/specs/2026-06-02-deliverable-post-url-duplicate-fix.md
@@ -82,4 +82,22 @@ CREATE UNIQUE INDEX uidx_deliverables_post_url
 - DB 변경 없음(클라이언트 로직 수정만) → `bash dev/build.sh` 재빌드 필요
 - 운영 핫픽스 성격(실사용 차단). dev 검증 후 운영 배포 여부는 사용자 확인. 보류 기능과 얽히면 메모리 `project_prod_hotfix_rebuild` 패턴(소스 diff apply + 재빌드)
 
-## 7. 구현 결과 (개발 세션이 채울 것)
+## 7. 구현 결과
+
+**구현일:** 2026-06-02
+**관련 커밋/PR:** dev #415(1차, post_url 기준) → **채널별 1건으로 정정**(feature/post-channel-fix)
+
+### 초안 대비 변경 — 경우의 수 ③ 정정 (중요)
+- 초안은 "다른 URL = 별도 행 허용"(여러 게시물)이었으나, **qa에서 데이터 정합성 문제 발견**: 관리자 결과물 관리(`admin-deliverables.js:243-244`)가 응모건당 post 1건 전제(`g.result` 단수)라, 다른 URL로 2건 생기면 **인플 화면 2건 / 관리자 화면 1건(먼저 행 가려짐)** 으로 불일치.
+- **2026-06-02 사용자 결정**: 게시물은 **채널별 1건**, 재제출(같은 URL/다른 URL)은 **같은 채널 기존 행 교체**.
+- 구현: 탐색 기준 `post_url` → **`post_channel`**(review_image 패턴), `maybeSingle` → `order(created_at).limit(1)`(과거 중복 대비), approved 차단 유지, post_url 새 값 갱신 + post_submissions append.
+- `friendlyErrorJa` + 사전: `postApproved`(승인 차단)·`postDuplicate`(uidx 안전망) 한·일.
+
+### 구현 중 기술 결정
+- 1차(#415) post_url 기준은 같은 URL 재제출만 막고 다른 URL은 별도 행 → 비즈니스(채널별 1건)와 불일치 → 채널별 교체로 재수정.
+
+### 후속 백로그 (별도 기획·사양서 필요)
+1. **관리자 결과물 관리 멀티채널 post 채널별 표시** — 현재 `g.result` 단수라 멀티채널 기프팅이면 채널별 게시물이 1건만 표시됨(가려짐). review_image처럼 채널별 배열 표시 필요.
+2. **스토리 = 이미지 제출**(1건에 여러 장) — 신규 기능. 인스타 스토리 등은 URL이 없어 이미지 제출.
+3. **채널별 1건 보장 유니크 인덱스**(DB, `(application_id, kind='post', post_channel)`) + **기존 중복 데이터 정리** — 과거 버그로 같은 채널 post 여러 행이 개발/운영 DB에 있을 수 있음. limit(1) 교체는 점진 수렴이라 잔여 중복은 별도 정리 SQL 필요.
+4. reviewer Warning: 다른 채널 같은 URL 시 `uidx_deliverables_post_url` 위반(드묾, 안전망 작동) — 채널-URL 조합 유니크 검토.

--- a/index.html
+++ b/index.html
@@ -4862,22 +4862,25 @@ async function insertDraftDeliverable(payload) {
         return;  // 기존 행 갱신 완료 — INSERT 스킵
       }
     }
-    // post(게시물 URL) 재제출: uidx_deliverables_post_url(application_id, kind='post', post_url) UNIQUE 충돌 방지.
-    //   탐색은 application_id + kind='post' + post_url 3개 모두 일치(다른 게시물 덮어쓰기 방지).
-    //   기존 행이 approved(승인)면 되돌리지 않고 차단(승인 결과물 draft 추락 방지),
-    //   그 외(rejected/pending/draft)면 status='draft' 로 되돌리고 반려사유 초기화 + post_submissions append + 채널 갱신.
-    //   (사양서 docs/specs/2026-06-02-deliverable-post-url-duplicate-fix.md 경우의 수 ①·③)
-    if (payload.kind === 'post' && payload.post_url) {
-      const {data: existing, error: selErr} = await db?.from('deliverables')
+    // post(게시물 URL) 제출: 채널마다 게시물 1건(교체). review_image 패턴과 동일하게 post_channel 기준 탐색.
+    //   (2026-06-02 사용자 결정: 기프팅/방문형 게시물은 채널별 1건 — 같은 채널 재제출은 같은 URL/다른 URL 모두 교체)
+    //   같은 채널의 기존 post 행이 있으면 그 행을 새 URL 로 교체(post_submissions 누적), 없으면 INSERT.
+    //   기존 행이 approved(승인)면 되돌리지 않고 차단(승인 결과물 draft 추락 방지).
+    //   ⚠️ 과거 버그(URL별 별도 행)로 같은 채널 post 가 여러 행일 수 있어 maybeSingle 대신 가장 오래된 1건 교체.
+    //   사양서 docs/specs/2026-06-02-deliverable-post-url-duplicate-fix.md (채널별 1건으로 정정)
+    if (payload.kind === 'post' && payload.post_channel) {
+      const {data: existRows, error: selErr} = await db?.from('deliverables')
         .select('id, status, post_submissions')
         .eq('application_id', payload.application_id)
         .eq('kind', 'post')
-        .eq('post_url', payload.post_url)
-        .maybeSingle();
+        .eq('post_channel', payload.post_channel)
+        .order('created_at', { ascending: true })
+        .limit(1);
       if (selErr) throw selErr;
+      const existing = existRows && existRows[0];
       if (existing?.id) {
         if (existing.status === 'approved') {
-          // 승인된 게시물은 재제출로 덮어쓰지 않음 (경우의 수 ①)
+          // 승인된 게시물은 재제출로 덮어쓰지 않음
           const apErr = new Error('この投稿は既に承認済みです。');
           apErr.code = 'post_already_approved';
           throw apErr;
@@ -4886,8 +4889,7 @@ async function insertDraftDeliverable(payload) {
         const {error: upErr} = await db?.from('deliverables')
           .update({
             status: 'draft',
-            // 채널이 명시 전달된 경우만 갱신 — 빈값/undefined 면 기존 채널 보존
-            ...(payload.post_channel ? { post_channel: payload.post_channel } : {}),
+            post_url: payload.post_url || null,   // 채널별 교체 — 새 URL 로 갱신
             reject_reason: null,
             reject_template_code: null,
             reviewed_by: null,


### PR DESCRIPTION
## 변경 요약
P0 1차 수정(#415, post_url 기준)의 정정. qa에서 데이터 정합성 문제 발견 — 관리자 결과물 관리가 응모건당 게시물 1건 전제(g.result 단수)인데, post_url 기준이면 다른 URL 제출 시 별도 행 → 인플 2건/관리자 1건 불일치.
- 사용자 결정: **게시물은 채널별 1건, 재제출(같은/다른 URL)은 같은 채널 기존 행 교체**
- 탐색 post_url → post_channel(review_image 패턴), limit(1), approved 차단 유지

## 요청 외 추가 변경
- 없음

## 관련 사양서
- docs/specs/2026-06-02-deliverable-post-url-duplicate-fix.md (구현 결과·정정·후속 백로그 작성)

## 후속 백로그
관리자 멀티채널 post 채널별 표시 / 스토리=이미지 제출 / 채널별 유니크 인덱스+중복정리 (별도 기획)

reviewer GO. DB 변경 없음. 운영 핫픽스

🤖 Generated with [Claude Code](https://claude.com/claude-code)