### PR TITLE
feat(admin): 인플 SNS 채널 드롭다운을 팔로워 옆으로 이동

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -12,7 +12,7 @@
 // 회귀(2026-05-12 PR #182 머지 직후 발생)를 방지하기 위한 자동 reload 가드.
 // sessionStorage 차단 환경(시크릿 모드 일부, 쿠키 차단)에서는 자연스럽게 skip.
 (function(){
-  var CURRENT_BUILD = 'v1780634878';
+  var CURRENT_BUILD = 'v1780636044';
   if (CURRENT_BUILD.indexOf('__') === 0) return; // 빌드 미적용 (dev/ 직접 열기) 시 skip
   try {
     var prev = sessionStorage.getItem('reverb.adminBuild');
@@ -2002,7 +2002,7 @@ textarea.form-input{resize:vertical;min-height:80px}
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-06-05 13:47 · 68a17a5</span>
+          <span class="admin-build-text">2026-06-05 14:07 · 37d9438</span>
         </div>
       </div>
     </aside>
@@ -2706,16 +2706,6 @@ textarea.form-input{resize:vertical;min-height:80px}
             </div>
             <div style="display:flex;align-items:flex-end;gap:12px;flex-wrap:wrap">
               <div class="admin-filter-group">
-                <label>SNS 채널</label>
-                <select id="infChannelFilter" class="admin-filter" onchange="switchInfTabFromSelect(this.value)">
-                  <option value="all">전체</option>
-                  <option value="instagram">Instagram</option>
-                  <option value="x">X(Twitter)</option>
-                  <option value="tiktok">TikTok</option>
-                  <option value="youtube">YouTube</option>
-                </select>
-              </div>
-              <div class="admin-filter-group">
                 <label>인증</label>
                 <select id="infFilterVerifiedSelect" class="admin-filter" onchange="rerenderInfluencersFromCache()">
                   <option value="all">전체</option>
@@ -2737,7 +2727,17 @@ textarea.form-input{resize:vertical;min-height:80px}
                 <div id="infPrefectureMulti" class="mf-wrap" style="max-width:200px"><button type="button" class="mf-btn" style="max-width:200px;overflow:hidden;text-overflow:ellipsis">전체 지역</button><div class="mf-drop" style="min-width:240px"></div></div>
               </div>
               <div class="admin-filter-group">
-                <label id="infFollowersLabel">팔로워 (합계 기준)</label>
+                <label>SNS 채널</label>
+                <select id="infChannelFilter" class="admin-filter" onchange="switchInfTabFromSelect(this.value)">
+                  <option value="all">전체 (합계 기준)</option>
+                  <option value="instagram">Instagram</option>
+                  <option value="x">X(Twitter)</option>
+                  <option value="tiktok">TikTok</option>
+                  <option value="youtube">YouTube</option>
+                </select>
+              </div>
+              <div class="admin-filter-group">
+                <label>팔로워</label>
                 <div style="display:flex;align-items:center;gap:4px">
                   <input type="number" id="infFollowersMin" class="admin-filter no-spinner" inputmode="numeric" min="0" step="1" placeholder="최소" style="width:84px" oninput="rerenderInfluencersFromCache()">
                   <span style="color:var(--muted)">~</span>
@@ -17384,7 +17384,6 @@ async function loadAdminInfluencers() {
   infUsersCache = users;
   _infViolationCounts = violations;
   initInfPrefectureMulti();
-  updateInfFollowersLabel();
   renderInfluencersPane(infUsersCache);
 }
 
@@ -17397,14 +17396,6 @@ function initInfPrefectureMulti() {
   options.push({ value: '未登録', label: '미등록' });
   options.push({ value: '海外', label: '해외' });
   syncMultiFilter('infPrefectureMulti', '전체 지역', options, rerenderInfluencersFromCache, { searchable: true, searchPlaceholder: '지역 검색' });
-}
-
-// 팔로워 범위 기준 라벨 — 채널 선택값에 맞춰 「(채널) 기준」 표시
-function updateInfFollowersLabel() {
-  const el = $('infFollowersLabel');
-  if (!el) return;
-  const map = { all: '합계', instagram: 'Instagram', x: 'X(Twitter)', tiktok: 'TikTok', youtube: 'YouTube' };
-  el.textContent = `팔로워 (${map[currentInfTab] || '합계'} 기준)`;
 }
 
 function rerenderInfluencersFromCache() {
@@ -17463,13 +17454,11 @@ function resetInfluencerFilters() {
   const mn = $('infFollowersMin'); if (mn) mn.value = '';
   const mx = $('infFollowersMax'); if (mx) mx.value = '';
   currentInfTab = 'all';
-  updateInfFollowersLabel();
   rerenderInfluencersFromCache();
 }
 
 function switchInfTabFromSelect(ch) {
   currentInfTab = ch || 'all';
-  updateInfFollowersLabel();
   rerenderInfluencersFromCache();
 }
 

--- a/dev/admin/index.html
+++ b/dev/admin/index.html
@@ -836,16 +836,6 @@
             </div>
             <div style="display:flex;align-items:flex-end;gap:12px;flex-wrap:wrap">
               <div class="admin-filter-group">
-                <label>SNS 채널</label>
-                <select id="infChannelFilter" class="admin-filter" onchange="switchInfTabFromSelect(this.value)">
-                  <option value="all">전체</option>
-                  <option value="instagram">Instagram</option>
-                  <option value="x">X(Twitter)</option>
-                  <option value="tiktok">TikTok</option>
-                  <option value="youtube">YouTube</option>
-                </select>
-              </div>
-              <div class="admin-filter-group">
                 <label>인증</label>
                 <select id="infFilterVerifiedSelect" class="admin-filter" onchange="rerenderInfluencersFromCache()">
                   <option value="all">전체</option>
@@ -867,7 +857,17 @@
                 <div id="infPrefectureMulti" class="mf-wrap" style="max-width:200px"><button type="button" class="mf-btn" style="max-width:200px;overflow:hidden;text-overflow:ellipsis">전체 지역</button><div class="mf-drop" style="min-width:240px"></div></div>
               </div>
               <div class="admin-filter-group">
-                <label id="infFollowersLabel">팔로워 (합계 기준)</label>
+                <label>SNS 채널</label>
+                <select id="infChannelFilter" class="admin-filter" onchange="switchInfTabFromSelect(this.value)">
+                  <option value="all">전체 (합계 기준)</option>
+                  <option value="instagram">Instagram</option>
+                  <option value="x">X(Twitter)</option>
+                  <option value="tiktok">TikTok</option>
+                  <option value="youtube">YouTube</option>
+                </select>
+              </div>
+              <div class="admin-filter-group">
+                <label>팔로워</label>
                 <div style="display:flex;align-items:center;gap:4px">
                   <input type="number" id="infFollowersMin" class="admin-filter no-spinner" inputmode="numeric" min="0" step="1" placeholder="최소" style="width:84px" oninput="rerenderInfluencersFromCache()">
                   <span style="color:var(--muted)">~</span>

--- a/dev/js/admin-influencers.js
+++ b/dev/js/admin-influencers.js
@@ -33,7 +33,6 @@ async function loadAdminInfluencers() {
   infUsersCache = users;
   _infViolationCounts = violations;
   initInfPrefectureMulti();
-  updateInfFollowersLabel();
   renderInfluencersPane(infUsersCache);
 }
 
@@ -46,14 +45,6 @@ function initInfPrefectureMulti() {
   options.push({ value: '未登録', label: '미등록' });
   options.push({ value: '海外', label: '해외' });
   syncMultiFilter('infPrefectureMulti', '전체 지역', options, rerenderInfluencersFromCache, { searchable: true, searchPlaceholder: '지역 검색' });
-}
-
-// 팔로워 범위 기준 라벨 — 채널 선택값에 맞춰 「(채널) 기준」 표시
-function updateInfFollowersLabel() {
-  const el = $('infFollowersLabel');
-  if (!el) return;
-  const map = { all: '합계', instagram: 'Instagram', x: 'X(Twitter)', tiktok: 'TikTok', youtube: 'YouTube' };
-  el.textContent = `팔로워 (${map[currentInfTab] || '합계'} 기준)`;
 }
 
 function rerenderInfluencersFromCache() {
@@ -112,13 +103,11 @@ function resetInfluencerFilters() {
   const mn = $('infFollowersMin'); if (mn) mn.value = '';
   const mx = $('infFollowersMax'); if (mx) mx.value = '';
   currentInfTab = 'all';
-  updateInfFollowersLabel();
   rerenderInfluencersFromCache();
 }
 
 function switchInfTabFromSelect(ch) {
   currentInfTab = ch || 'all';
-  updateInfFollowersLabel();
   rerenderInfluencersFromCache();
 }
 


### PR DESCRIPTION
## 변경 요약
- 기존 「SNS 채널」 드롭다운(#infChannelFilter)을 **팔로워 입력칸 바로 옆**(주소지 다음)으로 이동 — 이미 팔로워 기준을 결정하던 드롭다운이라 별도 추가 없이 위치만 이동
- 첫 옵션 「전체」 → 「전체 (합계 기준)」, 팔로워 라벨 「팔로워 (합계 기준)」 → 「팔로워」
- 더 이상 쓰지 않는 `updateInfFollowersLabel()` 함수 + 호출 3곳 제거

## 요청 외 추가 변경
- 없음

## 관련
- 'PR 1 — 인플루언서 조합 필터'(PR #437) 후속 (사용자 요청)

## 검증
- [via reviewer] 정적 검증 GO (stale 참조 0), qa skip(UI 이동·죽은 함수 제거)

🤖 Generated with [Claude Code](https://claude.com/claude-code)