### PR TITLE
fix(admin): 종료 캠페인 편집 버그 + 오류 메시지 한글화 + 상태 안내 모달

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -12,7 +12,7 @@
 // 회귀(2026-05-12 PR #182 머지 직후 발생)를 방지하기 위한 자동 reload 가드.
 // sessionStorage 차단 환경(시크릿 모드 일부, 쿠키 차단)에서는 자연스럽게 skip.
 (function(){
-  var CURRENT_BUILD = 'v1780550885';
+  var CURRENT_BUILD = 'v1780554075';
   if (CURRENT_BUILD.indexOf('__') === 0) return; // 빌드 미적용 (dev/ 직접 열기) 시 skip
   try {
     var prev = sessionStorage.getItem('reverb.adminBuild');
@@ -1993,7 +1993,7 @@ textarea.form-input{resize:vertical;min-height:80px}
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-06-04 14:28 · 6b38100</span>
+          <span class="admin-build-text">2026-06-04 15:21 · cce311a</span>
         </div>
       </div>
     </aside>
@@ -2208,7 +2208,7 @@ textarea.form-input{resize:vertical;min-height:80px}
               </div>
               <div class="form-group"><label class="form-label">상태</label>
                 <select id="editCampStatus" class="form-input">
-                  <option value="draft">준비</option><option value="scheduled">모집예정</option><option value="active">모집중</option><option value="closed">종료</option><option value="expired">노출마감</option>
+                  <option value="draft">준비</option><option value="scheduled">모집예정</option><option value="active">모집중</option><option value="closed">모집마감</option><option value="ended">종료</option><option value="expired">노출종료</option>
                 </select>
               </div>
             </div>
@@ -4089,66 +4089,103 @@ textarea.form-input{resize:vertical;min-height:80px}
 <div class="modal-overlay" id="campStatusHelpModal" style="z-index:600">
   <div class="modal" style="max-width:640px;border-radius:16px;margin:auto;max-height:88vh;overflow:hidden;display:flex;flex-direction:column">
     <div class="modal-header">
-      <div class="modal-title">캠페인 상태별 클라이언트 노출 안내</div>
+      <div class="modal-title">캠페인 상태 안내 — 노출 · 저절로 바뀜 · 수정 가능 여부</div>
       <div class="modal-close" onclick="closeModal('campStatusHelpModal')"><span class="material-icons-round notranslate" translate="no" style="font-size:18px">close</span></div>
     </div>
     <div class="modal-body" style="padding:20px;overflow-y:auto;flex:1;min-height:0">
+
+      <div style="font-size:13px;font-weight:700;color:var(--ink);margin-bottom:8px">① 상태와 인플루언서 노출</div>
       <table class="data-table" style="width:100%;font-size:12px">
         <thead>
           <tr style="background:var(--surface-dim)">
             <th style="padding:8px 10px;text-align:left">상태</th>
-            <th style="padding:8px 10px;text-align:left">의미</th>
-            <th style="padding:8px 10px;text-align:left">클라이언트(인플루언서) 노출</th>
-            <th style="padding:8px 10px;text-align:left">화면 표시</th>
+            <th style="padding:8px 10px;text-align:left">뜻</th>
+            <th style="padding:8px 10px;text-align:left">인플루언서에게 보이나요</th>
           </tr>
         </thead>
         <tbody>
           <tr>
-            <td style="padding:8px 10px"><span style="background:#EEE;color:#666;font-size:11px;font-weight:700;padding:2px 8px;border-radius:4px">draft</span></td>
-            <td style="padding:8px 10px">작성·검토중</td>
-            <td style="padding:8px 10px;color:var(--red);font-weight:600">노출 안 됨</td>
-            <td style="padding:8px 10px;color:var(--muted)">—</td>
+            <td style="padding:8px 10px"><span style="background:#EEE;color:#666;font-size:11px;font-weight:700;padding:2px 8px;border-radius:4px">준비</span></td>
+            <td style="padding:8px 10px">아직 만드는 중</td>
+            <td style="padding:8px 10px;color:var(--red);font-weight:600">안 보임</td>
           </tr>
           <tr>
-            <td style="padding:8px 10px"><span style="background:#FFF8E1;color:#8B6914;font-size:11px;font-weight:700;padding:2px 8px;border-radius:4px">scheduled</span></td>
-            <td style="padding:8px 10px">모집 시작 전</td>
-            <td style="padding:8px 10px;color:var(--green);font-weight:600">노출됨</td>
-            <td style="padding:8px 10px">「모집예정」 / 「近日公開」 배지</td>
+            <td style="padding:8px 10px"><span style="background:#FFF8E1;color:#8B6914;font-size:11px;font-weight:700;padding:2px 8px;border-radius:4px">모집예정</span></td>
+            <td style="padding:8px 10px">곧 모집 시작</td>
+            <td style="padding:8px 10px;color:var(--green);font-weight:600">보임 (近日公開)</td>
           </tr>
           <tr>
-            <td style="padding:8px 10px"><span style="background:#E6F3E8;color:#274;font-size:11px;font-weight:700;padding:2px 8px;border-radius:4px">active</span></td>
-            <td style="padding:8px 10px">모집중</td>
-            <td style="padding:8px 10px;color:var(--green);font-weight:600">노출됨</td>
-            <td style="padding:8px 10px">「모집중」 / 「募集中」 배지</td>
+            <td style="padding:8px 10px"><span style="background:#E6F3E8;color:#274;font-size:11px;font-weight:700;padding:2px 8px;border-radius:4px">모집중</span></td>
+            <td style="padding:8px 10px">지금 모집 중</td>
+            <td style="padding:8px 10px;color:var(--green);font-weight:600">보임 (募集中)</td>
           </tr>
           <tr>
-            <td style="padding:8px 10px"><span style="background:#F5F5F5;color:#999;font-size:11px;font-weight:700;padding:2px 8px;border-radius:4px">closed</span></td>
-            <td style="padding:8px 10px">모집 종료</td>
-            <td style="padding:8px 10px;color:var(--gold);font-weight:600">노출됨 (운영자가 OFF 할 때까지)</td>
-            <td style="padding:8px 10px">「募集締切」 오버레이 + 신청 버튼 비활성</td>
+            <td style="padding:8px 10px"><span style="background:#FCE4EC;color:#AD1457;font-size:11px;font-weight:700;padding:2px 8px;border-radius:4px">모집마감</span></td>
+            <td style="padding:8px 10px">모집 끝 · 결과물 받는 중</td>
+            <td style="padding:8px 10px;color:var(--gold);font-weight:600">보임 (募集締切), 끌 때까지</td>
           </tr>
           <tr>
-            <td style="padding:8px 10px"><span style="background:#EFEFEF;color:#888;font-size:11px;font-weight:700;padding:2px 8px;border-radius:4px">expired</span></td>
-            <td style="padding:8px 10px">노출 마감 (운영자가 노출 토글 OFF)</td>
-            <td style="padding:8px 10px;color:var(--red);font-weight:600">노출 안 됨</td>
-            <td style="padding:8px 10px;color:var(--muted)">—</td>
+            <td style="padding:8px 10px"><span style="background:#E8EAF6;color:#283593;font-size:11px;font-weight:700;padding:2px 8px;border-radius:4px">종료</span></td>
+            <td style="padding:8px 10px">결과물까지 다 끝남</td>
+            <td style="padding:8px 10px;color:var(--gold);font-weight:600">보임 (終了), 끌 때까지</td>
+          </tr>
+          <tr>
+            <td style="padding:8px 10px"><span style="background:#EFEFEF;color:#888;font-size:11px;font-weight:700;padding:2px 8px;border-radius:4px">노출종료</span></td>
+            <td style="padding:8px 10px">운영자가 화면에서 내림</td>
+            <td style="padding:8px 10px;color:var(--red);font-weight:600">안 보임</td>
           </tr>
         </tbody>
       </table>
-      <div style="margin-top:18px;padding:14px;background:var(--light-pink);border-radius:10px;font-size:12px;line-height:1.6">
-        <div style="font-weight:700;color:var(--dark-pink);margin-bottom:6px">자동 전이 규칙</div>
+
+      <div style="margin-top:18px;padding:14px;background:var(--light-pink);border-radius:10px;font-size:12px;line-height:1.7">
+        <div style="font-weight:700;color:var(--dark-pink);margin-bottom:6px">② 상태가 저절로 바뀌는 경우</div>
         <ul style="margin:0;padding-left:18px;color:var(--ink)">
-          <li><strong>모집 시작일(recruit_start) 도래</strong>하면 scheduled → active 로 자동 변경됩니다.</li>
-          <li><strong>모집 마감일(deadline) 경과</strong>하면 active → closed 로 자동 변경됩니다.</li>
-          <li>expired(노출 마감) 상태는 <strong>운영자가 「캠페인 노출」 토글 OFF</strong> 클릭으로만 진입합니다. 자동 전이 없음.</li>
-          <li>모집 마감일이 지난 캠페인은 active / scheduled 상태로 저장·변경할 수 없습니다.</li>
-          <li>closed / expired 캠페인의 주의사항·참여방법은 수정할 수 없습니다 (DB에서 이중 차단).</li>
+          <li>모집 <strong>시작일</strong>이 되면 → 모집예정에서 <strong>모집중</strong>으로 저절로</li>
+          <li>모집 <strong>마감일</strong>이 지나면 → 모집중에서 <strong>모집마감</strong>으로 저절로</li>
+          <li>결과물 <strong>제출 마감일</strong>이 지나면 → 모집마감에서 <strong>종료</strong>로 저절로</li>
+          <li><strong>노출종료</strong>는 저절로 안 됨 — 운영자가 「캠페인 노출」을 꺼야만 됩니다</li>
         </ul>
       </div>
-      <div style="margin-top:14px;padding:14px;background:var(--surface-dim);border-radius:10px;font-size:12px;line-height:1.6">
-        <div style="font-weight:700;color:var(--ink);margin-bottom:6px">전이 흐름</div>
-        <div style="font-family:monospace;font-size:11px;color:var(--ink)">draft → scheduled → active → closed (← 운영자가 OFF 시 expired)</div>
-        <div style="margin-top:6px;color:var(--muted)">closed 는 운영자가 토글 OFF 할 때까지 인플루언서에게 계속 노출(募集締切 표시). expired 는 완전 비노출.</div>
+
+      <div style="font-size:13px;font-weight:700;color:var(--ink);margin:18px 0 8px">③ 상태에 따라 고칠 수 있는 것 / 없는 것</div>
+      <table class="data-table" style="width:100%;font-size:12px">
+        <thead>
+          <tr style="background:var(--surface-dim)">
+            <th style="padding:8px 10px;text-align:left">무엇을</th>
+            <th style="padding:8px 10px;text-align:left">준비 · 모집예정 · 모집중</th>
+            <th style="padding:8px 10px;text-align:left">모집마감 · 종료 · 노출종료</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td style="padding:8px 10px">모집 기간(시작·마감일)</td>
+            <td style="padding:8px 10px;color:var(--green);font-weight:600">고칠 수 있음</td>
+            <td style="padding:8px 10px;color:var(--green);font-weight:600">고칠 수 있음</td>
+          </tr>
+          <tr>
+            <td style="padding:8px 10px">결과물 제출 마감일</td>
+            <td style="padding:8px 10px;color:var(--green);font-weight:600">고칠 수 있음</td>
+            <td style="padding:8px 10px;color:var(--green);font-weight:600">고칠 수 있음</td>
+          </tr>
+          <tr>
+            <td style="padding:8px 10px">구매 · 방문 기간</td>
+            <td style="padding:8px 10px;color:var(--green);font-weight:600">고칠 수 있음</td>
+            <td style="padding:8px 10px;color:var(--green);font-weight:600">고칠 수 있음</td>
+          </tr>
+          <tr>
+            <td style="padding:8px 10px">주의사항 · 참여방법 · NG사항</td>
+            <td style="padding:8px 10px;color:var(--green);font-weight:600">고칠 수 있음 *</td>
+            <td style="padding:8px 10px;color:var(--red);font-weight:600">못 고침</td>
+          </tr>
+        </tbody>
+      </table>
+      <div style="margin-top:10px;font-size:11px;color:var(--muted);line-height:1.7">
+        * 주의사항·참여방법·NG는 신청자가 1명이라도 있으면 「정말 바꿀까요?」 확인창이 뜹니다.<br>
+        * 「모집중」·「모집예정」으로 저장하려면 모집 마감일이 아직 안 지났어야 합니다.<br>
+        * 날짜는 서로 순서가 맞아야 저장됩니다 (모집마감 &gt; 시작, 제출마감 &gt; 구매·방문 종료 등).
+      </div>
+      <div style="margin-top:14px;padding:12px 14px;background:var(--surface-dim);border-radius:10px;font-size:12px;line-height:1.6;color:var(--ink)">
+        <strong>한 줄 정리:</strong> 날짜는 거의 다 고칠 수 있고, 모집마감 이후엔 <strong>주의사항·참여방법·NG</strong>만 잠깁니다.
       </div>
     </div>
     <div style="padding:14px 20px;border-top:1px solid var(--line);text-align:right">
@@ -9819,7 +9856,12 @@ function friendlyError(msg) {
   if (s.includes('timeout') || s.includes('timed out')) return '요청 시간이 초과되었습니다. [ERR_TIMEOUT_408]';
   if (s.includes('unauthorized') || s.includes('JWT')) return '인증이 만료되었습니다. 다시 로그인해주세요. [ERR_AUTH_401]';
   if (s.includes('email_not_confirmed')) return '이메일 인증이 완료되지 않았습니다. [ERR_EMAIL_UNVERIFIED]';
-  return s + ' [ERR_UNHANDLED]';
+  if (s.includes('violates check constraint') || s.includes('check_violation')) return '허용되지 않는 값입니다. 입력 내용을 다시 확인해주세요. [ERR_CHECK_23514]';
+  // DB 트리거·함수(RAISE)가 한글 안내 메시지를 던지면 그대로 보여준다 (예: 「모집마감 캠페인의 주의사항은…」)
+  if (/[가-힣]/.test(s)) return s;
+  // 미분류 영어 원문 — 화면에는 일반 안내만 노출하고, 원문은 콘솔에 기록(운영자 추적용)
+  try { console.warn('[friendlyError unhandled]', s); } catch (_) {}
+  return '처리 중 오류가 발생했습니다. 잠시 후 다시 시도하거나 관리자에게 문의해주세요. [ERR_UNHANDLED]';
 }
 
 // ════════════════════════════════════════════════════════════════════
@@ -16563,7 +16605,7 @@ async function onPublishFromView() {
     closeModal('adminNoticeViewModal');
     await loadAdminNotices();
     renderDashboardNotices();
-  } catch(e) { toast('게시 오류: ' + (e.message || e), 'error'); }
+  } catch(e) { toast('게시 오류: ' + friendlyError(e.message || e), 'error'); }
 }
 
 // 보기 모달에서 "게시 회수" 클릭 — published → draft (published_at 유지)
@@ -16578,7 +16620,7 @@ async function onUnpublishFromView() {
     closeModal('adminNoticeViewModal');
     await loadAdminNotices();
     renderDashboardNotices();
-  } catch(e) { toast('회수 오류: ' + (e.message || e), 'error'); }
+  } catch(e) { toast('회수 오류: ' + friendlyError(e.message || e), 'error'); }
 }
 
 function openAdminNoticeEdit(id) {
@@ -16714,7 +16756,7 @@ async function onSaveAdminNotice(mode) {
     closeModal('adminNoticeEditModal');
     await loadAdminNotices();
     renderDashboardNotices();
-  } catch(e) { toast('저장 오류: ' + (e.message || e), 'error'); }
+  } catch(e) { toast('저장 오류: ' + friendlyError(e.message || e), 'error'); }
 }
 
 async function onDeleteAdminNotice() {
@@ -16725,7 +16767,7 @@ async function onDeleteAdminNotice() {
     toast('삭제되었습니다');
     closeModal('adminNoticeEditModal');
     await refreshPane('admin-notices');
-  } catch(e) { toast('삭제 오류: ' + (e.message || e), 'error'); }
+  } catch(e) { toast('삭제 오류: ' + friendlyError(e.message || e), 'error'); }
 }
 
 // 대시보드 최근 공지 3건 렌더 — published 만 노출
