### PR TITLE
docs/chore: 서비스 건강도 점검 정정 (도쿄 stale·코드맵·미사용함수·gitignore)

### DIFF
--- a/.claude/agents/reverb-supabase-expert.md
+++ b/.claude/agents/reverb-supabase-expert.md
@@ -60,7 +60,7 @@ model: sonnet
 - [ ] 운영 DB 변경은 개발서버 먼저 → 검증 → 운영 적용
 
 ## 환경 분리
-- 운영서버: `twofagomeizrtkwlhsuv.supabase.co` (🇦🇺 Sydney `ap-southeast-2`, Pro / NANO compute)
+- 운영서버: `nrwtujmlbktxjgdwlpjj.supabase.co` (🇯🇵 Tokyo `ap-northeast-1`, Pro / NANO compute) — 2026-05-27 도쿄 이관 완료
 - 개발서버: `qysmxtipobomefudyixw.supabase.co` (🇯🇵 Tokyo `ap-northeast-1`, Pro / MICRO compute)
 - Org `jfun-reverb's Org`가 PRO 플랜 — 양 프로젝트 모두 Pro 혜택 적용 (compute만 별도 add-on)
 - URL/Key는 `SUPABASE_ENVS` 객체에서만 (하드코딩 금지)

--- a/.claude/commands/db-check.md
+++ b/.claude/commands/db-check.md
@@ -1,7 +1,7 @@
 Supabase 데이터베이스 상태 확인:
 
 1. **연결 확인**: Supabase REST API로 각 테이블 쿼리
-   - URL: https://twofagomeizrtkwlhsuv.supabase.co
+   - URL: https://nrwtujmlbktxjgdwlpjj.supabase.co
    - anon key 사용
 2. **테이블별 확인**:
    - `campaigns` — 행 수, status별 분포 (draft/scheduled/active/closed), 최근 생성일

--- a/.claude/rules/supabase.md
+++ b/.claude/rules/supabase.md
@@ -6,7 +6,7 @@ globs: "dev/lib/*.js,dev/js/*.js,supabase/**/*.sql"
 # Supabase 규칙
 
 ## 환경 분리
-- **운영서버**: `twofagomeizrtkwlhsuv.supabase.co` (🇦🇺 Sydney `ap-southeast-2`, Pro / NANO compute)
+- **운영서버**: `nrwtujmlbktxjgdwlpjj.supabase.co` (🇯🇵 Tokyo `ap-northeast-1`, Pro / NANO compute) — 2026-05-27 도쿄 이관 완료
 - **개발서버**: `qysmxtipobomefudyixw.supabase.co` (🇯🇵 Tokyo `ap-northeast-1`, Pro / MICRO compute) — Org 레벨 PRO라 양 프로젝트 모두 Pro 혜택
 - URL/Key 관리는 `dev/lib/supabase.js`의 `SUPABASE_ENVS`에서만 (하드코딩 금지)
 - 도메인 분기: `globalreverb.com` / `www.globalreverb.com` → 운영, 나머지 → 개발
@@ -24,7 +24,7 @@ globs: "dev/lib/*.js,dev/js/*.js,supabase/**/*.sql"
 - service_role key는 절대 클라이언트 코드에 넣지 않음
 
 ## Auth Confirm email 환경별 설정
-- **운영 프로젝트** (twofagomeizrtkwlhsuv): Authentication → Sign In / Providers → Email → `Confirm email` **ON** 유지 필수 (보안·메일 유효성 검증)
+- **운영 프로젝트** (nrwtujmlbktxjgdwlpjj): Authentication → Sign In / Providers → Email → `Confirm email` **ON** 유지 필수 (보안·메일 유효성 검증)
 - **개발 프로젝트** (qysmxtipobomefudyixw): `Confirm email` **OFF** — 테스트 인플루언서 계정 즉시 로그인 가능 (2026-04-16 설정)
 - 클라이언트 코드는 `signUp` 응답의 `data.session` 유무로 분기 (auth.js:57-65): session 있으면 바로 홈으로, 없으면 메일 확인 안내 화면
 - **대시보드 수동 설정은 repo에 반영되지 않음** — Supabase 프로젝트 재구축 시 이 섹션 참고하여 다시 설정

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,9 @@ errors-*.png
 toast-*.png
 inf-*.png
 regression-*.png
+activity-*.png
+broadcast-*.png
+bulk-*.png
 
 # Sales 정적 이미지 assets는 QA 패턴에서 제외
 !dev/sales/images/

