### PR TITLE
style(admin): SNS 채널 '전체' 옵션 라벨 되돌리기

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -12,7 +12,7 @@
 // 회귀(2026-05-12 PR #182 머지 직후 발생)를 방지하기 위한 자동 reload 가드.
 // sessionStorage 차단 환경(시크릿 모드 일부, 쿠키 차단)에서는 자연스럽게 skip.
 (function(){
-  var CURRENT_BUILD = 'v1780636044';
+  var CURRENT_BUILD = 'v1780636430';
   if (CURRENT_BUILD.indexOf('__') === 0) return; // 빌드 미적용 (dev/ 직접 열기) 시 skip
   try {
     var prev = sessionStorage.getItem('reverb.adminBuild');
@@ -2002,7 +2002,7 @@ textarea.form-input{resize:vertical;min-height:80px}
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-06-05 14:07 · 37d9438</span>
+          <span class="admin-build-text">2026-06-05 14:13 · ae2fdc9</span>
         </div>
       </div>
     </aside>
@@ -2729,7 +2729,7 @@ textarea.form-input{resize:vertical;min-height:80px}
               <div class="admin-filter-group">
                 <label>SNS 채널</label>
                 <select id="infChannelFilter" class="admin-filter" onchange="switchInfTabFromSelect(this.value)">
-                  <option value="all">전체 (합계 기준)</option>
+                  <option value="all">전체</option>
                   <option value="instagram">Instagram</option>
                   <option value="x">X(Twitter)</option>
                   <option value="tiktok">TikTok</option>

--- a/dev/admin/index.html
+++ b/dev/admin/index.html
@@ -859,7 +859,7 @@
               <div class="admin-filter-group">
                 <label>SNS 채널</label>
                 <select id="infChannelFilter" class="admin-filter" onchange="switchInfTabFromSelect(this.value)">
-                  <option value="all">전체 (합계 기준)</option>
+                  <option value="all">전체</option>
                   <option value="instagram">Instagram</option>
                   <option value="x">X(Twitter)</option>
                   <option value="tiktok">TikTok</option>


### PR DESCRIPTION
## 변경 요약
- 인플 「SNS 채널」 드롭다운 첫 옵션 「전체 (합계 기준)」 → 「전체」로 단순화 (사용자 요청)

## 관련
- 'PR 1 — 인플루언서 조합 필터' 후속

🤖 Generated with [Claude Code](https://claude.com/claude-code)