### PR TITLE
feat(messaging): 일괄발송 드롭다운 UX 개선 (N건 표시·선택 상단정렬·떠있게·전체선택)

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -12,7 +12,7 @@
 // 회귀(2026-05-12 PR #182 머지 직후 발생)를 방지하기 위한 자동 reload 가드.
 // sessionStorage 차단 환경(시크릿 모드 일부, 쿠키 차단)에서는 자연스럽게 skip.
 (function(){
-  var CURRENT_BUILD = 'v1780535599';
+  var CURRENT_BUILD = 'v1780538498';
   if (CURRENT_BUILD.indexOf('__') === 0) return; // 빌드 미적용 (dev/ 직접 열기) 시 skip
   try {
     var prev = sessionStorage.getItem('reverb.adminBuild');
@@ -1902,11 +1902,13 @@ textarea.form-input{resize:vertical;min-height:80px}
 .broadcast-recip-name { font-weight: 600; color: var(--ink); }
 .broadcast-recip-camp { flex: 1; font-size: 11px; color: var(--muted); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .broadcast-recip-status { font-size: 11px; color: var(--muted); }
-/* 일괄발송 캠페인 드롭다운 — 모달 body(overflow:auto)가 absolute 드롭을 자르는 문제 회피.
-   문서 흐름(static)으로 펼쳐 모달 자체 스크롤로 보이게 한다(포털 불필요, 이 드롭다운만 한정). */
-#bulkCampaignMulti .mf-drop { position: static; margin-top: 4px; min-width: 0; max-width: 100%; max-height: 240px; overflow-y: auto; box-shadow: none; border: 1px solid var(--line); }
+/* 일괄발송 캠페인 드롭다운 — 펼칠 때 아래 필터를 밀어내지 않도록 문서 흐름에서 띄움(absolute).
+   ② 캠페인이 모달 상단이고 240px 높이 제한이라 모달 body 안에 들어가 가려지지 않음. */
+#bulkCampaignMulti .mf-drop { min-width: 0; max-width: 100%; max-height: 240px; overflow-y: auto; box-shadow: 0 6px 20px rgba(0,0,0,.16); border: 1px solid var(--line); }
 /* 부가설명에 한글(모집타입·상태) 혼재 — 고정폭 대신 본문 폰트로 가독성 확보 (캠페인 번호 단독 드롭다운은 monospace 유지) */
 #bulkCampaignMulti .mf-item-sub { font-family: inherit; }
+/* 선택 항목 상단 정렬 구분선 (다중선택 드롭다운 공통) */
+.mf-selected-divider { border-top: 1px solid var(--outline); margin: 4px 0; }
 
 </style>
 </head>
@@ -1983,7 +1985,7 @@ textarea.form-input{resize:vertical;min-height:80px}
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-06-04 10:13 · 9ecc9fe</span>
+          <span class="admin-build-text">2026-06-04 11:01 · 7ca6bca</span>
         </div>
       </div>
     </aside>
@@ -4876,13 +4878,10 @@ textarea.form-input{resize:vertical;min-height:80px}
           <div id="bulkStatusChips" class="bulk-chk-row" style="margin-bottom:12px"></div>
           <div style="font-size:13px;color:var(--muted);margin-bottom:6px">모집 타입 <span style="font-size:11px">(선택 · 미선택 시 전체)</span></div>
           <div id="bulkRecruitTypeChips" class="bulk-chk-row" style="margin-bottom:14px"></div>
-          <!-- ② 캠페인 선택 (상태 선택 후 노출) -->
+          <!-- ② 캠페인 선택 (상태 선택 후 노출). 「전체 선택」은 드롭다운 맨 위 항목으로 통일 -->
           <div id="bulkCampaignSelectWrap" style="display:none">
-            <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:6px">
-              <div style="font-size:13px;color:var(--muted)">② 캠페인 <span style="font-size:11px">(여러 개 선택 가능 · 이름·번호 검색)</span></div>
-              <button type="button" class="btn btn-ghost btn-xs" onclick="selectAllBulkCampaigns()" style="padding:2px 10px;font-size:12px">전체 선택</button>
-            </div>
-            <div id="bulkCampaignMulti" class="mf-wrap" style="max-width:100%"><button type="button" class="mf-btn" style="width:100%;overflow:hidden;text-overflow:ellipsis">캠페인 선택</button><div class="mf-drop"></div></div>
+            <div style="font-size:13px;color:var(--muted);margin-bottom:6px">② 캠페인 <span style="font-size:11px">(여러 개 선택 가능 · 맨 위 「전체 선택」 · 이름·번호 검색)</span></div>
+            <div id="bulkCampaignMulti" class="mf-wrap" style="max-width:100%"><button type="button" class="mf-btn" style="width:100%;overflow:hidden;text-overflow:ellipsis">전체 선택</button><div class="mf-drop"></div></div>
             <div id="bulkCampaignEmpty" style="display:none;font-size:12px;color:var(--muted);margin-top:8px">선택한 조건의 캠페인이 없습니다. 다른 상태·타입을 골라주세요.</div>
           </div>
         </div>
@@ -10023,7 +10022,7 @@ function resetMultiFilter(containerId, allLabel) {
   const items = wrap.querySelectorAll('.mf-drop input[type="checkbox"]:not([value="all"])');
   if (allCb) { allCb.checked = true; allCb.indeterminate = false; }
   items.forEach(c => c.checked = true); // 전체 = 모든 항목 체크 표시
-  if (btn) { btn.textContent = allLabel; btn.classList.remove('has-selection'); }
+  if (btn) { btn.textContent = allLabel; btn.classList.remove('has-selection'); btn.removeAttribute('title'); }
 }
 // 모두 해제 — 일괄발송처럼 "명시 선택 강제" 맥락에서 사용.
 //   resetMultiFilter 는 "전체=모두 체크"(빈 배열 시맨틱)라 미선택 표현이 안 됨.
@@ -10033,7 +10032,7 @@ function clearMultiFilter(containerId, placeholderLabel) {
   if (!wrap) return;
   wrap.querySelectorAll('.mf-drop input[type="checkbox"]').forEach(c => { c.checked = false; c.indeterminate = false; });
   const btn = wrap.querySelector('.mf-btn');
-  if (btn) { btn.textContent = placeholderLabel || '선택'; btn.classList.remove('has-selection'); }
+  if (btn) { btn.textContent = placeholderLabel || '선택'; btn.classList.remove('has-selection'); btn.removeAttribute('title'); }
 }
 function updateFilterResetBtn(btnId, multiIds, searchId) {
   const btn = $(btnId);
@@ -10098,12 +10097,16 @@ function createMultiFilter(containerId, allLabel, options, onChange, opts = {}) 
     + options.map(renderOptionItem).join('')
     + emptyHtml;
   btn.textContent = allLabel;
-  // 토글 — 검색형이면 열 때 검색 input 포커스
+  // 토글 — 열 때 선택 항목을 상단으로 재정렬(체크 토글 중엔 순서 고정, 열 때만 1회), 검색형이면 검색 input 포커스
   btn.onclick = (e) => {
     e.stopPropagation();
+    const willOpen = !drop.classList.contains('open');
     drop.classList.toggle('open');
-    if (opts.searchable && drop.classList.contains('open')) {
-      const si = drop.querySelector('.mf-search'); if (si) setTimeout(() => si.focus(), 0);
+    if (willOpen) {
+      reorderSelectedFirst(drop);
+      if (opts.searchable) {
+        const si = drop.querySelector('.mf-search'); if (si) setTimeout(() => si.focus(), 0);
+      }
     }
   };
   // 체크 로직 — 옵션 체크박스만 (검색 input[type=search] 은 제외)
@@ -10116,6 +10119,7 @@ function createMultiFilter(containerId, allLabel, options, onChange, opts = {}) 
       allCb.checked = true;
       allCb.indeterminate = false;
       btn.textContent = allLabel;
+      btn.removeAttribute('title');
       btn.classList.remove('has-selection');
     } else if (selected.length === 0) {
       // 모두 해제 — 사용자가 「전체」 체크박스를 눌러 전체 해제한 표준 동작.
@@ -10124,13 +10128,15 @@ function createMultiFilter(containerId, allLabel, options, onChange, opts = {}) 
       allCb.checked = false;
       allCb.indeterminate = false;
       btn.textContent = allLabel;
+      btn.removeAttribute('title');
       btn.classList.remove('has-selection');
     } else {
-      // 일부 — 전체는 indeterminate
+      // 일부 — 전체는 indeterminate. 닫힘 버튼은 「다중 선택 N건」(선택 항목명은 tooltip 보존)
       allCb.checked = false;
       allCb.indeterminate = true;
-      // input에 data-label 보관(subLabel/count 영향 없음)
-      btn.textContent = selected.map(c => c.dataset.label || c.parentElement.textContent.trim()).join(', ');
+      const names = selected.map(c => c.dataset.label || c.parentElement.textContent.trim());
+      btn.textContent = '다중 선택 ' + selected.length + '건';
+      btn.title = names.join(', ');
       btn.classList.add('has-selection');
     }
     onChange(getMultiFilterValues(containerId));
@@ -10175,6 +10181,26 @@ function getMultiFilterValues(containerId) {
   // 전체(모두 체크) = 필터 없음 → 빈 배열
   if (allCb?.checked && !allCb.indeterminate) return [];
   return [...wrap.querySelectorAll('.mf-drop input[type="checkbox"]:not([value="all"]):checked')].map(c => c.value);
+}
+
+// 드롭다운 열 때 선택된 항목을 「전체」 항목 바로 아래로 모으고 구분선 삽입(선택 항목 상단 정렬).
+// 열 때 1회만 호출 → 체크 토글 중에는 순서가 튀지 않음. 한쪽만 있으면(전부/없음) 정렬 생략.
+function reorderSelectedFirst(drop) {
+  if (!drop) return;
+  drop.querySelectorAll('.mf-selected-divider').forEach(d => d.remove());
+  const items = [...drop.querySelectorAll('.mf-item:not(.all-item)')];
+  const checked = items.filter(it => it.querySelector('input[type="checkbox"]')?.checked);
+  const unchecked = items.filter(it => !it.querySelector('input[type="checkbox"]')?.checked);
+  if (!checked.length || !unchecked.length) return;
+  // 기준점: 「전체」 항목(없으면 검색창) 뒤에 선택→구분선→미선택 순으로 재배치
+  let ref = drop.querySelector('.all-item') || drop.querySelector('.mf-search-box');
+  if (!ref) return;
+  checked.forEach(it => { ref.after(it); ref = it; });
+  const divider = document.createElement('div');
+  divider.className = 'mf-selected-divider';
+  ref.after(divider);
+  ref = divider;
+  unchecked.forEach(it => { ref.after(it); ref = it; });
 }
 // 커스텀 confirm 모달 (Promise 반환)
 let _confirmResolver = null;
@@ -15889,7 +15915,7 @@ function refreshBulkCampaignList() {
   }
   if (selWrap) selWrap.style.display = '';
   populateBulkCampaigns(statuses, types);   // 상태 AND 타입 조건 캠페인만
-  if (typeof clearMultiFilter === 'function') clearMultiFilter('bulkCampaignMulti', '캠페인 선택');
+  if (typeof clearMultiFilter === 'function') clearMultiFilter('bulkCampaignMulti', '전체 선택');
 }
 
 function populateBulkCampaigns(statuses, recruitTypes) {
@@ -15913,21 +15939,11 @@ function populateBulkCampaigns(statuses, recruitTypes) {
   });
   // 결과물 관리와 동일한 검색형 다중필터 (캠페인명·번호 검색). 선택 변경 → onBulkCampaignChange
   if (typeof syncMultiFilter === 'function') {
-    syncMultiFilter('bulkCampaignMulti', '캠페인 선택', options, onBulkCampaignChange, { searchable: true, searchPlaceholder: '캠페인명 · 번호 검색' });
+    syncMultiFilter('bulkCampaignMulti', '전체 선택', options, onBulkCampaignChange, { searchable: true, searchPlaceholder: '캠페인명 · 번호 검색' });
   }
   // 빈 상태 안내 (선택 조건에 캠페인 0건)
   const empty = document.getElementById('bulkCampaignEmpty');
   if (empty) empty.style.display = camps.length ? 'none' : 'block';
-}
-
-// ② 캠페인 「전체 선택」 — 현재 필터된 캠페인 전부를 명시 대상으로. mf-wrap 「전체」 체크박스 토글.
-function selectAllBulkCampaigns() {
-  const wrap = document.getElementById('bulkCampaignMulti');
-  const allCb = wrap && wrap.querySelector('input[value="all"]');
-  if (!allCb) return;
-  allCb.checked = true;
-  allCb.indeterminate = false;
-  if (typeof allCb.onchange === 'function') allCb.onchange();   // 모든 항목 체크 + onBulkCampaignChange 트리거
 }
 
 function onBulkCampaignChange() {

--- a/dev/admin/index.html
+++ b/dev/admin/index.html
@@ -3027,13 +3027,10 @@
           <div id="bulkStatusChips" class="bulk-chk-row" style="margin-bottom:12px"></div>
           <div style="font-size:13px;color:var(--muted);margin-bottom:6px">모집 타입 <span style="font-size:11px">(선택 · 미선택 시 전체)</span></div>
           <div id="bulkRecruitTypeChips" class="bulk-chk-row" style="margin-bottom:14px"></div>
-          <!-- ② 캠페인 선택 (상태 선택 후 노출) -->
+          <!-- ② 캠페인 선택 (상태 선택 후 노출). 「전체 선택」은 드롭다운 맨 위 항목으로 통일 -->
           <div id="bulkCampaignSelectWrap" style="display:none">
-            <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:6px">
-              <div style="font-size:13px;color:var(--muted)">② 캠페인 <span style="font-size:11px">(여러 개 선택 가능 · 이름·번호 검색)</span></div>
-              <button type="button" class="btn btn-ghost btn-xs" onclick="selectAllBulkCampaigns()" style="padding:2px 10px;font-size:12px">전체 선택</button>
-            </div>
-            <div id="bulkCampaignMulti" class="mf-wrap" style="max-width:100%"><button type="button" class="mf-btn" style="width:100%;overflow:hidden;text-overflow:ellipsis">캠페인 선택</button><div class="mf-drop"></div></div>
+            <div style="font-size:13px;color:var(--muted);margin-bottom:6px">② 캠페인 <span style="font-size:11px">(여러 개 선택 가능 · 맨 위 「전체 선택」 · 이름·번호 검색)</span></div>
+            <div id="bulkCampaignMulti" class="mf-wrap" style="max-width:100%"><button type="button" class="mf-btn" style="width:100%;overflow:hidden;text-overflow:ellipsis">전체 선택</button><div class="mf-drop"></div></div>
             <div id="bulkCampaignEmpty" style="display:none;font-size:12px;color:var(--muted);margin-top:8px">선택한 조건의 캠페인이 없습니다. 다른 상태·타입을 골라주세요.</div>
           </div>
         </div>

--- a/dev/css/admin.css
+++ b/dev/css/admin.css
@@ -1452,8 +1452,10 @@
 .broadcast-recip-name { font-weight: 600; color: var(--ink); }
 .broadcast-recip-camp { flex: 1; font-size: 11px; color: var(--muted); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .broadcast-recip-status { font-size: 11px; color: var(--muted); }
-/* 일괄발송 캠페인 드롭다운 — 모달 body(overflow:auto)가 absolute 드롭을 자르는 문제 회피.
-   문서 흐름(static)으로 펼쳐 모달 자체 스크롤로 보이게 한다(포털 불필요, 이 드롭다운만 한정). */
-#bulkCampaignMulti .mf-drop { position: static; margin-top: 4px; min-width: 0; max-width: 100%; max-height: 240px; overflow-y: auto; box-shadow: none; border: 1px solid var(--line); }
+/* 일괄발송 캠페인 드롭다운 — 펼칠 때 아래 필터를 밀어내지 않도록 문서 흐름에서 띄움(absolute).
+   ② 캠페인이 모달 상단이고 240px 높이 제한이라 모달 body 안에 들어가 가려지지 않음. */
+#bulkCampaignMulti .mf-drop { min-width: 0; max-width: 100%; max-height: 240px; overflow-y: auto; box-shadow: 0 6px 20px rgba(0,0,0,.16); border: 1px solid var(--line); }
 /* 부가설명에 한글(모집타입·상태) 혼재 — 고정폭 대신 본문 폰트로 가독성 확보 (캠페인 번호 단독 드롭다운은 monospace 유지) */
 #bulkCampaignMulti .mf-item-sub { font-family: inherit; }
+/* 선택 항목 상단 정렬 구분선 (다중선택 드롭다운 공통) */
+.mf-selected-divider { border-top: 1px solid var(--outline); margin: 4px 0; }

--- a/dev/js/admin-core.js
+++ b/dev/js/admin-core.js
@@ -389,7 +389,7 @@ function resetMultiFilter(containerId, allLabel) {
   const items = wrap.querySelectorAll('.mf-drop input[type="checkbox"]:not([value="all"])');
   if (allCb) { allCb.checked = true; allCb.indeterminate = false; }
   items.forEach(c => c.checked = true); // 전체 = 모든 항목 체크 표시
-  if (btn) { btn.textContent = allLabel; btn.classList.remove('has-selection'); }
+  if (btn) { btn.textContent = allLabel; btn.classList.remove('has-selection'); btn.removeAttribute('title'); }
 }
 // 모두 해제 — 일괄발송처럼 "명시 선택 강제" 맥락에서 사용.
 //   resetMultiFilter 는 "전체=모두 체크"(빈 배열 시맨틱)라 미선택 표현이 안 됨.
@@ -399,7 +399,7 @@ function clearMultiFilter(containerId, placeholderLabel) {
   if (!wrap) return;
   wrap.querySelectorAll('.mf-drop input[type="checkbox"]').forEach(c => { c.checked = false; c.indeterminate = false; });
   const btn = wrap.querySelector('.mf-btn');
-  if (btn) { btn.textContent = placeholderLabel || '선택'; btn.classList.remove('has-selection'); }
+  if (btn) { btn.textContent = placeholderLabel || '선택'; btn.classList.remove('has-selection'); btn.removeAttribute('title'); }
 }
 function updateFilterResetBtn(btnId, multiIds, searchId) {
   const btn = $(btnId);
@@ -464,12 +464,16 @@ function createMultiFilter(containerId, allLabel, options, onChange, opts = {}) 
     + options.map(renderOptionItem).join('')
     + emptyHtml;
   btn.textContent = allLabel;
-  // 토글 — 검색형이면 열 때 검색 input 포커스
+  // 토글 — 열 때 선택 항목을 상단으로 재정렬(체크 토글 중엔 순서 고정, 열 때만 1회), 검색형이면 검색 input 포커스
   btn.onclick = (e) => {
     e.stopPropagation();
+    const willOpen = !drop.classList.contains('open');
     drop.classList.toggle('open');
-    if (opts.searchable && drop.classList.contains('open')) {
-      const si = drop.querySelector('.mf-search'); if (si) setTimeout(() => si.focus(), 0);
+    if (willOpen) {
+      reorderSelectedFirst(drop);
+      if (opts.searchable) {
+        const si = drop.querySelector('.mf-search'); if (si) setTimeout(() => si.focus(), 0);
+      }
     }
   };
   // 체크 로직 — 옵션 체크박스만 (검색 input[type=search] 은 제외)
@@ -482,6 +486,7 @@ function createMultiFilter(containerId, allLabel, options, onChange, opts = {}) 
       allCb.checked = true;
       allCb.indeterminate = false;
       btn.textContent = allLabel;
+      btn.removeAttribute('title');
       btn.classList.remove('has-selection');
     } else if (selected.length === 0) {
       // 모두 해제 — 사용자가 「전체」 체크박스를 눌러 전체 해제한 표준 동작.
@@ -490,13 +495,15 @@ function createMultiFilter(containerId, allLabel, options, onChange, opts = {}) 
       allCb.checked = false;
       allCb.indeterminate = false;
       btn.textContent = allLabel;
+      btn.removeAttribute('title');
       btn.classList.remove('has-selection');
     } else {
-      // 일부 — 전체는 indeterminate
+      // 일부 — 전체는 indeterminate. 닫힘 버튼은 「다중 선택 N건」(선택 항목명은 tooltip 보존)
       allCb.checked = false;
       allCb.indeterminate = true;
-      // input에 data-label 보관(subLabel/count 영향 없음)
-      btn.textContent = selected.map(c => c.dataset.label || c.parentElement.textContent.trim()).join(', ');
+      const names = selected.map(c => c.dataset.label || c.parentElement.textContent.trim());
+      btn.textContent = '다중 선택 ' + selected.length + '건';
+      btn.title = names.join(', ');
       btn.classList.add('has-selection');
     }
     onChange(getMultiFilterValues(containerId));
@@ -541,6 +548,26 @@ function getMultiFilterValues(containerId) {
   // 전체(모두 체크) = 필터 없음 → 빈 배열
   if (allCb?.checked && !allCb.indeterminate) return [];
   return [...wrap.querySelectorAll('.mf-drop input[type="checkbox"]:not([value="all"]):checked')].map(c => c.value);
+}
+
+// 드롭다운 열 때 선택된 항목을 「전체」 항목 바로 아래로 모으고 구분선 삽입(선택 항목 상단 정렬).
+// 열 때 1회만 호출 → 체크 토글 중에는 순서가 튀지 않음. 한쪽만 있으면(전부/없음) 정렬 생략.
+function reorderSelectedFirst(drop) {
+  if (!drop) return;
+  drop.querySelectorAll('.mf-selected-divider').forEach(d => d.remove());
+  const items = [...drop.querySelectorAll('.mf-item:not(.all-item)')];
+  const checked = items.filter(it => it.querySelector('input[type="checkbox"]')?.checked);
+  const unchecked = items.filter(it => !it.querySelector('input[type="checkbox"]')?.checked);
+  if (!checked.length || !unchecked.length) return;
+  // 기준점: 「전체」 항목(없으면 검색창) 뒤에 선택→구분선→미선택 순으로 재배치
+  let ref = drop.querySelector('.all-item') || drop.querySelector('.mf-search-box');
+  if (!ref) return;
+  checked.forEach(it => { ref.after(it); ref = it; });
+  const divider = document.createElement('div');
+  divider.className = 'mf-selected-divider';
+  ref.after(divider);
+  ref = divider;
+  unchecked.forEach(it => { ref.after(it); ref = it; });
 }
 // 커스텀 confirm 모달 (Promise 반환)
 let _confirmResolver = null;

--- a/dev/js/admin-messaging.js
+++ b/dev/js/admin-messaging.js
@@ -1036,7 +1036,7 @@ function refreshBulkCampaignList() {
   }
   if (selWrap) selWrap.style.display = '';
   populateBulkCampaigns(statuses, types);   // 상태 AND 타입 조건 캠페인만
-  if (typeof clearMultiFilter === 'function') clearMultiFilter('bulkCampaignMulti', '캠페인 선택');
+  if (typeof clearMultiFilter === 'function') clearMultiFilter('bulkCampaignMulti', '전체 선택');
 }
 
 function populateBulkCampaigns(statuses, recruitTypes) {
@@ -1060,21 +1060,11 @@ function populateBulkCampaigns(statuses, recruitTypes) {
   });
   // 결과물 관리와 동일한 검색형 다중필터 (캠페인명·번호 검색). 선택 변경 → onBulkCampaignChange
   if (typeof syncMultiFilter === 'function') {
-    syncMultiFilter('bulkCampaignMulti', '캠페인 선택', options, onBulkCampaignChange, { searchable: true, searchPlaceholder: '캠페인명 · 번호 검색' });
+    syncMultiFilter('bulkCampaignMulti', '전체 선택', options, onBulkCampaignChange, { searchable: true, searchPlaceholder: '캠페인명 · 번호 검색' });
   }
   // 빈 상태 안내 (선택 조건에 캠페인 0건)
   const empty = document.getElementById('bulkCampaignEmpty');
   if (empty) empty.style.display = camps.length ? 'none' : 'block';
-}
-
-// ② 캠페인 「전체 선택」 — 현재 필터된 캠페인 전부를 명시 대상으로. mf-wrap 「전체」 체크박스 토글.
-function selectAllBulkCampaigns() {
-  const wrap = document.getElementById('bulkCampaignMulti');
-  const allCb = wrap && wrap.querySelector('input[value="all"]');
-  if (!allCb) return;
-  allCb.checked = true;
-  allCb.indeterminate = false;
-  if (typeof allCb.onchange === 'function') allCb.onchange();   // 모든 항목 체크 + onBulkCampaignChange 트리거
 }
 
 function onBulkCampaignChange() {


### PR DESCRIPTION
## 변경 요약
- **공통 다중선택 드롭다운(8개 화면)**: 닫힘 버튼 「다중 선택 N건」 표시(선택명은 tooltip) + 펼칠 때 선택 항목이 구분선 위로 정렬
- **일괄발송 캠페인 드롭다운**: 펼칠 때 아래 필터를 밀어내지 않고 떠 있게(absolute) + 맨 위 항목/placeholder '캠페인 선택'→'전체 선택' + 바깥 「전체 선택」 버튼 제거(진입점 통일)

## 요청 외 추가 변경
- 없음

## 관련 사양서
- docs/specs/2026-06-02-bulk-message-target-redesign.md

## 검증
[via reviewer] GO — DOM 이동 후 핸들러 보존, 재렌더 시 구분선 제거, title 초기화 보강. Critical 없음
- 사용자 요청 1·2·3·6번 (4·5번 인플 필터는 PR 2, DB 변경)

## 운영 배포
- 보류 (일괄발송 전체 약관 게이트)

🤖 Generated with [Claude Code](https://claude.com/claude-code)