### PR TITLE
fix(messaging+admin): 일괄발송 드롭다운 폰트 + 채널 코드 노출(@cosme) 수정

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -12,7 +12,7 @@
 // 회귀(2026-05-12 PR #182 머지 직후 발생)를 방지하기 위한 자동 reload 가드.
 // sessionStorage 차단 환경(시크릿 모드 일부, 쿠키 차단)에서는 자연스럽게 skip.
 (function(){
-  var CURRENT_BUILD = 'v1780392545';
+  var CURRENT_BUILD = 'v1780392835';
   if (CURRENT_BUILD.indexOf('__') === 0) return; // 빌드 미적용 (dev/ 직접 열기) 시 skip
   try {
     var prev = sessionStorage.getItem('reverb.adminBuild');
@@ -1983,7 +1983,7 @@ textarea.form-input{resize:vertical;min-height:80px}
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-06-02 18:29 · 4bd858d</span>
+          <span class="admin-build-text">2026-06-02 18:33 · 645ad6e</span>
         </div>
       </div>
     </aside>
@@ -27586,6 +27586,11 @@ async function init() {
     // 메시지 배지는 refreshInboxData 끝의 updateInboxSidebarBadge 가 갱신 — 부트에서도 호출해
     // 새로고침 시 즉시 노출 (기존엔 페인 클릭 시에만 갱신되어 0으로 보이던 회귀).
     if (typeof refreshInboxData === 'function') refreshInboxData();
+
+    // 채널·카테고리·콘텐츠 종류 lookup 캐시 선로딩 (페인 분기보다 먼저, 모든 화면 공통).
+    // getChannelLabel 등은 동기 함수라 캐시가 없으면 @cosme(code: channel-xxxx)·LIPS 처럼
+    // CHANNEL_LABEL_FALLBACK 에 없는 채널이 코드 원문으로 노출됨. 진입 전에 1회 보장.
+    try { await Promise.all([fetchLookups('channel'), fetchLookups('category'), fetchLookups('content_type')]); } catch(e) { /* 폴백 OK — 화면 깨짐 없음 */ }
 
     // PR 3 부트 경량화 — 진입 화면(hash)에 필요한 데이터만 로드
     //  - dashboard: KPI·차트용 무거운 3종(캠페인/인플/신청 전건)을 여기서만 로드

--- a/admin/index.html
+++ b/admin/index.html
@@ -12,7 +12,7 @@
 // 회귀(2026-05-12 PR #182 머지 직후 발생)를 방지하기 위한 자동 reload 가드.
 // sessionStorage 차단 환경(시크릿 모드 일부, 쿠키 차단)에서는 자연스럽게 skip.
 (function(){
-  var CURRENT_BUILD = 'v1780391825';
+  var CURRENT_BUILD = 'v1780392545';
   if (CURRENT_BUILD.indexOf('__') === 0) return; // 빌드 미적용 (dev/ 직접 열기) 시 skip
   try {
     var prev = sessionStorage.getItem('reverb.adminBuild');
@@ -1905,6 +1905,8 @@ textarea.form-input{resize:vertical;min-height:80px}
 /* 일괄발송 캠페인 드롭다운 — 모달 body(overflow:auto)가 absolute 드롭을 자르는 문제 회피.
    문서 흐름(static)으로 펼쳐 모달 자체 스크롤로 보이게 한다(포털 불필요, 이 드롭다운만 한정). */
 #bulkCampaignMulti .mf-drop { position: static; margin-top: 4px; min-width: 0; max-width: 100%; max-height: 240px; overflow-y: auto; box-shadow: none; border: 1px solid var(--line); }
+/* 부가설명에 한글(모집타입·상태) 혼재 — 고정폭 대신 본문 폰트로 가독성 확보 (캠페인 번호 단독 드롭다운은 monospace 유지) */
+#bulkCampaignMulti .mf-item-sub { font-family: inherit; }
 
 </style>
 </head>
@@ -1981,7 +1983,7 @@ textarea.form-input{resize:vertical;min-height:80px}
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-06-02 18:17 · 3a3321b</span>
+          <span class="admin-build-text">2026-06-02 18:29 · 4bd858d</span>
         </div>
       </div>
     </aside>

--- a/dev/admin/app.js
+++ b/dev/admin/app.js
@@ -86,6 +86,11 @@ async function init() {
     // 새로고침 시 즉시 노출 (기존엔 페인 클릭 시에만 갱신되어 0으로 보이던 회귀).
     if (typeof refreshInboxData === 'function') refreshInboxData();
 
+    // 채널·카테고리·콘텐츠 종류 lookup 캐시 선로딩 (페인 분기보다 먼저, 모든 화면 공통).
+    // getChannelLabel 등은 동기 함수라 캐시가 없으면 @cosme(code: channel-xxxx)·LIPS 처럼
+    // CHANNEL_LABEL_FALLBACK 에 없는 채널이 코드 원문으로 노출됨. 진입 전에 1회 보장.
+    try { await Promise.all([fetchLookups('channel'), fetchLookups('category'), fetchLookups('content_type')]); } catch(e) { /* 폴백 OK — 화면 깨짐 없음 */ }
+
     // PR 3 부트 경량화 — 진입 화면(hash)에 필요한 데이터만 로드
     //  - dashboard: KPI·차트용 무거운 3종(캠페인/인플/신청 전건)을 여기서만 로드
     //  - 그 외 페인: 각 페인 loader 가 자기 데이터를 스스로 fetch → 무거운 3종 스킵

--- a/dev/css/admin.css
+++ b/dev/css/admin.css
@@ -1455,3 +1455,5 @@
 /* 일괄발송 캠페인 드롭다운 — 모달 body(overflow:auto)가 absolute 드롭을 자르는 문제 회피.
    문서 흐름(static)으로 펼쳐 모달 자체 스크롤로 보이게 한다(포털 불필요, 이 드롭다운만 한정). */
 #bulkCampaignMulti .mf-drop { position: static; margin-top: 4px; min-width: 0; max-width: 100%; max-height: 240px; overflow-y: auto; box-shadow: none; border: 1px solid var(--line); }
+/* 부가설명에 한글(모집타입·상태) 혼재 — 고정폭 대신 본문 폰트로 가독성 확보 (캠페인 번호 단독 드롭다운은 monospace 유지) */
+#bulkCampaignMulti .mf-item-sub { font-family: inherit; }


### PR DESCRIPTION
## 변경 요약
- **일괄발송 드롭다운 부가설명 폰트**: 한글(모집타입·상태) 혼재로 고정폭 폰트가 어색 → 일괄발송 드롭다운만 본문 폰트로(`#bulkCampaignMulti` 한정). 다른 화면 캠페인 번호 정렬은 유지
- **채널 코드 노출 근본 수정**: `@cosme`(내부 코드 `channel-96r9y3`)·`LIPS`가 일부 관리자 화면에서 코드 원문으로 노출되던 문제. 원인은 채널 이름 변환 캐시가 로드되기 전에 표시 함수가 호출된 것(데이터는 정상). 관리자 부팅 시 채널·카테고리·콘텐츠 종류 기준 데이터 캐시를 미리 1회 로드해 **모든 관리자 화면**에서 이름이 제대로 표시되도록 함

## 요청 외 추가 변경
- 없음 (채널 코드 노출은 일괄발송 드롭다운 검증 중 발견된 동일 영역 후속)

## 관련 사양서
- 없음

## 리뷰
[via reviewer] GO — 폰트 스코프 정확, 부팅 preload 위치가 메시지 페인 직행도 커버, fetchLookups 멱등(중복 쿼리 없음), 폴백 graceful, 부팅 경량화 의도와 충돌 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)