### PR TITLE
fix(mypage): 응모이력 상태 드롭다운 첫 로딩 빈 박스 방지

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -12,7 +12,7 @@
 // 회귀(2026-05-12 PR #182 머지 직후 발생)를 방지하기 위한 자동 reload 가드.
 // sessionStorage 차단 환경(시크릿 모드 일부, 쿠키 차단)에서는 자연스럽게 skip.
 (function(){
-  var CURRENT_BUILD = 'v1780634000';
+  var CURRENT_BUILD = 'v1780636874';
   if (CURRENT_BUILD.indexOf('__') === 0) return; // 빌드 미적용 (dev/ 직접 열기) 시 skip
   try {
     var prev = sessionStorage.getItem('reverb.adminBuild');
@@ -1997,7 +1997,7 @@ textarea.form-input{resize:vertical;min-height:80px}
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-06-05 13:33 · 6ba3c48</span>
+          <span class="admin-build-text">2026-06-05 14:21 · 3271495</span>
         </div>
       </div>
     </aside>

--- a/dev/index.html
+++ b/dev/index.html
@@ -905,7 +905,7 @@ window._supabaseLoaded = false;
   <div id="mypage-sub-applications" class="mypage-view">
     <div class="mypage-sub-header" style="justify-content:space-between">
       <span class="mypage-sub-title" data-i18n="mypage.menu.applications">応募履歴</span>
-      <select id="myApplyStatusSelect" class="form-input" style="padding:6px 30px 6px 12px;font-size:13px;font-weight:600;border-radius:8px;width:auto;max-width:55%" onchange="_myAppsTab=this.value;renderMyApplyList()"></select>
+      <select id="myApplyStatusSelect" class="form-input" style="padding:6px 30px 6px 12px;font-size:13px;font-weight:600;border-radius:8px;width:auto;max-width:55%" onchange="_myAppsTab=this.value;renderMyApplyList()"><option value="active2" data-i18n="appHistory.inProgress" selected>進行中</option></select>
     </div>
     <div class="container mypage-wrap" style="padding-left:0;padding-right:0">
       <div style="display:flex;gap:8px;padding:12px 16px 8px;align-items:center;flex-wrap:wrap">

--- a/dev/js/mypage.js
+++ b/dev/js/mypage.js
@@ -463,6 +463,10 @@ function openMypageSub(sub, pushHistory) {
   document.querySelectorAll('#page-mypage .mypage-view').forEach(v => v.classList.remove('active'));
   const target = $('mypage-sub-' + sub);
   if (target) target.classList.add('active');
+  // 응모이력 진입(햄버거·알림·새로고침 등 모든 경로) 시 상태 드롭다운을 현재 _myAppsTab 기준으로
+  // 즉시 채워 빈 박스/stale 선택 방지. 데이터 로드(loadMyApplications) 전이라도 항목은 보이고,
+  // 로드 완료 후 renderMyApplyTabs 재호출로 건수까지 갱신된다.
+  if (sub === 'applications' && typeof renderMyApplyTabs === 'function') renderMyApplyTabs();
   // 사용자 클릭 등 새 진입은 push (기본), popstate·새로고침 init·내부 폴백 등은 false 전달 → entry 누적 방지.
   if (pushHistory !== false) {
     history.pushState({page:'mypage', sub}, '', '#mypage-' + sub);

--- a/index.html
+++ b/index.html
@@ -1563,7 +1563,7 @@ textarea.form-input{resize:vertical;min-height:80px}
   <div id="mypage-sub-applications" class="mypage-view">
     <div class="mypage-sub-header" style="justify-content:space-between">
       <span class="mypage-sub-title" data-i18n="mypage.menu.applications">応募履歴</span>
-      <select id="myApplyStatusSelect" class="form-input" style="padding:6px 30px 6px 12px;font-size:13px;font-weight:600;border-radius:8px;width:auto;max-width:55%" onchange="_myAppsTab=this.value;renderMyApplyList()"></select>
+      <select id="myApplyStatusSelect" class="form-input" style="padding:6px 30px 6px 12px;font-size:13px;font-weight:600;border-radius:8px;width:auto;max-width:55%" onchange="_myAppsTab=this.value;renderMyApplyList()"><option value="active2" data-i18n="appHistory.inProgress" selected>進行中</option></select>
     </div>
     <div class="container mypage-wrap" style="padding-left:0;padding-right:0">
       <div style="display:flex;gap:8px;padding:12px 16px 8px;align-items:center;flex-wrap:wrap">
@@ -10977,6 +10977,10 @@ function openMypageSub(sub, pushHistory) {
   document.querySelectorAll('#page-mypage .mypage-view').forEach(v => v.classList.remove('active'));
   const target = $('mypage-sub-' + sub);
   if (target) target.classList.add('active');
+  // 응모이력 진입(햄버거·알림·새로고침 등 모든 경로) 시 상태 드롭다운을 현재 _myAppsTab 기준으로
+  // 즉시 채워 빈 박스/stale 선택 방지. 데이터 로드(loadMyApplications) 전이라도 항목은 보이고,
+  // 로드 완료 후 renderMyApplyTabs 재호출로 건수까지 갱신된다.
+  if (sub === 'applications' && typeof renderMyApplyTabs === 'function') renderMyApplyTabs();
   // 사용자 클릭 등 새 진입은 push (기본), popstate·새로고침 init·내부 폴백 등은 false 전달 → entry 누적 방지.
   if (pushHistory !== false) {
     history.pushState({page:'mypage', sub}, '', '#mypage-' + sub);


### PR DESCRIPTION
## 변경 요약
- 상태 드롭다운(myApplyStatusSelect)에 기본 항목(進行中) 정적 삽입 — 데이터 로드 전 빈 박스 방지
- openMypageSub('applications') 진입 시 renderMyApplyTabs() 즉시 호출 — 모든 진입 경로(햄버거/알림/새로고침)에서 채움 + stale 선택 방지

## 요청 외 추가 변경
- origin/dev(다른 세션 작업) 머지로 인한 빌드 산출물 재빌드(충돌 해소)

## 관련 사양서
- docs/specs/2026-06-04-application-history-status-dropdown.md (직전 드롭다운 전환의 후속 보강)

[via reviewer] static check GO
DB·마이그레이션·약관 무영향