### PR TITLE
feat(brand): 빈 브랜드 삭제 (연결 0건)

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -12,7 +12,7 @@
 // 회귀(2026-05-12 PR #182 머지 직후 발생)를 방지하기 위한 자동 reload 가드.
 // sessionStorage 차단 환경(시크릿 모드 일부, 쿠키 차단)에서는 자연스럽게 skip.
 (function(){
-  var CURRENT_BUILD = 'v1780969101';
+  var CURRENT_BUILD = 'v1780970365';
   if (CURRENT_BUILD.indexOf('__') === 0) return; // 빌드 미적용 (dev/ 직접 열기) 시 skip
   try {
     var prev = sessionStorage.getItem('reverb.adminBuild');
@@ -2002,7 +2002,7 @@ textarea.form-input{resize:vertical;min-height:80px}
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-06-09 10:38 · d279083</span>
+          <span class="admin-build-text">2026-06-09 10:59 · de4cd94</span>
         </div>
       </div>
     </aside>
@@ -7867,6 +7867,30 @@ async function deleteCompanyHard(companyId) {
   } catch(e) { console.error('[deleteCompanyHard]', e); return {ok:false, error: e?.message || 'unknown', code: e?.code}; }
 }
 
+// 브랜드 hard delete (연결 0건 한정). delete_brand RPC 경유 — brands 는 DELETE RLS 없어 직접 delete 불가.
+async function deleteBrand(brandId) {
+  if (!db) return {ok:false, error:'no_db'};
+  try {
+    const data = await retryWithRefresh(async () => {
+      const {data, error} = await db?.rpc('delete_brand', {p_brand_id: brandId});
+      if (error) throw error;
+      return data;
+    });
+    return {ok:true, data};
+  } catch(e) { console.error('[deleteBrand]', e); return {ok:false, error: e?.message || 'unknown', code: e?.code}; }
+}
+
+// 브랜드 연결 캠페인 수 — 삭제 버튼 사전 노출 판정용(신청 brand_applications 은 별도 조회).
+// 실제 삭제 차단은 delete_brand RPC 가 캠페인+신청 양쪽을 재검증하므로, 이 값이 틀려도 데이터 안전.
+async function countCampaignsByBrand(brandId) {
+  if (!db) return 0;
+  try {
+    const {count, error} = await db?.from('campaigns').select('id', {count:'exact', head:true}).eq('brand_id', brandId);
+    if (error) throw error;
+    return count || 0;
+  } catch(e) { console.error('[countCampaignsByBrand]', e); return 0; }
+}
+
 // 브랜드 할당 모달용 조회
 // unassignedOnly=true → company_id IS NULL 인 미분류 브랜드만
 // companyId 지정 시 → 현재 소속(= companyId) + 미분류 양쪽 모두 반환
@@ -11609,17 +11633,24 @@ async function openBrandDetailModal(id) {
   bodyEl.innerHTML = '<div style="text-align:center;padding:40px;color:var(--muted)"><span class="spinner" style="width:18px;height:18px;border-width:2px;border-color:rgba(200,120,163,.2);border-top-color:var(--pink);display:inline-block;vertical-align:middle;margin-right:6px"></span>불러오는 중…</div>';
   if (footerEl) footerEl.innerHTML = '';
   modal.classList.add('open');
-  var [b, apps, companies] = await Promise.all([
+  var [b, apps, companies, campCount] = await Promise.all([
     fetchBrandById(id),
     fetchBrandApplicationsByBrand(id),
-    (typeof fetchCompanies === 'function' ? fetchCompanies({ status: 'all' }) : Promise.resolve([]))
+    (typeof fetchCompanies === 'function' ? fetchCompanies({ status: 'all' }) : Promise.resolve([])),
+    (typeof countCampaignsByBrand === 'function' ? countCampaignsByBrand(id) : Promise.resolve(0))
   ]);
   if (!b) { bodyEl.innerHTML = '<div style="text-align:center;padding:40px;color:var(--muted)">데이터를 불러올 수 없습니다</div>'; return; }
   _brandFormCompanies = companies || [];
   if (titleEl) titleEl.innerHTML = renderBrandDetailHeaderHtml(b);
   bodyEl.innerHTML = renderBrandDetailFormHtml(b, apps);
   renderBrandContactsRows();
+  // 삭제 버튼 — 연결(캠페인·신청) 0건 + campaign_admin 이상일 때만 노출. 연결 있으면 병합 기능(추후) 유도.
+  var canDeleteBrand = (apps.length === 0) && (campCount === 0)
+    && (typeof isCampaignAdminOrAbove === 'function' && isCampaignAdminOrAbove());
   if (footerEl) footerEl.innerHTML = ''
+    + (canDeleteBrand
+        ? '<button class="btn btn-ghost btn-sm" onclick="deleteBrandConfirm()" style="display:inline-flex;align-items:center;gap:4px;color:#c0392b"><span class="material-icons-round notranslate" translate="no" style="font-size:14px">delete_outline</span>삭제</button>'
+        : '')
     + '<button class="btn btn-ghost btn-sm" onclick="closeBrandDetailModal();openNewBrandAppModal(\'' + esc(id) + '\')" style="display:inline-flex;align-items:center;gap:4px;margin-right:auto"><span class="material-icons-round notranslate" translate="no" style="font-size:14px">add</span>이 브랜드로 신규 신청</button>'
     + '<button class="btn btn-ghost btn-sm" onclick="closeBrandDetailModal()">닫기</button>'
     + '<button class="btn btn-primary btn-sm" onclick="saveBrandDetail()">저장</button>';
@@ -11629,6 +11660,19 @@ function closeBrandDetailModal() {
   var modal = $('brandDetailModal');
   if (modal) modal.classList.remove('open');
   _brandsCurrentId = null;
+}
+
+// 브랜드 삭제 — 연결 0건 빈 브랜드만(서버 delete_brand RPC 가 재검증). 되돌릴 수 없음.
+async function deleteBrandConfirm() {
+  var id = _brandsCurrentId;
+  if (!id) return;
+  if (!confirm('이 브랜드를 삭제할까요?\n연결된 캠페인·신청이 없는 빈 브랜드만 삭제됩니다. 되돌릴 수 없습니다.')) return;
+  var result = await deleteBrand(id);
+  if (!result.ok) { toast('삭제 실패: ' + (result.error || '알 수 없는 오류'), 'error'); return; }
+  toast('브랜드를 삭제했습니다');
+  closeBrandDetailModal();
+  if (typeof refreshPane === 'function') { await refreshPane('brands'); }
+  else if (typeof loadBrandsPane === 'function') { await loadBrandsPane(); }
 }
 
 // 헤더 — brand_no | name | status select (드롭다운, 활성/비활성 명확히 선택)
@@ -18892,7 +18936,9 @@ function renderDelivResultCellMonitor(g) {
         + 'onclick="event.stopPropagation();openImageLightbox(\'' + esc(d.receipt_url) + '\')">';
     }
     let badge;
-    if (d.status === 'approved')      badge = '<span style="font-size:10px;background:#E4F5E8;color:#2D7A3E;font-weight:600;padding:1px 6px;border-radius:3px">승인</span>';
+    // 마이그레이션 160: 대리 등록 행은 status 배지를 「대리 등록」으로 교체 (자동 승인이라 "승인" 표기 무의미)
+    if (d.submitted_by_admin) badge = '<span style="font-size:10px;background:#FEF3C7;color:#92400E;font-weight:600;padding:1px 6px;border-radius:3px" title="관리자 대리 등록·자동 승인">대리 등록</span>';
+    else if (d.status === 'approved') badge = '<span style="font-size:10px;background:#E4F5E8;color:#2D7A3E;font-weight:600;padding:1px 6px;border-radius:3px">승인</span>';
     else if (d.status === 'rejected') badge = '<span style="font-size:10px;background:#FFE4E4;color:#C33;font-weight:600;padding:1px 6px;border-radius:3px">비승인</span>';
     else if (d.status === 'draft')    badge = '<span style="font-size:10px;background:#e5e7eb;color:#555;font-weight:600;padding:1px 6px;border-radius:3px">임시</span>';
     else                              badge = '<span style="font-size:10px;background:#FFF4E4;color:#B8741A;font-weight:600;padding:1px 6px;border-radius:3px">검수대기</span>';
@@ -18927,7 +18973,7 @@ function renderDelivStatusCell(d, slot, rt) {
   // 마이그레이션 160: 대리 등록 행은 status 배지를 「대리 등록」으로 교체 (자동 승인이라 "승인" 표기 무의미)
   // 사용자 결정 2026-05-28: 「승인 + 작은 대리 마커」 중복 → 단일 「대리 등록」 배지로 통합
   const statusBadgeHtml = d.submitted_by_admin
-    ? `<span style="background:#FEF3C7;color:#92400E;border:1px solid #FBBF24;font-size:11px;font-weight:600;padding:2px 8px;border-radius:3px" title="관리자 대리 등록·자동 승인">대리 등록</span>`
+    ? `<span style="background:#FEF3C7;color:#92400E;font-size:11px;font-weight:600;padding:2px 8px;border-radius:3px" title="관리자 대리 등록·자동 승인">대리 등록</span>`
     : delivStatusBadge(d.status);
   return `<div style="display:flex;align-items:center;gap:6px">${preview}${statusBadgeHtml}</div>`;
 }

--- a/dev/js/admin-brand.js
+++ b/dev/js/admin-brand.js
@@ -1022,17 +1022,24 @@ async function openBrandDetailModal(id) {
   bodyEl.innerHTML = '<div style="text-align:center;padding:40px;color:var(--muted)"><span class="spinner" style="width:18px;height:18px;border-width:2px;border-color:rgba(200,120,163,.2);border-top-color:var(--pink);display:inline-block;vertical-align:middle;margin-right:6px"></span>불러오는 중…</div>';
   if (footerEl) footerEl.innerHTML = '';
   modal.classList.add('open');
-  var [b, apps, companies] = await Promise.all([
+  var [b, apps, companies, campCount] = await Promise.all([
     fetchBrandById(id),
     fetchBrandApplicationsByBrand(id),
-    (typeof fetchCompanies === 'function' ? fetchCompanies({ status: 'all' }) : Promise.resolve([]))
+    (typeof fetchCompanies === 'function' ? fetchCompanies({ status: 'all' }) : Promise.resolve([])),
+    (typeof countCampaignsByBrand === 'function' ? countCampaignsByBrand(id) : Promise.resolve(0))
   ]);
   if (!b) { bodyEl.innerHTML = '<div style="text-align:center;padding:40px;color:var(--muted)">데이터를 불러올 수 없습니다</div>'; return; }
   _brandFormCompanies = companies || [];
   if (titleEl) titleEl.innerHTML = renderBrandDetailHeaderHtml(b);
   bodyEl.innerHTML = renderBrandDetailFormHtml(b, apps);
   renderBrandContactsRows();
+  // 삭제 버튼 — 연결(캠페인·신청) 0건 + campaign_admin 이상일 때만 노출. 연결 있으면 병합 기능(추후) 유도.
+  var canDeleteBrand = (apps.length === 0) && (campCount === 0)
+    && (typeof isCampaignAdminOrAbove === 'function' && isCampaignAdminOrAbove());
   if (footerEl) footerEl.innerHTML = ''
+    + (canDeleteBrand
+        ? '<button class="btn btn-ghost btn-sm" onclick="deleteBrandConfirm()" style="display:inline-flex;align-items:center;gap:4px;color:#c0392b"><span class="material-icons-round notranslate" translate="no" style="font-size:14px">delete_outline</span>삭제</button>'
+        : '')
     + '<button class="btn btn-ghost btn-sm" onclick="closeBrandDetailModal();openNewBrandAppModal(\'' + esc(id) + '\')" style="display:inline-flex;align-items:center;gap:4px;margin-right:auto"><span class="material-icons-round notranslate" translate="no" style="font-size:14px">add</span>이 브랜드로 신규 신청</button>'
     + '<button class="btn btn-ghost btn-sm" onclick="closeBrandDetailModal()">닫기</button>'
     + '<button class="btn btn-primary btn-sm" onclick="saveBrandDetail()">저장</button>';
@@ -1042,6 +1049,19 @@ function closeBrandDetailModal() {
   var modal = $('brandDetailModal');
   if (modal) modal.classList.remove('open');
   _brandsCurrentId = null;
+}
+
+// 브랜드 삭제 — 연결 0건 빈 브랜드만(서버 delete_brand RPC 가 재검증). 되돌릴 수 없음.
+async function deleteBrandConfirm() {
+  var id = _brandsCurrentId;
+  if (!id) return;
+  if (!confirm('이 브랜드를 삭제할까요?\n연결된 캠페인·신청이 없는 빈 브랜드만 삭제됩니다. 되돌릴 수 없습니다.')) return;
+  var result = await deleteBrand(id);
+  if (!result.ok) { toast('삭제 실패: ' + (result.error || '알 수 없는 오류'), 'error'); return; }
+  toast('브랜드를 삭제했습니다');
+  closeBrandDetailModal();
+  if (typeof refreshPane === 'function') { await refreshPane('brands'); }
+  else if (typeof loadBrandsPane === 'function') { await loadBrandsPane(); }
 }
 
 // 헤더 — brand_no | name | status select (드롭다운, 활성/비활성 명확히 선택)

--- a/dev/js/admin-deliverables.js
+++ b/dev/js/admin-deliverables.js
@@ -597,7 +597,9 @@ function renderDelivResultCellMonitor(g) {
         + 'onclick="event.stopPropagation();openImageLightbox(\'' + esc(d.receipt_url) + '\')">';
     }
     let badge;
-    if (d.status === 'approved')      badge = '<span style="font-size:10px;background:#E4F5E8;color:#2D7A3E;font-weight:600;padding:1px 6px;border-radius:3px">승인</span>';
+    // 마이그레이션 160: 대리 등록 행은 status 배지를 「대리 등록」으로 교체 (자동 승인이라 "승인" 표기 무의미)
+    if (d.submitted_by_admin) badge = '<span style="font-size:10px;background:#FEF3C7;color:#92400E;font-weight:600;padding:1px 6px;border-radius:3px" title="관리자 대리 등록·자동 승인">대리 등록</span>';
+    else if (d.status === 'approved') badge = '<span style="font-size:10px;background:#E4F5E8;color:#2D7A3E;font-weight:600;padding:1px 6px;border-radius:3px">승인</span>';
     else if (d.status === 'rejected') badge = '<span style="font-size:10px;background:#FFE4E4;color:#C33;font-weight:600;padding:1px 6px;border-radius:3px">비승인</span>';
     else if (d.status === 'draft')    badge = '<span style="font-size:10px;background:#e5e7eb;color:#555;font-weight:600;padding:1px 6px;border-radius:3px">임시</span>';
     else                              badge = '<span style="font-size:10px;background:#FFF4E4;color:#B8741A;font-weight:600;padding:1px 6px;border-radius:3px">검수대기</span>';
@@ -632,7 +634,7 @@ function renderDelivStatusCell(d, slot, rt) {
   // 마이그레이션 160: 대리 등록 행은 status 배지를 「대리 등록」으로 교체 (자동 승인이라 "승인" 표기 무의미)
   // 사용자 결정 2026-05-28: 「승인 + 작은 대리 마커」 중복 → 단일 「대리 등록」 배지로 통합
   const statusBadgeHtml = d.submitted_by_admin
-    ? `<span style="background:#FEF3C7;color:#92400E;border:1px solid #FBBF24;font-size:11px;font-weight:600;padding:2px 8px;border-radius:3px" title="관리자 대리 등록·자동 승인">대리 등록</span>`
+    ? `<span style="background:#FEF3C7;color:#92400E;font-size:11px;font-weight:600;padding:2px 8px;border-radius:3px" title="관리자 대리 등록·자동 승인">대리 등록</span>`
     : delivStatusBadge(d.status);
   return `<div style="display:flex;align-items:center;gap:6px">${preview}${statusBadgeHtml}</div>`;
 }

--- a/dev/lib/storage.js
+++ b/dev/lib/storage.js
@@ -2061,6 +2061,30 @@ async function deleteCompanyHard(companyId) {
   } catch(e) { console.error('[deleteCompanyHard]', e); return {ok:false, error: e?.message || 'unknown', code: e?.code}; }
 }
 
+// 브랜드 hard delete (연결 0건 한정). delete_brand RPC 경유 — brands 는 DELETE RLS 없어 직접 delete 불가.
+async function deleteBrand(brandId) {
+  if (!db) return {ok:false, error:'no_db'};
+  try {
+    const data = await retryWithRefresh(async () => {
+      const {data, error} = await db?.rpc('delete_brand', {p_brand_id: brandId});
+      if (error) throw error;
+      return data;
+    });
+    return {ok:true, data};
+  } catch(e) { console.error('[deleteBrand]', e); return {ok:false, error: e?.message || 'unknown', code: e?.code}; }
+}
+
+// 브랜드 연결 캠페인 수 — 삭제 버튼 사전 노출 판정용(신청 brand_applications 은 별도 조회).
+// 실제 삭제 차단은 delete_brand RPC 가 캠페인+신청 양쪽을 재검증하므로, 이 값이 틀려도 데이터 안전.
+async function countCampaignsByBrand(brandId) {
+  if (!db) return 0;
+  try {
+    const {count, error} = await db?.from('campaigns').select('id', {count:'exact', head:true}).eq('brand_id', brandId);
+    if (error) throw error;
+    return count || 0;
+  } catch(e) { console.error('[countCampaignsByBrand]', e); return 0; }
+}
+
 // 브랜드 할당 모달용 조회
 // unassignedOnly=true → company_id IS NULL 인 미분류 브랜드만
 // companyId 지정 시 → 현재 소속(= companyId) + 미분류 양쪽 모두 반환

--- a/docs/specs/2026-06-09-brand-delete-merge.md
+++ b/docs/specs/2026-06-09-brand-delete-merge.md
@@ -1,0 +1,65 @@
+# 브랜드 삭제 + 병합 기능
+
+**작성일:** 2026-06-09
+
+> 브랜드 관리(#brands)에 브랜드 삭제(연결 0건) + 다른 브랜드로 병합 기능 추가. 중복 등록 브랜드 정리용. (계기: BR-2026-0024 BENTON / BR-2026-0042 벤튼 중복)
+
+## 현재 상태 (검증 완료)
+- `dev/js/admin-brand.js` — 브랜드 자체 삭제/병합 **없음**(메모·담당자 삭제만). 참고: `admin-company.js` `deleteCompanyHard`(연결 0건 시 직접 delete — companies는 DELETE RLS 있음).
+- **brands는 DELETE RLS 정책 없음**(082 의도적 — soft delete=archived 방침) → 직접 `db.from('brands').delete()`는 **무음 실패**. 삭제·병합은 **SECURITY DEFINER RPC 필수**.
+- FK: `brand_applications.brand_id`→brands ON DELETE **RESTRICT** / `campaigns.brand_id`→brands ON DELETE **SET NULL** / 채번 카운터 2종 PK→brands ON DELETE **CASCADE**.
+- 채번 `B{brand_seq}-A{app}-C{camp}`. 채번 트리거는 BEFORE INSERT 전용(`campaign_no IS NOT NULL` 가드) → 브랜드 바뀌면 RPC가 직접 재채번. 기존 `link_campaign_to_application`/`unlink`(advisory_xact_lock 2단·legacy_no 누적·numbering_legacy_map) 패턴 재사용.
+- 173 트리거 `sync_campaign_brand_names()`는 brands name 변경에만 발화 — **brand_id 이동(병합)엔 미발화** → 병합 RPC가 campaigns.brand/brand_ja/brand_en 수동 동기화 필요.
+- `sync_brand_application_stats`(082): brand_applications.brand_id 변경 시 양쪽 total_applications 자동 재집계(병합 시 추가 처리 불필요).
+- brands RLS: SELECT/CUD `is_campaign_admin()` 이상. 마지막 마이그레이션 173.
+
+## 의심·경우의 수 (요약)
+1. [데이터] 신청 파생 캠페인은 신청을 먼저 옮겨야 A세그먼트 채번 정합 → **부분 병합 불가, 브랜드 통째 병합만**.
+2. [데이터] A-seq/C-seq >999 오버플로 가드(121 패턴 보유).
+3. [동시성] 병합 중 신규 INSERT → advisory_xact_lock 양쪽(uuid 작은쪽 먼저).
+4. [UX] 되돌릴 수 없는 병합 — 확인 모달에 방향(원본→대상)·옮길 캠페인 N·신청 M·번호 재발급·옛 번호 보존·복구불가 명시 의무.
+5. [권한] campaign_manager에 버튼 노출 시 권한 에러 → 버튼 `isCampaignAdminOrAbove` 숨김 + RPC 가드 이중.
+
+## 사용자 확정 결정 (2026-06-09)
+- 병합 범위: **브랜드 통째**(신청+캠페인 전부 이동·재채번)
+- 병합 후 원본: **보관 처리(archived)** — 완전 삭제 아님
+- 회사 일치: **같은 company_id만 허용** (다르면 차단)
+- 삭제 조건: **연결 0건만 hard delete**, 연결 있으면 병합 유도
+- 진행 순서: **PR 1 삭제 먼저 → PR 2 병합 나중**
+
+## 설계
+
+### PR 1 — 브랜드 삭제 (연결 0건)
+- 신규 마이그레이션 1개: `delete_brand(p_brand_id uuid)` RPC — `is_campaign_admin()` 가드 + 연결(campaigns·brand_applications) 0건 검증 후 hard delete. 0건 아니면 22023 에러(병합 안내). SECURITY DEFINER + search_path=''. 카운터 CASCADE 자동 정리.
+- `dev/lib/storage.js`: `deleteBrand(brandId)` 래퍼(RPC 호출).
+- `dev/js/admin-brand.js`: 브랜드 상세 모달에 삭제 버튼(연결 0건일 때만 노출 — 모달 열 때 campaigns count 조회 + total_applications) + 확인 모달. `isCampaignAdminOrAbove` 분기. 저장 후 `refreshPane('brands')`.
+
+### PR 2 — 브랜드 병합 (PR 1 운영 배포 후)
+- 신규 마이그레이션 1개: `merge_brands(p_source uuid, p_target uuid)` RPC — 같은 company_id 검증, advisory_xact_lock 2단, 신청→캠페인 순 brand_id 이동 + 재채번(legacy_no 누적·numbering_legacy_map) + campaigns brand/brand_ja/brand_en 동기화 + 원본 archived. jsonb 반환(moved_apps/moved_campaigns). 121 패턴 재사용.
+- 병합 모달(대상 드롭다운 + 영향 요약 N·M + 되돌리기 불가 경고). storage 래퍼.
+
+## 약관 영향
+- 브랜드명=사업자 상호(개인정보 아님). brand_applications 담당자 연락처는 이동일 뿐 수집항목·목적 무변화 → 약관 변경 불요. 운영 배포 후 /약관확인 권고.
+
+## 구현 결과 — PR 1 (브랜드 삭제, 연결 0건)
+
+**구현일:** 2026-06-09
+**브랜치:** feature/brand-delete
+
+- 마이그레이션 **174** `delete_brand_rpc.sql` — `delete_brand(p_brand_id uuid)` RPC. is_campaign_admin 가드 + 연결(campaigns·brand_applications) 0건 검증 후 hard delete. 0건 아니면 22023(병합 안내). SECURITY DEFINER + search_path=''. 카운터 CASCADE 자동.
+- `dev/lib/storage.js` — `deleteBrand(brandId)`(delete_brand RPC 래퍼, retryWithRefresh) + `countCampaignsByBrand(brandId)`(삭제 버튼 사전 판정용, 실제 차단은 RPC 재검증).
+- `dev/js/admin-brand.js` — 상세 모달 footer에 삭제 버튼(`apps.length===0 && campCount===0 && isCampaignAdminOrAbove()` 일 때만 노출) + `deleteBrandConfirm()`(confirm → deleteBrand → toast → refreshPane('brands')).
+- `shared.js` PANE_REFRESHERS 'brands'는 **이미 등록돼 있어** 추가 불필요(reviewer가 중복 지적 → 회수).
+
+### 초안 대비
+- confirm() 유지(프로젝트에 확인 모달 헬퍼 없음, 회사·메모 삭제도 confirm 패턴).
+- 권한 분기 폴백을 안전 방향(함수 미존재=false)으로 수정(reviewer Critical).
+
+### 검증
+- reverb-supabase-expert: 174 블로커 없음(search_path·가드·멱등성 통과, campaigns SET NULL race는 0건 가드로 차단).
+- reverb-reviewer GO(Critical 2건 수정 후 재GO). qa 권장 light.
+
+### PR 2 (병합) — 미착수
+- merge_brands RPC + 병합 모달. PR 1 운영 배포 후.
+
+## 구현 결과 — PR 2 (개발 세션이 채울 것)

--- a/index.html
+++ b/index.html
@@ -6092,6 +6092,30 @@ async function deleteCompanyHard(companyId) {
   } catch(e) { console.error('[deleteCompanyHard]', e); return {ok:false, error: e?.message || 'unknown', code: e?.code}; }
 }
 
+// 브랜드 hard delete (연결 0건 한정). delete_brand RPC 경유 — brands 는 DELETE RLS 없어 직접 delete 불가.
+async function deleteBrand(brandId) {
+  if (!db) return {ok:false, error:'no_db'};
+  try {
+    const data = await retryWithRefresh(async () => {
+      const {data, error} = await db?.rpc('delete_brand', {p_brand_id: brandId});
+      if (error) throw error;
+      return data;
+    });
+    return {ok:true, data};
+  } catch(e) { console.error('[deleteBrand]', e); return {ok:false, error: e?.message || 'unknown', code: e?.code}; }
+}
+
+// 브랜드 연결 캠페인 수 — 삭제 버튼 사전 노출 판정용(신청 brand_applications 은 별도 조회).
+// 실제 삭제 차단은 delete_brand RPC 가 캠페인+신청 양쪽을 재검증하므로, 이 값이 틀려도 데이터 안전.
+async function countCampaignsByBrand(brandId) {
+  if (!db) return 0;
+  try {
+    const {count, error} = await db?.from('campaigns').select('id', {count:'exact', head:true}).eq('brand_id', brandId);
+    if (error) throw error;
+    return count || 0;
+  } catch(e) { console.error('[countCampaignsByBrand]', e); return 0; }
+}
+
 // 브랜드 할당 모달용 조회
 // unassignedOnly=true → company_id IS NULL 인 미분류 브랜드만
 // companyId 지정 시 → 현재 소속(= companyId) + 미분류 양쪽 모두 반환

--- a/supabase/migrations/174_delete_brand_rpc.sql
+++ b/supabase/migrations/174_delete_brand_rpc.sql
@@ -1,0 +1,52 @@
+-- ============================================================
+-- 174: 브랜드 삭제 RPC (연결 0건 한정 hard delete)
+--
+-- brands 는 DELETE 행 단위 보안 정책(RLS)이 없어(082 — soft delete 방침)
+-- 클라이언트 직접 delete 가 무음 실패. 삭제는 본 SECURITY DEFINER RPC 경유.
+-- 연결(campaigns·brand_applications) 0건일 때만 삭제, 아니면 병합 안내 에러.
+-- 채번 카운터(brand_application_counter·brand_external_campaign_counter)는
+-- brand_id PK ON DELETE CASCADE 라 자동 정리.
+--
+-- 사양서: docs/specs/2026-06-09-brand-delete-merge.md (PR 1)
+-- 롤백: DROP FUNCTION IF EXISTS public.delete_brand(uuid);
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.delete_brand(p_brand_id uuid)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_camps  bigint;
+  v_apps   bigint;
+  v_exists boolean;
+BEGIN
+  -- 권한: campaign_admin 이상
+  IF NOT public.is_campaign_admin() THEN
+    RAISE EXCEPTION '권한이 없습니다 (campaign_admin 이상 필요)' USING ERRCODE = '42501';
+  END IF;
+
+  SELECT EXISTS(SELECT 1 FROM public.brands WHERE id = p_brand_id) INTO v_exists;
+  IF NOT v_exists THEN
+    RAISE EXCEPTION '브랜드를 찾을 수 없습니다' USING ERRCODE = '22023';
+  END IF;
+
+  SELECT count(*) INTO v_camps FROM public.campaigns          WHERE brand_id = p_brand_id;
+  SELECT count(*) INTO v_apps  FROM public.brand_applications WHERE brand_id = p_brand_id;
+
+  IF v_camps > 0 OR v_apps > 0 THEN
+    RAISE EXCEPTION '연결된 캠페인 %건, 신청 %건이 있어 삭제할 수 없습니다. 병합 기능을 사용하세요.', v_camps, v_apps
+      USING ERRCODE = '22023';
+  END IF;
+
+  DELETE FROM public.brands WHERE id = p_brand_id;
+
+  RETURN jsonb_build_object('ok', true, 'deleted', p_brand_id);
+END;
+$$;
+
+COMMENT ON FUNCTION public.delete_brand(uuid) IS
+  '브랜드 hard delete (연결 0건 한정). campaign_admin 가드. 연결 있으면 22023 + 병합 안내.';
+
+GRANT EXECUTE ON FUNCTION public.delete_brand(uuid) TO authenticated;


### PR DESCRIPTION
## 변경 요약
- 브랜드 관리에 삭제 기능 추가(연결된 캠페인·신청이 0건인 빈 브랜드만). 중복 등록 정리용.
- brands는 삭제 권한 정책이 없어 전용 함수(delete_brand RPC) 경유. 연결 있으면 차단 + 병합 안내.

## DB 변경 (⚠️ 코드 배포 전 개발 DB 적용)
- 마이그레이션 174 (delete_brand RPC)

## 관련 사양서
- docs/specs/2026-06-09-brand-delete-merge.md (PR 1 / PR 2 병합은 후속)

## 검증
- supabase-expert 174 통과 / reviewer GO / 빌드 통과 / qa 권장 light

🤖 Generated with [Claude Code](https://claude.com/claude-code)