@@ -17819,7 +17861,7 @@ async function onInfluencerVerify() {
     _infViolationCounts = {};
     await openInfluencerDetail(_currentDetailInfluencer.id);
     await refreshPane('influencers');
-  } catch(e) { toast('오류: ' + (e.message || e), 'error'); }
+  } catch(e) { toast('오류: ' + friendlyError(e.message || e), 'error'); }
 }
 
 async function onInfluencerUnverify() {
@@ -17832,7 +17874,7 @@ async function onInfluencerUnverify() {
     _infViolationCounts = {};
     await openInfluencerDetail(_currentDetailInfluencer.id);
     await refreshPane('influencers');
-  } catch(e) { toast('오류: ' + (e.message || e), 'error'); }
+  } catch(e) { toast('오류: ' + friendlyError(e.message || e), 'error'); }
 }
 
 // 위반 기록 편집 — _currentFlagsCache 에서 id로 찾아 모달 오픈
@@ -17906,7 +17948,7 @@ async function onSaveEditViolation() {
     _editingKeptUrlMap = {};
     if (_currentDetailInfluencer) await openInfluencerDetail(_currentDetailInfluencer.id);
     await refreshPane('influencers');
-  } catch(e) { toast('오류: ' + (e.message || e), 'error'); }
+  } catch(e) { toast('오류: ' + friendlyError(e.message || e), 'error'); }
 }
 
 // 신청 이력의 cancelled 보조 행에서 호출 — 위반 등록 폼에 자동 prefill
@@ -17972,7 +18014,7 @@ async function onInfluencerRecordViolation() {
     _infViolationCounts[_currentDetailInfluencer.id] = (_infViolationCounts[_currentDetailInfluencer.id] || 0) + 1;
     rerenderInfluencersFromCache();
     await openInfluencerDetail(_currentDetailInfluencer.id);
-  } catch(e) { toast('오류: ' + (e.message || e), 'error'); }
+  } catch(e) { toast('오류: ' + friendlyError(e.message || e), 'error'); }
 }
 
 async function onInfluencerBlacklist() {
@@ -17989,7 +18031,7 @@ async function onInfluencerBlacklist() {
     _infViolationCounts = {};
     await openInfluencerDetail(_currentDetailInfluencer.id);
     await refreshPane('influencers');
-  } catch(e) { toast('오류: ' + (e.message || e), 'error'); }
+  } catch(e) { toast('오류: ' + friendlyError(e.message || e), 'error'); }
 }
 
 async function onInfluencerUnblacklist() {
@@ -18002,7 +18044,7 @@ async function onInfluencerUnblacklist() {
     _infViolationCounts = {};
     await openInfluencerDetail(_currentDetailInfluencer.id);
     await refreshPane('influencers');
-  } catch(e) { toast('오류: ' + (e.message || e), 'error'); }
+  } catch(e) { toast('오류: ' + friendlyError(e.message || e), 'error'); }
 }
 
 // 인플루언서 이름 클릭 = 어디서든 풀 상세 모달(상태 관리·이력 포함)로 통일
@@ -22673,7 +22715,7 @@ async function saveMyAdminInfo() {
     updateSidebarProfile();
     toast('정보가 저장되었습니다','success');
   } catch(e) {
-    toast('저장 오류: ' + e.message,'error');
+    toast('저장 오류: ' + friendlyError(e.message),'error');
   }
 }
 
@@ -22948,7 +22990,7 @@ async function renderLookupsTable() {
   try {
     rows = await fetchLookupsAll(_currentLookupKind);
   } catch(e) {
-    tbody.innerHTML = `<tr><td colspan="${colspan}" style="text-align:center;color:var(--red);padding:24px">조회 실패: ${esc(e.message||String(e))}</td></tr>`;
+    tbody.innerHTML = `<tr><td colspan="${colspan}" style="text-align:center;color:var(--red);padding:24px">조회 실패: ${esc(friendlyError(e.message||String(e)))}</td></tr>`;
     return;
   }
   if (!rows.length) {
@@ -23108,7 +23150,7 @@ async function moveLookup(idA, idB) {
     else await swapLookupOrder(idA, idB);
     renderLookupsTable();
   } catch(e) {
-    toast('정렬 변경 실패: ' + (e.message||String(e)),'error');
+    toast('정렬 변경 실패: ' + friendlyError(e.message||String(e)),'error');
   }
 }
 
@@ -23125,7 +23167,7 @@ async function toggleLookupActive(id, nextActive) {
     }
     renderLookupsTable();
   } catch(e) {
-    toast('상태 변경 실패: ' + (e.message||String(e)),'error');
+    toast('상태 변경 실패: ' + friendlyError(e.message||String(e)),'error');
   }
 }
 
