### PR TITLE
style(admin): 인플 팔로워 입력칸 숫자 화살표 제거

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -12,7 +12,7 @@
 // 회귀(2026-05-12 PR #182 머지 직후 발생)를 방지하기 위한 자동 reload 가드.
 // sessionStorage 차단 환경(시크릿 모드 일부, 쿠키 차단)에서는 자연스럽게 skip.
 (function(){
-  var CURRENT_BUILD = 'v1780634000';
+  var CURRENT_BUILD = 'v1780634878';
   if (CURRENT_BUILD.indexOf('__') === 0) return; // 빌드 미적용 (dev/ 직접 열기) 시 skip
   try {
     var prev = sessionStorage.getItem('reverb.adminBuild');
@@ -459,6 +459,11 @@ textarea.form-input{resize:vertical;min-height:80px}
 /* 필터 공통 */
 .admin-filter{padding:6px 28px 6px 8px;font-size:12px;border:1px solid var(--outline);border-radius:6px;outline:none;color:var(--ink)}
 .admin-filter.active{background-color:#fff}
+/* 숫자 입력칸: 증감 화살표(스피너) 제거 → 직접 입력만. 드롭다운용 우측 패딩도 정상화 */
+.admin-filter.no-spinner{padding-right:8px}
+.no-spinner::-webkit-inner-spin-button,
+.no-spinner::-webkit-outer-spin-button{-webkit-appearance:none;margin:0}
+.no-spinner[type=number]{-moz-appearance:textfield;appearance:textfield}
 .admin-filter-search{padding:6px 10px 6px 28px;font-size:12px;border:1px solid var(--outline);border-radius:6px;width:100%;box-sizing:border-box;outline:none}
 /* 페이지 제목 + 필터 영역 */
 .admin-sticky-header{padding-bottom:12px}
@@ -1997,7 +2002,7 @@ textarea.form-input{resize:vertical;min-height:80px}
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-06-05 13:33 · 6ba3c48</span>
+          <span class="admin-build-text">2026-06-05 13:47 · 68a17a5</span>
         </div>
       </div>
     </aside>
@@ -2734,9 +2739,9 @@ textarea.form-input{resize:vertical;min-height:80px}
               <div class="admin-filter-group">
                 <label id="infFollowersLabel">팔로워 (합계 기준)</label>
                 <div style="display:flex;align-items:center;gap:4px">
-                  <input type="number" id="infFollowersMin" class="admin-filter" min="0" step="1" placeholder="최소" style="width:84px" oninput="rerenderInfluencersFromCache()">
+                  <input type="number" id="infFollowersMin" class="admin-filter no-spinner" inputmode="numeric" min="0" step="1" placeholder="최소" style="width:84px" oninput="rerenderInfluencersFromCache()">
                   <span style="color:var(--muted)">~</span>
-                  <input type="number" id="infFollowersMax" class="admin-filter" min="0" step="1" placeholder="최대" style="width:84px" oninput="rerenderInfluencersFromCache()">
+                  <input type="number" id="infFollowersMax" class="admin-filter no-spinner" inputmode="numeric" min="0" step="1" placeholder="최대" style="width:84px" oninput="rerenderInfluencersFromCache()">
                 </div>
               </div>
               <div class="admin-filter-group" style="justify-content:flex-end">

--- a/dev/admin/index.html
+++ b/dev/admin/index.html
@@ -869,9 +869,9 @@
               <div class="admin-filter-group">
                 <label id="infFollowersLabel">팔로워 (합계 기준)</label>
                 <div style="display:flex;align-items:center;gap:4px">
-                  <input type="number" id="infFollowersMin" class="admin-filter" min="0" step="1" placeholder="최소" style="width:84px" oninput="rerenderInfluencersFromCache()">
+                  <input type="number" id="infFollowersMin" class="admin-filter no-spinner" inputmode="numeric" min="0" step="1" placeholder="최소" style="width:84px" oninput="rerenderInfluencersFromCache()">
                   <span style="color:var(--muted)">~</span>
-                  <input type="number" id="infFollowersMax" class="admin-filter" min="0" step="1" placeholder="최대" style="width:84px" oninput="rerenderInfluencersFromCache()">
+                  <input type="number" id="infFollowersMax" class="admin-filter no-spinner" inputmode="numeric" min="0" step="1" placeholder="최대" style="width:84px" oninput="rerenderInfluencersFromCache()">
                 </div>
               </div>
               <div class="admin-filter-group" style="justify-content:flex-end">

--- a/dev/css/admin.css
+++ b/dev/css/admin.css
@@ -9,6 +9,11 @@
 /* 필터 공통 */
 .admin-filter{padding:6px 28px 6px 8px;font-size:12px;border:1px solid var(--outline);border-radius:6px;outline:none;color:var(--ink)}
 .admin-filter.active{background-color:#fff}
+/* 숫자 입력칸: 증감 화살표(스피너) 제거 → 직접 입력만. 드롭다운용 우측 패딩도 정상화 */
+.admin-filter.no-spinner{padding-right:8px}
+.no-spinner::-webkit-inner-spin-button,
+.no-spinner::-webkit-outer-spin-button{-webkit-appearance:none;margin:0}
+.no-spinner[type=number]{-moz-appearance:textfield;appearance:textfield}
 .admin-filter-search{padding:6px 10px 6px 28px;font-size:12px;border:1px solid var(--outline);border-radius:6px;width:100%;box-sizing:border-box;outline:none}
 /* 페이지 제목 + 필터 영역 */
 .admin-sticky-header{padding-bottom:12px}


### PR DESCRIPTION
## 변경 요약
- 인플루언서 조합 필터의 팔로워 최소/최대 입력칸에서 숫자 증감 화살표(스피너) 제거 → 직접 입력만
- `type=number` 유지(최소/최대 파싱 그대로), `.no-spinner` 클래스 + `inputmode=numeric` 추가. 범위 한정 CSS

## 요청 외 추가 변경
- 없음

## 관련
- 'PR 1 — 인플루언서 조합 필터'(PR #437) 후속 미세 조정

## 검증
- [via reviewer] 정적 검증 GO (전역 number input 오염 없음 확인), qa skip(표시 조정 단독)

🤖 Generated with [Claude Code](https://claude.com/claude-code)