### PR TITLE
fix(ui): 숫자 입력칸 마우스 휠 값 변경 차단 (전역)

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -12,7 +12,7 @@
 // 회귀(2026-05-12 PR #182 머지 직후 발생)를 방지하기 위한 자동 reload 가드.
 // sessionStorage 차단 환경(시크릿 모드 일부, 쿠키 차단)에서는 자연스럽게 skip.
 (function(){
-  var CURRENT_BUILD = 'v1780637514';
+  var CURRENT_BUILD = 'v1780638205';
   if (CURRENT_BUILD.indexOf('__') === 0) return; // 빌드 미적용 (dev/ 직접 열기) 시 skip
   try {
     var prev = sessionStorage.getItem('reverb.adminBuild');
@@ -2002,7 +2002,7 @@ textarea.form-input{resize:vertical;min-height:80px}
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-06-05 14:31 · 3f1f218</span>
+          <span class="admin-build-text">2026-06-05 14:43 · ecb54bf</span>
         </div>
       </div>
     </aside>
@@ -5774,6 +5774,15 @@ const CAMPAIGN_STATUS_BADGE_CLASS = {
   draft: 'badge-gray', scheduled: 'badge-blue', active: 'badge-green',
   closed_recruit: 'badge-pink', closed_done: 'badge-done', expired: 'badge-expired'
 };
+
+// 숫자 입력칸(type=number): 포커스 중 마우스 휠로 값이 바뀌는 기본 동작 차단 (오입력 방지).
+// 전역 1회 등록 → 관리자·인플 양쪽 빌드의 모든 숫자 입력칸에 일괄 적용. 휠은 페이지 스크롤만.
+document.addEventListener('wheel', function (e) {
+  const el = e.target;
+  if (el && el.tagName === 'INPUT' && el.type === 'number' && document.activeElement === el) {
+    e.preventDefault();
+  }
+}, { passive: false });
 
 // ══════════════════════════════════════
 // STORAGE — Supabase API 호출 함수 모음

--- a/dev/lib/shared.js
+++ b/dev/lib/shared.js
@@ -644,3 +644,12 @@ const CAMPAIGN_STATUS_BADGE_CLASS = {
   draft: 'badge-gray', scheduled: 'badge-blue', active: 'badge-green',
   closed_recruit: 'badge-pink', closed_done: 'badge-done', expired: 'badge-expired'
 };
+
+// 숫자 입력칸(type=number): 포커스 중 마우스 휠로 값이 바뀌는 기본 동작 차단 (오입력 방지).
+// 전역 1회 등록 → 관리자·인플 양쪽 빌드의 모든 숫자 입력칸에 일괄 적용. 휠은 페이지 스크롤만.
+document.addEventListener('wheel', function (e) {
+  const el = e.target;
+  if (el && el.tagName === 'INPUT' && el.type === 'number' && document.activeElement === el) {
+    e.preventDefault();
+  }
+}, { passive: false });

--- a/index.html
+++ b/index.html
@@ -2501,6 +2501,15 @@ const CAMPAIGN_STATUS_BADGE_CLASS = {
   closed_recruit: 'badge-pink', closed_done: 'badge-done', expired: 'badge-expired'
 };
 
+// 숫자 입력칸(type=number): 포커스 중 마우스 휠로 값이 바뀌는 기본 동작 차단 (오입력 방지).
+// 전역 1회 등록 → 관리자·인플 양쪽 빌드의 모든 숫자 입력칸에 일괄 적용. 휠은 페이지 스크롤만.
+document.addEventListener('wheel', function (e) {
+  const el = e.target;
+  if (el && el.tagName === 'INPUT' && el.type === 'number' && document.activeElement === el) {
+    e.preventDefault();
+  }
+}, { passive: false });
+
 // ══════════════════════════════════════
 // i18n — 일본어 (기본)
 // ══════════════════════════════════════


### PR DESCRIPTION
## 변경 요약
- type=number 입력칸에서 포커스 중 마우스 휠로 값이 바뀌던 기본 동작을 전역으로 차단
- shared.js에 wheel 리스너 1개 추가 → 관리자·인플 양쪽 빌드의 모든 숫자 입력칸에 일괄 적용. 페이지 스크롤은 정상

## 관련
- 인플 팔로워 범위 입력칸 휠 오입력 방지 (사용자 요청, 동일 기능 전체 적용)

## 검증
- [via reviewer] 정적 검증 GO (조건·중복·sales 충돌 없음 확인), qa skip

🤖 Generated with [Claude Code](https://claude.com/claude-code)