@@ -23141,7 +23183,7 @@ async function handleLookupDelete(row) {
       toast('삭제했습니다','success');
       renderLookupsTable();
     } catch(e) {
-      toast('삭제 실패: ' + (e.message||String(e)),'error');
+      toast('삭제 실패: ' + friendlyError(e.message||String(e)),'error');
     }
     return;
   }
@@ -23158,7 +23200,7 @@ async function handleLookupDelete(row) {
     toast('삭제했습니다','success');
     renderLookupsTable();
   } catch(e) {
-    toast('삭제 실패: ' + (e.message||String(e)),'error');
+    toast('삭제 실패: ' + friendlyError(e.message||String(e)),'error');
   }
 }
 
@@ -23193,7 +23235,7 @@ async function renderPsetTable() {
   tbody.innerHTML = `<tr><td colspan="${colspan}" style="text-align:center;color:var(--muted);padding:24px"><span class="spinner" style="width:20px;height:20px;border-width:2px;border-color:rgba(200,120,163,.2);border-top-color:var(--pink)"></span></td></tr>`;
   let rows = [];
   try { rows = await fetchParticipationSetsAll(); } catch(e) {
-    tbody.innerHTML = `<tr><td colspan="${colspan}" style="text-align:center;color:var(--red);padding:24px">조회 실패: ${esc(e.message||String(e))}</td></tr>`;
+    tbody.innerHTML = `<tr><td colspan="${colspan}" style="text-align:center;color:var(--red);padding:24px">조회 실패: ${esc(friendlyError(e.message||String(e)))}</td></tr>`;
     return;
   }
   if (!rows.length) {
@@ -23329,7 +23371,7 @@ async function savePsetEdit() {
     toast('저장했습니다','success');
     renderLookupsTable();
   } catch(e) {
-    show('저장 실패: ' + (e.message||String(e)));
+    show('저장 실패: ' + friendlyError(e.message||String(e)));
   }
 }
 
@@ -23364,7 +23406,7 @@ async function renderCsetTable() {
   tbody.innerHTML = `<tr><td colspan="${colspan}" style="text-align:center;color:var(--muted);padding:24px"><span class="spinner" style="width:20px;height:20px;border-width:2px;border-color:rgba(200,120,163,.2);border-top-color:var(--pink)"></span></td></tr>`;
   let rows = [];
   try { rows = await fetchCautionSetsAll(); } catch(e) {
-    tbody.innerHTML = `<tr><td colspan="${colspan}" style="text-align:center;color:var(--red);padding:24px">조회 실패: ${esc(e.message||String(e))}</td></tr>`;
+    tbody.innerHTML = `<tr><td colspan="${colspan}" style="text-align:center;color:var(--red);padding:24px">조회 실패: ${esc(friendlyError(e.message||String(e)))}</td></tr>`;
     return;
   }
   if (!rows.length) {
@@ -23658,7 +23700,7 @@ function _bindMiniEditorLinkPopoverEvents(pop, aEl, contentDiv, href) {
         ta.select(); document.execCommand('copy'); document.body.removeChild(ta);
       }
       toast('링크를 복사했습니다','success');
-    } catch(e) { toast('복사 실패: ' + (e.message||String(e)),'error'); }
+    } catch(e) { toast('복사 실패: ' + friendlyError(e.message||String(e)),'error'); }
   });
 
   // 새 탭으로 열기 (편집 중에도 실제 링크 확인 가능)
@@ -23882,7 +23924,7 @@ async function saveCsetEdit() {
     toast('저장했습니다','success');
     renderLookupsTable();
   } catch(e) {
-    show('저장 실패: ' + (e.message||String(e)));
+    show('저장 실패: ' + friendlyError(e.message||String(e)));
   }
 }
 
