### PR TITLE
feat(campaign): 브랜드명 다국어 표시 (관리자 한>영>일 / 인플 일>영>한)

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -12,7 +12,7 @@
 // 회귀(2026-05-12 PR #182 머지 직후 발생)를 방지하기 위한 자동 reload 가드.
 // sessionStorage 차단 환경(시크릿 모드 일부, 쿠키 차단)에서는 자연스럽게 skip.
 (function(){
-  var CURRENT_BUILD = 'v1780898864';
+  var CURRENT_BUILD = 'v1780918439';
   if (CURRENT_BUILD.indexOf('__') === 0) return; // 빌드 미적용 (dev/ 직접 열기) 시 skip
   try {
     var prev = sessionStorage.getItem('reverb.adminBuild');
@@ -2002,7 +2002,7 @@ textarea.form-input{resize:vertical;min-height:80px}
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-06-08 15:07 · b1fde71</span>
+          <span class="admin-build-text">2026-06-08 20:33 · 8483314</span>
         </div>
       </div>
     </aside>
@@ -5782,6 +5782,19 @@ const CAMPAIGN_STATUS_BADGE_CLASS = {
   closed_recruit: 'badge-pink', closed_done: 'badge-done', expired: 'badge-expired'
 };
 
+// 브랜드명 다국어 표시 헬퍼 (2026-06-08, 사양서 docs/specs/2026-06-08-brand-name-i18n.md)
+//   캠페인 객체의 brand(한국어)/brand_ja/brand_en 비정규화 컬럼에서 화면별 우선순위로 선택.
+//   관리자: 한국어 > 영어 > 일본어 / 인플루언서: 일본어 > 영어 > 한국어 (빈칸 방지 폴백).
+//   brand 값은 brand_id 연결 캠페인의 경우 brands 마스터 동기화 복사본(트리거 173).
+function brandLabelAdmin(c) {
+  if (!c) return '';
+  return (c.brand || c.brand_en || c.brand_ja || '').trim();
+}
+function brandLabelInflu(c) {
+  if (!c) return '';
+  return (c.brand_ja || c.brand_en || c.brand || '').trim();
+}
+
 // 숫자 입력칸(type=number): 포커스 중 마우스 휠로 값이 바뀌는 기본 동작 차단 (오입력 방지).
 // 전역 1회 등록 → 관리자·인플 양쪽 빌드의 모든 숫자 입력칸에 일괄 적용. 휠은 페이지 스크롤만.
 document.addEventListener('wheel', function (e) {
@@ -5853,7 +5866,7 @@ async function fetchCampaigns() {
 // ※ autoOpenCampaigns / autoCloseCampaigns 는 status / recruit_start / deadline 만 참조하므로
 //    목록 전용 컬럼셋에서도 문제없이 실행된다. 목록 진입 시 자동 전환을 유지하기 위해 여기서도 호출.
 const ADMIN_LIST_COLUMNS = [
-  'id', 'title', 'brand', 'brand_ko', 'product', 'product_ko',
+  'id', 'title', 'brand', 'brand_ko', 'brand_ja', 'brand_en', 'product', 'product_ko',
   'campaign_no', 'legacy_no',
   'recruit_type', 'channel', 'status',
   'slots', 'view_count',
@@ -15360,7 +15373,7 @@ function renderInboxCampaignList() {
     const typeBadge = (c && typeof getRecruitTypeBadgeKoSm === 'function') ? getRecruitTypeBadgeKoSm(c.recruit_type) : '';
     const statusBadge = c ? inboxCampStatusBadge(c.status) : '';
     // 브랜드 · 모집인원
-    const brand = c ? esc(c.brand_ko || c.brand || '') : '';
+    const brand = c ? esc(brandLabelAdmin(c)) : '';
     const slots = (c && c.slots) ? `모집 ${c.slots}명` : '';
     const sub = [brand, slots].filter(Boolean).join(' · ');
     return `<button type="button" class="inbox-camp-item ${active}" onclick="selectInboxCampaign('${esc(g.campaign_id)}')">
@@ -15433,7 +15446,7 @@ function renderInboxThreadList() {
     if (sentMode) {
       const c = inboxCampaignById(t.campaign_id);
       const ct = c ? (c.title || '(제목 없음)') : '(캠페인)';
-      const cb = c ? (c.brand_ko || c.brand || '') : '';
+      const cb = c ? brandLabelAdmin(c) : '';
       campLabel = `<span class="inbox-thread-camp">${esc(ct)}${cb ? ` · ${esc(cb)}` : ''}</span>`;
       timeVal = _inboxSentAtMap.get(t.application_id) || t.last_message_at;
     }
@@ -15537,7 +15550,7 @@ function filteredInboxThreads() {
     list = list.filter(t => {
       const inf = (_inboxInflMap && _inboxInflMap[t.influencer_id]) || {};
       const camp = inboxCampaignById(t.campaign_id);
-      const bag = [inf.name, inf.name_kana, inf.email, camp && camp.title, camp && (camp.brand_ko || camp.brand)]
+      const bag = [inf.name, inf.name_kana, inf.email, camp && camp.title, camp && (camp.brand_ko || camp.brand), camp && camp.brand_ja, camp && camp.brand_en]
         .filter(Boolean).join(' ').toLowerCase();
       return bag.includes(_inboxSearch);
     });
@@ -18835,7 +18848,7 @@ function renderDelivAppRow(g) {
 
   return `<tr data-app-id="${esc(g.application_id)}" style="${rowStyle}">
     <td>${rtBadge}</td>
-    <td>${campNoBadge}<div>${esc(camp.title || '—')}</div><div style="font-size:10px;color:var(--muted)">${esc(camp.brand || '')}</div></td>
+    <td>${campNoBadge}<div>${esc(camp.title || '—')}</div><div style="font-size:10px;color:var(--muted)">${esc(brandLabelAdmin(camp))}</div></td>
     <td style="font-size:11px;color:var(--ink);white-space:nowrap">${periodRangeCell(ps, pe)}</td>
     <td style="font-size:11px;color:var(--ink);white-space:nowrap">${periodSingleCell(camp.submission_end)}</td>
     <td><div style="font-weight:600;color:var(--pink);cursor:pointer" onclick="openInfluencerModal('${esc(inf.id||'')}')">${infName}${(typeof influencerStatusBadges === 'function') ? influencerStatusBadges(inf) : ''}</div>${infSub ? `<div style="font-size:10px;color:var(--muted)">${infSub}</div>` : ''}<div style="margin-top:4px">${renderApplicantMsgBtn({id: g.application_id, campaign_id: (camp && camp.id) || ''})}</div></td>
@@ -19934,14 +19947,14 @@ function _renderAdminProxyCampList(query) {
   const q = (query || '').trim().toLowerCase();
   const filtered = Array.from(campMap.values()).filter(c => {
     if (!q) return true;
-    return matchSearchTokens(q, [c.title, c.brand, c.campaign_no]);
+    return matchSearchTokens(q, [c.title, c.brand, c.brand_ja, c.brand_en, c.campaign_no]);
   });
   if (!filtered.length) {
     list.innerHTML = '<div class="empty">일치하는 캠페인 없음</div>';
     return;
   }
   list.innerHTML = filtered.slice(0, 100).map(c => {
-    const meta = `${c.brand || ''} · ${c.campaign_no || '—'} · ${c.recruit_type || ''}`;
+    const meta = `${brandLabelAdmin(c)} · ${c.campaign_no || '—'} · ${c.recruit_type || ''}`;
     return `<div class="item" onmousedown="selectAdminProxyCamp('${esc(c.id)}')">
       <div>${esc(c.title || '제목 없음')}</div>
       <div class="item-meta">${esc(meta)}</div>
@@ -19955,7 +19968,7 @@ function selectAdminProxyCamp(campId, silent) {
   const camp = app.campaigns;
   const hid = $('adminProxyCampId'); if (hid) hid.value = campId;
   const inp = $('adminProxyCampInput');
-  if (inp) inp.value = `${camp.title || ''} (${camp.brand || ''})`;
+  if (inp) inp.value = `${camp.title || ''} (${brandLabelAdmin(camp)})`;
   const list = $('adminProxyCampList'); if (list) list.classList.remove('open');
   // 인플 input 활성화 + 검색 리스트 미리 렌더
   const infInput = $('adminProxyInfInput');
@@ -20566,7 +20579,7 @@ function _buildCampaignSummarySheet(wb, campaigns, appsByCampId) {
     ws.addRow({
       no:       c.campaign_no || '',
       title:    c.title || '',
-      brand:    c.brand_ko || c.brand || '',
+      brand:    brandLabelAdmin(c) || '',
       product:  c.product_ko || c.product || '',
       rtype:    rtypeLabel(c.recruit_type),
       status:   statusKo(c.status),
@@ -21249,7 +21262,7 @@ async function exportCampaignDeliverables(campId) {
 
     ws.mergeCells('A2:V2');
     var m = ws.getCell('A2');
-    m.value = '브랜드: ' + (camp.brand || '—')
+    m.value = '브랜드: ' + (brandLabelAdmin(camp) || '—')
       + '  ·  신청 건수: ' + groupList.length + '건'
       + '  ·  결과물 합계: ' + delivs.length + '건'
       + '  ·  생성일: ' + new Date().toLocaleString('ko-KR');
@@ -21394,7 +21407,7 @@ async function exportCampaignDeliverables(campId) {
     // 7) 파일 저장
     var buffer = await wb.xlsx.writeBuffer();
     var blob = new Blob([buffer], {type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'});
-    var safeBrand = (camp.brand || 'brand').replace(/[\/\\?%*:|"<>]/g, '_');
+    var safeBrand = (brandLabelAdmin(camp) || 'brand').replace(/[\/\\?%*:|"<>]/g, '_');
     var today = new Date().toISOString().slice(0, 10);
     var fname = (camp.campaign_no || camp.id.slice(0,8)) + '_' + safeBrand + '_결과물_' + today + '.xlsx';
 
@@ -21508,7 +21521,7 @@ async function _exportCampDelivsMonitorMulti(camp, delivs, userById, campChannel
   // row 2: 메타 정보 머지
   ws.mergeCells('A2:' + lastColLetter + '2');
   var m = ws.getCell('A2');
-  m.value = '브랜드: ' + (camp.brand || '—')
+  m.value = '브랜드: ' + (brandLabelAdmin(camp) || '—')
     + '  ·  신청 건수: ' + groupList.length + '건'
     + '  ·  결과물 합계: ' + delivs.length + '건'
     + '  ·  채널: ' + campChannels.map(chLabelOf).join(', ')
@@ -21638,7 +21651,7 @@ async function _exportCampDelivsMonitorMulti(camp, delivs, userById, campChannel
   if (skipDownload) return ws;
   var buffer = await wb.xlsx.writeBuffer();
   var blob = new Blob([buffer], {type:'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'});
-  var safeBrand = (camp.brand || 'brand').replace(/[\/\\?%*:|"<>]/g, '_');
+  var safeBrand = (brandLabelAdmin(camp) || 'brand').replace(/[\/\\?%*:|"<>]/g, '_');
   var today = new Date().toISOString().slice(0, 10);
   var fname = (camp.campaign_no || camp.id.slice(0,8)) + '_' + safeBrand + '_결과물_' + today + '.xlsx';
   var link = document.createElement('a');
@@ -22032,7 +22045,7 @@ function renderRecentAppsTable(apps, camps, users) {
           <div style="min-width:0">
             <div>${typeLabel}</div>
             <strong style="font-size:13px;cursor:pointer" onclick="openCampPreviewModal('${camp.id}')">${esc(camp.title)||'—'}</strong>
-            <div style="font-size:11px;color:var(--muted)">${esc(camp.brand)||''}</div>
+            <div style="font-size:11px;color:var(--muted)">${esc(brandLabelAdmin(camp))}</div>
             ${camp.slots?`<div style="font-size:10px;color:var(--muted);margin-top:2px">모집 ${camp.slots}명 · 빈자리 <span style="color:${_dRem>0?'var(--green)':'var(--red)'};font-weight:600">${_dRem>0?_dRem+'건':'없음'}</span></div>`:''}
           </div>
         </div>
@@ -22711,8 +22724,8 @@ async function renderAppCampList() {
     const imgs = [camp.img1,camp.img2,camp.img3,camp.img4,camp.img5,camp.img6,camp.img7,camp.img8,camp.image_url].filter(Boolean).filter((v,i,arr)=>arr.indexOf(v)===i);
     const thumbUrl = imgs[0] || '';
     const typeLabel = getRecruitTypeBadgeKoSm(camp.recruit_type);
-    const brandPrimary = camp.brand_ko || camp.brand || '';
-    const brandSub     = (camp.brand_ko && camp.brand && camp.brand_ko !== camp.brand) ? camp.brand : '';
+    const brandPrimary = brandLabelAdmin(camp);
+    const brandSub     = '';
     const productPrimary = camp.product_ko || camp.product || '';
     const productSub     = (camp.product_ko && camp.product && camp.product_ko !== camp.product) ? camp.product : '';
     return `<tr data-id="${esc(a.id)}">
@@ -24824,7 +24837,7 @@ async function loadAdminCampaigns(useCache) {
   const searchVal = ($('adminCampSearch')?.value || '').trim().toLowerCase();
   if (searchVal) {
     camps = camps.filter(c => matchSearchTokens(searchVal,
-      [c.title, c.brand, c.brand_ko, c.product, c.product_ko, c.campaign_no]));
+      [c.title, c.brand, c.brand_ko, c.brand_ja, c.brand_en, c.product, c.product_ko, c.campaign_no]));
   }
 
   updateFilterResetBtn('btnCampFilterReset', ['campTypeMulti','campStatusMulti'], 'adminCampSearch');
@@ -24919,8 +24932,8 @@ async function loadAdminCampaigns(useCache) {
         </div>
       </td>
       ${(()=>{
-        const bp = c.brand_ko || c.brand || '';
-        const bs = (c.brand_ko && c.brand && c.brand_ko !== c.brand) ? c.brand : '';
+        const bp = brandLabelAdmin(c);
+        const bs = '';
         const pp = c.product_ko || c.product || '';
         const ps = (c.product_ko && c.product && c.product_ko !== c.product) ? c.product : '';
         return `<td style="font-size:12px;color:var(--ink);min-width:100px;max-width:160px;word-break:break-word">
@@ -26260,6 +26273,10 @@ async function saveCampaignEdit() {
     if (!title || !brandId) { toast('캠페인명과 브랜드는 필수입니다','error'); return; }
     const sourceAppId = $('editCampSourceAppId')?.value || null;
     const brand = gv('editCampBrand').trim();
+    // 브랜드명 일본어/영문 — 마스터(brands)에서 복사. brand_id 연결 캠페인은 173 트리거가 이후 동기화.
+    const _editBrand = (_campBrandsCache || []).find(b => b.id === brandId);
+    const brandJa = (_editBrand?.name_ja || '').trim();
+    const brandEn = (_editBrand?.name_en || '').trim();
 
     const editDeadline = gv('editCampDeadline');
     const editDateErrs = validateCampDateRanges('editCamp');
@@ -26291,6 +26308,8 @@ async function saveCampaignEdit() {
       brand_id: brandId,
       source_application_id: sourceAppId || null,
       brand_ko: gv('editCampBrandKo')?.trim() || null,
+      brand_ja: brandJa || null,
+      brand_en: brandEn || null,
       product: gv('editCampProduct'),
       product_ko: gv('editCampProductKo')?.trim() || null,
       product_url: cleanUrl(gv('editCampProductUrl')),
@@ -26429,6 +26448,7 @@ async function duplicateCampaign(campId) {
     const copy = {
       title: '[복사] ' + src.title,
       brand: src.brand, brand_ko: src.brand_ko || null,
+      brand_ja: src.brand_ja || null, brand_en: src.brand_en || null,
       product: src.product, product_ko: src.product_ko || null,
       product_url: src.product_url,
       type: src.type, channel: src.channel, channel_match: src.channel_match || 'or', min_followers: src.min_followers||0, category: src.category,
@@ -26648,7 +26668,7 @@ function renderCampPreview(mode) {
           ${slideUrls.length>1?`<div class="cp-hero-count">1/${slideUrls.length}</div>`:''}
         </div>
         <div class="cp-head">
-          ${camp.brand?`<div class="cp-brand">${esc(camp.brand)}</div>`:''}
+          ${(()=>{const bl=brandLabelInflu(camp);return bl?`<div class="cp-brand">${esc(bl)}</div>`:'';})()}
           ${rtLabel?`<div class="cp-rt">${esc(rtLabel)}</div>`:''}
           <div class="cp-title">${esc(camp.title||'(캠페인명)')}</div>
           ${camp.product_price>0?`<div class="cp-price-box"><span class="cp-price-amount">¥${camp.product_price.toLocaleString()}</span><span class="cp-price-label">${rewardLabelJa}</span></div>`:''}
@@ -26980,6 +27000,9 @@ async function addCampaign() {
   const _pickedBrand = (_campBrandsCache || []).find(b => b.id === brandId);
   const brand = (_pickedBrand?.name || $('newCampBrand').value || '').trim();
   const brandKo = ($('newCampBrandKo')?.value || '').trim();
+  // 브랜드명 일본어/영문 — 마스터(brands)에서 복사. brand_id 연결 캠페인은 173 트리거가 이후 동기화.
+  const brandJa = (_pickedBrand?.name_ja || '').trim();
+  const brandEn = (_pickedBrand?.name_en || '').trim();
   const product = $('newCampProduct').value.trim();
   const productKo = ($('newCampProductKo')?.value || '').trim();
   const productUrl = cleanUrl($('newCampProductUrl')?.value)||'';
@@ -27010,6 +27033,8 @@ async function addCampaign() {
     brand_id: brandId,
     source_application_id: sourceAppId || null,
     brand_ko: brandKo || null,
+    brand_ja: brandJa || null,
+    brand_en: brandEn || null,
     product_ko: productKo || null,
     type: ch.split(',').includes('qoo10')?'qoo10':'nano', channel:ch, channel_match: document.querySelector('input[name="newChannelMatch"]:checked')?.value || 'or', primary_channel: (recruitType==='monitor') ? null : ($('newCampPrimaryChannel')?.value || null), min_followers: (recruitType==='monitor') ? 0 : (parseInt($('newCampMinFollowers')?.value)||0), category:cat,
     recruit_type: recruitType,

--- a/dev/js/admin-applications.js
+++ b/dev/js/admin-applications.js
@@ -369,8 +369,8 @@ async function renderAppCampList() {
     const imgs = [camp.img1,camp.img2,camp.img3,camp.img4,camp.img5,camp.img6,camp.img7,camp.img8,camp.image_url].filter(Boolean).filter((v,i,arr)=>arr.indexOf(v)===i);
     const thumbUrl = imgs[0] || '';
     const typeLabel = getRecruitTypeBadgeKoSm(camp.recruit_type);
-    const brandPrimary = camp.brand_ko || camp.brand || '';
-    const brandSub     = (camp.brand_ko && camp.brand && camp.brand_ko !== camp.brand) ? camp.brand : '';
+    const brandPrimary = brandLabelAdmin(camp);
+    const brandSub     = '';
     const productPrimary = camp.product_ko || camp.product || '';
     const productSub     = (camp.product_ko && camp.product && camp.product_ko !== camp.product) ? camp.product : '';
     return `<tr data-id="${esc(a.id)}">

--- a/dev/js/admin-dashboard.js
+++ b/dev/js/admin-dashboard.js
@@ -88,7 +88,7 @@ function renderRecentAppsTable(apps, camps, users) {
           <div style="min-width:0">
             <div>${typeLabel}</div>
             <strong style="font-size:13px;cursor:pointer" onclick="openCampPreviewModal('${camp.id}')">${esc(camp.title)||'—'}</strong>
-            <div style="font-size:11px;color:var(--muted)">${esc(camp.brand)||''}</div>
+            <div style="font-size:11px;color:var(--muted)">${esc(brandLabelAdmin(camp))}</div>
             ${camp.slots?`<div style="font-size:10px;color:var(--muted);margin-top:2px">모집 ${camp.slots}명 · 빈자리 <span style="color:${_dRem>0?'var(--green)':'var(--red)'};font-weight:600">${_dRem>0?_dRem+'건':'없음'}</span></div>`:''}
           </div>
         </div>

--- a/dev/js/admin-deliverables.js
+++ b/dev/js/admin-deliverables.js
@@ -553,7 +553,7 @@ function renderDelivAppRow(g) {
 
   return `<tr data-app-id="${esc(g.application_id)}" style="${rowStyle}">
     <td>${rtBadge}</td>
-    <td>${campNoBadge}<div>${esc(camp.title || '—')}</div><div style="font-size:10px;color:var(--muted)">${esc(camp.brand || '')}</div></td>
+    <td>${campNoBadge}<div>${esc(camp.title || '—')}</div><div style="font-size:10px;color:var(--muted)">${esc(brandLabelAdmin(camp))}</div></td>
     <td style="font-size:11px;color:var(--ink);white-space:nowrap">${periodRangeCell(ps, pe)}</td>
     <td style="font-size:11px;color:var(--ink);white-space:nowrap">${periodSingleCell(camp.submission_end)}</td>
     <td><div style="font-weight:600;color:var(--pink);cursor:pointer" onclick="openInfluencerModal('${esc(inf.id||'')}')">${infName}${(typeof influencerStatusBadges === 'function') ? influencerStatusBadges(inf) : ''}</div>${infSub ? `<div style="font-size:10px;color:var(--muted)">${infSub}</div>` : ''}<div style="margin-top:4px">${renderApplicantMsgBtn({id: g.application_id, campaign_id: (camp && camp.id) || ''})}</div></td>
@@ -1652,14 +1652,14 @@ function _renderAdminProxyCampList(query) {
   const q = (query || '').trim().toLowerCase();
   const filtered = Array.from(campMap.values()).filter(c => {
     if (!q) return true;
-    return matchSearchTokens(q, [c.title, c.brand, c.campaign_no]);
+    return matchSearchTokens(q, [c.title, c.brand, c.brand_ja, c.brand_en, c.campaign_no]);
   });
   if (!filtered.length) {
     list.innerHTML = '<div class="empty">일치하는 캠페인 없음</div>';
     return;
   }
   list.innerHTML = filtered.slice(0, 100).map(c => {
-    const meta = `${c.brand || ''} · ${c.campaign_no || '—'} · ${c.recruit_type || ''}`;
+    const meta = `${brandLabelAdmin(c)} · ${c.campaign_no || '—'} · ${c.recruit_type || ''}`;
     return `<div class="item" onmousedown="selectAdminProxyCamp('${esc(c.id)}')">
       <div>${esc(c.title || '제목 없음')}</div>
       <div class="item-meta">${esc(meta)}</div>
@@ -1673,7 +1673,7 @@ function selectAdminProxyCamp(campId, silent) {
   const camp = app.campaigns;
   const hid = $('adminProxyCampId'); if (hid) hid.value = campId;
   const inp = $('adminProxyCampInput');
-  if (inp) inp.value = `${camp.title || ''} (${camp.brand || ''})`;
+  if (inp) inp.value = `${camp.title || ''} (${brandLabelAdmin(camp)})`;
   const list = $('adminProxyCampList'); if (list) list.classList.remove('open');
   // 인플 input 활성화 + 검색 리스트 미리 렌더
   const infInput = $('adminProxyInfInput');

--- a/dev/js/admin-excel.js
+++ b/dev/js/admin-excel.js
@@ -242,7 +242,7 @@ function _buildCampaignSummarySheet(wb, campaigns, appsByCampId) {
     ws.addRow({
       no:       c.campaign_no || '',
       title:    c.title || '',
-      brand:    c.brand_ko || c.brand || '',
+      brand:    brandLabelAdmin(c) || '',
       product:  c.product_ko || c.product || '',
       rtype:    rtypeLabel(c.recruit_type),
       status:   statusKo(c.status),
@@ -925,7 +925,7 @@ async function exportCampaignDeliverables(campId) {
 
     ws.mergeCells('A2:V2');
     var m = ws.getCell('A2');
-    m.value = '브랜드: ' + (camp.brand || '—')
+    m.value = '브랜드: ' + (brandLabelAdmin(camp) || '—')
       + '  ·  신청 건수: ' + groupList.length + '건'
       + '  ·  결과물 합계: ' + delivs.length + '건'
       + '  ·  생성일: ' + new Date().toLocaleString('ko-KR');
@@ -1070,7 +1070,7 @@ async function exportCampaignDeliverables(campId) {
     // 7) 파일 저장
     var buffer = await wb.xlsx.writeBuffer();
     var blob = new Blob([buffer], {type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'});
-    var safeBrand = (camp.brand || 'brand').replace(/[\/\\?%*:|"<>]/g, '_');
+    var safeBrand = (brandLabelAdmin(camp) || 'brand').replace(/[\/\\?%*:|"<>]/g, '_');
     var today = new Date().toISOString().slice(0, 10);
     var fname = (camp.campaign_no || camp.id.slice(0,8)) + '_' + safeBrand + '_결과물_' + today + '.xlsx';
 
@@ -1184,7 +1184,7 @@ async function _exportCampDelivsMonitorMulti(camp, delivs, userById, campChannel
   // row 2: 메타 정보 머지
   ws.mergeCells('A2:' + lastColLetter + '2');
   var m = ws.getCell('A2');
-  m.value = '브랜드: ' + (camp.brand || '—')
+  m.value = '브랜드: ' + (brandLabelAdmin(camp) || '—')
     + '  ·  신청 건수: ' + groupList.length + '건'
     + '  ·  결과물 합계: ' + delivs.length + '건'
     + '  ·  채널: ' + campChannels.map(chLabelOf).join(', ')
@@ -1314,7 +1314,7 @@ async function _exportCampDelivsMonitorMulti(camp, delivs, userById, campChannel
   if (skipDownload) return ws;
   var buffer = await wb.xlsx.writeBuffer();
   var blob = new Blob([buffer], {type:'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'});
-  var safeBrand = (camp.brand || 'brand').replace(/[\/\\?%*:|"<>]/g, '_');
+  var safeBrand = (brandLabelAdmin(camp) || 'brand').replace(/[\/\\?%*:|"<>]/g, '_');
   var today = new Date().toISOString().slice(0, 10);
   var fname = (camp.campaign_no || camp.id.slice(0,8)) + '_' + safeBrand + '_결과물_' + today + '.xlsx';
   var link = document.createElement('a');

--- a/dev/js/admin-messaging.js
+++ b/dev/js/admin-messaging.js
@@ -187,7 +187,7 @@ function renderInboxCampaignList() {
     const typeBadge = (c && typeof getRecruitTypeBadgeKoSm === 'function') ? getRecruitTypeBadgeKoSm(c.recruit_type) : '';
     const statusBadge = c ? inboxCampStatusBadge(c.status) : '';
     // 브랜드 · 모집인원
-    const brand = c ? esc(c.brand_ko || c.brand || '') : '';
+    const brand = c ? esc(brandLabelAdmin(c)) : '';
     const slots = (c && c.slots) ? `모집 ${c.slots}명` : '';
     const sub = [brand, slots].filter(Boolean).join(' · ');
     return `<button type="button" class="inbox-camp-item ${active}" onclick="selectInboxCampaign('${esc(g.campaign_id)}')">
@@ -260,7 +260,7 @@ function renderInboxThreadList() {
     if (sentMode) {
       const c = inboxCampaignById(t.campaign_id);
       const ct = c ? (c.title || '(제목 없음)') : '(캠페인)';
-      const cb = c ? (c.brand_ko || c.brand || '') : '';
+      const cb = c ? brandLabelAdmin(c) : '';
       campLabel = `<span class="inbox-thread-camp">${esc(ct)}${cb ? ` · ${esc(cb)}` : ''}</span>`;
       timeVal = _inboxSentAtMap.get(t.application_id) || t.last_message_at;
     }
@@ -364,7 +364,7 @@ function filteredInboxThreads() {
     list = list.filter(t => {
       const inf = (_inboxInflMap && _inboxInflMap[t.influencer_id]) || {};
       const camp = inboxCampaignById(t.campaign_id);
-      const bag = [inf.name, inf.name_kana, inf.email, camp && camp.title, camp && (camp.brand_ko || camp.brand)]
+      const bag = [inf.name, inf.name_kana, inf.email, camp && camp.title, camp && (camp.brand_ko || camp.brand), camp && camp.brand_ja, camp && camp.brand_en]
         .filter(Boolean).join(' ').toLowerCase();
       return bag.includes(_inboxSearch);
     });

--- a/dev/js/admin.js
+++ b/dev/js/admin.js
@@ -262,7 +262,7 @@ async function loadAdminCampaigns(useCache) {
   const searchVal = ($('adminCampSearch')?.value || '').trim().toLowerCase();
   if (searchVal) {
     camps = camps.filter(c => matchSearchTokens(searchVal,
-      [c.title, c.brand, c.brand_ko, c.product, c.product_ko, c.campaign_no]));
+      [c.title, c.brand, c.brand_ko, c.brand_ja, c.brand_en, c.product, c.product_ko, c.campaign_no]));
   }
 
   updateFilterResetBtn('btnCampFilterReset', ['campTypeMulti','campStatusMulti'], 'adminCampSearch');
@@ -357,8 +357,8 @@ async function loadAdminCampaigns(useCache) {
         </div>
       </td>
       ${(()=>{
-        const bp = c.brand_ko || c.brand || '';
-        const bs = (c.brand_ko && c.brand && c.brand_ko !== c.brand) ? c.brand : '';
+        const bp = brandLabelAdmin(c);
+        const bs = '';
         const pp = c.product_ko || c.product || '';
         const ps = (c.product_ko && c.product && c.product_ko !== c.product) ? c.product : '';
         return `<td style="font-size:12px;color:var(--ink);min-width:100px;max-width:160px;word-break:break-word">
@@ -1698,6 +1698,10 @@ async function saveCampaignEdit() {
     if (!title || !brandId) { toast('캠페인명과 브랜드는 필수입니다','error'); return; }
     const sourceAppId = $('editCampSourceAppId')?.value || null;
     const brand = gv('editCampBrand').trim();
+    // 브랜드명 일본어/영문 — 마스터(brands)에서 복사. brand_id 연결 캠페인은 173 트리거가 이후 동기화.
+    const _editBrand = (_campBrandsCache || []).find(b => b.id === brandId);
+    const brandJa = (_editBrand?.name_ja || '').trim();
+    const brandEn = (_editBrand?.name_en || '').trim();
 
     const editDeadline = gv('editCampDeadline');
     const editDateErrs = validateCampDateRanges('editCamp');
@@ -1729,6 +1733,8 @@ async function saveCampaignEdit() {
       brand_id: brandId,
       source_application_id: sourceAppId || null,
       brand_ko: gv('editCampBrandKo')?.trim() || null,
+      brand_ja: brandJa || null,
+      brand_en: brandEn || null,
       product: gv('editCampProduct'),
       product_ko: gv('editCampProductKo')?.trim() || null,
       product_url: cleanUrl(gv('editCampProductUrl')),
@@ -1867,6 +1873,7 @@ async function duplicateCampaign(campId) {
     const copy = {
       title: '[복사] ' + src.title,
       brand: src.brand, brand_ko: src.brand_ko || null,
+      brand_ja: src.brand_ja || null, brand_en: src.brand_en || null,
       product: src.product, product_ko: src.product_ko || null,
       product_url: src.product_url,
       type: src.type, channel: src.channel, channel_match: src.channel_match || 'or', min_followers: src.min_followers||0, category: src.category,
@@ -2086,7 +2093,7 @@ function renderCampPreview(mode) {
           ${slideUrls.length>1?`<div class="cp-hero-count">1/${slideUrls.length}</div>`:''}
         </div>
         <div class="cp-head">
-          ${camp.brand?`<div class="cp-brand">${esc(camp.brand)}</div>`:''}
+          ${(()=>{const bl=brandLabelInflu(camp);return bl?`<div class="cp-brand">${esc(bl)}</div>`:'';})()}
           ${rtLabel?`<div class="cp-rt">${esc(rtLabel)}</div>`:''}
           <div class="cp-title">${esc(camp.title||'(캠페인명)')}</div>
           ${camp.product_price>0?`<div class="cp-price-box"><span class="cp-price-amount">¥${camp.product_price.toLocaleString()}</span><span class="cp-price-label">${rewardLabelJa}</span></div>`:''}
@@ -2418,6 +2425,9 @@ async function addCampaign() {
   const _pickedBrand = (_campBrandsCache || []).find(b => b.id === brandId);
   const brand = (_pickedBrand?.name || $('newCampBrand').value || '').trim();
   const brandKo = ($('newCampBrandKo')?.value || '').trim();
+  // 브랜드명 일본어/영문 — 마스터(brands)에서 복사. brand_id 연결 캠페인은 173 트리거가 이후 동기화.
+  const brandJa = (_pickedBrand?.name_ja || '').trim();
+  const brandEn = (_pickedBrand?.name_en || '').trim();
   const product = $('newCampProduct').value.trim();
   const productKo = ($('newCampProductKo')?.value || '').trim();
   const productUrl = cleanUrl($('newCampProductUrl')?.value)||'';
@@ -2448,6 +2458,8 @@ async function addCampaign() {
     brand_id: brandId,
     source_application_id: sourceAppId || null,
     brand_ko: brandKo || null,
+    brand_ja: brandJa || null,
+    brand_en: brandEn || null,
     product_ko: productKo || null,
     type: ch.split(',').includes('qoo10')?'qoo10':'nano', channel:ch, channel_match: document.querySelector('input[name="newChannelMatch"]:checked')?.value || 'or', primary_channel: (recruitType==='monitor') ? null : ($('newCampPrimaryChannel')?.value || null), min_followers: (recruitType==='monitor') ? 0 : (parseInt($('newCampMinFollowers')?.value)||0), category:cat,
     recruit_type: recruitType,

--- a/dev/js/application.js
+++ b/dev/js/application.js
@@ -90,7 +90,7 @@ async function openCampaign(id) {
 
       <div style="background:#fff;border-bottom:1px solid var(--line);margin-bottom:10px">
         <div style="padding:16px 0 12px">
-          <div style="font-size:11px;color:var(--pink);font-weight:700;letter-spacing:.06em;margin-bottom:5px">${esc(camp.brand)}</div>
+          <div style="font-size:11px;color:var(--pink);font-weight:700;letter-spacing:.06em;margin-bottom:5px">${esc(brandLabelInflu(camp))}</div>
           ${camp.recruit_type ? `<div style="font-size:10px;font-weight:700;color:var(--pink);margin-bottom:4px">${esc(getRecruitTypeLabelJa(camp.recruit_type))}</div>` : ''}
           <div style="font-size:18px;font-weight:800;color:var(--ink);line-height:1.3;margin-bottom:10px">${esc(camp.title)}</div>
           ${camp.product_price>0?`<div style="display:inline-flex;align-items:center;gap:6px;background:var(--light-pink);border-radius:8px;padding:6px 12px;margin-bottom:4px"><span style="font-size:17px;font-weight:900;color:var(--pink)">¥${camp.product_price.toLocaleString()}</span><span style="font-size:12px;color:var(--dark-pink);font-weight:600">${camp.recruit_type === 'monitor' ? t('detail.rewardPayback') : t('detail.rewardProduct')}</span></div>`:''}
@@ -593,7 +593,7 @@ async function openActivityPage(applicationId, campaignId, from) {
     prevBlocked.style.display = 'none';
   }
   $('activityCampTitle').textContent = camp.title || '';
-  $('activityCampBrand').textContent = camp.brand || '';
+  $('activityCampBrand').textContent = brandLabelInflu(camp);
   const rtLabel = $('activityRecruitLabel');
   if (rtLabel) {
     if (camp.recruit_type && typeof getRecruitTypeLabelJa === 'function') {

--- a/dev/js/campaign.js
+++ b/dev/js/campaign.js
@@ -53,7 +53,7 @@ function updateStats(camps) {
   const visible = visibleCamps(camps);
   $('statCampaigns').textContent = visible.length;
   $('campCount').textContent = visible.length;
-  $('statBrands').textContent = [...new Set(camps.map(c=>c.brand))].length;
+  $('statBrands').textContent = [...new Set(camps.map(c=>brandLabelInflu(c)))].length;
   buildChannelFilters(visible);
 }
 
@@ -215,7 +215,7 @@ function renderCampaignGrid() {
   if (campPageStatusFilter !== 'all') camps = camps.filter(c => c.status === campPageStatusFilter);
   if (campPageSearch) {
     camps = camps.filter(c => {
-      const haystack = ((c.title||'') + ' ' + (c.brand||'') + ' ' + (c.brand_ko||'') + ' ' + (c.product||'') + ' ' + (c.product_ko||'') + ' ' + (c.campaign_no||'')).toLowerCase();
+      const haystack = ((c.title||'') + ' ' + (c.brand||'') + ' ' + (c.brand_ko||'') + ' ' + (c.brand_ja||'') + ' ' + (c.brand_en||'') + ' ' + (c.product||'') + ' ' + (c.product_ko||'') + ' ' + (c.campaign_no||'')).toLowerCase();
       return haystack.includes(campPageSearch);
     });
   }
@@ -288,7 +288,7 @@ function buildCampCards(camps) {
         <div class="camp-ch-badge" style="z-index:3;top:auto;bottom:8px;right:auto;left:8px">${esc(getChannelLabel((c.channel||'').split(',')[0].trim()))}${(c.channel||'').split(',').filter(Boolean).length>1?` <span style="opacity:.7">+${(c.channel||'').split(',').filter(Boolean).length-1}</span>`:''}</div>
       </div>
       <div class="camp-body">
-        <div class="camp-brand">${esc(c.brand)}</div>
+        <div class="camp-brand">${esc(brandLabelInflu(c))}</div>
         ${typeLabel ? `<div style="font-size:10px;font-weight:700;color:var(--pink);margin:2px 0">${esc(typeLabel)}</div>` : ''}
         <div class="camp-title">${esc(c.title)}</div>
         ${c.content_types ? `<div style="display:flex;gap:4px;flex-wrap:wrap;margin-top:4px">${c.content_types.split(',').map(t=>`<span style="font-size:10px;background:var(--light-pink);color:var(--dark-pink);padding:2px 8px;border-radius:20px;font-weight:600">${esc(getLookupLabel('content_type', t.trim()))}</span>`).join('')}</div>` : ''}

--- a/dev/js/mypage.js
+++ b/dev/js/mypage.js
@@ -278,7 +278,7 @@ async function renderMyApplyList() {
       <div class="apply-item-info">
         ${camp.recruit_type ? `<div style="font-size:10px;font-weight:700;color:var(--pink);margin-bottom:2px">${esc(getRecruitTypeLabelJa(camp.recruit_type))}</div>` : ''}
         <div class="apply-item-name" style="display:flex;align-items:center;gap:6px"><span style="overflow:hidden;text-overflow:ellipsis;white-space:nowrap;min-width:0;flex:1">${esc(camp.title||a.campaign_id)}</span></div>
-        <div class="apply-item-meta">${esc(camp.brand||'')} · ${t('appHistory.applyDate')} ${formatDate(a.created_at)}</div>
+        <div class="apply-item-meta">${esc(brandLabelInflu(camp))} · ${t('appHistory.applyDate')} ${formatDate(a.created_at)}</div>
         ${cautionLine}
         ${cancelledLine}
         ${badgeRow}

--- a/dev/lib/shared.js
+++ b/dev/lib/shared.js
@@ -645,6 +645,19 @@ const CAMPAIGN_STATUS_BADGE_CLASS = {
   closed_recruit: 'badge-pink', closed_done: 'badge-done', expired: 'badge-expired'
 };
 
+// 브랜드명 다국어 표시 헬퍼 (2026-06-08, 사양서 docs/specs/2026-06-08-brand-name-i18n.md)
+//   캠페인 객체의 brand(한국어)/brand_ja/brand_en 비정규화 컬럼에서 화면별 우선순위로 선택.
+//   관리자: 한국어 > 영어 > 일본어 / 인플루언서: 일본어 > 영어 > 한국어 (빈칸 방지 폴백).
+//   brand 값은 brand_id 연결 캠페인의 경우 brands 마스터 동기화 복사본(트리거 173).
+function brandLabelAdmin(c) {
+  if (!c) return '';
+  return (c.brand || c.brand_en || c.brand_ja || '').trim();
+}
+function brandLabelInflu(c) {
+  if (!c) return '';
+  return (c.brand_ja || c.brand_en || c.brand || '').trim();
+}
+
 // 숫자 입력칸(type=number): 포커스 중 마우스 휠로 값이 바뀌는 기본 동작 차단 (오입력 방지).
 // 전역 1회 등록 → 관리자·인플 양쪽 빌드의 모든 숫자 입력칸에 일괄 적용. 휠은 페이지 스크롤만.
 document.addEventListener('wheel', function (e) {

--- a/dev/lib/storage.js
+++ b/dev/lib/storage.js
@@ -60,7 +60,7 @@ async function fetchCampaigns() {
 // ※ autoOpenCampaigns / autoCloseCampaigns 는 status / recruit_start / deadline 만 참조하므로
 //    목록 전용 컬럼셋에서도 문제없이 실행된다. 목록 진입 시 자동 전환을 유지하기 위해 여기서도 호출.
 const ADMIN_LIST_COLUMNS = [
-  'id', 'title', 'brand', 'brand_ko', 'product', 'product_ko',
+  'id', 'title', 'brand', 'brand_ko', 'brand_ja', 'brand_en', 'product', 'product_ko',
   'campaign_no', 'legacy_no',
   'recruit_type', 'channel', 'status',
   'slots', 'view_count',

--- a/docs/specs/2026-06-08-brand-name-i18n.md
+++ b/docs/specs/2026-06-08-brand-name-i18n.md
@@ -96,4 +96,34 @@ brandLabelInflu(b)  = b.name_ja || b.name_en || b.name (한국어) || ''
 - 표기 시점: 항상 마스터 최신
 - 마스터 정정: 후보 제안 + 사람 검수
 
-## 구현 결과 (개발 세션이 채울 것)
+## 구현 결과 — PR 1 (B안: 비정규화 + 트리거 동기화)
+
+**구현일:** 2026-06-08
+**브랜치:** feature/brand-name-i18n
+
+### 채택안: B안 (supabase-expert 권고)
+설계 검토에서 사양서 A안(brands RLS 개방)은 **brands에 사업자번호·청구이메일 등 민감 컬럼이 섞여 있어 통째 개방 불가**, 관리자/인플이 모두 `authenticated`라 컬럼 단위 권한 분리도 불가로 판명. **B안(campaigns에 다국어 비정규화 + brands UPDATE 트리거 동기화)** 채택 — 인플은 campaigns만 읽으므로 brands RLS·민감정보 노출 변화 0, 「항상 마스터 최신」은 트리거가 보장.
+
+### 마이그레이션 (개발 세션 생성 시점 확정 번호)
+- **172** `campaigns_brand_i18n_columns.sql` — `campaigns`에 `brand_ja`·`brand_en` 컬럼 추가 + brand_id 조인 백필
+- **173** `brands_sync_campaign_names.sql` — `brands` AFTER UPDATE OF name/name_ja/name_en 트리거 `sync_campaign_brand_names()`(연결 campaigns의 brand/brand_ja/brand_en 동기화, SECURITY DEFINER + search_path='')
+
+### 코드
+- `dev/lib/shared.js` — 헬퍼 2종: `brandLabelAdmin(c)`(brand>brand_en>brand_ja), `brandLabelInflu(c)`(brand_ja>brand_en>brand). 양쪽 빌드 포함.
+- `dev/lib/storage.js` — ADMIN_LIST_COLUMNS에 brand_ja/brand_en 추가(인플 fetch는 select* 라 자동).
+- 캠페인 저장/복제/편집(admin.js): `_pickedBrand`/`_campBrandsCache`에서 name_ja/name_en 추출 → brand_ja/brand_en 저장.
+- **표시 통일(헬퍼 폴백으로 회귀 없음)**: 관리자 목록(admin.js:360)·미리보기(2096)·검색(265)·엑셀(admin-excel.js 245/928/1187/safeBrand)·결과물(admin-deliverables 556/1655/1662/1676)·신청(admin-applications 372)·메시지(admin-messaging 190/263/367)·대시보드(admin-dashboard 91) = `brandLabelAdmin` / 인플 카드(campaign.js 291)·통계(56)·검색(218)·상세(application.js 93)·활동(596)·마이페이지(mypage.js 281) = `brandLabelInflu`.
+
+### 초안 대비 변경
+- A안(RLS 개방) → **B안(트리거 동기화)** 으로 변경(민감 컬럼 노출 차단). 사양서 본문 설계 A는 폐기.
+- campaigns에 `brand_ja`/`brand_en` 컬럼 추가(초안엔 없던 비정규화 — B안 선택의 결과).
+- 표시 통일 범위가 캠페인 목록을 넘어 **전 화면**으로 확장(reverb-reviewer 일관성 경고 반영).
+
+### 검증
+- reverb-supabase-expert: 마이그레이션 172/173 전체 통과(멱등성·search_path·무한루프 없음·기존 트리거 충돌 없음).
+- reverb-reviewer GO 2회(본체 + 일관성 추가분).
+- qa-tester 권장: light(인플 응모 플로우 표시 변경) — 사용자 트리거.
+
+### 남은 작업 (PR 2·3)
+- PR 2: `brands.name`에 일본어 잘못 든 행 진단(가나 정규식 SQL) → 후보 검수 → name_ja 이동.
+- PR 3: 죽은 칸 `campaigns.brand_ko` 참조 제거.

--- a/index.html
+++ b/index.html
@@ -2501,6 +2501,19 @@ const CAMPAIGN_STATUS_BADGE_CLASS = {
   closed_recruit: 'badge-pink', closed_done: 'badge-done', expired: 'badge-expired'
 };
 
+// 브랜드명 다국어 표시 헬퍼 (2026-06-08, 사양서 docs/specs/2026-06-08-brand-name-i18n.md)
+//   캠페인 객체의 brand(한국어)/brand_ja/brand_en 비정규화 컬럼에서 화면별 우선순위로 선택.
+//   관리자: 한국어 > 영어 > 일본어 / 인플루언서: 일본어 > 영어 > 한국어 (빈칸 방지 폴백).
+//   brand 값은 brand_id 연결 캠페인의 경우 brands 마스터 동기화 복사본(트리거 173).
+function brandLabelAdmin(c) {
+  if (!c) return '';
+  return (c.brand || c.brand_en || c.brand_ja || '').trim();
+}
+function brandLabelInflu(c) {
+  if (!c) return '';
+  return (c.brand_ja || c.brand_en || c.brand || '').trim();
+}
+
 // 숫자 입력칸(type=number): 포커스 중 마우스 휠로 값이 바뀌는 기본 동작 차단 (오입력 방지).
 // 전역 1회 등록 → 관리자·인플 양쪽 빌드의 모든 숫자 입력칸에 일괄 적용. 휠은 페이지 스크롤만.
 document.addEventListener('wheel', function (e) {
@@ -4078,7 +4091,7 @@ async function fetchCampaigns() {
 // ※ autoOpenCampaigns / autoCloseCampaigns 는 status / recruit_start / deadline 만 참조하므로
 //    목록 전용 컬럼셋에서도 문제없이 실행된다. 목록 진입 시 자동 전환을 유지하기 위해 여기서도 호출.
 const ADMIN_LIST_COLUMNS = [
-  'id', 'title', 'brand', 'brand_ko', 'product', 'product_ko',
+  'id', 'title', 'brand', 'brand_ko', 'brand_ja', 'brand_en', 'product', 'product_ko',
   'campaign_no', 'legacy_no',
   'recruit_type', 'channel', 'status',
   'slots', 'view_count',
@@ -8352,7 +8365,7 @@ function updateStats(camps) {
   const visible = visibleCamps(camps);
   $('statCampaigns').textContent = visible.length;
   $('campCount').textContent = visible.length;
-  $('statBrands').textContent = [...new Set(camps.map(c=>c.brand))].length;
+  $('statBrands').textContent = [...new Set(camps.map(c=>brandLabelInflu(c)))].length;
   buildChannelFilters(visible);
 }
 
@@ -8514,7 +8527,7 @@ function renderCampaignGrid() {
   if (campPageStatusFilter !== 'all') camps = camps.filter(c => c.status === campPageStatusFilter);
   if (campPageSearch) {
     camps = camps.filter(c => {
-      const haystack = ((c.title||'') + ' ' + (c.brand||'') + ' ' + (c.brand_ko||'') + ' ' + (c.product||'') + ' ' + (c.product_ko||'') + ' ' + (c.campaign_no||'')).toLowerCase();
+      const haystack = ((c.title||'') + ' ' + (c.brand||'') + ' ' + (c.brand_ko||'') + ' ' + (c.brand_ja||'') + ' ' + (c.brand_en||'') + ' ' + (c.product||'') + ' ' + (c.product_ko||'') + ' ' + (c.campaign_no||'')).toLowerCase();
       return haystack.includes(campPageSearch);
     });
   }
@@ -8587,7 +8600,7 @@ function buildCampCards(camps) {
         <div class="camp-ch-badge" style="z-index:3;top:auto;bottom:8px;right:auto;left:8px">${esc(getChannelLabel((c.channel||'').split(',')[0].trim()))}${(c.channel||'').split(',').filter(Boolean).length>1?` <span style="opacity:.7">+${(c.channel||'').split(',').filter(Boolean).length-1}</span>`:''}</div>
       </div>
       <div class="camp-body">
-        <div class="camp-brand">${esc(c.brand)}</div>
+        <div class="camp-brand">${esc(brandLabelInflu(c))}</div>
         ${typeLabel ? `<div style="font-size:10px;font-weight:700;color:var(--pink);margin:2px 0">${esc(typeLabel)}</div>` : ''}
         <div class="camp-title">${esc(c.title)}</div>
         ${c.content_types ? `<div style="display:flex;gap:4px;flex-wrap:wrap;margin-top:4px">${c.content_types.split(',').map(t=>`<span style="font-size:10px;background:var(--light-pink);color:var(--dark-pink);padding:2px 8px;border-radius:20px;font-weight:600">${esc(getLookupLabel('content_type', t.trim()))}</span>`).join('')}</div>` : ''}
@@ -8953,7 +8966,7 @@ async function openCampaign(id) {
 
       <div style="background:#fff;border-bottom:1px solid var(--line);margin-bottom:10px">
         <div style="padding:16px 0 12px">
-          <div style="font-size:11px;color:var(--pink);font-weight:700;letter-spacing:.06em;margin-bottom:5px">${esc(camp.brand)}</div>
+          <div style="font-size:11px;color:var(--pink);font-weight:700;letter-spacing:.06em;margin-bottom:5px">${esc(brandLabelInflu(camp))}</div>
           ${camp.recruit_type ? `<div style="font-size:10px;font-weight:700;color:var(--pink);margin-bottom:4px">${esc(getRecruitTypeLabelJa(camp.recruit_type))}</div>` : ''}
           <div style="font-size:18px;font-weight:800;color:var(--ink);line-height:1.3;margin-bottom:10px">${esc(camp.title)}</div>
           ${camp.product_price>0?`<div style="display:inline-flex;align-items:center;gap:6px;background:var(--light-pink);border-radius:8px;padding:6px 12px;margin-bottom:4px"><span style="font-size:17px;font-weight:900;color:var(--pink)">¥${camp.product_price.toLocaleString()}</span><span style="font-size:12px;color:var(--dark-pink);font-weight:600">${camp.recruit_type === 'monitor' ? t('detail.rewardPayback') : t('detail.rewardProduct')}</span></div>`:''}
@@ -9456,7 +9469,7 @@ async function openActivityPage(applicationId, campaignId, from) {
     prevBlocked.style.display = 'none';
   }
   $('activityCampTitle').textContent = camp.title || '';
-  $('activityCampBrand').textContent = camp.brand || '';
+  $('activityCampBrand').textContent = brandLabelInflu(camp);
   const rtLabel = $('activityRecruitLabel');
   if (rtLabel) {
     if (camp.recruit_type && typeof getRecruitTypeLabelJa === 'function') {
@@ -10813,7 +10826,7 @@ async function renderMyApplyList() {
       <div class="apply-item-info">
         ${camp.recruit_type ? `<div style="font-size:10px;font-weight:700;color:var(--pink);margin-bottom:2px">${esc(getRecruitTypeLabelJa(camp.recruit_type))}</div>` : ''}
         <div class="apply-item-name" style="display:flex;align-items:center;gap:6px"><span style="overflow:hidden;text-overflow:ellipsis;white-space:nowrap;min-width:0;flex:1">${esc(camp.title||a.campaign_id)}</span></div>
-        <div class="apply-item-meta">${esc(camp.brand||'')} · ${t('appHistory.applyDate')} ${formatDate(a.created_at)}</div>
+        <div class="apply-item-meta">${esc(brandLabelInflu(camp))} · ${t('appHistory.applyDate')} ${formatDate(a.created_at)}</div>
         ${cautionLine}
         ${cancelledLine}
         ${badgeRow}

--- a/supabase/migrations/172_campaigns_brand_i18n_columns.sql
+++ b/supabase/migrations/172_campaigns_brand_i18n_columns.sql
@@ -1,0 +1,37 @@
+-- ============================================================
+-- 172: campaigns 에 브랜드명 일본어/영문 비정규화 컬럼 추가 + 백필
+--
+-- 배경: 캠페인 목록·인플 화면이 campaigns.brand(한국어 스냅샷) 하나만 표시 →
+--       같은 브랜드라도 캠페인마다 brand 스냅샷이 한국어/일본어로 섞여 혼재.
+-- 해결: brands 마스터의 3국어(name/name_ja/name_en)를 campaigns 에 비정규화 복사.
+--       표시 헬퍼가 화면별 우선순위(관리자 한>영>일 / 인플 일>영>한)로 선택.
+--       「항상 마스터 최신」은 173 의 brands UPDATE 동기화 트리거가 보장.
+--
+-- 사양서: docs/specs/2026-06-08-brand-name-i18n.md (B안)
+-- 롤백: ALTER TABLE public.campaigns DROP COLUMN IF EXISTS brand_ja, DROP COLUMN IF EXISTS brand_en;
+-- ============================================================
+
+ALTER TABLE public.campaigns
+  ADD COLUMN IF NOT EXISTS brand_ja  text,   -- 일본어 브랜드명 (brands.name_ja 동기화 복사본)
+  ADD COLUMN IF NOT EXISTS brand_en  text;   -- 영문   브랜드명 (brands.name_en 동기화 복사본)
+
+COMMENT ON COLUMN public.campaigns.brand_ja IS
+  'brands.name_ja 동기화 복사본. brands UPDATE 트리거(173)가 자동 갱신. 인플 표시 우선순위 1위.';
+COMMENT ON COLUMN public.campaigns.brand_en IS
+  'brands.name_en 동기화 복사본. brands UPDATE 트리거(173)가 자동 갱신. 표시 폴백 2위(관리자·인플 공용).';
+
+-- 기존 캠페인 백필 (brand_id IS NOT NULL 행만 대상 — 외부 캠페인은 brand 직접 입력 유지)
+UPDATE public.campaigns c
+SET
+  brand_ja = b.name_ja,
+  brand_en = b.name_en
+FROM public.brands b
+WHERE c.brand_id = b.id
+  AND c.brand_id IS NOT NULL;
+
+-- 백필 결과 확인용 (적용 후 SQL Editor 에서 실행)
+-- SELECT count(*) AS total,
+--        count(*) FILTER (WHERE brand_ja IS NOT NULL) AS has_ja,
+--        count(*) FILTER (WHERE brand_en IS NOT NULL) AS has_en,
+--        count(*) FILTER (WHERE brand_id IS NULL)     AS no_brand_id
+-- FROM public.campaigns;

--- a/supabase/migrations/173_brands_sync_campaign_names.sql
+++ b/supabase/migrations/173_brands_sync_campaign_names.sql
@@ -1,0 +1,51 @@
+-- ============================================================
+-- 173: brands 브랜드명 변경 시 연결된 campaigns 자동 동기화 트리거
+--
+-- 「항상 마스터 최신」 구현 — 마스터(brands)에서 name/name_ja/name_en 을 고치면
+-- 연결된 모든 campaigns 의 brand/brand_ja/brand_en 을 즉시 갱신.
+-- (인플/관리자는 campaigns 만 읽으므로 brands RLS·민감 컬럼 노출 변화 없음)
+--
+-- 사양서: docs/specs/2026-06-08-brand-name-i18n.md (B안)
+-- 의존: 172 (campaigns.brand_ja/brand_en 컬럼)
+-- 롤백:
+--   DROP TRIGGER IF EXISTS trg_brands_sync_campaigns ON public.brands;
+--   DROP FUNCTION IF EXISTS public.sync_campaign_brand_names();
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.sync_campaign_brand_names()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+BEGIN
+  -- 이름 3종 중 하나라도 바뀌었을 때만 campaigns 갱신 (불필요한 UPDATE 방지)
+  IF (NEW.name    IS DISTINCT FROM OLD.name)
+  OR (NEW.name_ja IS DISTINCT FROM OLD.name_ja)
+  OR (NEW.name_en IS DISTINCT FROM OLD.name_en)
+  THEN
+    UPDATE public.campaigns
+    SET
+      brand    = NEW.name,       -- 한국어 (관리자 표시·검색 haystack 기준)
+      brand_ja = NEW.name_ja,
+      brand_en = NEW.name_en
+    WHERE brand_id = NEW.id;
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+COMMENT ON FUNCTION public.sync_campaign_brand_names() IS
+  'brands.name / name_ja / name_en 변경 시 연결된 campaigns 행 동기화. AFTER UPDATE 트리거. trg_brand_name_normalized(BEFORE) 이후 발화.';
+
+DROP TRIGGER IF EXISTS trg_brands_sync_campaigns ON public.brands;
+CREATE TRIGGER trg_brands_sync_campaigns
+  AFTER UPDATE OF name, name_ja, name_en
+  ON public.brands
+  FOR EACH ROW
+  EXECUTE FUNCTION public.sync_campaign_brand_names();
+
+-- 검증 (트리거 등록 확인)
+-- SELECT trigger_name, event_manipulation, action_timing
+-- FROM information_schema.triggers
+-- WHERE event_object_table = 'brands' ORDER BY action_timing, trigger_name;


### PR DESCRIPTION
## 변경 요약
- 캠페인 관리 목록에서 같은 브랜드가 일본어/한국어로 섞여 보이던 버그 해결. 원인: 캠페인이 브랜드명을 한국어 스냅샷 하나만 저장·표시하고 마스터의 일본어·영문 이름을 안 씀.
- B안(비정규화 + 트리거 동기화): `campaigns`에 `brand_ja`/`brand_en` 추가 + 마스터(brands) 변경 시 자동 동기화 트리거. 인플은 campaigns만 읽어 brands 민감정보 노출 0.
- 화면별 우선순위 헬퍼: 관리자 한국어>영어>일본어 / 인플루언서 일본어>영어>한국어. 전 화면 통일.

## 요청 외 추가 변경
- 일관성 위해 캠페인 목록 외 전 표시처(엑셀·결과물·신청·메시지·대시보드·인플 마이페이지) 통일 (reviewer 경고 반영).

## 관련 사양서
- docs/specs/2026-06-08-brand-name-i18n.md

## DB 변경 (⚠️ 코드 배포 전 개발 DB 적용 필요)
- 마이그레이션 172 (campaigns.brand_ja/brand_en + 백필), 173 (brands 동기화 트리거)

## 검증
- supabase-expert: 172/173 통과 / reviewer GO 2회 / 빌드 통과 / qa 권장 light

🤖 Generated with [Claude Code](https://claude.com/claude-code)