### PR TITLE
feat(admin): 인플루언서 주소지·팔로워 조합 필터 (PR 1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,7 +154,7 @@
 - **캠페인 ↔ 신청 연결/해제**: `link_campaign_to_application` / `unlink_campaign_from_application` RPC. 같은 brand_id 검증 후 채번 재발급 + `legacy_no` 콤마 누적 + `numbering_legacy_map` UPSERT. 동시성 `pg_advisory_xact_lock` 2단 잠금. 멱등성 `unchanged:true` 반환. 가드 `is_campaign_admin()` 이상
 
 ### 인플루언서 관리
-- **목록**: 채널/인증/위반 드롭다운 3종 sticky-header + 통합 검색
+- **목록**: 채널/인증/위반 드롭다운 + 주소지(도도부현 다중선택, 「未登録」·「海外」 포함) + 팔로워 범위(채널 선택 기준, 전체=4채널 합계) sticky-header + 통합 검색 + 결과 인원수 표시. 주소지·팔로워는 클라 in-memory 필터(`classifyPrefecture`/`followerValueByChannel` 공용 헬퍼, admin-core.js). 엑셀 내보내기는 PR 2(미착수)
 - **상태 관리**(인증/위반/블랙리스트): 상세 모달에 상태 관리 카드 + 관리자 이력 카드 (사유별 누적 pill + 타임라인 + 위반 행 편집). 인증/위반 배지는 이름 옆 노출 (블랙일 땐 블랙 단독). 사유는 `blacklist_reason` ∪ `violation_reason` lookup 통합. 증빙 파일 업로드 (`influencer-flag-evidence` 비공개 버킷, 10MB, image/PDF). RPC: `setInfluencerVerified`/`setInfluencerBlacklist`/`recordInfluencerViolation`/`updateInfluencerViolation` (evidence_paths 미변경=null, 전체 삭제=[])
 - **전화번호 표시 포맷**(`formatPhoneDisplay` in ui.js): KR/JP 번호 정규화 (11자리 3-4-4, 10자리 02/03/06 → 2-4-4 else 3-3-4, `+81`/`+82` 지원). 매칭 실패 시 원문 폴백
 

--- a/admin/index.html
+++ b/admin/index.html
@@ -12,7 +12,7 @@
 // 회귀(2026-05-12 PR #182 머지 직후 발생)를 방지하기 위한 자동 reload 가드.
 // sessionStorage 차단 환경(시크릿 모드 일부, 쿠키 차단)에서는 자연스럽게 skip.
 (function(){
-  var CURRENT_BUILD = 'v1780632122';
+  var CURRENT_BUILD = 'v1780633101';
   if (CURRENT_BUILD.indexOf('__') === 0) return; // 빌드 미적용 (dev/ 직접 열기) 시 skip
   try {
     var prev = sessionStorage.getItem('reverb.adminBuild');
@@ -1997,7 +1997,7 @@ textarea.form-input{resize:vertical;min-height:80px}
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-06-05 13:02 · 9df2e69</span>
+          <span class="admin-build-text">2026-06-05 13:18 · 4bb4a99</span>
         </div>
       </div>
     </aside>
@@ -2726,6 +2726,18 @@ textarea.form-input{resize:vertical;min-height:80px}
                   <option value="has">위반 있음</option>
                   <option value="blacklist">블랙리스트</option>
                 </select>
+              </div>
+              <div class="admin-filter-group">
+                <label>주소지(도도부현)</label>
+                <div id="infPrefectureMulti" class="mf-wrap" style="max-width:200px"><button type="button" class="mf-btn" style="max-width:200px;overflow:hidden;text-overflow:ellipsis">전체 지역</button><div class="mf-drop" style="min-width:240px"></div></div>
+              </div>
+              <div class="admin-filter-group">
+                <label id="infFollowersLabel">팔로워 (합계 기준)</label>
+                <div style="display:flex;align-items:center;gap:4px">
+                  <input type="number" id="infFollowersMin" class="admin-filter" min="0" step="1" placeholder="최소" style="width:84px" oninput="rerenderInfluencersFromCache()">
+                  <span style="color:var(--muted)">~</span>
+                  <input type="number" id="infFollowersMax" class="admin-filter" min="0" step="1" placeholder="최대" style="width:84px" oninput="rerenderInfluencersFromCache()">
+                </div>
               </div>
               <div class="admin-filter-group" style="justify-content:flex-end">
                 <label>&nbsp;</label>
@@ -10303,6 +10315,24 @@ function getMultiFilterValues(containerId) {
   return [...wrap.querySelectorAll('.mf-drop input[type="checkbox"]:not([value="all"]):checked')].map(c => c.value);
 }
 
+// ── 도도부현·팔로워 공용 분류 헬퍼 (인플 조합 필터·대시보드 재사용) ──
+// prefecture 값을 「정식 도도부현 키(일본어)」 | '未登録' | '海外' 로 분류.
+//  · NULL/빈값 = 未登録, PREFECTURE_KO 키에 있으면 정식, 그 외 비어있지 않은 값 = 海外
+function classifyPrefecture(pref) {
+  const p = (pref == null) ? '' : String(pref).trim();
+  if (!p) return '未登録';
+  const map = (typeof PREFECTURE_KO !== 'undefined') ? PREFECTURE_KO : {};
+  return map[p] ? p : '海外';
+}
+
+// 채널 기준 팔로워 수. 'all'(또는 미지정)이면 4개 채널 합계, 특정 채널이면 그 채널만.
+//  · LIPS·@cosme 는 팔로워 컬럼이 없어 합계에서 제외됨
+function followerValueByChannel(u, ch) {
+  const map = { instagram: 'ig_followers', x: 'x_followers', tiktok: 'tiktok_followers', youtube: 'youtube_followers' };
+  if (ch && map[ch]) return u[map[ch]] || 0;
+  return (u.ig_followers || 0) + (u.x_followers || 0) + (u.tiktok_followers || 0) + (u.youtube_followers || 0);
+}
+
 // 드롭다운 열 때 선택된 항목을 「전체」 항목 바로 아래로 모으고 구분선 삽입(선택 항목 상단 정렬).
 // 열 때 1회만 호출 → 체크 토글 중에는 순서가 튀지 않음. 한쪽만 있으면(전부/없음) 정렬 생략.
 function reorderSelectedFirst(drop) {
@@ -17348,7 +17378,28 @@ async function loadAdminInfluencers() {
   ]);
   infUsersCache = users;
   _infViolationCounts = violations;
+  initInfPrefectureMulti();
+  updateInfFollowersLabel();
   renderInfluencersPane(infUsersCache);
+}
+
+// 주소지(도도부현) 다중필터 옵션 초기화 — PREFECTURE_KO(일본어 키→한국어 라벨) + 미등록 + 해외.
+// syncMultiFilter 는 옵션 변화 시에만 재생성하므로 반복 호출해도 선택 상태 보존.
+function initInfPrefectureMulti() {
+  if (typeof syncMultiFilter !== 'function') return;
+  const map = (typeof PREFECTURE_KO !== 'undefined') ? PREFECTURE_KO : {};
+  const options = Object.keys(map).map(ja => ({ value: ja, label: map[ja] }));
+  options.push({ value: '未登録', label: '미등록' });
+  options.push({ value: '海外', label: '해외' });
+  syncMultiFilter('infPrefectureMulti', '전체 지역', options, rerenderInfluencersFromCache, { searchable: true, searchPlaceholder: '지역 검색' });
+}
+
+// 팔로워 범위 기준 라벨 — 채널 선택값에 맞춰 「(채널) 기준」 표시
+function updateInfFollowersLabel() {
+  const el = $('infFollowersLabel');
+  if (!el) return;
+  const map = { all: '합계', instagram: 'Instagram', x: 'X(Twitter)', tiktok: 'TikTok', youtube: 'YouTube' };
+  el.textContent = `팔로워 (${map[currentInfTab] || '합계'} 기준)`;
 }
 
 function rerenderInfluencersFromCache() {
@@ -17360,6 +17411,13 @@ function renderInfluencersPane(users) {
   const verifiedSel = $('infFilterVerifiedSelect')?.value || 'all';
   const violationSel = $('infFilterViolationSelect')?.value || 'all';
   const searchQ = ($('infSearch')?.value || '').trim().toLowerCase();
+  // 주소지(다중) — 미선택이면 빈 배열(=전체). classifyPrefecture 로 정식/未登録/海外 분류 후 매칭
+  const prefSel = (typeof getMultiFilterValues === 'function') ? getMultiFilterValues('infPrefectureMulti') : [];
+  // 팔로워 범위 — 비우면 하한/상한 무제한
+  const minRaw = $('infFollowersMin')?.value;
+  const maxRaw = $('infFollowersMax')?.value;
+  const minF = (minRaw !== '' && minRaw != null) ? Number(minRaw) : null;
+  const maxF = (maxRaw !== '' && maxRaw != null) ? Number(maxRaw) : null;
   // 단어 단위 AND 매칭 (matchSearchTokens, 전각/반각 공백 무관)
   const matchSearch = (u) => matchSearchTokens(searchQ, [
     u.name_kanji, u.name, u.name_kana, u.email,
@@ -17373,12 +17431,20 @@ function renderInfluencersPane(users) {
     if (violationSel === 'has' && vc === 0 && !u.is_blacklisted) return false;
     if (violationSel === 'blacklist' && !u.is_blacklisted) return false;
     if (!matchSearch(u)) return false;
+    // 주소지(다중)
+    if (prefSel.length && !prefSel.includes(classifyPrefecture(u.prefecture))) return false;
+    // 팔로워 범위 (채널 선택값 기준, all=합계)
+    if (minF != null || maxF != null) {
+      const fv = followerValueByChannel(u, currentInfTab);
+      if (minF != null && fv < minF) return false;
+      if (maxF != null && fv > maxF) return false;
+    }
     return true;
   });
   const totalEl = $('infTotalCount');
   if (totalEl) totalEl.textContent = `${filtered.length}명 표시 (전체 ${users.length}명)`;
   const resetBtn = $('btnInfFilterReset');
-  const anyActive = (verifiedSel !== 'all' || violationSel !== 'all' || currentInfTab !== 'all' || !!searchQ);
+  const anyActive = (verifiedSel !== 'all' || violationSel !== 'all' || currentInfTab !== 'all' || !!searchQ || prefSel.length > 0 || minF != null || maxF != null);
   if (resetBtn) resetBtn.style.display = anyActive ? '' : 'none';
   renderInfTable(filtered, currentInfTab);
 }
@@ -17388,12 +17454,17 @@ function resetInfluencerFilters() {
   const w = $('infFilterViolationSelect'); if (w) w.value = 'all';
   const c = $('infChannelFilter'); if (c) c.value = 'all';
   const s = $('infSearch'); if (s) s.value = '';
+  if (typeof resetMultiFilter === 'function') resetMultiFilter('infPrefectureMulti', '전체 지역');
+  const mn = $('infFollowersMin'); if (mn) mn.value = '';
+  const mx = $('infFollowersMax'); if (mx) mx.value = '';
   currentInfTab = 'all';
+  updateInfFollowersLabel();
   rerenderInfluencersFromCache();
 }
 
 function switchInfTabFromSelect(ch) {
   currentInfTab = ch || 'all';
+  updateInfFollowersLabel();
   rerenderInfluencersFromCache();
 }
 

--- a/dev/admin/index.html
+++ b/dev/admin/index.html
@@ -862,6 +862,18 @@
                   <option value="blacklist">블랙리스트</option>
                 </select>
               </div>
+              <div class="admin-filter-group">
+                <label>주소지(도도부현)</label>
+                <div id="infPrefectureMulti" class="mf-wrap" style="max-width:200px"><button type="button" class="mf-btn" style="max-width:200px;overflow:hidden;text-overflow:ellipsis">전체 지역</button><div class="mf-drop" style="min-width:240px"></div></div>
+              </div>
+              <div class="admin-filter-group">
+                <label id="infFollowersLabel">팔로워 (합계 기준)</label>
+                <div style="display:flex;align-items:center;gap:4px">
+                  <input type="number" id="infFollowersMin" class="admin-filter" min="0" step="1" placeholder="최소" style="width:84px" oninput="rerenderInfluencersFromCache()">
+                  <span style="color:var(--muted)">~</span>
+                  <input type="number" id="infFollowersMax" class="admin-filter" min="0" step="1" placeholder="최대" style="width:84px" oninput="rerenderInfluencersFromCache()">
+                </div>
+              </div>
               <div class="admin-filter-group" style="justify-content:flex-end">
                 <label>&nbsp;</label>
                 <button class="btn btn-ghost btn-xs" id="btnInfFilterReset" onclick="resetInfluencerFilters()" style="display:none">초기화</button>

--- a/dev/js/admin-core.js
+++ b/dev/js/admin-core.js
@@ -553,6 +553,24 @@ function getMultiFilterValues(containerId) {
   return [...wrap.querySelectorAll('.mf-drop input[type="checkbox"]:not([value="all"]):checked')].map(c => c.value);
 }
 
+// ── 도도부현·팔로워 공용 분류 헬퍼 (인플 조합 필터·대시보드 재사용) ──
+// prefecture 값을 「정식 도도부현 키(일본어)」 | '未登録' | '海外' 로 분류.
+//  · NULL/빈값 = 未登録, PREFECTURE_KO 키에 있으면 정식, 그 외 비어있지 않은 값 = 海外
+function classifyPrefecture(pref) {
+  const p = (pref == null) ? '' : String(pref).trim();
+  if (!p) return '未登録';
+  const map = (typeof PREFECTURE_KO !== 'undefined') ? PREFECTURE_KO : {};
+  return map[p] ? p : '海外';
+}
+
+// 채널 기준 팔로워 수. 'all'(또는 미지정)이면 4개 채널 합계, 특정 채널이면 그 채널만.
+//  · LIPS·@cosme 는 팔로워 컬럼이 없어 합계에서 제외됨
+function followerValueByChannel(u, ch) {
+  const map = { instagram: 'ig_followers', x: 'x_followers', tiktok: 'tiktok_followers', youtube: 'youtube_followers' };
+  if (ch && map[ch]) return u[map[ch]] || 0;
+  return (u.ig_followers || 0) + (u.x_followers || 0) + (u.tiktok_followers || 0) + (u.youtube_followers || 0);
+}
+
 // 드롭다운 열 때 선택된 항목을 「전체」 항목 바로 아래로 모으고 구분선 삽입(선택 항목 상단 정렬).
 // 열 때 1회만 호출 → 체크 토글 중에는 순서가 튀지 않음. 한쪽만 있으면(전부/없음) 정렬 생략.
 function reorderSelectedFirst(drop) {

--- a/dev/js/admin-influencers.js
+++ b/dev/js/admin-influencers.js
@@ -32,7 +32,28 @@ async function loadAdminInfluencers() {
   ]);
   infUsersCache = users;
   _infViolationCounts = violations;
+  initInfPrefectureMulti();
+  updateInfFollowersLabel();
   renderInfluencersPane(infUsersCache);
+}
+
+// 주소지(도도부현) 다중필터 옵션 초기화 — PREFECTURE_KO(일본어 키→한국어 라벨) + 미등록 + 해외.
+// syncMultiFilter 는 옵션 변화 시에만 재생성하므로 반복 호출해도 선택 상태 보존.
+function initInfPrefectureMulti() {
+  if (typeof syncMultiFilter !== 'function') return;
+  const map = (typeof PREFECTURE_KO !== 'undefined') ? PREFECTURE_KO : {};
+  const options = Object.keys(map).map(ja => ({ value: ja, label: map[ja] }));
+  options.push({ value: '未登録', label: '미등록' });
+  options.push({ value: '海外', label: '해외' });
+  syncMultiFilter('infPrefectureMulti', '전체 지역', options, rerenderInfluencersFromCache, { searchable: true, searchPlaceholder: '지역 검색' });
+}
+
+// 팔로워 범위 기준 라벨 — 채널 선택값에 맞춰 「(채널) 기준」 표시
+function updateInfFollowersLabel() {
+  const el = $('infFollowersLabel');
+  if (!el) return;
+  const map = { all: '합계', instagram: 'Instagram', x: 'X(Twitter)', tiktok: 'TikTok', youtube: 'YouTube' };
+  el.textContent = `팔로워 (${map[currentInfTab] || '합계'} 기준)`;
 }
 
 function rerenderInfluencersFromCache() {
@@ -44,6 +65,13 @@ function renderInfluencersPane(users) {
   const verifiedSel = $('infFilterVerifiedSelect')?.value || 'all';
   const violationSel = $('infFilterViolationSelect')?.value || 'all';
   const searchQ = ($('infSearch')?.value || '').trim().toLowerCase();
+  // 주소지(다중) — 미선택이면 빈 배열(=전체). classifyPrefecture 로 정식/未登録/海外 분류 후 매칭
+  const prefSel = (typeof getMultiFilterValues === 'function') ? getMultiFilterValues('infPrefectureMulti') : [];
+  // 팔로워 범위 — 비우면 하한/상한 무제한
+  const minRaw = $('infFollowersMin')?.value;
+  const maxRaw = $('infFollowersMax')?.value;
+  const minF = (minRaw !== '' && minRaw != null) ? Number(minRaw) : null;
+  const maxF = (maxRaw !== '' && maxRaw != null) ? Number(maxRaw) : null;
   // 단어 단위 AND 매칭 (matchSearchTokens, 전각/반각 공백 무관)
   const matchSearch = (u) => matchSearchTokens(searchQ, [
     u.name_kanji, u.name, u.name_kana, u.email,
@@ -57,12 +85,20 @@ function renderInfluencersPane(users) {
     if (violationSel === 'has' && vc === 0 && !u.is_blacklisted) return false;
     if (violationSel === 'blacklist' && !u.is_blacklisted) return false;
     if (!matchSearch(u)) return false;
+    // 주소지(다중)
+    if (prefSel.length && !prefSel.includes(classifyPrefecture(u.prefecture))) return false;
+    // 팔로워 범위 (채널 선택값 기준, all=합계)
+    if (minF != null || maxF != null) {
+      const fv = followerValueByChannel(u, currentInfTab);
+      if (minF != null && fv < minF) return false;
+      if (maxF != null && fv > maxF) return false;
+    }
     return true;
   });
   const totalEl = $('infTotalCount');
   if (totalEl) totalEl.textContent = `${filtered.length}명 표시 (전체 ${users.length}명)`;
   const resetBtn = $('btnInfFilterReset');
-  const anyActive = (verifiedSel !== 'all' || violationSel !== 'all' || currentInfTab !== 'all' || !!searchQ);
+  const anyActive = (verifiedSel !== 'all' || violationSel !== 'all' || currentInfTab !== 'all' || !!searchQ || prefSel.length > 0 || minF != null || maxF != null);
   if (resetBtn) resetBtn.style.display = anyActive ? '' : 'none';
   renderInfTable(filtered, currentInfTab);
 }
@@ -72,12 +108,17 @@ function resetInfluencerFilters() {
   const w = $('infFilterViolationSelect'); if (w) w.value = 'all';
   const c = $('infChannelFilter'); if (c) c.value = 'all';
   const s = $('infSearch'); if (s) s.value = '';
+  if (typeof resetMultiFilter === 'function') resetMultiFilter('infPrefectureMulti', '전체 지역');
+  const mn = $('infFollowersMin'); if (mn) mn.value = '';
+  const mx = $('infFollowersMax'); if (mx) mx.value = '';
   currentInfTab = 'all';
+  updateInfFollowersLabel();
   rerenderInfluencersFromCache();
 }
 
 function switchInfTabFromSelect(ch) {
   currentInfTab = ch || 'all';
+  updateInfFollowersLabel();
   rerenderInfluencersFromCache();
 }
 

--- a/docs/specs/2026-06-04-influencer-combo-filter.md
+++ b/docs/specs/2026-06-04-influencer-combo-filter.md
@@ -115,13 +115,18 @@ if (maxF != null && fv > maxF) return false;
 
 ## 구현 결과 (개발 세션이 채울 것)
 
-**구현일:**
-**관련 커밋·PR:**
+**구현일:** 2026-06-05 (PR 1만)
+**관련 커밋·PR:** (PR 1 — dev 머지 후 기록)
 
 ### 초안 대비 변경 사항
-- 추가된 것:
-- 빠진 것:
+- 추가된 것: 없음 (초안 PR 1 설계 그대로)
+- 빠진 것: **PR 2(필터 결과 엑셀 내보내기 + 권한별 민감정보 열)는 이번 사이클 미착수** — 별도 PR로 진행 예정
 - 달라진 것:
+  - 결과 인원수는 사양서가 「sticky-header 표시 의무」라 했으나, 기존에 카드 헤더의 `#infTotalCount`가 이미 "N명 표시 (전체 N명)" 형식으로 존재하여 **그대로 재사용**(중복 표시 회피). 필터 활성 시 초기화 버튼이 함께 노출됨.
 
 ### 구현 중 기술 결정 사항
-- (운영 DB prefecture distinct 점검 결과, 합계 팔로워 정의, 다중필터 헬퍼 재사용 방식, 카운트 표시 위치 등)
+- **공용 헬퍼 위치**: `classifyPrefecture(pref)` + `followerValueByChannel(u, ch)`를 `admin-core.js`(다중필터 섹션, `getMultiFilterValues` 직후)에 배치. `PREFECTURE_KO`(admin-dashboard.js, 빌드상 뒤)는 `typeof` 가드 + 런타임 호출이라 안전(reviewer Warning 1: 페인 진입 시점엔 전 스크립트 로드 완료 → 실질 위험 없음 확인).
+- **다중필터 재사용**: 기존 일괄발송 `bulkPrefectureMulti`와 동일하게 `syncMultiFilter`(searchable) 사용. 단 인플 필터는 PREFECTURE_KO 47개 + 「未登録」 + 「海外」 옵션을 추가(일괄발송은 서버 RPC 매칭이라 未登録/海外 미포함). value는 일본어 정식 키(`大阪府`)·`未登録`·`海外`.
+- **합계 팔로워 정의**: `ig+x+tiktok+youtube_followers`, 각 NULL=0. LIPS·@cosme는 팔로워 컬럼 없어 합계 제외. 채널 선택값(`currentInfTab`) 기준이며 'all'이면 합계.
+- **운영 DB prefecture distinct 점검**: 미수행(개발 세션이 운영 DB 직접 쿼리 안 함). 비정식 표기(`大阪` 등 府 누락)는 `海外`로 분류되는 한계 존재 — 사양서 「의심 3번」대로 운영 실데이터 검증 권고로 남김.
+- **백로그(reviewer Warning 2)**: 추후 채널 드롭다운에 LIPS·@cosme 추가 시 `followerValueByChannel` map에 없어 합계 폴백 → 그때 함께 처리.


### PR DESCRIPTION
## 변경 요약
- 인플루언서 관리 목록에 **주소지(도도부현 다중선택, 「未登録」·「海外」 포함)** + **팔로워 범위(채널 선택 기준, 전체=4채널 합계)** 필터 추가
- 결과 인원수는 기존 `#infTotalCount`(N명 표시) 재사용
- 클라 in-memory 필터 — **DB 무변경**. 공용 헬퍼 `classifyPrefecture`/`followerValueByChannel`(admin-core.js), `syncMultiFilter` 드롭다운 재사용

## 요청 외 추가 변경
- 없음

## 관련 사양서
- docs/specs/2026-06-04-influencer-combo-filter.md (PR 1 부분. PR 2 엑셀 내보내기는 미착수)

## 검증
- [via reviewer] 정적 검증 GO (Warning 2건 모두 실질 위험 없음: PREFECTURE_KO 정의 순서=런타임 안전, LIPS/@cosme 채널 폴백=현재 드롭다운에 없어 무관·백로그)
- 빌드 완료, 루트 admin/index.html 반영 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)