@@ -23913,7 +23955,7 @@ async function renderNgSetTable() {
   tbody.innerHTML = `<tr><td colspan="${colspan}" style="text-align:center;color:var(--muted);padding:24px"><span class="spinner" style="width:20px;height:20px;border-width:2px;border-color:rgba(200,120,163,.2);border-top-color:var(--pink)"></span></td></tr>`;
   let rows = [];
   try { rows = await fetchNgSetsAll(); } catch(e) {
-    tbody.innerHTML = `<tr><td colspan="${colspan}" style="text-align:center;color:var(--red);padding:24px">조회 실패: ${esc(e.message||String(e))}</td></tr>`;
+    tbody.innerHTML = `<tr><td colspan="${colspan}" style="text-align:center;color:var(--red);padding:24px">조회 실패: ${esc(friendlyError(e.message||String(e)))}</td></tr>`;
     return;
   }
   if (!rows.length) {
@@ -24058,7 +24100,7 @@ async function saveNgSetEdit() {
     toast('저장했습니다','success');
     renderLookupsTable();
   } catch(e) {
-    show('저장 실패: ' + (e.message||String(e)));
+    show('저장 실패: ' + friendlyError(e.message||String(e)));
   }
 }
 
@@ -24896,7 +24938,16 @@ async function openEditCampaign(campId) {
 //   조건: status === 'closed' 또는 'expired' 일 때 비활성화 + 잠금 메시지 노출
 function applyEditFormSensitiveLocks(status) {
   const isLocked = status === 'closed' || status === 'ended' || status === 'expired';
-  const lockLabel = status === 'expired' ? '노출마감' : status === 'ended' ? '종료' : '모집마감';
+  const lockLabel = status === 'expired' ? '노출종료' : status === 'ended' ? '종료' : '모집마감';
+  // 모집마감·종료·노출종료 상태에서는 상태 드롭다운을 현재 상태로 고정(임의 변경·빈값 저장 차단).
+  // 상태 되돌리기가 필요하면 「캠페인 노출」 토글로 처리한다.
+  const statusSel = $('editCampStatus');
+  if (statusSel) {
+    statusSel.disabled = isLocked;
+    statusSel.title = isLocked ? `${lockLabel} 캠페인의 상태는 변경할 수 없습니다 (「캠페인 노출」 토글로 조정)` : '';
+    statusSel.style.opacity = isLocked ? '0.6' : '';
+    statusSel.style.cursor = isLocked ? 'not-allowed' : '';
+  }
   ['Pset', 'Cset', 'Nset'].forEach(kind => {
     const card = $('editCamp' + kind + 'Summary');
     if (!card) return;
@@ -25091,7 +25142,7 @@ async function openCautionHistoryModal(campId) {
     _cautionHistoryState.list = Array.isArray(list) ? list : [];
     renderCautionHistoryModal();
   } catch(e) {
-    if (body) body.innerHTML = `<div style="padding:24px;color:#B3261E;font-size:13px">이력 불러오기 실패: ${esc(e.message||String(e))}</div>`;
+    if (body) body.innerHTML = `<div style="padding:24px;color:#B3261E;font-size:13px">이력 불러오기 실패: ${esc(friendlyError(e.message||String(e)))}</div>`;
   }
 }
 
@@ -25911,7 +25962,9 @@ async function saveCampaignEdit() {
     const editDeadline = gv('editCampDeadline');
     const editDateErrs = validateCampDateRanges('editCamp');
     if (editDateErrs.length) { toast(editDateErrs[0].msg, 'error'); validateCampDateRangesInline('editCamp'); return; }
-    const editStatus = gv('editCampStatus');
+    // 빈값 가드 — 드롭다운에 없는 상태(disabled 등)거나 값이 비면 원본 상태로 폴백.
+    // 종료(ended) 캠페인 편집 시 status='' 저장으로 campaigns_status_check 위반하던 버그 방지.
+    const editStatus = gv('editCampStatus') || (_editCampOriginal && _editCampOriginal.status) || 'active';
     if (editDeadline && (editStatus === 'active' || editStatus === 'scheduled')) {
       const dl = new Date(editDeadline); dl.setHours(23,59,59,999);
       if (new Date() > dl) {
@@ -25965,7 +26018,7 @@ async function saveCampaignEdit() {
       guide: gv('editCampGuide'),
       // 067 legacy 컬럼은 더 이상 갱신하지 않음 (070 마이그레이션에서 DROP 예정)
       // ng legacy 컬럼은 NG-PR-B에서 갱신 중단 — ng_set_id/ng_items 로 대체 (NG-PR-F에서 DROP 예정)
-      status: gv('editCampStatus'),
+      status: editStatus,
       ...collectCampPsetPayload('edit'),
       ...collectCampCsetPayload('edit'),
       ...collectCampNsetPayload('edit'),
@@ -27736,7 +27789,7 @@ function _renderCampVisibilityToggle(prefix, status, dateRefs) {
   toggle.setAttribute('aria-checked', isOff ? 'false' : 'true');
   toggle.disabled = isDraft;
   if (statusEl) {
-    var labels = { draft: '준비', scheduled: '모집예정', active: '모집중', closed: '모집마감', ended: '종료', expired: '노출마감 (수동)' };
+    var labels = { draft: '준비', scheduled: '모집예정', active: '모집중', closed: '모집마감', ended: '종료', expired: '노출종료 (수동)' };
     statusEl.textContent = '상태: ' + (labels[status] || status || '미정');
     statusEl.classList.toggle('is-off', isOff);
   }
@@ -27758,7 +27811,7 @@ async function onCampVisibilityToggle(prefix) {
     if (campId) {
       try {
         await toggleCampaignVisibility(campId, false);
-        toast('캠페인 노출이 OFF (노출마감) 로 변경되었습니다');
+        toast('캠페인 노출이 OFF (노출종료) 로 변경되었습니다');
         _renderCampVisibilityToggle(prefix, 'expired', { recruit_start: toggle.dataset.recruitStart, deadline: toggle.dataset.deadline });
         // 폼 상태 드롭다운도 갱신 (있으면)
         var statusSel = $('editCampStatus');
@@ -27766,7 +27819,7 @@ async function onCampVisibilityToggle(prefix) {
         await refreshPane('campaigns');
       } catch (e) {
         console.error('[toggleCampaignVisibility OFF]', e);
-        toast('변경 실패: ' + (e.message || e), 'error');
+        toast('변경 실패: ' + friendlyError(e.message || e), 'error');
       }
     } else {
       // 신규 등록 폼은 아직 DB에 없음 — UI 상태만 변경
@@ -27784,7 +27837,7 @@ async function onCampVisibilityToggle(prefix) {
         await refreshPane('campaigns');
       } catch (e) {
         console.error('[toggleCampaignVisibility ON]', e);
-        toast('변경 실패: ' + (e.message || e), 'error');
+        toast('변경 실패: ' + friendlyError(e.message || e), 'error');
       }
     } else {
       // 신규 등록 폼 — 기본 active 로 가정
@@ -27808,7 +27861,7 @@ async function onCampQuickVisibilityToggle(ev, campId, currentStatus) {
     await refreshPane('campaigns');
   } catch (e) {
     console.error('[onCampQuickVisibilityToggle]', e);
-    toast('변경 실패: ' + (e.message || e), 'error');
+    toast('변경 실패: ' + friendlyError(e.message || e), 'error');
   }
 }
 

--- a/dev/admin/index.html
+++ b/dev/admin/index.html
@@ -347,7 +347,7 @@
               </div>
               <div class="form-group"><label class="form-label">상태</label>
                 <select id="editCampStatus" class="form-input">
-                  <option value="draft">준비</option><option value="scheduled">모집예정</option><option value="active">모집중</option><option value="closed">종료</option><option value="expired">노출마감</option>
+                  <option value="draft">준비</option><option value="scheduled">모집예정</option><option value="active">모집중</option><option value="closed">모집마감</option><option value="ended">종료</option><option value="expired">노출종료</option>
                 </select>
               </div>
             </div>
@@ -2230,66 +2230,103 @@
 <div class="modal-overlay" id="campStatusHelpModal" style="z-index:600">
   <div class="modal" style="max-width:640px;border-radius:16px;margin:auto;max-height:88vh;overflow:hidden;display:flex;flex-direction:column">
     <div class="modal-header">
-      <div class="modal-title">캠페인 상태별 클라이언트 노출 안내</div>
+      <div class="modal-title">캠페인 상태 안내 — 노출 · 저절로 바뀜 · 수정 가능 여부</div>
       <div class="modal-close" onclick="closeModal('campStatusHelpModal')"><span class="material-icons-round notranslate" translate="no" style="font-size:18px">close</span></div>
     </div>
     <div class="modal-body" style="padding:20px;overflow-y:auto;flex:1;min-height:0">
+
+      <div style="font-size:13px;font-weight:700;color:var(--ink);margin-bottom:8px">① 상태와 인플루언서 노출</div>
       <table class="data-table" style="width:100%;font-size:12px">
         <thead>
           <tr style="background:var(--surface-dim)">
             <th style="padding:8px 10px;text-align:left">상태</th>
-            <th style="padding:8px 10px;text-align:left">의미</th>
-            <th style="padding:8px 10px;text-align:left">클라이언트(인플루언서) 노출</th>
-            <th style="padding:8px 10px;text-align:left">화면 표시</th>
+            <th style="padding:8px 10px;text-align:left">뜻</th>
+            <th style="padding:8px 10px;text-align:left">인플루언서에게 보이나요</th>
           </tr>
         </thead>
         <tbody>
           <tr>
-            <td style="padding:8px 10px"><span style="background:#EEE;color:#666;font-size:11px;font-weight:700;padding:2px 8px;border-radius:4px">draft</span></td>
-            <td style="padding:8px 10px">작성·검토중</td>
-            <td style="padding:8px 10px;color:var(--red);font-weight:600">노출 안 됨</td>
-            <td style="padding:8px 10px;color:var(--muted)">—</td>
+            <td style="padding:8px 10px"><span style="background:#EEE;color:#666;font-size:11px;font-weight:700;padding:2px 8px;border-radius:4px">준비</span></td>
+            <td style="padding:8px 10px">아직 만드는 중</td>
+            <td style="padding:8px 10px;color:var(--red);font-weight:600">안 보임</td>
           </tr>
           <tr>
-            <td style="padding:8px 10px"><span style="background:#FFF8E1;color:#8B6914;font-size:11px;font-weight:700;padding:2px 8px;border-radius:4px">scheduled</span></td>
-            <td style="padding:8px 10px">모집 시작 전</td>
-            <td style="padding:8px 10px;color:var(--green);font-weight:600">노출됨</td>
-            <td style="padding:8px 10px">「모집예정」 / 「近日公開」 배지</td>
+            <td style="padding:8px 10px"><span style="background:#FFF8E1;color:#8B6914;font-size:11px;font-weight:700;padding:2px 8px;border-radius:4px">모집예정</span></td>
+            <td style="padding:8px 10px">곧 모집 시작</td>
+            <td style="padding:8px 10px;color:var(--green);font-weight:600">보임 (近日公開)</td>
           </tr>
           <tr>
-            <td style="padding:8px 10px"><span style="background:#E6F3E8;color:#274;font-size:11px;font-weight:700;padding:2px 8px;border-radius:4px">active</span></td>
-            <td style="padding:8px 10px">모집중</td>
-            <td style="padding:8px 10px;color:var(--green);font-weight:600">노출됨</td>
-            <td style="padding:8px 10px">「모집중」 / 「募集中」 배지</td>
+            <td style="padding:8px 10px"><span style="background:#E6F3E8;color:#274;font-size:11px;font-weight:700;padding:2px 8px;border-radius:4px">모집중</span></td>
+            <td style="padding:8px 10px">지금 모집 중</td>
+            <td style="padding:8px 10px;color:var(--green);font-weight:600">보임 (募集中)</td>
           </tr>
           <tr>
-            <td style="padding:8px 10px"><span style="background:#F5F5F5;color:#999;font-size:11px;font-weight:700;padding:2px 8px;border-radius:4px">closed</span></td>
-            <td style="padding:8px 10px">모집 종료</td>
-            <td style="padding:8px 10px;color:var(--gold);font-weight:600">노출됨 (운영자가 OFF 할 때까지)</td>
-            <td style="padding:8px 10px">「募集締切」 오버레이 + 신청 버튼 비활성</td>
+            <td style="padding:8px 10px"><span style="background:#FCE4EC;color:#AD1457;font-size:11px;font-weight:700;padding:2px 8px;border-radius:4px">모집마감</span></td>
+            <td style="padding:8px 10px">모집 끝 · 결과물 받는 중</td>
+            <td style="padding:8px 10px;color:var(--gold);font-weight:600">보임 (募集締切), 끌 때까지</td>
           </tr>
           <tr>
-            <td style="padding:8px 10px"><span style="background:#EFEFEF;color:#888;font-size:11px;font-weight:700;padding:2px 8px;border-radius:4px">expired</span></td>
-            <td style="padding:8px 10px">노출 마감 (운영자가 노출 토글 OFF)</td>
-            <td style="padding:8px 10px;color:var(--red);font-weight:600">노출 안 됨</td>
-            <td style="padding:8px 10px;color:var(--muted)">—</td>
+            <td style="padding:8px 10px"><span style="background:#E8EAF6;color:#283593;font-size:11px;font-weight:700;padding:2px 8px;border-radius:4px">종료</span></td>
+            <td style="padding:8px 10px">결과물까지 다 끝남</td>
+            <td style="padding:8px 10px;color:var(--gold);font-weight:600">보임 (終了), 끌 때까지</td>
+          </tr>
+          <tr>
+            <td style="padding:8px 10px"><span style="background:#EFEFEF;color:#888;font-size:11px;font-weight:700;padding:2px 8px;border-radius:4px">노출종료</span></td>
+            <td style="padding:8px 10px">운영자가 화면에서 내림</td>
+            <td style="padding:8px 10px;color:var(--red);font-weight:600">안 보임</td>
           </tr>
         </tbody>
       </table>
-      <div style="margin-top:18px;padding:14px;background:var(--light-pink);border-radius:10px;font-size:12px;line-height:1.6">
-        <div style="font-weight:700;color:var(--dark-pink);margin-bottom:6px">자동 전이 규칙</div>
+
+      <div style="margin-top:18px;padding:14px;background:var(--light-pink);border-radius:10px;font-size:12px;line-height:1.7">
+        <div style="font-weight:700;color:var(--dark-pink);margin-bottom:6px">② 상태가 저절로 바뀌는 경우</div>
         <ul style="margin:0;padding-left:18px;color:var(--ink)">
-          <li><strong>모집 시작일(recruit_start) 도래</strong>하면 scheduled → active 로 자동 변경됩니다.</li>
-          <li><strong>모집 마감일(deadline) 경과</strong>하면 active → closed 로 자동 변경됩니다.</li>
-          <li>expired(노출 마감) 상태는 <strong>운영자가 「캠페인 노출」 토글 OFF</strong> 클릭으로만 진입합니다. 자동 전이 없음.</li>
-          <li>모집 마감일이 지난 캠페인은 active / scheduled 상태로 저장·변경할 수 없습니다.</li>
-          <li>closed / expired 캠페인의 주의사항·참여방법은 수정할 수 없습니다 (DB에서 이중 차단).</li>
+          <li>모집 <strong>시작일</strong>이 되면 → 모집예정에서 <strong>모집중</strong>으로 저절로</li>
+          <li>모집 <strong>마감일</strong>이 지나면 → 모집중에서 <strong>모집마감</strong>으로 저절로</li>
+          <li>결과물 <strong>제출 마감일</strong>이 지나면 → 모집마감에서 <strong>종료</strong>로 저절로</li>
+          <li><strong>노출종료</strong>는 저절로 안 됨 — 운영자가 「캠페인 노출」을 꺼야만 됩니다</li>
         </ul>
       </div>
-      <div style="margin-top:14px;padding:14px;background:var(--surface-dim);border-radius:10px;font-size:12px;line-height:1.6">
-        <div style="font-weight:700;color:var(--ink);margin-bottom:6px">전이 흐름</div>
-        <div style="font-family:monospace;font-size:11px;color:var(--ink)">draft → scheduled → active → closed (← 운영자가 OFF 시 expired)</div>
-        <div style="margin-top:6px;color:var(--muted)">closed 는 운영자가 토글 OFF 할 때까지 인플루언서에게 계속 노출(募集締切 표시). expired 는 완전 비노출.</div>
+
+      <div style="font-size:13px;font-weight:700;color:var(--ink);margin:18px 0 8px">③ 상태에 따라 고칠 수 있는 것 / 없는 것</div>
+      <table class="data-table" style="width:100%;font-size:12px">
+        <thead>
+          <tr style="background:var(--surface-dim)">
+            <th style="padding:8px 10px;text-align:left">무엇을</th>
+            <th style="padding:8px 10px;text-align:left">준비 · 모집예정 · 모집중</th>
+            <th style="padding:8px 10px;text-align:left">모집마감 · 종료 · 노출종료</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td style="padding:8px 10px">모집 기간(시작·마감일)</td>
+            <td style="padding:8px 10px;color:var(--green);font-weight:600">고칠 수 있음</td>
+            <td style="padding:8px 10px;color:var(--green);font-weight:600">고칠 수 있음</td>
+          </tr>
+          <tr>
+            <td style="padding:8px 10px">결과물 제출 마감일</td>
+            <td style="padding:8px 10px;color:var(--green);font-weight:600">고칠 수 있음</td>
+            <td style="padding:8px 10px;color:var(--green);font-weight:600">고칠 수 있음</td>
+          </tr>
+          <tr>
+            <td style="padding:8px 10px">구매 · 방문 기간</td>
+            <td style="padding:8px 10px;color:var(--green);font-weight:600">고칠 수 있음</td>
+            <td style="padding:8px 10px;color:var(--green);font-weight:600">고칠 수 있음</td>
+          </tr>
+          <tr>
+            <td style="padding:8px 10px">주의사항 · 참여방법 · NG사항</td>
+            <td style="padding:8px 10px;color:var(--green);font-weight:600">고칠 수 있음 *</td>
+            <td style="padding:8px 10px;color:var(--red);font-weight:600">못 고침</td>
+          </tr>
+        </tbody>
+      </table>
+      <div style="margin-top:10px;font-size:11px;color:var(--muted);line-height:1.7">
+        * 주의사항·참여방법·NG는 신청자가 1명이라도 있으면 「정말 바꿀까요?」 확인창이 뜹니다.<br>
+        * 「모집중」·「모집예정」으로 저장하려면 모집 마감일이 아직 안 지났어야 합니다.<br>
+        * 날짜는 서로 순서가 맞아야 저장됩니다 (모집마감 &gt; 시작, 제출마감 &gt; 구매·방문 종료 등).
+      </div>
+      <div style="margin-top:14px;padding:12px 14px;background:var(--surface-dim);border-radius:10px;font-size:12px;line-height:1.6;color:var(--ink)">
+        <strong>한 줄 정리:</strong> 날짜는 거의 다 고칠 수 있고, 모집마감 이후엔 <strong>주의사항·참여방법·NG</strong>만 잠깁니다.
       </div>
     </div>
     <div style="padding:14px 20px;border-top:1px solid var(--line);text-align:right">

--- a/dev/js/admin-accounts.js
+++ b/dev/js/admin-accounts.js
@@ -217,7 +217,7 @@ async function saveMyAdminInfo() {
     updateSidebarProfile();
     toast('정보가 저장되었습니다','success');
   } catch(e) {
-    toast('저장 오류: ' + e.message,'error');
+    toast('저장 오류: ' + friendlyError(e.message),'error');
   }
 }
 

--- a/dev/js/admin-core.js
+++ b/dev/js/admin-core.js
@@ -111,7 +111,12 @@ function friendlyError(msg) {
   if (s.includes('timeout') || s.includes('timed out')) return '요청 시간이 초과되었습니다. [ERR_TIMEOUT_408]';
   if (s.includes('unauthorized') || s.includes('JWT')) return '인증이 만료되었습니다. 다시 로그인해주세요. [ERR_AUTH_401]';
   if (s.includes('email_not_confirmed')) return '이메일 인증이 완료되지 않았습니다. [ERR_EMAIL_UNVERIFIED]';
-  return s + ' [ERR_UNHANDLED]';
+  if (s.includes('violates check constraint') || s.includes('check_violation')) return '허용되지 않는 값입니다. 입력 내용을 다시 확인해주세요. [ERR_CHECK_23514]';
+  // DB 트리거·함수(RAISE)가 한글 안내 메시지를 던지면 그대로 보여준다 (예: 「모집마감 캠페인의 주의사항은…」)
+  if (/[가-힣]/.test(s)) return s;
+  // 미분류 영어 원문 — 화면에는 일반 안내만 노출하고, 원문은 콘솔에 기록(운영자 추적용)
+  try { console.warn('[friendlyError unhandled]', s); } catch (_) {}
+  return '처리 중 오류가 발생했습니다. 잠시 후 다시 시도하거나 관리자에게 문의해주세요. [ERR_UNHANDLED]';
 }
 
 // ════════════════════════════════════════════════════════════════════

--- a/dev/js/admin-influencers.js
+++ b/dev/js/admin-influencers.js
@@ -661,7 +661,7 @@ async function onInfluencerVerify() {
     _infViolationCounts = {};
     await openInfluencerDetail(_currentDetailInfluencer.id);
     await refreshPane('influencers');
-  } catch(e) { toast('오류: ' + (e.message || e), 'error'); }
+  } catch(e) { toast('오류: ' + friendlyError(e.message || e), 'error'); }
 }
 
 async function onInfluencerUnverify() {
@@ -674,7 +674,7 @@ async function onInfluencerUnverify() {
     _infViolationCounts = {};
     await openInfluencerDetail(_currentDetailInfluencer.id);
     await refreshPane('influencers');
-  } catch(e) { toast('오류: ' + (e.message || e), 'error'); }
+  } catch(e) { toast('오류: ' + friendlyError(e.message || e), 'error'); }
 }
 
 // 위반 기록 편집 — _currentFlagsCache 에서 id로 찾아 모달 오픈
@@ -748,7 +748,7 @@ async function onSaveEditViolation() {
     _editingKeptUrlMap = {};
     if (_currentDetailInfluencer) await openInfluencerDetail(_currentDetailInfluencer.id);
     await refreshPane('influencers');
-  } catch(e) { toast('오류: ' + (e.message || e), 'error'); }
+  } catch(e) { toast('오류: ' + friendlyError(e.message || e), 'error'); }
 }
 
 // 신청 이력의 cancelled 보조 행에서 호출 — 위반 등록 폼에 자동 prefill
@@ -814,7 +814,7 @@ async function onInfluencerRecordViolation() {
     _infViolationCounts[_currentDetailInfluencer.id] = (_infViolationCounts[_currentDetailInfluencer.id] || 0) + 1;
     rerenderInfluencersFromCache();
     await openInfluencerDetail(_currentDetailInfluencer.id);
-  } catch(e) { toast('오류: ' + (e.message || e), 'error'); }
+  } catch(e) { toast('오류: ' + friendlyError(e.message || e), 'error'); }
 }
 
 async function onInfluencerBlacklist() {
@@ -831,7 +831,7 @@ async function onInfluencerBlacklist() {
     _infViolationCounts = {};
     await openInfluencerDetail(_currentDetailInfluencer.id);
     await refreshPane('influencers');
-  } catch(e) { toast('오류: ' + (e.message || e), 'error'); }
+  } catch(e) { toast('오류: ' + friendlyError(e.message || e), 'error'); }
 }
 
 async function onInfluencerUnblacklist() {
@@ -844,7 +844,7 @@ async function onInfluencerUnblacklist() {
     _infViolationCounts = {};
     await openInfluencerDetail(_currentDetailInfluencer.id);
     await refreshPane('influencers');
-  } catch(e) { toast('오류: ' + (e.message || e), 'error'); }
+  } catch(e) { toast('오류: ' + friendlyError(e.message || e), 'error'); }
 }
 
 // 인플루언서 이름 클릭 = 어디서든 풀 상세 모달(상태 관리·이력 포함)로 통일

--- a/dev/js/admin-lookups.js
+++ b/dev/js/admin-lookups.js
@@ -87,7 +87,7 @@ async function renderLookupsTable() {
   try {
     rows = await fetchLookupsAll(_currentLookupKind);
   } catch(e) {
-    tbody.innerHTML = `<tr><td colspan="${colspan}" style="text-align:center;color:var(--red);padding:24px">조회 실패: ${esc(e.message||String(e))}</td></tr>`;
+    tbody.innerHTML = `<tr><td colspan="${colspan}" style="text-align:center;color:var(--red);padding:24px">조회 실패: ${esc(friendlyError(e.message||String(e)))}</td></tr>`;
     return;
   }
   if (!rows.length) {
@@ -247,7 +247,7 @@ async function moveLookup(idA, idB) {
     else await swapLookupOrder(idA, idB);
     renderLookupsTable();
   } catch(e) {
-    toast('정렬 변경 실패: ' + (e.message||String(e)),'error');
+    toast('정렬 변경 실패: ' + friendlyError(e.message||String(e)),'error');
   }
 }
 
@@ -264,7 +264,7 @@ async function toggleLookupActive(id, nextActive) {
     }
     renderLookupsTable();
   } catch(e) {
-    toast('상태 변경 실패: ' + (e.message||String(e)),'error');
+    toast('상태 변경 실패: ' + friendlyError(e.message||String(e)),'error');
   }
 }
 