--- a/admin/index.html
+++ b/admin/index.html
@@ -12,7 +12,7 @@
 // 회귀(2026-05-12 PR #182 머지 직후 발생)를 방지하기 위한 자동 reload 가드.
 // sessionStorage 차단 환경(시크릿 모드 일부, 쿠키 차단)에서는 자연스럽게 skip.
 (function(){
-  var CURRENT_BUILD = 'v1780392835';
+  var CURRENT_BUILD = 'v1780394945';
   if (CURRENT_BUILD.indexOf('__') === 0) return; // 빌드 미적용 (dev/ 직접 열기) 시 skip
   try {
     var prev = sessionStorage.getItem('reverb.adminBuild');
@@ -1983,7 +1983,7 @@ textarea.form-input{resize:vertical;min-height:80px}
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-06-02 18:33 · 645ad6e</span>
+          <span class="admin-build-text">2026-06-02 19:09 · 25bcbc4</span>
         </div>
       </div>
     </aside>
@@ -15702,12 +15702,6 @@ function inboxCampaignById(id) {
 function campaignTitleById(id) {
   const c = inboxCampaignById(id);
   return c ? (c.title || '(제목 없음)') : '(캠페인)';
-}
-function influencerNameById(id) {
-  if (!id) return '(인플루언서)';
-  const inf = _inboxInflMap && _inboxInflMap[id];
-  if (!inf) return '(인플루언서)';
-  return inf.name || inf.name_kana || inf.email || '(이름 없음)';
 }
 
 // ════════════════════════════════════════════════════════════════════

--- a/dev/js/admin-messaging.js
+++ b/dev/js/admin-messaging.js
@@ -889,12 +889,6 @@ function campaignTitleById(id) {
   const c = inboxCampaignById(id);
   return c ? (c.title || '(제목 없음)') : '(캠페인)';
 }
-function influencerNameById(id) {
-  if (!id) return '(인플루언서)';
-  const inf = _inboxInflMap && _inboxInflMap[id];
-  if (!inf) return '(인플루언서)';
-  return inf.name || inf.name_kana || inf.email || '(이름 없음)';
-}
 
 // ════════════════════════════════════════════════════════════════════
 // 일괄 발송 (BCC) — PR 3, 마이그레이션 167

--- a/docs/CODEMAPS/admin-app.md
+++ b/docs/CODEMAPS/admin-app.md
@@ -193,6 +193,12 @@ campaigns, applications, influencers, influencer_flags, deliverables, deliverabl
 ### storage.js 호출 함수 (주요)
 fetchCampaigns, fetchInfluencers, fetchApplications, fetchDeliverables, fetchDeliverablesByCampaign, fetchLookupsAll, fetchParticipationSetsAll, fetchCautionSetsAll, fetchNgSetsAll, setInfluencerVerified, setInfluencerBlacklist, recordInfluencerViolation, updateDeliverableStatus
 
+### 응모건 메시지 (admin-messaging.js)
+- `loadMessagesInbox()` — 받은편지함 3단 페인(#adminPane-messages) 진입
+- `openAdminMessageModal(appId, campId)` / `sendAdminMessage()` — 응모건 1:1 메시지 모달·관리자 발신
+- `hideApplicationMessage()` / `unhideApplicationMessage()` / `markApplicationResolved()` — 강제 숨김·복구·응대 완료
+- **일괄 발송 (BCC, PR 3·마이그레이션 167)**: `openBulkMessageModal()` — 캠페인 다중선택(mf-wrap)+필터 2단계 모달 / `recountBulk()` — 캠페인별 대상 합산(resolveBulkRecipients N회) / `confirmBulkSend()` — 발송(sendApplicationMessageBulk) / `switchInboxTab()` — 받은편지함·발송이력 탭 / `loadBroadcasts()`·`openBroadcastDetail()`·`confirmBroadcastWithdraw()` — 발송 이력 목록·상세·일괄 회수(withdrawBroadcast)
+
 ### 원격 호출 함수(RPC) — 관리자 전용
 invite_admin, remove_admin_role, delete_admin_completely, update_receipt_admin, record_caution_history
 

--- a/docs/CODEMAPS/data-layer.md
+++ b/docs/CODEMAPS/data-layer.md
@@ -105,7 +105,7 @@
 - 운영 현황: `get_brand_ops_overview` / `get_brand_ops_detail`(≈120)
 - 홍보 메일 헬퍼: `get_promo_digest_targets` / `mark_promo_digest_sent` / `track_promo_click`(141)
 
-## 마이그레이션 최근 흐름 (125~144)
+## 마이그레이션 최근 흐름 (125~167)
 ```
 128 receipt_required_fields        영수증 필수 필드(order_number/purchase_date/purchase_amount)
 129 remove_post_deadline           campaigns.post_deadline 제거(노출 토글로 교체)
@@ -120,12 +120,35 @@
 142 promo_digest_cron               캠페인 홍보 메일 cron 스케줄
 143 promo_targets_total_counts      홍보 메일 대상 건수 집계
 144 application_messages            응모건 메시지 PR 1 (테이블/뷰/RPC/트리거)
+145 application_messages_pr2        응모건 메시지 PR 2 (관리자 발신/숨김/응대)
+146 faq_nodes_and_interactions      자동응답 FAQ 트리/측정
+147 companies_backfill              회사명 기반 회사 마스터 백필
+148 brand_ops_alert_reasons         운영 현황 사유 배너
+149 brand_ops_detail_camp_expand    브랜드 상세 캠페인 확장
+150 brand_ops_detail_camp_periods   브랜드 상세 구매/방문 기간
+151 campaign_application_counts     캠페인 신청 카운트 DB 집계
+152 admin_promo_email_subscription  관리자 홍보 메일 구독
+153 policy_notice_log               약관 30일 사전 통지 로그
+154 application_approved_notification 승인 알림 트리거
+155 faq_nodes_text_fix              FAQ 문구 정정
+156 campaign_status_ended           closed→ended 자동 전이
+157 lips_cosme_channels             LIPS/@cosme 채널(리뷰어 전용)
+158 review_image_channel_unique     리뷰어 채널별 결과물 유니크
+159 review_image_channel_notification 채널별 결과물 알림
+160 admin_proxy_deliverable         관리자 결과물 대리 등록
+161 admin_proxy_notify_reason_label 대리 등록 알림 사유 라벨
+162 review_image_channel_assign     레거시 결과물 채널 지정
+163 admin_proxy_evidence            대리 등록 증빙
+164 admin_email_consolidation       관리자 메일 종류 통합(daily_digest)
+165 client_error_logs               사용자 앱 에러 수집
+166 influencer_flags_retention      위반 기록 3년 정리 cron
+167 bulk_message                    응모건 메시지 일괄 발송(PR 3) RPC 4종
 ```
 > 정확한 번호·파일명은 항상 `ls supabase/migrations/` 로 확인.
 
 ## 환경 분기 (supabase.js)
 - `SUPABASE_ENVS` — production / staging 2개
-  - production: `twofagomeizrtkwlhsuv.supabase.co` (globalreverb.com, www.globalreverb.com)
+  - production: `nrwtujmlbktxjgdwlpjj.supabase.co` (globalreverb.com, www.globalreverb.com) — 🇯🇵 Tokyo, 2026-05-27 이관
   - staging: `qysmxtipobomefudyixw.supabase.co` (dev.globalreverb.com, localhost, 그 외 전부)
 - `resolveSupabaseEnv(hostname)` — 운영 도메인만 엄격 매칭, 나머지는 staging
 - 전역 플래그: `IS_STAGING`, `window.__REVERB_ENV__`

--- a/docs/PROJECT_CONTEXT.md
+++ b/docs/PROJECT_CONTEXT.md
@@ -25,9 +25,9 @@
 
 ### 2-1. 개인정보 보호
 - **한국 PIPA** (개인정보 보호법) + **일본 APPI** (個人情報保護法) **이중 준수**
-- **국외 이전 동의**: 일본 거주자 데이터를 **호주 시드니**(Supabase 운영 — AWS Sydney 리전)로 이전함에 대한 **명시적 동의 필수**. 현재 `influencers.terms_agreed_at`, `privacy_agreed_at`에서 포괄 동의 기록 중. 추후 "국외 이전" 별도 동의 항목 분리 예정.
+- **국외 이전 동의**: 일본 거주자 데이터를 **일본 도쿄**(Supabase 운영 — AWS Tokyo `ap-northeast-1` 리전, 2026-05-27 시드니→도쿄 이관 완료)로 이전함에 대한 **명시적 동의 필수**. 현재 `influencers.terms_agreed_at`, `privacy_agreed_at`에서 포괄 동의 기록 중. 추후 "국외 이전" 별도 동의 항목 분리 예정.
 - **처리위탁 업체** (개인정보처리방침 §처리위탁 반영 대상):
-  - **Supabase Inc.** (미국 법인 / 데이터 처리 리전: 호주 시드니 AWS) — DB, Auth, Storage, Email Confirmation
+  - **Supabase Inc.** (미국 법인 / 데이터 처리 리전: 일본 도쿄 AWS) — DB, Auth, Storage, Email Confirmation
   - **Vercel Inc.** (미국) — 정적 호스팅, 엣지 함수
   - **Brevo (Sendinblue SA)** (프랑스, EU) — 트랜잭션 메일 발송 (SMTP 릴레이)
   - 각 업체별로 위탁 사항·위탁 기간·국외 이전 경유지 명시 필요
@@ -77,7 +77,7 @@
 - **신규 개인정보 수집 채널**: `brand_applications` 테이블은 인플루언서 데이터와 **별개**의 광고주 개인정보 수집 채널. 수집 항목: 담당자 이름·전화·이메일·세금계산서 이메일(reviewer). 사업자등록증 이미지 및 `brand-docs` Storage 버킷은 2026-04-21(migration 057)에 수집·저장 중단
 - **Edge Function**: `notify-brand-application` (Supabase Functions) — `brand_applications` INSERT 후 클라이언트가 호출 → `admins.receive_brand_notify=true` + env `NOTIFY_ADMIN_EMAILS` 합산 대상에게 Brevo SMTP 경유 알림 메일 발송
 - **서브도메인**: `sales.globalreverb.com` / `sales-dev.globalreverb.com` (별도 Vercel 프로젝트 `reverb-sales`, Root Directory=`sales/`). `noindex/nofollow` 메타 유지(검색 노출 차단). 별도 favicon으로 STAGING DEV 아이콘 누수 방지
-- **PIPA/APPI 일관성**: 광고주 데이터도 호주 시드니 AWS 리전(Supabase 운영)으로 국외 이전됨 → PRIVACY §5 반영 필요 (docs/PRIVACY_{kr,ja}.md §5 광고주 항목 포함됨)
+- **PIPA/APPI 일관성**: 광고주 데이터도 일본 도쿄 AWS 리전(Supabase 운영, 2026-05-27 도쿄 이관)으로 국외 이전됨 → PRIVACY §5 반영 필요 (docs/PRIVACY_{kr,ja}.md §5 광고주 항목 포함됨)
 - **처리위탁 범위**: Edge Function·Storage 모두 Supabase Inc. 위탁 내. 별도 수탁사 추가 없음 (2026-04-20 결정)
 - **광고주 자유 입력란**(운영, migration 068, 2026-04-23): `brand_applications.request_note text NULL` — 신청 폼 「기타/요청사항」 자유 입력. `submit_brand_application()` 원격 호출 함수(RPC)에 `p_request_note` 파라미터 추가. 외부 노출 형식 변경이지만 신규 수집 항목 아님 — 약관 영향 없음. 자유 입력란이라 광고주가 본인 외 제3자 정보를 입력할 위험은 운영 가이드(폼 안내 문구)로 대응
 - **신청번호 포맷 (운영)**: 서버 트리거가 v1 `JFUN-{Q|N}-YYYYMMDD-NNN`(reviewer=Q, seeding=N, 연도 4자리 숫자) 채번 — `brand_applications.application_no` UNIQUE

--- a/docs/service-flow.html
+++ b/docs/service-flow.html
@@ -160,7 +160,7 @@ flowchart TB
     B7 -->|OK| B8[anon INSERT<br/>submit_brand_application RPC]
   end
 
-  subgraph DB["🗃 Supabase (Sydney)"]
+  subgraph DB["🗃 Supabase (Tokyo)"]
     T1[BEFORE INSERT 트리거<br/>generate_brand_application_no<br/>JST JFUN-Q|N-YYYYMMDD-NNN] --> T2[BEFORE INSERT 트리거<br/>recalc_brand_application_totals<br/>total_jpy · total_qty · estimated_krw]
     T2 --> T3[INSERT 완료<br/>status=new]
   end


### PR DESCRIPTION
전수조사 발견 6건 정정 (P0·@cosme 별도). 도쿄 이관 stale(supabase.md·PROJECT_CONTEXT·service-flow·data-layer·supabase-expert.md·db-check.md) + 코드맵 마이그레이션 167·일괄발송 함수 + influencerNameById 제거 + .gitignore QA png. reviewer GO, DB 무영향, qa skip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)