### PR TITLE
fix(messaging): 일괄발송 대상 계산 시간 제한 (계산중 고착 방지)

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -12,7 +12,7 @@
 // 회귀(2026-05-12 PR #182 머지 직후 발생)를 방지하기 위한 자동 reload 가드.
 // sessionStorage 차단 환경(시크릿 모드 일부, 쿠키 차단)에서는 자연스럽게 skip.
 (function(){
-  var CURRENT_BUILD = 'v1780534404';
+  var CURRENT_BUILD = 'v1780535599';
   if (CURRENT_BUILD.indexOf('__') === 0) return; // 빌드 미적용 (dev/ 직접 열기) 시 skip
   try {
     var prev = sessionStorage.getItem('reverb.adminBuild');
@@ -1983,7 +1983,7 @@ textarea.form-input{resize:vertical;min-height:80px}
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-06-04 09:53 · 1b9fa66</span>
+          <span class="admin-build-text">2026-06-04 10:13 · 9ecc9fe</span>
         </div>
       </div>
     </aside>
@@ -16018,6 +16018,8 @@ function scheduleBulkRecount() {
   _bulkRecountTimer = setTimeout(recountBulk, 350);
 }
 
+const BULK_RECOUNT_TIMEOUT_MS = 15000;   // 대상 계산 시간 제한 — 네트워크 지연·장애 시 「계산 중」 고착 방지
+
 async function recountBulk() {
   if (!_bulkState || !_bulkState.campaignIds || !_bulkState.campaignIds.length) return;
   const filters = collectBulkFilters();
@@ -16025,8 +16027,12 @@ async function recountBulk() {
   const loading = document.getElementById('bulkCountLoading');
   if (loading) loading.style.display = 'inline';
   try {
-    // 캠페인별 대상 해결 후 application_id 합집합 (캠페인마다 자기 채널·팔로워 기준 정확 적용)
-    const results = await Promise.all(campaignIds.map(cid => resolveBulkRecipients(cid, filters)));
+    // 캠페인별 대상 해결 후 application_id 합집합 (캠페인마다 자기 채널·팔로워 기준 정확 적용).
+    // 네트워크 hang 대비 시간 제한 — 초과 시 reject 되어 catch 로 떨어지고 loading 해제됨.
+    const results = await Promise.race([
+      Promise.all(campaignIds.map(cid => resolveBulkRecipients(cid, filters))),
+      new Promise((_, reject) => setTimeout(() => reject(new Error('bulk_recount_timeout')), BULK_RECOUNT_TIMEOUT_MS)),
+    ]);
     // 계산 도중 선택이 바뀌었으면 폐기 (오래된 결과 반영 방지)
     if (JSON.stringify(_bulkState.campaignIds) !== JSON.stringify(campaignIds)) return;
     const idSet = new Set();
@@ -16037,8 +16043,12 @@ async function recountBulk() {
     updateBulkCount(ids.length);
     document.getElementById('bulkNextBtn').disabled = ids.length === 0;
   } catch (e) {
-    console.error('[recountBulk]', e);
-    toast('대상 계산에 실패했습니다.');
+    if (e && e.message === 'bulk_recount_timeout') {
+      toast('대상 계산이 지연됩니다. 네트워크 확인 후 필터를 다시 조정해 주세요.');
+    } else {
+      console.error('[recountBulk]', e);
+      toast('대상 계산에 실패했습니다.');
+    }
     updateBulkCount(0);
     document.getElementById('bulkNextBtn').disabled = true;
   } finally {

--- a/dev/js/admin-messaging.js
+++ b/dev/js/admin-messaging.js
@@ -1165,6 +1165,8 @@ function scheduleBulkRecount() {
   _bulkRecountTimer = setTimeout(recountBulk, 350);
 }
 
+const BULK_RECOUNT_TIMEOUT_MS = 15000;   // 대상 계산 시간 제한 — 네트워크 지연·장애 시 「계산 중」 고착 방지
+
 async function recountBulk() {
   if (!_bulkState || !_bulkState.campaignIds || !_bulkState.campaignIds.length) return;
   const filters = collectBulkFilters();
@@ -1172,8 +1174,12 @@ async function recountBulk() {
   const loading = document.getElementById('bulkCountLoading');
   if (loading) loading.style.display = 'inline';
   try {
-    // 캠페인별 대상 해결 후 application_id 합집합 (캠페인마다 자기 채널·팔로워 기준 정확 적용)
-    const results = await Promise.all(campaignIds.map(cid => resolveBulkRecipients(cid, filters)));
+    // 캠페인별 대상 해결 후 application_id 합집합 (캠페인마다 자기 채널·팔로워 기준 정확 적용).
+    // 네트워크 hang 대비 시간 제한 — 초과 시 reject 되어 catch 로 떨어지고 loading 해제됨.
+    const results = await Promise.race([
+      Promise.all(campaignIds.map(cid => resolveBulkRecipients(cid, filters))),
+      new Promise((_, reject) => setTimeout(() => reject(new Error('bulk_recount_timeout')), BULK_RECOUNT_TIMEOUT_MS)),
+    ]);
     // 계산 도중 선택이 바뀌었으면 폐기 (오래된 결과 반영 방지)
     if (JSON.stringify(_bulkState.campaignIds) !== JSON.stringify(campaignIds)) return;
     const idSet = new Set();
@@ -1184,8 +1190,12 @@ async function recountBulk() {
     updateBulkCount(ids.length);
     document.getElementById('bulkNextBtn').disabled = ids.length === 0;
   } catch (e) {
-    console.error('[recountBulk]', e);
-    toast('대상 계산에 실패했습니다.');
+    if (e && e.message === 'bulk_recount_timeout') {
+      toast('대상 계산이 지연됩니다. 네트워크 확인 후 필터를 다시 조정해 주세요.');
+    } else {
+      console.error('[recountBulk]', e);
+      toast('대상 계산에 실패했습니다.');
+    }
     updateBulkCount(0);
     document.getElementById('bulkNextBtn').disabled = true;
   } finally {

--- a/index.html
+++ b/index.html
@@ -6771,7 +6771,7 @@ async function fetchApplicationHideHistory(applicationId) {
 // 일괄 발송 (관리자 → N명 BCC). applicationIds 는 이미 cancelled 제외된 배열.
 //   contextKind: 'campaign'|'manual', contextCampaignId/contextFilter 는 감사·재현용 스냅샷.
 //   반환: broadcast_id (uuid).
-async function sendApplicationMessageBulk(applicationIds, body, attachments = [], contextKind = 'manual', contextCampaignId = null, contextFilter = null) {
+async function sendApplicationMessageBulk(applicationIds, body, attachments = [], contextKind = 'manual', contextCampaignId = null, contextFilter = null, title = null) {
   if (!db) throw new Error('DB 미연결');
   return await retryWithRefresh(async () => {
     const {data, error} = await db.rpc('send_application_message_bulk', {
@@ -6781,6 +6781,7 @@ async function sendApplicationMessageBulk(applicationIds, body, attachments = []
       p_context_kind: contextKind,
       p_context_campaign_id: contextCampaignId,
       p_context_filter: contextFilter,
+      p_title: title || null,   // 관리자 전용 제목 (인플 메시지 본문 미포함)
     });
     if (error) throw error;
     return data;
@@ -6802,16 +6803,23 @@ async function withdrawBroadcast(broadcastId, reasonCode, reasonMemo = null) {
 }
 
 // 캠페인 단위 발송 대상 응모 id 해결 (cancelled 항상 제외). 미리보기 카운트 = 배열 길이.
-//   filters: { appStatuses[], deliverableStatuses[], channels[], minFollowers }
+//   filters: { appStatuses[], receiptStatuses[], postStatuses[], channels[], minFollowers,
+//              requireVerified, excludeViolation, excludeBlacklist }
+//   - receiptStatuses: 영수증(kind='receipt') 결과물 상태 / postStatuses: 게시물·리뷰이미지 상태
+//   - excludeBlacklist 기본 true (명시적 false 일 때만 블랙리스트 포함)
 //   반환: uuid[] (조건 만족 application id 배열, 빈 배열 가능)
 async function resolveBulkRecipients(campaignId, filters = {}) {
   if (!db || !campaignId) return [];
   const {data, error} = await db.rpc('resolve_bulk_recipients', {
     p_campaign_id: campaignId,
     p_app_statuses: filters.appStatuses && filters.appStatuses.length ? filters.appStatuses : null,
-    p_deliverable_statuses: filters.deliverableStatuses && filters.deliverableStatuses.length ? filters.deliverableStatuses : null,
+    p_receipt_statuses: filters.receiptStatuses && filters.receiptStatuses.length ? filters.receiptStatuses : null,
+    p_post_statuses: filters.postStatuses && filters.postStatuses.length ? filters.postStatuses : null,
     p_channels: filters.channels && filters.channels.length ? filters.channels : null,
     p_min_followers: (filters.minFollowers != null && filters.minFollowers !== '') ? Number(filters.minFollowers) : null,
+    p_require_verified: !!filters.requireVerified,
+    p_exclude_violation: !!filters.excludeViolation,
+    p_exclude_blacklist: filters.excludeBlacklist !== false,
   });
   if (error) throw error;
   return data || [];
@@ -6823,7 +6831,7 @@ async function resolveBulkRecipients(campaignId, filters = {}) {
 async function fetchBroadcasts(opts = {}) {
   if (!db) return [];
   let q = db?.from('application_message_broadcasts')
-    .select('id, sender_id, sender_name, body, attachments, recipient_count, created_at, context_kind, context_campaign_id, context_filter, withdrawn_at, withdrawn_by, withdrawn_reason_code')
+    .select('id, sender_id, sender_name, title, body, attachments, recipient_count, created_at, context_kind, context_campaign_id, context_filter, withdrawn_at, withdrawn_by, withdrawn_reason_code')
     .order('created_at', { ascending: false })
     .limit(opts.limit || 100);
   if (opts.senderId) q = q.eq('sender_id', opts.senderId);


### PR DESCRIPTION
## 변경 요약
- 일괄발송 대상 수 계산(`recountBulk`)에 15초 시간 제한 추가. 네트워크 지연·장애로 계산 RPC가 응답 없이 멈춰도 「계산 중…」 표시가 고착되지 않고 안내 후 해제

## 요청 외 추가 변경
- 없음

## 관련 사양서
- docs/specs/2026-06-02-bulk-message-target-redesign.md

## 검증
[via reviewer] GO — Promise.race/finally로 스피너 해제 보장, 늦게 끝나는 fetch는 안전하게 무시
- qa light에서 발견한 「계산 중」 고착(Playwright 토큰 차단 환경 특성) 방어

## 운영 배포
- 보류 (일괄발송 전체 약관 게이트)

🤖 Generated with [Claude Code](https://claude.com/claude-code)