@@ -280,7 +280,7 @@ async function handleLookupDelete(row) {
       toast('삭제했습니다','success');
       renderLookupsTable();
     } catch(e) {
-      toast('삭제 실패: ' + (e.message||String(e)),'error');
+      toast('삭제 실패: ' + friendlyError(e.message||String(e)),'error');
     }
     return;
   }
@@ -297,7 +297,7 @@ async function handleLookupDelete(row) {
     toast('삭제했습니다','success');
     renderLookupsTable();
   } catch(e) {
-    toast('삭제 실패: ' + (e.message||String(e)),'error');
+    toast('삭제 실패: ' + friendlyError(e.message||String(e)),'error');
   }
 }
 
@@ -332,7 +332,7 @@ async function renderPsetTable() {
   tbody.innerHTML = `<tr><td colspan="${colspan}" style="text-align:center;color:var(--muted);padding:24px"><span class="spinner" style="width:20px;height:20px;border-width:2px;border-color:rgba(200,120,163,.2);border-top-color:var(--pink)"></span></td></tr>`;
   let rows = [];
   try { rows = await fetchParticipationSetsAll(); } catch(e) {
-    tbody.innerHTML = `<tr><td colspan="${colspan}" style="text-align:center;color:var(--red);padding:24px">조회 실패: ${esc(e.message||String(e))}</td></tr>`;
+    tbody.innerHTML = `<tr><td colspan="${colspan}" style="text-align:center;color:var(--red);padding:24px">조회 실패: ${esc(friendlyError(e.message||String(e)))}</td></tr>`;
     return;
   }
   if (!rows.length) {
@@ -468,7 +468,7 @@ async function savePsetEdit() {
     toast('저장했습니다','success');
     renderLookupsTable();
   } catch(e) {
-    show('저장 실패: ' + (e.message||String(e)));
+    show('저장 실패: ' + friendlyError(e.message||String(e)));
   }
 }
 
@@ -503,7 +503,7 @@ async function renderCsetTable() {
   tbody.innerHTML = `<tr><td colspan="${colspan}" style="text-align:center;color:var(--muted);padding:24px"><span class="spinner" style="width:20px;height:20px;border-width:2px;border-color:rgba(200,120,163,.2);border-top-color:var(--pink)"></span></td></tr>`;
   let rows = [];
   try { rows = await fetchCautionSetsAll(); } catch(e) {
-    tbody.innerHTML = `<tr><td colspan="${colspan}" style="text-align:center;color:var(--red);padding:24px">조회 실패: ${esc(e.message||String(e))}</td></tr>`;
+    tbody.innerHTML = `<tr><td colspan="${colspan}" style="text-align:center;color:var(--red);padding:24px">조회 실패: ${esc(friendlyError(e.message||String(e)))}</td></tr>`;
     return;
   }
   if (!rows.length) {
@@ -797,7 +797,7 @@ function _bindMiniEditorLinkPopoverEvents(pop, aEl, contentDiv, href) {
         ta.select(); document.execCommand('copy'); document.body.removeChild(ta);
       }
       toast('링크를 복사했습니다','success');
-    } catch(e) { toast('복사 실패: ' + (e.message||String(e)),'error'); }
+    } catch(e) { toast('복사 실패: ' + friendlyError(e.message||String(e)),'error'); }
   });
 
   // 새 탭으로 열기 (편집 중에도 실제 링크 확인 가능)
