### PR TITLE
feat(bulk-message): 일괄발송 대상조건 정교화 PR 2 — 완전승인 토글·건/명 카운트·라벨

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -12,7 +12,7 @@
 // 회귀(2026-05-12 PR #182 머지 직후 발생)를 방지하기 위한 자동 reload 가드.
 // sessionStorage 차단 환경(시크릿 모드 일부, 쿠키 차단)에서는 자연스럽게 skip.
 (function(){
-  var CURRENT_BUILD = 'v1780650333';
+  var CURRENT_BUILD = 'v1780650390';
   if (CURRENT_BUILD.indexOf('__') === 0) return; // 빌드 미적용 (dev/ 직접 열기) 시 skip
   try {
     var prev = sessionStorage.getItem('reverb.adminBuild');
@@ -2002,7 +2002,7 @@ textarea.form-input{resize:vertical;min-height:80px}
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-06-05 18:05 · eda9dc6</span>
+          <span class="admin-build-text">2026-06-05 18:06 · 4345fef</span>
         </div>
       </div>
     </aside>

--- a/admin/index.html
+++ b/admin/index.html
@@ -12,7 +12,7 @@
 // 회귀(2026-05-12 PR #182 머지 직후 발생)를 방지하기 위한 자동 reload 가드.
 // sessionStorage 차단 환경(시크릿 모드 일부, 쿠키 차단)에서는 자연스럽게 skip.
 (function(){
-  var CURRENT_BUILD = 'v1780646149';
+  var CURRENT_BUILD = 'v1780650333';
   if (CURRENT_BUILD.indexOf('__') === 0) return; // 빌드 미적용 (dev/ 직접 열기) 시 skip
   try {
     var prev = sessionStorage.getItem('reverb.adminBuild');
@@ -2002,7 +2002,7 @@ textarea.form-input{resize:vertical;min-height:80px}
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-06-05 16:55 · 8644c29</span>
+          <span class="admin-build-text">2026-06-05 18:05 · eda9dc6</span>
         </div>
       </div>
     </aside>
@@ -4967,6 +4967,9 @@ textarea.form-input{resize:vertical;min-height:80px}
             <div id="bulkAppStatus" class="bulk-chk-row"></div>
           </div>
           <div id="bulkDelivWrap">
+            <div id="bulkTypeMixNote" style="display:none;font-size:11px;color:var(--muted);background:var(--bg);border-radius:8px;padding:8px 10px;margin-bottom:10px;line-height:1.5">
+              영수증 조건은 <b>리뷰어 신청건에만</b> 적용됩니다. 기프팅·방문형 신청건은 영수증 조건과 무관하게 포함됩니다.
+            </div>
             <div id="bulkReceiptWrap" style="display:none;margin-bottom:12px">
               <div style="font-size:13px;color:var(--muted);margin-bottom:6px">영수증 상태 <span style="font-size:11px">(리뷰어 캠페인)</span></div>
               <div id="bulkReceiptStatus" class="bulk-chk-row"></div>
@@ -4975,6 +4978,8 @@ textarea.form-input{resize:vertical;min-height:80px}
               <div style="font-size:13px;color:var(--muted);margin-bottom:6px">결과물 상태 <span style="font-size:11px">(게시물·리뷰 이미지)</span></div>
               <div id="bulkPostStatus" class="bulk-chk-row"></div>
             </div>
+            <label class="bulk-chk" style="margin-top:10px"><input type="checkbox" id="bulkFullApproved" onchange="scheduleBulkRecount()">완전 승인만 (부분 승인 제외)</label>
+            <div style="font-size:11px;color:var(--muted);margin-top:2px;line-height:1.5">체크 시 결과물이 <b>모두 승인된</b> 신청건만 — 미승인·검수중·반려·작성중 결과물이 하나라도 있으면 제외됩니다.</div>
           </div>
           <div>
             <div style="font-size:13px;color:var(--muted);margin-bottom:6px">④ 인플루언서 상태</div>
@@ -4989,7 +4994,7 @@ textarea.form-input{resize:vertical;min-height:80px}
             <div id="bulkPrefectureMulti" class="mf-wrap" style="max-width:100%"><button type="button" class="mf-btn" style="width:100%;overflow:hidden;text-overflow:ellipsis">전체 지역</button><div class="mf-drop"></div></div>
           </div>
           <div>
-            <div style="font-size:13px;color:var(--muted);margin-bottom:6px">SNS 채널 <span style="font-size:11px">(인플루언서 보유 채널 · 미선택 시 전체)</span></div>
+            <div style="font-size:13px;color:var(--muted);margin-bottom:6px">인플루언서 보유 SNS <span style="font-size:11px">(캠페인 모집 채널이 아니라 인플루언서가 가진 SNS 기준 · 미선택 시 전체)</span></div>
             <div id="bulkSnsChannels" class="bulk-chk-row"></div>
           </div>
           <div>
@@ -5009,15 +5014,15 @@ textarea.form-input{resize:vertical;min-height:80px}
           </div>
         </div>
         <div class="bulk-count-box" id="bulkCountBox" style="display:none;background:var(--bg);border-radius:10px;padding:12px 14px;font-size:14px;color:var(--ink)">
-          선택된 수신자 <b id="bulkCount" style="color:var(--brand,#16A34A)">0</b>명
+          선택 <b id="bulkCount" style="color:var(--brand,#16A34A)">0</b>건 <span style="color:var(--muted)">(받는 사람 <b id="bulkCountPeople" style="color:var(--ink)">0</b>명)</span>
           <span id="bulkCountLoading" style="display:none;font-size:12px;color:var(--muted)"> · 계산 중…</span>
-          <span id="bulkCancelledNote" style="display:block;font-size:11px;color:var(--muted);margin-top:4px">취소(cancelled)한 응모는 제외됩니다.</span>
+          <span id="bulkCancelledNote" style="display:block;font-size:11px;color:var(--muted);margin-top:4px">동일인이 여러 신청건이면 신청건마다 1통씩 발송됩니다. 취소(cancelled)한 응모는 제외됩니다.</span>
         </div>
       </div>
       <!-- STEP 2: 본문 작성 -->
       <div id="bulkStep2" style="display:none;flex-direction:column;gap:12px">
         <div style="font-size:13px;color:var(--ink);background:var(--bg);border-radius:10px;padding:10px 12px">
-          받는 사람 <b id="bulkCount2">0</b>명 — 각자의 1:1 대화방으로 도착하며 <b>서로 누가 받았는지 모릅니다(BCC)</b>.
+          <b id="bulkCount2">0</b>건 발송 <span style="color:var(--muted)">(받는 사람 <b id="bulkCount2People">0</b>명)</span> — 각 신청건의 1:1 대화방으로 도착하며 <b>서로 누가 받았는지 모릅니다(BCC)</b>. 동일인이 여러 신청건이면 각 건마다 1통씩 갑니다.
         </div>
         <div>
           <div style="font-size:13px;color:var(--muted);margin-bottom:6px">발송 제목 <span style="font-size:11px">(관리자용 · 선택)</span></div>
@@ -8647,9 +8652,21 @@ async function resolveBulkRecipients(campaignId, filters = {}) {
     p_require_verified: !!filters.requireVerified,
     p_exclude_violation: !!filters.excludeViolation,
     p_exclude_blacklist: filters.excludeBlacklist !== false,
+    // 완전 승인만(부분 승인 제외) — 통합 토글 1개가 영수증·게시물 양쪽을 함께 true (마이그레이션 171)
+    p_receipt_all_approved: !!filters.fullApproved,
+    p_post_all_approved: !!filters.fullApproved,
   });
   if (error) throw error;
   return data || [];
+}
+
+// 응모 ID 배열의 distinct user_id 수 (일괄발송 「○건(○명)」 표시용 — 동일인 중복 응모 인지).
+//   appIds 는 BULK_MAX(200) 이하라 in() 단일 쿼리로 안전(PostgREST 1000행 cap 미만).
+async function countDistinctUsersForApps(appIds) {
+  if (!db || !appIds || !appIds.length) return 0;
+  const {data, error} = await db?.from('applications').select('user_id').in('id', appIds);
+  if (error) throw error;
+  return new Set((data || []).map(r => r.user_id).filter(Boolean)).size;
 }
 
 // 발송 이력 목록 (관리자). application_message_broadcasts 직접 조회.
@@ -16199,6 +16216,7 @@ function openBulkMessageModal(presetAppIds) {
     _bulkState.recruitTypes = [];
     _bulkState.availableCampaignIds = [];
     _bulkState.hasMonitor = false;
+    _bulkState.hasNonMonitor = false;
     renderBulkStatusChips();        // ① 캠페인 상태 칩 (미선택 상태)
     renderBulkRecruitTypeChips();   // 모집 타입 칩 (미선택 = 전체)
     document.getElementById('bulkCampaignSelectWrap').style.display = 'none';
@@ -16210,6 +16228,9 @@ function openBulkMessageModal(presetAppIds) {
     const v = document.getElementById('bulkInflVerified'); if (v) v.checked = false;
     const nv = document.getElementById('bulkInflNoViolation'); if (nv) nv.checked = false;
     const nb = document.getElementById('bulkInflNoBlacklist'); if (nb) nb.checked = true;
+    // 완전 승인 토글·타입혼합 배너 초기화 (모달 재오픈 시 이전 상태 잔존 방지)
+    const fa = document.getElementById('bulkFullApproved'); if (fa) fa.checked = false;
+    const mix = document.getElementById('bulkTypeMixNote'); if (mix) mix.style.display = 'none';
     // 팔로워 필터 기본값: 채널별·Instagram·빈값
     const fmPer = document.querySelector('input[name="bulkFollowerMode"][value="per_channel"]'); if (fmPer) fmPer.checked = true;
     const fc = document.getElementById('bulkFollowerChannel'); if (fc) { fc.value = 'instagram'; fc.style.display = ''; }
@@ -16317,6 +16338,11 @@ function renderBulkReceiptVisibility(campaignIds) {
     const c = camps.find(x => x.id === cid);
     return c && c.recruit_type === 'monitor';
   });
+  // 리뷰어(monitor)와 기프팅·방문형이 섞였는지 — 영수증 필터 타입혼합 안내 배너 노출 판정
+  _bulkState.hasNonMonitor = campaignIds.some(cid => {
+    const c = camps.find(x => x.id === cid);
+    return c && c.recruit_type !== 'monitor';
+  });
 }
 
 // 응모·영수증·결과물 상태 체크박스 — 모달 열 때 1회 렌더(선택 보존). 영수증·결과물 동일 status 코드.
@@ -16370,6 +16396,8 @@ function collectBulkFilters() {
     requireVerified: document.getElementById('bulkInflVerified')?.checked || false,
     excludeViolation: document.getElementById('bulkInflNoViolation')?.checked || false,
     excludeBlacklist: document.getElementById('bulkInflNoBlacklist')?.checked !== false,
+    // 완전 승인만(부분 승인 제외) — 승인 응모 포함 시에만 의미. 통합 토글 1개가 영수증·게시물 함께 적용
+    fullApproved: approved ? (document.getElementById('bulkFullApproved')?.checked || false) : false,
   };
 }
 
@@ -16382,6 +16410,9 @@ function scheduleBulkRecount() {
   // 영수증 필터는 승인 + 리뷰어(monitor) 캠페인 포함 시만 노출
   const receiptWrap = document.getElementById('bulkReceiptWrap');
   if (receiptWrap) receiptWrap.style.display = (approved && _bulkState && _bulkState.hasMonitor) ? '' : 'none';
+  // 타입혼합 안내 배너 — 리뷰어 + 기프팅·방문형이 섞였을 때(영수증 조건이 일부 신청건에만 적용됨)
+  const mixNote = document.getElementById('bulkTypeMixNote');
+  if (mixNote) mixNote.style.display = (approved && _bulkState && _bulkState.hasMonitor && _bulkState.hasNonMonitor) ? '' : 'none';
   clearTimeout(_bulkRecountTimer);
   _bulkRecountTimer = setTimeout(recountBulk, 350);
 }
@@ -16408,7 +16439,13 @@ async function recountBulk() {
     const ids = Array.from(idSet);
     _bulkState.recipientIds = ids;
     _bulkState.filterSnapshot = filters;
-    updateBulkCount(ids.length);
+    // 사람 수(distinct user) — 동일인이 여러 신청건으로 중복되므로 「건」과 별도 표기.
+    // 실패해도 발송엔 지장 없으므로 건수로 폴백.
+    let people = ids.length;
+    try { people = await countDistinctUsersForApps(ids); } catch (_e) { people = ids.length; }
+    if (JSON.stringify(_bulkState.campaignIds) !== JSON.stringify(campaignIds)) return;
+    _bulkState.recipientPeople = people;
+    updateBulkCount(ids.length, people);
     document.getElementById('bulkNextBtn').disabled = ids.length === 0;
   } catch (e) {
     if (e && e.message === 'bulk_recount_timeout') {
@@ -16424,15 +16461,20 @@ async function recountBulk() {
   }
 }
 
-function updateBulkCount(n) {
-  const el = document.getElementById('bulkCount'); if (el) el.textContent = n;
+// n = 신청건 수(발송 통 수 — 동일인 여러 건이면 각 건마다 1통), people = 도달 인원(distinct user).
+function updateBulkCount(n, people) {
+  const ppl = (people != null) ? people : n;
+  const el = document.getElementById('bulkCount'); if (el) el.textContent = n;            // 건수
+  const elp = document.getElementById('bulkCountPeople'); if (elp) elp.textContent = ppl;  // 사람 수
+  // STEP 2: 실제 발송 통 수 = 신청건 수(n). 사람 수(ppl)는 괄호로 병기.
   const el2 = document.getElementById('bulkCount2'); if (el2) el2.textContent = n;
+  const el2p = document.getElementById('bulkCount2People'); if (el2p) el2p.textContent = ppl;
 }
 
 function bulkStepNext() {
   if (!_bulkState || !_bulkState.recipientIds.length) { toast('대상이 없습니다.'); return; }
   if (_bulkState.recipientIds.length > BULK_MAX) {
-    toast(`1회 최대 ${BULK_MAX}명까지 발송할 수 있습니다. 필터로 범위를 좁혀주세요.`); return;
+    toast(`1회 최대 ${BULK_MAX}건까지 발송할 수 있습니다. 필터로 범위를 좁혀주세요.`); return;
   }
   document.getElementById('bulkStep1').style.display = 'none';
   document.getElementById('bulkStep2').style.display = 'flex';
@@ -16474,7 +16516,7 @@ async function confirmBulkSend() {
     const contextFilter = _bulkState.presetIds ? null : { ...(_bulkState.filterSnapshot || {}), campaign_ids: campIds };
     const title = document.getElementById('bulkTitle')?.value.trim() || null;   // 관리자 전용 제목 (선택)
     await sendApplicationMessageBulk(ids, body, [], contextKind, contextCampaignId, contextFilter, title);
-    toast(`${ids.length}명에게 발송했습니다.`);
+    toast(`${ids.length}건 발송했습니다.`);
     closeBulkMessageModal();
     if (_inboxTab === 'broadcasts') loadBroadcasts();
     // 받은편지함 탭의 미읽음·응대 배지 stale 방지 (발송 = 자동 응대 완료) — 비동기 갱신

--- a/dev/admin/index.html
+++ b/dev/admin/index.html
@@ -3099,6 +3099,9 @@
             <div id="bulkAppStatus" class="bulk-chk-row"></div>
           </div>
           <div id="bulkDelivWrap">
+            <div id="bulkTypeMixNote" style="display:none;font-size:11px;color:var(--muted);background:var(--bg);border-radius:8px;padding:8px 10px;margin-bottom:10px;line-height:1.5">
+              영수증 조건은 <b>리뷰어 신청건에만</b> 적용됩니다. 기프팅·방문형 신청건은 영수증 조건과 무관하게 포함됩니다.
+            </div>
             <div id="bulkReceiptWrap" style="display:none;margin-bottom:12px">
               <div style="font-size:13px;color:var(--muted);margin-bottom:6px">영수증 상태 <span style="font-size:11px">(리뷰어 캠페인)</span></div>
               <div id="bulkReceiptStatus" class="bulk-chk-row"></div>
@@ -3107,6 +3110,8 @@
               <div style="font-size:13px;color:var(--muted);margin-bottom:6px">결과물 상태 <span style="font-size:11px">(게시물·리뷰 이미지)</span></div>
               <div id="bulkPostStatus" class="bulk-chk-row"></div>
             </div>
+            <label class="bulk-chk" style="margin-top:10px"><input type="checkbox" id="bulkFullApproved" onchange="scheduleBulkRecount()">완전 승인만 (부분 승인 제외)</label>
+            <div style="font-size:11px;color:var(--muted);margin-top:2px;line-height:1.5">체크 시 결과물이 <b>모두 승인된</b> 신청건만 — 미승인·검수중·반려·작성중 결과물이 하나라도 있으면 제외됩니다.</div>
           </div>
           <div>
             <div style="font-size:13px;color:var(--muted);margin-bottom:6px">④ 인플루언서 상태</div>
@@ -3121,7 +3126,7 @@
             <div id="bulkPrefectureMulti" class="mf-wrap" style="max-width:100%"><button type="button" class="mf-btn" style="width:100%;overflow:hidden;text-overflow:ellipsis">전체 지역</button><div class="mf-drop"></div></div>
           </div>
           <div>
-            <div style="font-size:13px;color:var(--muted);margin-bottom:6px">SNS 채널 <span style="font-size:11px">(인플루언서 보유 채널 · 미선택 시 전체)</span></div>
+            <div style="font-size:13px;color:var(--muted);margin-bottom:6px">인플루언서 보유 SNS <span style="font-size:11px">(캠페인 모집 채널이 아니라 인플루언서가 가진 SNS 기준 · 미선택 시 전체)</span></div>
             <div id="bulkSnsChannels" class="bulk-chk-row"></div>
           </div>
           <div>
@@ -3141,15 +3146,15 @@
           </div>
         </div>
         <div class="bulk-count-box" id="bulkCountBox" style="display:none;background:var(--bg);border-radius:10px;padding:12px 14px;font-size:14px;color:var(--ink)">
-          선택된 수신자 <b id="bulkCount" style="color:var(--brand,#16A34A)">0</b>명
+          선택 <b id="bulkCount" style="color:var(--brand,#16A34A)">0</b>건 <span style="color:var(--muted)">(받는 사람 <b id="bulkCountPeople" style="color:var(--ink)">0</b>명)</span>
           <span id="bulkCountLoading" style="display:none;font-size:12px;color:var(--muted)"> · 계산 중…</span>
-          <span id="bulkCancelledNote" style="display:block;font-size:11px;color:var(--muted);margin-top:4px">취소(cancelled)한 응모는 제외됩니다.</span>
+          <span id="bulkCancelledNote" style="display:block;font-size:11px;color:var(--muted);margin-top:4px">동일인이 여러 신청건이면 신청건마다 1통씩 발송됩니다. 취소(cancelled)한 응모는 제외됩니다.</span>
         </div>
       </div>
       <!-- STEP 2: 본문 작성 -->
       <div id="bulkStep2" style="display:none;flex-direction:column;gap:12px">
         <div style="font-size:13px;color:var(--ink);background:var(--bg);border-radius:10px;padding:10px 12px">
-          받는 사람 <b id="bulkCount2">0</b>명 — 각자의 1:1 대화방으로 도착하며 <b>서로 누가 받았는지 모릅니다(BCC)</b>.
+          <b id="bulkCount2">0</b>건 발송 <span style="color:var(--muted)">(받는 사람 <b id="bulkCount2People">0</b>명)</span> — 각 신청건의 1:1 대화방으로 도착하며 <b>서로 누가 받았는지 모릅니다(BCC)</b>. 동일인이 여러 신청건이면 각 건마다 1통씩 갑니다.
         </div>
         <div>
           <div style="font-size:13px;color:var(--muted);margin-bottom:6px">발송 제목 <span style="font-size:11px">(관리자용 · 선택)</span></div>

--- a/dev/js/admin-messaging.js
+++ b/dev/js/admin-messaging.js
@@ -1043,6 +1043,7 @@ function openBulkMessageModal(presetAppIds) {
     _bulkState.recruitTypes = [];
     _bulkState.availableCampaignIds = [];
     _bulkState.hasMonitor = false;
+    _bulkState.hasNonMonitor = false;
     renderBulkStatusChips();        // ① 캠페인 상태 칩 (미선택 상태)
     renderBulkRecruitTypeChips();   // 모집 타입 칩 (미선택 = 전체)
     document.getElementById('bulkCampaignSelectWrap').style.display = 'none';
@@ -1054,6 +1055,9 @@ function openBulkMessageModal(presetAppIds) {
     const v = document.getElementById('bulkInflVerified'); if (v) v.checked = false;
     const nv = document.getElementById('bulkInflNoViolation'); if (nv) nv.checked = false;
     const nb = document.getElementById('bulkInflNoBlacklist'); if (nb) nb.checked = true;
+    // 완전 승인 토글·타입혼합 배너 초기화 (모달 재오픈 시 이전 상태 잔존 방지)
+    const fa = document.getElementById('bulkFullApproved'); if (fa) fa.checked = false;
+    const mix = document.getElementById('bulkTypeMixNote'); if (mix) mix.style.display = 'none';
     // 팔로워 필터 기본값: 채널별·Instagram·빈값
     const fmPer = document.querySelector('input[name="bulkFollowerMode"][value="per_channel"]'); if (fmPer) fmPer.checked = true;
     const fc = document.getElementById('bulkFollowerChannel'); if (fc) { fc.value = 'instagram'; fc.style.display = ''; }
@@ -1161,6 +1165,11 @@ function renderBulkReceiptVisibility(campaignIds) {
     const c = camps.find(x => x.id === cid);
     return c && c.recruit_type === 'monitor';
   });
+  // 리뷰어(monitor)와 기프팅·방문형이 섞였는지 — 영수증 필터 타입혼합 안내 배너 노출 판정
+  _bulkState.hasNonMonitor = campaignIds.some(cid => {
+    const c = camps.find(x => x.id === cid);
+    return c && c.recruit_type !== 'monitor';
+  });
 }
 
 // 응모·영수증·결과물 상태 체크박스 — 모달 열 때 1회 렌더(선택 보존). 영수증·결과물 동일 status 코드.
@@ -1214,6 +1223,8 @@ function collectBulkFilters() {
     requireVerified: document.getElementById('bulkInflVerified')?.checked || false,
     excludeViolation: document.getElementById('bulkInflNoViolation')?.checked || false,
     excludeBlacklist: document.getElementById('bulkInflNoBlacklist')?.checked !== false,
+    // 완전 승인만(부분 승인 제외) — 승인 응모 포함 시에만 의미. 통합 토글 1개가 영수증·게시물 함께 적용
+    fullApproved: approved ? (document.getElementById('bulkFullApproved')?.checked || false) : false,
   };
 }
 
@@ -1226,6 +1237,9 @@ function scheduleBulkRecount() {
   // 영수증 필터는 승인 + 리뷰어(monitor) 캠페인 포함 시만 노출
   const receiptWrap = document.getElementById('bulkReceiptWrap');
   if (receiptWrap) receiptWrap.style.display = (approved && _bulkState && _bulkState.hasMonitor) ? '' : 'none';
+  // 타입혼합 안내 배너 — 리뷰어 + 기프팅·방문형이 섞였을 때(영수증 조건이 일부 신청건에만 적용됨)
+  const mixNote = document.getElementById('bulkTypeMixNote');
+  if (mixNote) mixNote.style.display = (approved && _bulkState && _bulkState.hasMonitor && _bulkState.hasNonMonitor) ? '' : 'none';
   clearTimeout(_bulkRecountTimer);
   _bulkRecountTimer = setTimeout(recountBulk, 350);
 }
@@ -1252,7 +1266,13 @@ async function recountBulk() {
     const ids = Array.from(idSet);
     _bulkState.recipientIds = ids;
     _bulkState.filterSnapshot = filters;
-    updateBulkCount(ids.length);
+    // 사람 수(distinct user) — 동일인이 여러 신청건으로 중복되므로 「건」과 별도 표기.
+    // 실패해도 발송엔 지장 없으므로 건수로 폴백.
+    let people = ids.length;
+    try { people = await countDistinctUsersForApps(ids); } catch (_e) { people = ids.length; }
+    if (JSON.stringify(_bulkState.campaignIds) !== JSON.stringify(campaignIds)) return;
+    _bulkState.recipientPeople = people;
+    updateBulkCount(ids.length, people);
     document.getElementById('bulkNextBtn').disabled = ids.length === 0;
   } catch (e) {
     if (e && e.message === 'bulk_recount_timeout') {
@@ -1268,15 +1288,20 @@ async function recountBulk() {
   }
 }
 
-function updateBulkCount(n) {
-  const el = document.getElementById('bulkCount'); if (el) el.textContent = n;
+// n = 신청건 수(발송 통 수 — 동일인 여러 건이면 각 건마다 1통), people = 도달 인원(distinct user).
+function updateBulkCount(n, people) {
+  const ppl = (people != null) ? people : n;
+  const el = document.getElementById('bulkCount'); if (el) el.textContent = n;            // 건수
+  const elp = document.getElementById('bulkCountPeople'); if (elp) elp.textContent = ppl;  // 사람 수
+  // STEP 2: 실제 발송 통 수 = 신청건 수(n). 사람 수(ppl)는 괄호로 병기.
   const el2 = document.getElementById('bulkCount2'); if (el2) el2.textContent = n;
+  const el2p = document.getElementById('bulkCount2People'); if (el2p) el2p.textContent = ppl;
 }
 
 function bulkStepNext() {
   if (!_bulkState || !_bulkState.recipientIds.length) { toast('대상이 없습니다.'); return; }
   if (_bulkState.recipientIds.length > BULK_MAX) {
-    toast(`1회 최대 ${BULK_MAX}명까지 발송할 수 있습니다. 필터로 범위를 좁혀주세요.`); return;
+    toast(`1회 최대 ${BULK_MAX}건까지 발송할 수 있습니다. 필터로 범위를 좁혀주세요.`); return;
   }
   document.getElementById('bulkStep1').style.display = 'none';
   document.getElementById('bulkStep2').style.display = 'flex';
@@ -1318,7 +1343,7 @@ async function confirmBulkSend() {
     const contextFilter = _bulkState.presetIds ? null : { ...(_bulkState.filterSnapshot || {}), campaign_ids: campIds };
     const title = document.getElementById('bulkTitle')?.value.trim() || null;   // 관리자 전용 제목 (선택)
     await sendApplicationMessageBulk(ids, body, [], contextKind, contextCampaignId, contextFilter, title);
-    toast(`${ids.length}명에게 발송했습니다.`);
+    toast(`${ids.length}건 발송했습니다.`);
     closeBulkMessageModal();
     if (_inboxTab === 'broadcasts') loadBroadcasts();
     // 받은편지함 탭의 미읽음·응대 배지 stale 방지 (발송 = 자동 응대 완료) — 비동기 갱신

--- a/dev/lib/storage.js
+++ b/dev/lib/storage.js
@@ -2859,9 +2859,21 @@ async function resolveBulkRecipients(campaignId, filters = {}) {
     p_require_verified: !!filters.requireVerified,
     p_exclude_violation: !!filters.excludeViolation,
     p_exclude_blacklist: filters.excludeBlacklist !== false,
+    // 완전 승인만(부분 승인 제외) — 통합 토글 1개가 영수증·게시물 양쪽을 함께 true (마이그레이션 171)
+    p_receipt_all_approved: !!filters.fullApproved,
+    p_post_all_approved: !!filters.fullApproved,
   });
   if (error) throw error;
   return data || [];
+}
+
+// 응모 ID 배열의 distinct user_id 수 (일괄발송 「○건(○명)」 표시용 — 동일인 중복 응모 인지).
+//   appIds 는 BULK_MAX(200) 이하라 in() 단일 쿼리로 안전(PostgREST 1000행 cap 미만).
+async function countDistinctUsersForApps(appIds) {
+  if (!db || !appIds || !appIds.length) return 0;
+  const {data, error} = await db?.from('applications').select('user_id').in('id', appIds);
+  if (error) throw error;
+  return new Set((data || []).map(r => r.user_id).filter(Boolean)).size;
 }
 
 // 발송 이력 목록 (관리자). application_message_broadcasts 직접 조회.

--- a/index.html
+++ b/index.html
@@ -6877,9 +6877,21 @@ async function resolveBulkRecipients(campaignId, filters = {}) {
     p_require_verified: !!filters.requireVerified,
     p_exclude_violation: !!filters.excludeViolation,
     p_exclude_blacklist: filters.excludeBlacklist !== false,
+    // 완전 승인만(부분 승인 제외) — 통합 토글 1개가 영수증·게시물 양쪽을 함께 true (마이그레이션 171)
+    p_receipt_all_approved: !!filters.fullApproved,
+    p_post_all_approved: !!filters.fullApproved,
   });
   if (error) throw error;
   return data || [];
+}
+
+// 응모 ID 배열의 distinct user_id 수 (일괄발송 「○건(○명)」 표시용 — 동일인 중복 응모 인지).
+//   appIds 는 BULK_MAX(200) 이하라 in() 단일 쿼리로 안전(PostgREST 1000행 cap 미만).
+async function countDistinctUsersForApps(appIds) {
+  if (!db || !appIds || !appIds.length) return 0;
+  const {data, error} = await db?.from('applications').select('user_id').in('id', appIds);
+  if (error) throw error;
+  return new Set((data || []).map(r => r.user_id).filter(Boolean)).size;
 }
 
 // 발송 이력 목록 (관리자). application_message_broadcasts 직접 조회.


### PR DESCRIPTION
## 변경 요약
- 항목 A: 대상 카운트를 「○건 (받는 사람 ○명)」으로 분리 표시(동일인 중복 인지). 사람 수 = distinct user_id(`countDistinctUsersForApps`)
- 항목 B: 결과물 영역에 「완전 승인만(부분 승인 제외)」 통합 토글 1개 → 마이그레이션 171의 `p_receipt_all_approved`·`p_post_all_approved` 함께 전달
- 항목 C: 채널 라벨 "인플루언서 보유 SNS"로 명확화 + 리뷰어·기프팅 혼합 시 영수증 조건 안내 배너
- 발송 토스트·한도 메시지 단위를 「건」으로 통일

## 요청 외 추가 변경
- 없음 (origin/dev 머지 재빌드만)

## 관련 사양서
- docs/specs/2026-06-05-bulk-message-filter-refinement.md (PR 2 = 화면)

## 검증
- [via reviewer] static check GO (db?. / null-filter / toast 단위 반영)
- [via supabase-expert] storage.js 래퍼 — 171 시그니처 일치 확인
- 빌드·반영 확인. qa light는 사용자 트리거 시(Playwright 단일 자원 규칙)

운영 배포 안 함 — PR 1·2 묶어 사용자 확인 후 별도 진행.