### PR TITLE
fix(admin): 대리등록 모달 캠페인 누락 (승인 500건 초과)

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -12,7 +12,7 @@
 // 회귀(2026-05-12 PR #182 머지 직후 발생)를 방지하기 위한 자동 reload 가드.
 // sessionStorage 차단 환경(시크릿 모드 일부, 쿠키 차단)에서는 자연스럽게 skip.
 (function(){
-  var CURRENT_BUILD = 'v1780918439';
+  var CURRENT_BUILD = 'v1780969101';
   if (CURRENT_BUILD.indexOf('__') === 0) return; // 빌드 미적용 (dev/ 직접 열기) 시 skip
   try {
     var prev = sessionStorage.getItem('reverb.adminBuild');
@@ -2002,7 +2002,7 @@ textarea.form-input{resize:vertical;min-height:80px}
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-06-08 20:33 · 8483314</span>
+          <span class="admin-build-text">2026-06-09 10:38 · d279083</span>
         </div>
       </div>
     </aside>
@@ -19864,29 +19864,43 @@ async function _loadAdminProxyApprovedApps() {
   // PostgREST schema cache 가 applications.campaign_id / applications.user_id 의 FK 임베드를
   // 인식 못 하는 사례(스키마 새로고침 지연 등)가 있어 분리 쿼리 + 클라이언트 join 패턴 사용.
   if (!db) return [];
-  // 1. approved 신청만 (status·reviewed_at 정렬)
-  const {data: apps, error} = await db?.from('applications')
-    .select('id, status, campaign_id, user_id, reviewed_at')
-    .eq('status', 'approved')
-    .order('reviewed_at', {ascending: false})
-    .limit(500);
-  if (error) throw error;
+  // 1. approved 신청 전건 — 과거 .limit(500) 으로 잘라 승인 누적 500건 밖(오래 전 승인)
+  //    캠페인이 후보에서 통째로 누락되는 버그가 있었음. fetchAllPaged 로 1000행 cap 우회.
+  const apps = await fetchAllPaged(() =>
+    db.from('applications')
+      .select('id, status, campaign_id, user_id, reviewed_at')
+      .eq('status', 'approved')
+      .order('reviewed_at', {ascending: false})
+  );
   if (!apps || !apps.length) return [];
-  // 2. 관련 캠페인 + 인플 별도 IN 쿼리 (병렬)
+  // 2. 관련 캠페인 + 인플 별도 IN 쿼리 — id 목록이 1000개를 넘거나 URL 이 길어질 수 있어 배치 분할
   const campIds = [...new Set(apps.map(a => a.campaign_id).filter(Boolean))];
   const userIds = [...new Set(apps.map(a => a.user_id).filter(Boolean))];
-  const [campRes, infRes] = await Promise.all([
-    campIds.length ? db?.from('campaigns').select('id, title, brand, recruit_type, channel, campaign_no').in('id', campIds) : {data: []},
-    userIds.length ? db?.from('influencers').select('id, name, name_kana, email').in('id', userIds) : {data: []}
+  const [campRows, infRows] = await Promise.all([
+    _proxyFetchByIds('campaigns', 'id, title, brand, brand_ja, brand_en, recruit_type, channel, campaign_no', campIds),
+    _proxyFetchByIds('influencers', 'id, name, name_kana, email', userIds)
   ]);
   const campMap = {};
-  (campRes?.data || []).forEach(c => { campMap[c.id] = c; });
+  campRows.forEach(c => { campMap[c.id] = c; });
   const infMap = {};
-  (infRes?.data || []).forEach(u => { infMap[u.id] = u; });
+  infRows.forEach(u => { infMap[u.id] = u; });
   // 3. 클라이언트 join — 캠페인·인플 둘 다 있는 것만 노출 (RLS 누락 행 자동 필터)
   return apps
     .map(a => ({...a, campaigns: campMap[a.campaign_id], influencers: infMap[a.user_id]}))
     .filter(a => a.campaigns && a.influencers);
+}
+
+// id 목록을 배치로 나눠 IN 조회 (PostgREST URL 길이·1000행 cap 회피)
+async function _proxyFetchByIds(table, cols, ids, batchSize = 200) {
+  if (!db || !ids.length) return [];
+  const out = [];
+  for (let i = 0; i < ids.length; i += batchSize) {
+    const chunk = ids.slice(i, i + batchSize);
+    const {data, error} = await db.from(table).select(cols).in('id', chunk);
+    if (error) throw error;
+    if (data) out.push(...data);
+  }
+  return out;
 }
 
 async function _loadAdminProxyReasons() {

--- a/dev/js/admin-deliverables.js
+++ b/dev/js/admin-deliverables.js
@@ -1569,29 +1569,43 @@ async function _loadAdminProxyApprovedApps() {
   // PostgREST schema cache 가 applications.campaign_id / applications.user_id 의 FK 임베드를
   // 인식 못 하는 사례(스키마 새로고침 지연 등)가 있어 분리 쿼리 + 클라이언트 join 패턴 사용.
   if (!db) return [];
-  // 1. approved 신청만 (status·reviewed_at 정렬)
-  const {data: apps, error} = await db?.from('applications')
-    .select('id, status, campaign_id, user_id, reviewed_at')
-    .eq('status', 'approved')
-    .order('reviewed_at', {ascending: false})
-    .limit(500);
-  if (error) throw error;
+  // 1. approved 신청 전건 — 과거 .limit(500) 으로 잘라 승인 누적 500건 밖(오래 전 승인)
+  //    캠페인이 후보에서 통째로 누락되는 버그가 있었음. fetchAllPaged 로 1000행 cap 우회.
+  const apps = await fetchAllPaged(() =>
+    db.from('applications')
+      .select('id, status, campaign_id, user_id, reviewed_at')
+      .eq('status', 'approved')
+      .order('reviewed_at', {ascending: false})
+  );
   if (!apps || !apps.length) return [];
-  // 2. 관련 캠페인 + 인플 별도 IN 쿼리 (병렬)
+  // 2. 관련 캠페인 + 인플 별도 IN 쿼리 — id 목록이 1000개를 넘거나 URL 이 길어질 수 있어 배치 분할
   const campIds = [...new Set(apps.map(a => a.campaign_id).filter(Boolean))];
   const userIds = [...new Set(apps.map(a => a.user_id).filter(Boolean))];
-  const [campRes, infRes] = await Promise.all([
-    campIds.length ? db?.from('campaigns').select('id, title, brand, recruit_type, channel, campaign_no').in('id', campIds) : {data: []},
-    userIds.length ? db?.from('influencers').select('id, name, name_kana, email').in('id', userIds) : {data: []}
+  const [campRows, infRows] = await Promise.all([
+    _proxyFetchByIds('campaigns', 'id, title, brand, brand_ja, brand_en, recruit_type, channel, campaign_no', campIds),
+    _proxyFetchByIds('influencers', 'id, name, name_kana, email', userIds)
   ]);
   const campMap = {};
-  (campRes?.data || []).forEach(c => { campMap[c.id] = c; });
+  campRows.forEach(c => { campMap[c.id] = c; });
   const infMap = {};
-  (infRes?.data || []).forEach(u => { infMap[u.id] = u; });
+  infRows.forEach(u => { infMap[u.id] = u; });
   // 3. 클라이언트 join — 캠페인·인플 둘 다 있는 것만 노출 (RLS 누락 행 자동 필터)
   return apps
     .map(a => ({...a, campaigns: campMap[a.campaign_id], influencers: infMap[a.user_id]}))
     .filter(a => a.campaigns && a.influencers);
+}
+
+// id 목록을 배치로 나눠 IN 조회 (PostgREST URL 길이·1000행 cap 회피)
+async function _proxyFetchByIds(table, cols, ids, batchSize = 200) {
+  if (!db || !ids.length) return [];
+  const out = [];
+  for (let i = 0; i < ids.length; i += batchSize) {
+    const chunk = ids.slice(i, i + batchSize);
+    const {data, error} = await db.from(table).select(cols).in('id', chunk);
+    if (error) throw error;
+    if (data) out.push(...data);
+  }
+  return out;
 }
 
 async function _loadAdminProxyReasons() {

--- a/docs/specs/2026-05-28-admin-proxy-deliverable.md
+++ b/docs/specs/2026-05-28-admin-proxy-deliverable.md
@@ -380,3 +380,20 @@ GRANT EXECUTE ON FUNCTION public.admin_create_deliverable_proxy(uuid, text, text
 - 회수 Storage 삭제 실패 처리: 회수 DB 행 삭제는 성공 처리, Storage 실패 시 `warning` toast만 (사용자 결정)
 
 **운영 배포:** 미완료 (개발서버 검증 완료, 운영 배포 별도 협의)
+
+---
+
+### 버그 수정 — 대리등록 모달 캠페인 누락 (2026-06-09)
+
+**증상:** 관리자 결과물 대리등록 모달에서 일부 캠페인(예: `B0023-C001`)이 캠페인 검색 후보에 아예 안 떠 대리등록 불가.
+
+**원인:** 캠페인 후보는 "승인(approved) 신청이 있는 캠페인"만 노출하는데, `_loadAdminProxyApprovedApps()` 가 승인 신청을 `reviewed_at` 내림차순 `.limit(500)` 으로 잘라 가져옴. 운영 DB에 승인 신청이 1,600건+ 누적되자 오래 전 승인된 캠페인(B0023-C001 은 최근 순위 1,360위~)이 500건 밖으로 밀려 후보에서 통째로 누락. (`CLAUDE.md` 「PostgREST 1000-row cap 대응」 규칙에도 어긋나 있던 코드)
+
+**수정:** `dev/js/admin-deliverables.js`
+- `.limit(500)` 제거 → `fetchAllPaged()` (storage.js 전건 조회 헬퍼)로 승인 신청 전건 수집
+- 캠페인·인플 IN 조회를 `_proxyFetchByIds()` 배치 헬퍼(200개씩)로 분할 — id 목록이 1,000개 초과·URL 길이 초과 대비
+- campaigns select 에 `brand_ja`, `brand_en` 컬럼 추가 (2026-06-08 브랜드명 다국어 작업 이후 `brandLabelAdmin`·검색이 이 컬럼을 쓰는데 select 누락 상태였음)
+
+**DB 변경:** 없음 (조회 방식만 변경)
+
+**백로그(구조 개선):** 모달 열 때마다 승인 신청 전건을 미리 로드하는 구조라 승인 누적이 커질수록 모달 로드가 느려짐. 근본적으로는 "캠페인을 먼저 선택 → 해당 캠페인 승인 신청만 로드"하는 흐름으로 재설계 권장. 화면 흐름 변경이라 별도 사이클.


### PR DESCRIPTION
## 변경 요약
- 관리자 결과물 대리등록 모달에서 승인 신청이 500건 밖으로 밀린 캠페인(예: B0023-C001)이 후보에 안 뜨던 버그 수정
- `.limit(500)` → `fetchAllPaged()` 전건 조회 + 캠페인·인플 IN 조회 배치 분할
- campaigns select 에 brand_ja/brand_en 추가 (브랜드명 다국어 표시 정합)

## 요청 외 추가 변경
- 없음 (brand_ja/brand_en 누락은 본 버그와 동일 함수 내 정합 보정이라 동봉)

## 관련 사양서
- docs/specs/2026-05-28-admin-proxy-deliverable.md (버그 수정 섹션 추가)

DB 변경 없음. reviewer GO.

🤖 Generated with [Claude Code](https://claude.com/claude-code)