@@ -1021,7 +1021,7 @@ async function saveCsetEdit() {
     toast('저장했습니다','success');
     renderLookupsTable();
   } catch(e) {
-    show('저장 실패: ' + (e.message||String(e)));
+    show('저장 실패: ' + friendlyError(e.message||String(e)));
   }
 }
 
@@ -1052,7 +1052,7 @@ async function renderNgSetTable() {
   tbody.innerHTML = `<tr><td colspan="${colspan}" style="text-align:center;color:var(--muted);padding:24px"><span class="spinner" style="width:20px;height:20px;border-width:2px;border-color:rgba(200,120,163,.2);border-top-color:var(--pink)"></span></td></tr>`;
   let rows = [];
   try { rows = await fetchNgSetsAll(); } catch(e) {
-    tbody.innerHTML = `<tr><td colspan="${colspan}" style="text-align:center;color:var(--red);padding:24px">조회 실패: ${esc(e.message||String(e))}</td></tr>`;
+    tbody.innerHTML = `<tr><td colspan="${colspan}" style="text-align:center;color:var(--red);padding:24px">조회 실패: ${esc(friendlyError(e.message||String(e)))}</td></tr>`;
     return;
   }
   if (!rows.length) {
@@ -1197,6 +1197,6 @@ async function saveNgSetEdit() {
     toast('저장했습니다','success');
     renderLookupsTable();
   } catch(e) {
-    show('저장 실패: ' + (e.message||String(e)));
+    show('저장 실패: ' + friendlyError(e.message||String(e)));
   }
 }

--- a/dev/js/admin-notices.js
+++ b/dev/js/admin-notices.js
@@ -160,7 +160,7 @@ async function onPublishFromView() {
     closeModal('adminNoticeViewModal');
     await loadAdminNotices();
     renderDashboardNotices();
-  } catch(e) { toast('게시 오류: ' + (e.message || e), 'error'); }
+  } catch(e) { toast('게시 오류: ' + friendlyError(e.message || e), 'error'); }
 }
 
 // 보기 모달에서 "게시 회수" 클릭 — published → draft (published_at 유지)
@@ -175,7 +175,7 @@ async function onUnpublishFromView() {
     closeModal('adminNoticeViewModal');
     await loadAdminNotices();
     renderDashboardNotices();
-  } catch(e) { toast('회수 오류: ' + (e.message || e), 'error'); }
+  } catch(e) { toast('회수 오류: ' + friendlyError(e.message || e), 'error'); }
 }
 
 function openAdminNoticeEdit(id) {
@@ -311,7 +311,7 @@ async function onSaveAdminNotice(mode) {
     closeModal('adminNoticeEditModal');
     await loadAdminNotices();
     renderDashboardNotices();
-  } catch(e) { toast('저장 오류: ' + (e.message || e), 'error'); }
+  } catch(e) { toast('저장 오류: ' + friendlyError(e.message || e), 'error'); }
 }
 
 async function onDeleteAdminNotice() {
@@ -322,7 +322,7 @@ async function onDeleteAdminNotice() {
     toast('삭제되었습니다');
     closeModal('adminNoticeEditModal');
     await refreshPane('admin-notices');
-  } catch(e) { toast('삭제 오류: ' + (e.message || e), 'error'); }
+  } catch(e) { toast('삭제 오류: ' + friendlyError(e.message || e), 'error'); }
 }
 
 // 대시보드 최근 공지 3건 렌더 — published 만 노출

