### PR TITLE
feat(messaging): 일괄발송에 모집 타입 칩 + 캠페인 전체 선택 추가

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -12,7 +12,7 @@
 // 회귀(2026-05-12 PR #182 머지 직후 발생)를 방지하기 위한 자동 reload 가드.
 // sessionStorage 차단 환경(시크릿 모드 일부, 쿠키 차단)에서는 자연스럽게 skip.
 (function(){
-  var CURRENT_BUILD = 'v1780395733';
+  var CURRENT_BUILD = 'v1780534404';
   if (CURRENT_BUILD.indexOf('__') === 0) return; // 빌드 미적용 (dev/ 직접 열기) 시 skip
   try {
     var prev = sessionStorage.getItem('reverb.adminBuild');
@@ -1983,7 +1983,7 @@ textarea.form-input{resize:vertical;min-height:80px}
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-06-02 19:22 · e59f2f8</span>
+          <span class="admin-build-text">2026-06-04 09:53 · 1b9fa66</span>
         </div>
       </div>
     </aside>
@@ -4871,14 +4871,19 @@ textarea.form-input{resize:vertical;min-height:80px}
       <div id="bulkStep1" style="display:flex;flex-direction:column;gap:14px">
         <div id="bulkPresetInfo" style="display:none;font-size:13px;color:var(--muted);background:var(--bg);border-radius:10px;padding:10px 12px"></div>
         <div id="bulkCampaignPick">
-          <!-- ① 캠페인 상태 먼저 선택 → 해당 상태 캠페인만 목록에 노출 -->
+          <!-- ① 캠페인 상태 + 모집 타입 먼저 선택 → 조건에 맞는 캠페인만 목록에 노출 -->
           <div style="font-size:13px;color:var(--muted);margin-bottom:6px">① 캠페인 상태 <span style="font-size:11px">(먼저 선택)</span></div>
-          <div id="bulkStatusChips" class="bulk-chk-row" style="margin-bottom:14px"></div>
+          <div id="bulkStatusChips" class="bulk-chk-row" style="margin-bottom:12px"></div>
+          <div style="font-size:13px;color:var(--muted);margin-bottom:6px">모집 타입 <span style="font-size:11px">(선택 · 미선택 시 전체)</span></div>
+          <div id="bulkRecruitTypeChips" class="bulk-chk-row" style="margin-bottom:14px"></div>
           <!-- ② 캠페인 선택 (상태 선택 후 노출) -->
           <div id="bulkCampaignSelectWrap" style="display:none">
-            <div style="font-size:13px;color:var(--muted);margin-bottom:6px">② 캠페인 <span style="font-size:11px">(여러 개 선택 가능 · 이름·번호 검색)</span></div>
+            <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:6px">
+              <div style="font-size:13px;color:var(--muted)">② 캠페인 <span style="font-size:11px">(여러 개 선택 가능 · 이름·번호 검색)</span></div>
+              <button type="button" class="btn btn-ghost btn-xs" onclick="selectAllBulkCampaigns()" style="padding:2px 10px;font-size:12px">전체 선택</button>
+            </div>
             <div id="bulkCampaignMulti" class="mf-wrap" style="max-width:100%"><button type="button" class="mf-btn" style="width:100%;overflow:hidden;text-overflow:ellipsis">캠페인 선택</button><div class="mf-drop"></div></div>
-            <div id="bulkCampaignEmpty" style="display:none;font-size:12px;color:var(--muted);margin-top:8px">선택한 상태의 캠페인이 없습니다. 다른 상태를 골라주세요.</div>
+            <div id="bulkCampaignEmpty" style="display:none;font-size:12px;color:var(--muted);margin-top:8px">선택한 조건의 캠페인이 없습니다. 다른 상태·타입을 골라주세요.</div>
           </div>
         </div>
         <div id="bulkFilters" style="display:none;flex-direction:column;gap:12px">
@@ -15831,8 +15836,11 @@ function openBulkMessageModal(presetAppIds) {
     document.getElementById('bulkCountBox').style.display = 'none';
     document.getElementById('bulkNextBtn').disabled = true;
     _bulkState.statuses = [];
+    _bulkState.recruitTypes = [];
+    _bulkState.availableCampaignIds = [];
     _bulkState.hasMonitor = false;
-    renderBulkStatusChips();      // ① 캠페인 상태 칩 (미선택 상태)
+    renderBulkStatusChips();        // ① 캠페인 상태 칩 (미선택 상태)
+    renderBulkRecruitTypeChips();   // 모집 타입 칩 (미선택 = 전체)
     document.getElementById('bulkCampaignSelectWrap').style.display = 'none';
     renderBulkStatusFilters();    // 응모·영수증·결과물 status 체크박스 (기본값)
     // 인플 상태 토글 기본값 복원 (블랙리스트 제외만 기본 켜짐)
@@ -15846,35 +15854,51 @@ function openBulkMessageModal(presetAppIds) {
 }
 function closeBulkMessageModal() { closeModal('bulkMessageModal'); _bulkState = null; }
 
-// ① 캠페인 상태 칩 (다중선택). 변경 → onBulkStatusChipChange
+// ① 캠페인 상태 칩 (다중선택). 변경 → 캠페인 목록 갱신
 function renderBulkStatusChips() {
   document.getElementById('bulkStatusChips').innerHTML = BULK_CAMPAIGN_STATUSES.map(s =>
     `<label class="bulk-chk"><input type="checkbox" value="${s.code}" onchange="onBulkStatusChipChange()">${s.label}</label>`).join('');
 }
 
-function onBulkStatusChipChange() {
+// 모집 타입 칩 (다중선택, 선택적 — 미선택 시 전체 타입). 변경 → 캠페인 목록 갱신
+function renderBulkRecruitTypeChips() {
+  const _rtKo = (typeof RECRUIT_TYPE_LABEL_KO !== 'undefined') ? RECRUIT_TYPE_LABEL_KO : { monitor:'리뷰어', gifting:'기프팅', visit:'방문형' };
+  const types = [['monitor', _rtKo.monitor], ['gifting', _rtKo.gifting], ['visit', _rtKo.visit]];
+  document.getElementById('bulkRecruitTypeChips').innerHTML = types.map(([code, label]) =>
+    `<label class="bulk-chk"><input type="checkbox" value="${code}" onchange="onBulkRecruitChipChange()">${label}</label>`).join('');
+}
+
+function onBulkStatusChipChange() { refreshBulkCampaignList(); }
+function onBulkRecruitChipChange() { refreshBulkCampaignList(); }
+
+// 상태·모집타입 칩 변경 시 ② 캠페인 목록 갱신. 상태는 필수 게이트(미선택 시 ② 숨김), 타입은 선택적.
+function refreshBulkCampaignList() {
   const statuses = Array.from(document.querySelectorAll('#bulkStatusChips input:checked')).map(i => i.value);
+  const types = Array.from(document.querySelectorAll('#bulkRecruitTypeChips input:checked')).map(i => i.value);
   _bulkState.statuses = statuses;
+  _bulkState.recruitTypes = types;
   _bulkState.campaignIds = [];
   const selWrap = document.getElementById('bulkCampaignSelectWrap');
   document.getElementById('bulkFilters').style.display = 'none';
   document.getElementById('bulkCountBox').style.display = 'none';
   document.getElementById('bulkNextBtn').disabled = true;
   if (!statuses.length) {
-    // 상태 미선택 → ② 캠페인 선택 숨김
+    // 상태 미선택 → ② 캠페인 선택 숨김 (모집 타입만으론 목록 안 띄움)
     if (selWrap) selWrap.style.display = 'none';
     return;
   }
   if (selWrap) selWrap.style.display = '';
-  populateBulkCampaigns(statuses);   // 선택 상태 캠페인만 목록 노출
+  populateBulkCampaigns(statuses, types);   // 상태 AND 타입 조건 캠페인만
   if (typeof clearMultiFilter === 'function') clearMultiFilter('bulkCampaignMulti', '캠페인 선택');
 }
 
-function populateBulkCampaigns(statuses) {
+function populateBulkCampaigns(statuses, recruitTypes) {
   const allow = (statuses && statuses.length) ? statuses : ['active', 'closed', 'ended'];
+  const typeAllow = (recruitTypes && recruitTypes.length) ? recruitTypes : null;   // null = 전체 타입
   const camps = (typeof allCampaigns !== 'undefined' ? allCampaigns : [])
-    .filter(c => allow.includes(c.status))
+    .filter(c => allow.includes(c.status) && (!typeAllow || typeAllow.includes(c.recruit_type)))
     .sort((a, b) => (b.created_at || '').localeCompare(a.created_at || ''));
+  _bulkState.availableCampaignIds = camps.map(c => c.id);   // 「전체 선택」용 현재 목록 전체 id
   // 드롭다운 부가설명: 캠페인 번호 · 모집타입 · 상태 · 채널 (대상 캠페인 식별 보조)
   const _rtKo = (typeof RECRUIT_TYPE_LABEL_KO !== 'undefined') ? RECRUIT_TYPE_LABEL_KO : { monitor:'리뷰어', gifting:'기프팅', visit:'방문형' };
   const _stKo = { active:'모집중', closed:'모집마감', ended:'종료' };
@@ -15891,15 +15915,33 @@ function populateBulkCampaigns(statuses) {
   if (typeof syncMultiFilter === 'function') {
     syncMultiFilter('bulkCampaignMulti', '캠페인 선택', options, onBulkCampaignChange, { searchable: true, searchPlaceholder: '캠페인명 · 번호 검색' });
   }
-  // 빈 상태 안내 (선택 상태에 캠페인 0건)
+  // 빈 상태 안내 (선택 조건에 캠페인 0건)
   const empty = document.getElementById('bulkCampaignEmpty');
   if (empty) empty.style.display = camps.length ? 'none' : 'block';
 }
 
+// ② 캠페인 「전체 선택」 — 현재 필터된 캠페인 전부를 명시 대상으로. mf-wrap 「전체」 체크박스 토글.
+function selectAllBulkCampaigns() {
+  const wrap = document.getElementById('bulkCampaignMulti');
+  const allCb = wrap && wrap.querySelector('input[value="all"]');
+  if (!allCb) return;
+  allCb.checked = true;
+  allCb.indeterminate = false;
+  if (typeof allCb.onchange === 'function') allCb.onchange();   // 모든 항목 체크 + onBulkCampaignChange 트리거
+}
+
 function onBulkCampaignChange() {
-  const ids = (typeof getMultiFilterValues === 'function') ? getMultiFilterValues('bulkCampaignMulti') : [];
+  let ids = (typeof getMultiFilterValues === 'function') ? getMultiFilterValues('bulkCampaignMulti') : [];
+  // mf-wrap 「전체 체크」(모두 선택)는 빈배열을 반환(필터 없음 시맨틱) → 현재 필터된 전체 캠페인을 명시 대상으로 치환
+  if (!ids.length) {
+    const wrap = document.getElementById('bulkCampaignMulti');
+    const allCb = wrap && wrap.querySelector('input[value="all"]');
+    if (allCb && allCb.checked && !allCb.indeterminate) {
+      ids = (_bulkState.availableCampaignIds || []).slice();
+    }
+  }
   _bulkState.campaignIds = ids;
-  // [] = 미선택(mf-wrap 전체체크/모두해제 모두 빈 배열) → 일괄발송은 대상 0 (명시 선택 강제)
+  // [] = 모두 해제(선택 없음) → 일괄발송은 대상 0 (명시 선택 강제)
   if (!ids.length) {
     document.getElementById('bulkFilters').style.display = 'none';
     document.getElementById('bulkCountBox').style.display = 'none';

--- a/dev/admin/index.html
+++ b/dev/admin/index.html
@@ -3022,14 +3022,19 @@
       <div id="bulkStep1" style="display:flex;flex-direction:column;gap:14px">
         <div id="bulkPresetInfo" style="display:none;font-size:13px;color:var(--muted);background:var(--bg);border-radius:10px;padding:10px 12px"></div>
         <div id="bulkCampaignPick">
-          <!-- ① 캠페인 상태 먼저 선택 → 해당 상태 캠페인만 목록에 노출 -->
+          <!-- ① 캠페인 상태 + 모집 타입 먼저 선택 → 조건에 맞는 캠페인만 목록에 노출 -->
           <div style="font-size:13px;color:var(--muted);margin-bottom:6px">① 캠페인 상태 <span style="font-size:11px">(먼저 선택)</span></div>
-          <div id="bulkStatusChips" class="bulk-chk-row" style="margin-bottom:14px"></div>
+          <div id="bulkStatusChips" class="bulk-chk-row" style="margin-bottom:12px"></div>
+          <div style="font-size:13px;color:var(--muted);margin-bottom:6px">모집 타입 <span style="font-size:11px">(선택 · 미선택 시 전체)</span></div>
+          <div id="bulkRecruitTypeChips" class="bulk-chk-row" style="margin-bottom:14px"></div>
           <!-- ② 캠페인 선택 (상태 선택 후 노출) -->
           <div id="bulkCampaignSelectWrap" style="display:none">
-            <div style="font-size:13px;color:var(--muted);margin-bottom:6px">② 캠페인 <span style="font-size:11px">(여러 개 선택 가능 · 이름·번호 검색)</span></div>
+            <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:6px">
+              <div style="font-size:13px;color:var(--muted)">② 캠페인 <span style="font-size:11px">(여러 개 선택 가능 · 이름·번호 검색)</span></div>
+              <button type="button" class="btn btn-ghost btn-xs" onclick="selectAllBulkCampaigns()" style="padding:2px 10px;font-size:12px">전체 선택</button>
+            </div>
             <div id="bulkCampaignMulti" class="mf-wrap" style="max-width:100%"><button type="button" class="mf-btn" style="width:100%;overflow:hidden;text-overflow:ellipsis">캠페인 선택</button><div class="mf-drop"></div></div>
-            <div id="bulkCampaignEmpty" style="display:none;font-size:12px;color:var(--muted);margin-top:8px">선택한 상태의 캠페인이 없습니다. 다른 상태를 골라주세요.</div>
+            <div id="bulkCampaignEmpty" style="display:none;font-size:12px;color:var(--muted);margin-top:8px">선택한 조건의 캠페인이 없습니다. 다른 상태·타입을 골라주세요.</div>
           </div>
         </div>
         <div id="bulkFilters" style="display:none;flex-direction:column;gap:12px">

--- a/dev/js/admin-messaging.js
+++ b/dev/js/admin-messaging.js
@@ -983,8 +983,11 @@ function openBulkMessageModal(presetAppIds) {
     document.getElementById('bulkCountBox').style.display = 'none';
     document.getElementById('bulkNextBtn').disabled = true;
     _bulkState.statuses = [];
+    _bulkState.recruitTypes = [];
+    _bulkState.availableCampaignIds = [];
     _bulkState.hasMonitor = false;
-    renderBulkStatusChips();      // ① 캠페인 상태 칩 (미선택 상태)
+    renderBulkStatusChips();        // ① 캠페인 상태 칩 (미선택 상태)
+    renderBulkRecruitTypeChips();   // 모집 타입 칩 (미선택 = 전체)
     document.getElementById('bulkCampaignSelectWrap').style.display = 'none';
     renderBulkStatusFilters();    // 응모·영수증·결과물 status 체크박스 (기본값)
     // 인플 상태 토글 기본값 복원 (블랙리스트 제외만 기본 켜짐)
@@ -998,35 +1001,51 @@ function openBulkMessageModal(presetAppIds) {
 }
 function closeBulkMessageModal() { closeModal('bulkMessageModal'); _bulkState = null; }
 
-// ① 캠페인 상태 칩 (다중선택). 변경 → onBulkStatusChipChange
+// ① 캠페인 상태 칩 (다중선택). 변경 → 캠페인 목록 갱신
 function renderBulkStatusChips() {
   document.getElementById('bulkStatusChips').innerHTML = BULK_CAMPAIGN_STATUSES.map(s =>
     `<label class="bulk-chk"><input type="checkbox" value="${s.code}" onchange="onBulkStatusChipChange()">${s.label}</label>`).join('');
 }
 
-function onBulkStatusChipChange() {
+// 모집 타입 칩 (다중선택, 선택적 — 미선택 시 전체 타입). 변경 → 캠페인 목록 갱신
+function renderBulkRecruitTypeChips() {
+  const _rtKo = (typeof RECRUIT_TYPE_LABEL_KO !== 'undefined') ? RECRUIT_TYPE_LABEL_KO : { monitor:'리뷰어', gifting:'기프팅', visit:'방문형' };
+  const types = [['monitor', _rtKo.monitor], ['gifting', _rtKo.gifting], ['visit', _rtKo.visit]];
+  document.getElementById('bulkRecruitTypeChips').innerHTML = types.map(([code, label]) =>
+    `<label class="bulk-chk"><input type="checkbox" value="${code}" onchange="onBulkRecruitChipChange()">${label}</label>`).join('');
+}
+
+function onBulkStatusChipChange() { refreshBulkCampaignList(); }
+function onBulkRecruitChipChange() { refreshBulkCampaignList(); }
+
+// 상태·모집타입 칩 변경 시 ② 캠페인 목록 갱신. 상태는 필수 게이트(미선택 시 ② 숨김), 타입은 선택적.
+function refreshBulkCampaignList() {
   const statuses = Array.from(document.querySelectorAll('#bulkStatusChips input:checked')).map(i => i.value);
+  const types = Array.from(document.querySelectorAll('#bulkRecruitTypeChips input:checked')).map(i => i.value);
   _bulkState.statuses = statuses;
+  _bulkState.recruitTypes = types;
   _bulkState.campaignIds = [];
   const selWrap = document.getElementById('bulkCampaignSelectWrap');
   document.getElementById('bulkFilters').style.display = 'none';
   document.getElementById('bulkCountBox').style.display = 'none';
   document.getElementById('bulkNextBtn').disabled = true;
   if (!statuses.length) {
-    // 상태 미선택 → ② 캠페인 선택 숨김
+    // 상태 미선택 → ② 캠페인 선택 숨김 (모집 타입만으론 목록 안 띄움)
     if (selWrap) selWrap.style.display = 'none';
     return;
   }
   if (selWrap) selWrap.style.display = '';
-  populateBulkCampaigns(statuses);   // 선택 상태 캠페인만 목록 노출
+  populateBulkCampaigns(statuses, types);   // 상태 AND 타입 조건 캠페인만
   if (typeof clearMultiFilter === 'function') clearMultiFilter('bulkCampaignMulti', '캠페인 선택');
 }
 
-function populateBulkCampaigns(statuses) {
+function populateBulkCampaigns(statuses, recruitTypes) {
   const allow = (statuses && statuses.length) ? statuses : ['active', 'closed', 'ended'];
+  const typeAllow = (recruitTypes && recruitTypes.length) ? recruitTypes : null;   // null = 전체 타입
   const camps = (typeof allCampaigns !== 'undefined' ? allCampaigns : [])
-    .filter(c => allow.includes(c.status))
+    .filter(c => allow.includes(c.status) && (!typeAllow || typeAllow.includes(c.recruit_type)))
     .sort((a, b) => (b.created_at || '').localeCompare(a.created_at || ''));
+  _bulkState.availableCampaignIds = camps.map(c => c.id);   // 「전체 선택」용 현재 목록 전체 id
   // 드롭다운 부가설명: 캠페인 번호 · 모집타입 · 상태 · 채널 (대상 캠페인 식별 보조)
   const _rtKo = (typeof RECRUIT_TYPE_LABEL_KO !== 'undefined') ? RECRUIT_TYPE_LABEL_KO : { monitor:'리뷰어', gifting:'기프팅', visit:'방문형' };
   const _stKo = { active:'모집중', closed:'모집마감', ended:'종료' };
@@ -1043,15 +1062,33 @@ function populateBulkCampaigns(statuses) {
   if (typeof syncMultiFilter === 'function') {
     syncMultiFilter('bulkCampaignMulti', '캠페인 선택', options, onBulkCampaignChange, { searchable: true, searchPlaceholder: '캠페인명 · 번호 검색' });
   }
-  // 빈 상태 안내 (선택 상태에 캠페인 0건)
+  // 빈 상태 안내 (선택 조건에 캠페인 0건)
   const empty = document.getElementById('bulkCampaignEmpty');
   if (empty) empty.style.display = camps.length ? 'none' : 'block';
 }
 
+// ② 캠페인 「전체 선택」 — 현재 필터된 캠페인 전부를 명시 대상으로. mf-wrap 「전체」 체크박스 토글.
+function selectAllBulkCampaigns() {
+  const wrap = document.getElementById('bulkCampaignMulti');
+  const allCb = wrap && wrap.querySelector('input[value="all"]');
+  if (!allCb) return;
+  allCb.checked = true;
+  allCb.indeterminate = false;
+  if (typeof allCb.onchange === 'function') allCb.onchange();   // 모든 항목 체크 + onBulkCampaignChange 트리거
+}
+
 function onBulkCampaignChange() {
-  const ids = (typeof getMultiFilterValues === 'function') ? getMultiFilterValues('bulkCampaignMulti') : [];
+  let ids = (typeof getMultiFilterValues === 'function') ? getMultiFilterValues('bulkCampaignMulti') : [];
+  // mf-wrap 「전체 체크」(모두 선택)는 빈배열을 반환(필터 없음 시맨틱) → 현재 필터된 전체 캠페인을 명시 대상으로 치환
+  if (!ids.length) {
+    const wrap = document.getElementById('bulkCampaignMulti');
+    const allCb = wrap && wrap.querySelector('input[value="all"]');
+    if (allCb && allCb.checked && !allCb.indeterminate) {
+      ids = (_bulkState.availableCampaignIds || []).slice();
+    }
+  }
   _bulkState.campaignIds = ids;
-  // [] = 미선택(mf-wrap 전체체크/모두해제 모두 빈 배열) → 일괄발송은 대상 0 (명시 선택 강제)
+  // [] = 모두 해제(선택 없음) → 일괄발송은 대상 0 (명시 선택 강제)
   if (!ids.length) {
     document.getElementById('bulkFilters').style.display = 'none';
     document.getElementById('bulkCountBox').style.display = 'none';


### PR DESCRIPTION
## 변경 요약
- 일괄발송 모달 ① 캠페인 상태 칩 아래에 **모집 타입 칩**(리뷰어/기프팅/방문형) 추가. 상태 AND 타입으로 캠페인 목록을 좁힘(상태 필수, 타입 선택적·미선택 시 전체)
- ② 캠페인 **전체 선택** 버튼 — 현재 필터된 캠페인 전부를 대상으로

## 요청 외 추가 변경
- 없음

## 관련 사양서
- docs/specs/2026-06-02-bulk-message-target-redesign.md (대상선택 재설계 후속)

## 검증
[via reviewer] GO — 전체선택 로직(mf-wrap 전체체크=빈배열 시맨틱 구분)·상태 게이트·200명 한도 정상. Warning 1(함수 51줄, 경미)
- DB·약관 무영향 (캠페인 목록 필터 UI만)

## 운영 배포
- 보류 (일괄발송 전체가 메시지 약관 게이트, 마이그레이션 167·168과 함께)

🤖 Generated with [Claude Code](https://claude.com/claude-code)