--- a/dev/js/admin.js
+++ b/dev/js/admin.js
@@ -678,7 +678,16 @@ async function openEditCampaign(campId) {
 //   조건: status === 'closed' 또는 'expired' 일 때 비활성화 + 잠금 메시지 노출
 function applyEditFormSensitiveLocks(status) {
   const isLocked = status === 'closed' || status === 'ended' || status === 'expired';
-  const lockLabel = status === 'expired' ? '노출마감' : status === 'ended' ? '종료' : '모집마감';
+  const lockLabel = status === 'expired' ? '노출종료' : status === 'ended' ? '종료' : '모집마감';
+  // 모집마감·종료·노출종료 상태에서는 상태 드롭다운을 현재 상태로 고정(임의 변경·빈값 저장 차단).
+  // 상태 되돌리기가 필요하면 「캠페인 노출」 토글로 처리한다.
+  const statusSel = $('editCampStatus');
+  if (statusSel) {
+    statusSel.disabled = isLocked;
+    statusSel.title = isLocked ? `${lockLabel} 캠페인의 상태는 변경할 수 없습니다 (「캠페인 노출」 토글로 조정)` : '';
+    statusSel.style.opacity = isLocked ? '0.6' : '';
+    statusSel.style.cursor = isLocked ? 'not-allowed' : '';
+  }
   ['Pset', 'Cset', 'Nset'].forEach(kind => {
     const card = $('editCamp' + kind + 'Summary');
     if (!card) return;
@@ -873,7 +882,7 @@ async function openCautionHistoryModal(campId) {
     _cautionHistoryState.list = Array.isArray(list) ? list : [];
     renderCautionHistoryModal();
   } catch(e) {
-    if (body) body.innerHTML = `<div style="padding:24px;color:#B3261E;font-size:13px">이력 불러오기 실패: ${esc(e.message||String(e))}</div>`;
+    if (body) body.innerHTML = `<div style="padding:24px;color:#B3261E;font-size:13px">이력 불러오기 실패: ${esc(friendlyError(e.message||String(e)))}</div>`;
   }
 }
 
@@ -1693,7 +1702,9 @@ async function saveCampaignEdit() {
     const editDeadline = gv('editCampDeadline');
     const editDateErrs = validateCampDateRanges('editCamp');
     if (editDateErrs.length) { toast(editDateErrs[0].msg, 'error'); validateCampDateRangesInline('editCamp'); return; }
-    const editStatus = gv('editCampStatus');
+    // 빈값 가드 — 드롭다운에 없는 상태(disabled 등)거나 값이 비면 원본 상태로 폴백.
+    // 종료(ended) 캠페인 편집 시 status='' 저장으로 campaigns_status_check 위반하던 버그 방지.
+    const editStatus = gv('editCampStatus') || (_editCampOriginal && _editCampOriginal.status) || 'active';
     if (editDeadline && (editStatus === 'active' || editStatus === 'scheduled')) {
       const dl = new Date(editDeadline); dl.setHours(23,59,59,999);
       if (new Date() > dl) {
@@ -1747,7 +1758,7 @@ async function saveCampaignEdit() {
       guide: gv('editCampGuide'),
       // 067 legacy 컬럼은 더 이상 갱신하지 않음 (070 마이그레이션에서 DROP 예정)
       // ng legacy 컬럼은 NG-PR-B에서 갱신 중단 — ng_set_id/ng_items 로 대체 (NG-PR-F에서 DROP 예정)
-      status: gv('editCampStatus'),
+      status: editStatus,
       ...collectCampPsetPayload('edit'),
       ...collectCampCsetPayload('edit'),
       ...collectCampNsetPayload('edit'),
@@ -3518,7 +3529,7 @@ function _renderCampVisibilityToggle(prefix, status, dateRefs) {
   toggle.setAttribute('aria-checked', isOff ? 'false' : 'true');
   toggle.disabled = isDraft;
   if (statusEl) {
-    var labels = { draft: '준비', scheduled: '모집예정', active: '모집중', closed: '모집마감', ended: '종료', expired: '노출마감 (수동)' };
+    var labels = { draft: '준비', scheduled: '모집예정', active: '모집중', closed: '모집마감', ended: '종료', expired: '노출종료 (수동)' };
     statusEl.textContent = '상태: ' + (labels[status] || status || '미정');
     statusEl.classList.toggle('is-off', isOff);
   }
@@ -3540,7 +3551,7 @@ async function onCampVisibilityToggle(prefix) {
     if (campId) {
       try {
         await toggleCampaignVisibility(campId, false);
-        toast('캠페인 노출이 OFF (노출마감) 로 변경되었습니다');
+        toast('캠페인 노출이 OFF (노출종료) 로 변경되었습니다');
         _renderCampVisibilityToggle(prefix, 'expired', { recruit_start: toggle.dataset.recruitStart, deadline: toggle.dataset.deadline });
         // 폼 상태 드롭다운도 갱신 (있으면)
         var statusSel = $('editCampStatus');
@@ -3548,7 +3559,7 @@ async function onCampVisibilityToggle(prefix) {
         await refreshPane('campaigns');
       } catch (e) {
         console.error('[toggleCampaignVisibility OFF]', e);
-        toast('변경 실패: ' + (e.message || e), 'error');
+        toast('변경 실패: ' + friendlyError(e.message || e), 'error');
       }
     } else {
       // 신규 등록 폼은 아직 DB에 없음 — UI 상태만 변경
@@ -3566,7 +3577,7 @@ async function onCampVisibilityToggle(prefix) {
         await refreshPane('campaigns');
       } catch (e) {
         console.error('[toggleCampaignVisibility ON]', e);
-        toast('변경 실패: ' + (e.message || e), 'error');
+        toast('변경 실패: ' + friendlyError(e.message || e), 'error');
       }
     } else {
       // 신규 등록 폼 — 기본 active 로 가정
@@ -3590,7 +3601,7 @@ async function onCampQuickVisibilityToggle(ev, campId, currentStatus) {
     await refreshPane('campaigns');
   } catch (e) {
     console.error('[onCampQuickVisibilityToggle]', e);
-    toast('변경 실패: ' + (e.message || e), 'error');
+    toast('변경 실패: ' + friendlyError(e.message || e), 'error');
   }
 }
 

--- a/docs/specs/2026-06-04-campaign-status-help-and-error-ko.md
+++ b/docs/specs/2026-06-04-campaign-status-help-and-error-ko.md
@@ -1,0 +1,165 @@
+# 캠페인 상태 안내 개선 + 관리자 오류 메시지 한글화 (+ 종료 캠페인 편집 버그)
+
+**작성일:** 2026-06-04
+**작성 세션:** 기획/설계
+**상태:** 초안 (사용자 정책 확정, 개발 미착수) — ⚠️ PR 1 은 운영 버그 수정(우선)
+
+---
+
+## 배경 (사용자 요청)
+
+1. 「캠페인 상태별 클라이언트 노출 안내」 모달을 **더 알아보기 쉽게** 정리: ① 상태를 관리자 화면 한글 표기로 ② "전이" 용어를 초등학생도 알 만한 쉬운 말로 ③ **어떤 상태에서 무엇을 수정 가능/불가**인지 추가
+2. 관리자 캠페인 편집 「변경 저장」 시 영어 오류 노출:
+   `저장 오류: new row for relation "campaigns" violates check constraint "campaigns_status_check" [ERR_UNHANDLED]`
+3. "관리자 페이지에서 오류 메시지는 한글로 알려주면 좋겠다"
+
+→ 조사 결과 2번은 **단순 한글화 누락이 아니라 실제 버그**(종료 상태 캠페인 편집 시 빈 상태값 저장 시도)로 판명.
+
+**사용자 확정 정책:**
+- 미분류 오류(한글 매핑에 없는 것) = **일반 한글 안내 + 식별코드만**, 영어 원문은 화면에서 숨기고 오류 로그에만 기록
+
+---
+
+## 현재 상태 (작성일 2026-06-04 기준 — planning.md 규칙 A)
+
+### 캠페인 상태 (6단계) — 실제 한글 라벨
+`dev/lib/shared.js` 626~643 `campaignStatusLabelKey`/`CAMPAIGN_STATUS_LABEL`:
+| status | 한글 라벨 | 일본어 | 의미 |
+|---|---|---|---|
+| draft | 준비 | 準備中 | 작성·검토 중 |
+| scheduled | 모집예정 | 近日公開 | 모집 시작 전 |
+| active | 모집중 | 募集中 | 모집 진행 중 |
+| closed | 모집마감 | 募集締切 | 모집 종료·결과물 받는 중 (submission_end 경과 시 라벨이 「종료」로 표시) |
+| ended | 종료 | 終了 | 결과물까지 완료 |
+| expired | 노출종료 | 掲載終了 | 운영자가 노출 OFF |
+
+### 자동 상태 변경 (모달이 "전이"라 부르는 것) — `dev/lib/storage.js` 125~214
+- `autoOpenCampaigns` recruit_start 도래 → scheduled→active
+- `autoCloseCampaigns` deadline 경과 → active→closed
+- `autoEndCampaigns` submission_end 경과 → closed→ended
+- expired 는 `toggleCampaignVisibility` OFF 만 (자동 없음)
+
+### 상태별 수정 제약 (실측 — 안내 ③에 들어갈 내용)
+- **DB 트리거**(마이그레이션 075·108·156 `block_closed_campaign_caution_participation_update`): `closed`·`ended`·`expired` 에서 **주의사항(caution)·참여방법(participation)·NG(ng) 변경 차단**. 날짜 컬럼은 차단 안 함.
+- **클라 검증**(`dev/js/admin.js` `validateCampDateRanges` 1137·`saveCampaignEdit` 1697): 날짜는 **순서·정합성**만 검증(모집마감>시작, 제출마감>구매/방문 종료, 구매·방문은 모집~제출 윈도우 내). `active`/`scheduled` 로 저장 시 deadline 경과면 차단.
+- 결론: **날짜류는 거의 모든 상태에서 수정 가능**(정합성만 맞으면). 막히는 건 ①모집마감 이후 주의사항·참여방법·NG ②마감 지난 캠페인을 모집중/모집예정으로 되돌리기 ③날짜 정합성 위반.
+
+### 오류 한글화 구조 — `dev/js/admin-core.js` 99~115 `friendlyError`
+- 13개 패턴 한글 매핑(23505·42501·23503·23502·네트워크·429·404·408·401 등)
+- ❌ **23514(check_violation)·P0001(트리거 RAISE) 매핑 없음** → 영어 원문 + `[ERR_UNHANDLED]` 노출
+- DB 트리거가 던지는 **한글 메시지**(「모집마감 캠페인의 주의사항은…」)도 매핑 안 돼 `[ERR_UNHANDLED]` 가 붙음
+- raw 노출 호출부(friendlyError 미경유): `admin-accounts.js`(220), `admin-notices.js`(163·178·314·325), `admin-influencers.js`(664·677·751·817·834·847), `admin-lookups.js`(250·267·283·300·800), `admin.js`(3551·3569·3593)
+- 인플루언서용은 별도 `friendlyErrorJa`(`dev/js/ui.js` 115). client_error_logs(마이그레이션 165) 에 원문 기록 경로 존재
+
+### 🐞 버그 — `campaigns_status_check` 위반의 진짜 원인
+- 편집 폼 상태 드롭다운 `editCampStatus`(`dev/admin/index.html` 349~351): **옵션이 draft/scheduled/active/closed/expired 5개뿐, `ended` 없음 + `closed` 라벨이 "종료"로 오기**(실제 closed=모집마감).
+- `campaigns_status_check` 는 ended 포함 6개 허용. **운영 DB 확인 완료(2026-06-04)**: `CHECK (status = ANY (ARRAY['draft','scheduled','active','closed','ended','expired']))` — DB 정상, ended 허용됨.
+- **확정 원인**: 자동으로 `ended` 가 된 캠페인을 편집 → 드롭다운에 ended 옵션이 없어 select 값이 **빈 문자열**로 저장 시도 → `status=''` 가 check 위반 → 영어 오류. **DB 문제 아니라 프론트 드롭다운 누락이 원인.**
+- **영향**: 종료된 캠페인은 현재 편집·저장 불가(날짜만 바꾸려 해도 status='' 로 통째 막힘 — 사용자가 "날짜 안 고쳐짐"으로 체감). 운영 영향 범위 = 운영 `status='ended'` 캠페인 수(첫 진단 쿼리로 확인 권고).
+
+---
+
+## 의심·경우의 수 (planning.md 규칙 B)
+
+1. **(버그 핵심) ended 드롭다운 처리** — 단순히 `ended` 옵션을 추가하면 관리자가 **임의로 ended/closed 상태를 직접 바꿀 수 있게** 됨(현재 status 드롭다운은 값 그대로 UPDATE). 자동 전이로만 되던 상태를 사람이 손으로 바꾸는 부작용. → 두 방향: (가) 옵션 추가하되 deadline 검증처럼 가드 / (나) 종료/모집마감 상태일 땐 드롭다운을 **현재 상태 표시·고정**(임의 변경 차단)하고 빈값 저장만 방지. 개발/planner 정밀 판단 필요.
+2. **(데이터) 운영 ended 캠페인 수** — 0건이면 잠복 버그(아직 안 터짐), 다수면 이미 편집 불가 상태. 운영 진단 SQL 선행.
+3. **(UX) 안내 모달 정보량** — 노출+자동변경+수정제약을 한 모달에 다 넣으면 복잡. 초등학생 눈높이 위해 **3섹션 명확 구분 + 표 간결**. 제목도 「노출 안내」→「상태 안내(노출·자동변경·수정 가능 여부)」로 확장.
+4. **(UX) 오류 한글화 일관성** — 미분류 오류를 일반 안내로 덮으면 운영자가 원인 추적 불가 → 식별코드 + client_error_logs 원문 기록 병행 필수.
+5. **(기술) DB 한글 메시지 통과** — 트리거가 던지는 한글 메시지(주의사항 잠금 등)는 그대로 보여주는 게 친절. friendlyError 가 "한글이면 통과" 분기 필요(영어 원문만 일반안내로 치환).
+6. **(권한·환경) friendlyError 적용 범위** — raw 노출 호출부 일괄 교체 시 회귀 위험 낮으나, 각 호출부의 prefix("저장 오류:" 등) 유지하며 메시지부만 friendlyError 통과.
+
+### 현재 구현 충돌
+- 안내 모달은 ended·NG 차단·closed→ended 자동변경을 누락 중 → 재작성으로 해소.
+- friendlyError 보강은 추가형이라 충돌 없음. 단 미분류→일반안내 전환 시 기존에 영어라도 보던 정보가 사라지므로 로그 기록 필수.
+
+### 의도 모호점
+- 버그 수정 방식 1번(가/나) — 사용자 확인 또는 개발/planner 위임.
+
+---
+
+## 제안 / 설계
+
+### PR 1 — 🐞 종료 캠페인 편집 버그 수정 (우선)
+- `editCampStatus` 드롭다운: `closed` 라벨 "종료"→**"모집마감"** 수정, **`ended`(종료) 옵션 추가**(또는 위 경우의 수 1번 (나) 방식으로 종료/모집마감 시 상태 고정+빈값 방지).
+- 운영 DB 진단 SQL 선행: `status='ended'` 캠페인 수 + `campaigns_status_check` 에 ended 포함 확인.
+- reverb-planner 사전 검토(상태 드롭다운 동작 변경) + qa Light.
+
+### PR 2 — 관리자 오류 메시지 한글화
+- `friendlyError`(admin-core.js)에 매핑 추가: `violates check constraint`→「허용되지 않는 값입니다. 다시 확인해주세요. [ERR_CHECK_23514]」, P0001/트리거 한글 메시지는 **한글이면 원문 통과**, 그 외 미분류는 **「처리 중 오류가 발생했습니다 [ERR_UNHANDLED]」 일반 안내**(영어 원문 화면 숨김).
+- 미분류 오류 발생 시 **원문을 client_error_logs/console 에 기록**(운영자 추적용).
+- raw 노출 호출부(위 5개 파일) 일괄 `friendlyError()` 경유로 교체(prefix 유지).
+- reverb-reviewer + qa Light.
+
+### PR 3 — 캠페인 상태 안내 모달 재작성
+모달(`dev/admin/index.html` `campStatusHelpModal` 2220~2288) 제목·내용 교체. **확정 콘텐츠**:
+
+**제목:** 「캠페인 상태 안내 — 노출·자동 변경·수정 가능 여부」
+
+**① 상태와 인플루언서 노출**
+| 상태 | 뜻 | 인플루언서에게 보이나요 |
+|---|---|---|
+| 준비 | 아직 만드는 중 | 안 보임 |
+| 모집예정 | 곧 모집 시작 | 보임 (近日公開) |
+| 모집중 | 지금 모집 중 | 보임 (募集中) |
+| 모집마감 | 모집 끝·결과물 받는 중 | 보임 (募集締切), 끌 때까지 |
+| 종료 | 결과물까지 다 끝남 | 보임 (終了), 끌 때까지 |
+| 노출종료 | 운영자가 화면에서 내림 | 안 보임 |
+
+**② 상태가 저절로 바뀌는 경우** ("전이"→"저절로 바뀜")
+- 모집 시작일이 되면 → 모집예정에서 **모집중**으로 저절로
+- 모집 마감일이 지나면 → 모집중에서 **모집마감**으로 저절로
+- 결과물 제출 마감일이 지나면 → 모집마감에서 **종료**로 저절로
+- **노출종료**는 저절로 안 됨 — 운영자가 「캠페인 노출」을 꺼야만
+
+**③ 상태에 따라 고칠 수 있는 것 / 없는 것**
+| 무엇을 | 준비·모집예정·모집중 | 모집마감·종료·노출종료 |
+|---|---|---|
+| 모집 기간(시작·마감일) | 고칠 수 있음 | 고칠 수 있음 |
+| 결과물 제출 마감일 | 고칠 수 있음 | 고칠 수 있음 |
+| 구매·방문 기간 | 고칠 수 있음 | 고칠 수 있음 |
+| 주의사항·참여방법·NG사항 | 고칠 수 있음* | **못 고침** |
+
+\* 신청자가 1명이라도 있으면 "정말 바꿀까요?" 확인창이 뜸.
+\* 「모집중」·「모집예정」으로 저장하려면 모집 마감일이 아직 안 지났어야 함.
+\* 날짜는 서로 순서가 맞아야 저장됨(모집마감>시작, 제출마감>구매·방문 종료 등).
+
+→ 핵심 한 줄: **날짜는 거의 다 고칠 수 있고, 모집마감 이후엔 주의사항·참여방법·NG만 잠긴다.**
+
+### 의존성
+- PR 1(버그)·PR 2(한글화) 먼저, PR 3(안내문구)는 독립. PR 1 은 운영 버그라 우선.
+- ⚠️ 마이그레이션 불필요(전부 코드). 단 운영 DB constraint 진단은 선행.
+
+---
+
+## 사용자 확인 필요 (개발 착수 전)
+- PR 1 버그 수정 방식: (가) ended 옵션 추가해 상태 직접 변경 허용 / (나) 종료·모집마감 시 상태 고정+빈값만 방지(임의 변경 차단). → 개발/planner 판단 위임 가능.
+
+---
+
+## 구현 결과
+
+**구현일:** 2026-06-04
+**관련 커밋·PR:** (개발 세션 dev 머지 — 본 커밋)
+**버그 수정 방식:** 사용자 확정 = **(나) 상태 칸 고정** (AskUserQuestion 2026-06-04)
+
+### PR 1 — 종료 캠페인 편집 버그 수정 (상태 칸 고정)
+- `dev/admin/index.html` `editCampStatus` 드롭다운: `closed` 라벨 "종료"→**"모집마감"**, `expired` "노출마감"→**"노출종료"**, **`ended`(종료) 옵션 추가**. 이제 종료 캠페인을 열어도 드롭다운에 해당 값이 있어 빈 문자열이 안 됨.
+- `dev/js/admin.js` `applyEditFormSensitiveLocks`: 모집마감·종료·노출종료 상태일 때 **상태 드롭다운을 `disabled`로 고정**(임의 변경·실수 차단). lockLabel `expired` 표기도 "노출마감"→"노출종료"로 통일. 상태 되돌리기는 기존 「캠페인 노출」 토글로 처리.
+- `dev/js/admin.js` `saveCampaignEdit`: `editStatus` 빈값 가드(`gv('editCampStatus') || _editCampOriginal.status || 'active'`) + `updates.status`도 `editStatus` 사용으로 통일 → `campaigns_status_check` 위반 원천 차단.
+
+### PR 2 — 관리자 오류 메시지 한글화
+- `dev/js/admin-core.js` `friendlyError` 보강: ① `violates check constraint`(23514) 매핑 추가 ② **한글 포함 메시지는 원문 통과**(DB 트리거/함수 RAISE 한글 안내 그대로 노출) ③ **미분류 영어 원문은 「처리 중 오류가 발생했습니다 … [ERR_UNHANDLED]」 일반 안내로 치환**, 원문은 `console.warn('[friendlyError unhandled]', …)`로 기록.
+- raw 노출 호출부 일괄 `friendlyError()` 경유로 교체(prefix 유지): `admin-accounts.js`(저장 오류 1곳), `admin-notices.js`(4곳), `admin-influencers.js`(6곳), `admin-lookups.js`(`(e.message||String(e))` 12곳 전부 — toast·show·인라인 esc), `admin.js`(변경 실패 toast 3곳 + 이력 불러오기 실패 인라인 1곳).
+
+### PR 3 — 캠페인 상태 안내 모달 재작성
+- `campStatusHelpModal` 제목·본문 전면 교체. 사양서 확정 콘텐츠(① 상태·노출 6행 표, ② 「저절로 바뀜」 4줄, ③ 수정 가능/불가 표 + 각주 + 한 줄 정리)를 기존 디자인 톤(테이블·light-pink/surface-dim 박스·CSS 변수) 유지하며 적용. 영어 status 코드(draft/closed 등) 제거 → 한글 라벨로.
+
+### 초안 대비 변경 사항
+- **추가:** friendlyError 미경유 호출부를 사양서 지목 범위보다 넓게 일괄 교체(`admin-lookups.js`의 textContent/인라인 조회 실패까지 포함 — 일관성). 모집마감 배지색 핑크(#FCE4EC), 종료 배지색 남보라(#E8EAF6)로 목록 컬러와 정합.
+- **빠진 것:** 운영 DB `ended` 캠페인 수 진단 SQL은 코드 변경과 무관해 개발 세션에서 미실행(코드는 ended 0건이든 다수든 동일하게 안전). 운영 배포 시 확인 권고.
+- **달라진 것:** friendlyError 미분류 기록을 `client_error_logs` 자동 적재가 아닌 **`console.warn`으로 한정**. 사유 = 적재에 필요한 fingerprint/마스킹 헬퍼는 인플 앱 `error-report.js` 전용이라 관리자 빌드에 없음. 화면 일반화 + 콘솔 원문 기록으로 사양 의도(원문 숨김·추적 가능) 충족.
+
+### 구현 중 기술 결정 사항
+- disabled `<select>`도 JS `.value` 접근은 정상이므로 빈값은 안 나지만, 안전망으로 `saveCampaignEdit`에 원본 상태 폴백 가드 추가(이중 방어).
+- friendlyError 분기 순서: 기존 영어 매핑 → check constraint → **한글 통과** → 미분류 일반화. 한글 통과를 미분류 직전에 둬 영어 check 등은 먼저 잡고, 트리거 한글 안내만 원문 노출.
+- 마이그레이션 없음(전부 코드). DB·RLS·Auth·약관 무영향.


### PR DESCRIPTION
## 변경 요약
- **PR 1 — 종료 캠페인 편집 버그 수정**: editCampStatus 드롭다운에 `ended` 옵션 누락 + closed 라벨 오기로, 종료 캠페인 편집 시 status='' 저장 → `campaigns_status_check` 위반(영어 오류). ended 옵션 추가 + closed/expired 라벨 정정 + 모집마감/종료/노출종료 상태 드롭다운 고정(disabled) + 빈값 폴백 가드로 해결.
- **PR 2 — 관리자 오류 메시지 한글화**: friendlyError에 check 제약(23514) 매핑 + 한글 트리거 메시지 원문 통과 + 미분류 영어는 일반 안내로 치환(원문 console 기록). raw 노출 호출부 일괄 friendlyError 경유.
- **PR 3 — 캠페인 상태 안내 모달 재작성**: 영어 status 코드 제거, 쉬운 한글 3섹션(상태·노출 / 저절로 바뀜 / 수정 가능 여부).

## 요청 외 추가 변경
- 사양서 범위(편집 드롭다운·안내 모달)를 넘어 friendlyError 미경유 호출부를 일관성 위해 일괄 교체.
- ⚠️ **별도 백로그**: admin-brand-ops/dashboard/excel/messaging 의 자체 상태 라벨(`closed:'종료'`·`expired:'노출마감'`)이 정식 매핑과 불일치 — 이번 PR 범위 밖, 후속 통일 권고.

## 관련 사양서
- docs/specs/2026-06-04-campaign-status-help-and-error-ko.md (구현 결과 작성 완료)

## 검증
- 마이그레이션 없음. DB/RLS/Auth/약관 무영향.
- reverb-reviewer GO (Critical 2건 수정 후 재확인).

🤖 Generated with [Claude Code](https://claude.com/claude-code)