### PR TITLE
feat(brand): 브랜드 병합 (캠페인·신청 이동 + 채번 재발급)

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -12,7 +12,7 @@
 // 회귀(2026-05-12 PR #182 머지 직후 발생)를 방지하기 위한 자동 reload 가드.
 // sessionStorage 차단 환경(시크릿 모드 일부, 쿠키 차단)에서는 자연스럽게 skip.
 (function(){
-  var CURRENT_BUILD = 'v1780971114';
+  var CURRENT_BUILD = 'v1780973694';
   if (CURRENT_BUILD.indexOf('__') === 0) return; // 빌드 미적용 (dev/ 직접 열기) 시 skip
   try {
     var prev = sessionStorage.getItem('reverb.adminBuild');
@@ -2002,7 +2002,7 @@ textarea.form-input{resize:vertical;min-height:80px}
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-06-09 11:11 · 4d32958</span>
+          <span class="admin-build-text">2026-06-09 11:54 · 26243d4</span>
         </div>
       </div>
     </aside>
@@ -7881,6 +7881,19 @@ async function deleteBrand(brandId) {
   } catch(e) { console.error('[deleteBrand]', e); return {ok:false, error: e?.message || 'unknown', code: e?.code}; }
 }
 
+// 브랜드 병합 — source 신청·캠페인을 target 으로 이동 + 채번 재발급, 원본 archived. merge_brands RPC.
+async function mergeBrands(sourceId, targetId) {
+  if (!db) return {ok:false, error:'no_db'};
+  try {
+    const data = await retryWithRefresh(async () => {
+      const {data, error} = await db?.rpc('merge_brands', {p_source: sourceId, p_target: targetId});
+      if (error) throw error;
+      return data;
+    });
+    return {ok:true, data};
+  } catch(e) { console.error('[mergeBrands]', e); return {ok:false, error: e?.message || 'unknown', code: e?.code}; }
+}
+
 // 브랜드별 캠페인 수 일괄 집계 — 브랜드 목록 「캠페인 수」 컬럼용. {brand_id: count} 반환.
 // 1000행 캡 대응 range loop (대시보드 집계 패턴).
 async function fetchCampaignCountsByBrand() {
@@ -11667,12 +11680,15 @@ async function openBrandDetailModal(id) {
   if (titleEl) titleEl.innerHTML = renderBrandDetailHeaderHtml(b);
   bodyEl.innerHTML = renderBrandDetailFormHtml(b, apps);
   renderBrandContactsRows();
-  // 삭제 버튼 — 연결(캠페인·신청) 0건 + campaign_admin 이상일 때만 노출. 연결 있으면 병합 기능(추후) 유도.
-  var canDeleteBrand = (apps.length === 0) && (campCount === 0)
-    && (typeof isCampaignAdminOrAbove === 'function' && isCampaignAdminOrAbove());
+  // 삭제(연결 0건만)·병합(연결 유무 무관) 버튼 — campaign_admin 이상만.
+  var isAdm = (typeof isCampaignAdminOrAbove === 'function' && isCampaignAdminOrAbove());
+  var canDeleteBrand = (apps.length === 0) && (campCount === 0) && isAdm;
   if (footerEl) footerEl.innerHTML = ''
     + (canDeleteBrand
         ? '<button class="btn btn-ghost btn-sm" onclick="deleteBrandConfirm()" style="display:inline-flex;align-items:center;gap:4px;color:#c0392b"><span class="material-icons-round notranslate" translate="no" style="font-size:14px">delete_outline</span>삭제</button>'
+        : '')
+    + (isAdm
+        ? '<button class="btn btn-ghost btn-sm" onclick="openBrandMergeModal(\'' + esc(id) + '\')" style="display:inline-flex;align-items:center;gap:4px;color:#c0392b"><span class="material-icons-round notranslate" translate="no" style="font-size:14px">merge</span>병합</button>'
         : '')
     + '<button class="btn btn-ghost btn-sm" onclick="closeBrandDetailModal();openNewBrandAppModal(\'' + esc(id) + '\')" style="display:inline-flex;align-items:center;gap:4px;margin-right:auto"><span class="material-icons-round notranslate" translate="no" style="font-size:14px">add</span>이 브랜드로 신규 신청</button>'
     + '<button class="btn btn-ghost btn-sm" onclick="closeBrandDetailModal()">닫기</button>'
@@ -11693,6 +11709,54 @@ async function deleteBrandConfirm() {
   var result = await deleteBrand(id);
   if (!result.ok) { toast('삭제 실패: ' + (result.error || '알 수 없는 오류'), 'error'); return; }
   toast('브랜드를 삭제했습니다');
+  closeBrandDetailModal();
+  if (typeof refreshPane === 'function') { await refreshPane('brands'); }
+  else if (typeof loadBrandsPane === 'function') { await loadBrandsPane(); }
+}
+
+// 브랜드 병합 모달 — 같은 회사 다른 활성 브랜드로 source 의 캠페인·신청 이동(채번 재발급). 원본 보관.
+async function openBrandMergeModal(sourceId) {
+  var src = (_brandsCache || []).find(function(b){ return b.id === sourceId; });
+  if (!src) return;
+  // 회사 미지정 브랜드는 병합 금지 (무관 브랜드 오병합 방지 — 서버 merge_brands 도 동일 가드)
+  if (!src.company_id) { toast('회사가 지정되지 않은 브랜드는 병합할 수 없습니다. 먼저 「회사」를 연결하세요.', 'warn'); return; }
+  var campCount = (typeof countCampaignsByBrand === 'function') ? await countCampaignsByBrand(sourceId) : 0;
+  var apps = (typeof fetchBrandApplicationsByBrand === 'function') ? (await fetchBrandApplicationsByBrand(sourceId) || []) : [];
+  var targets = (_brandsCache || []).filter(function(b){
+    return b.id !== sourceId && b.status === 'active' && b.company_id && b.company_id === src.company_id;
+  });
+  if (!targets.length) { toast('같은 회사에 병합할 다른 활성 브랜드가 없습니다', 'warn'); return; }
+  var opts = targets.map(function(b){
+    return '<option value="' + esc(b.id) + '">' + esc(b.name || b.brand_no || '브랜드') + (b.name_ja ? ' (' + esc(b.name_ja) + ')' : '') + ' · ' + esc(b.brand_no || '') + '</option>';
+  }).join('');
+  var ov = document.createElement('div');
+  ov.id = 'brandMergeOverlay';
+  ov.style.cssText = 'position:fixed;inset:0;background:rgba(0,0,0,.45);z-index:700;display:flex;align-items:center;justify-content:center';
+  ov.innerHTML = '<div style="background:#fff;border-radius:12px;width:480px;max-width:92vw;padding:24px;box-shadow:0 12px 48px rgba(0,0,0,.25)">'
+    + '<h3 style="margin:0 0 8px;font-size:16px;font-weight:700;color:var(--ink)">브랜드 병합</h3>'
+    + '<p style="margin:0 0 16px;font-size:12px;color:var(--muted);line-height:1.6">원본 「' + esc(src.name || src.brand_no || '') + '」의 <b>캠페인 ' + campCount + '건·신청 ' + apps.length + '건</b>을 아래 브랜드로 옮기고, 원본은 보관 처리합니다.<br>캠페인·신청 번호는 재발급되며(옛 번호는 보존) <b style="color:#c0392b">되돌릴 수 없습니다.</b></p>'
+    + '<label style="font-size:12px;font-weight:600;color:var(--ink);display:block;margin-bottom:6px">병합 대상 브랜드 (같은 회사)</label>'
+    + '<select id="brandMergeTarget" style="width:100%;padding:9px;border:1px solid var(--line);border-radius:8px;font-size:14px;margin-bottom:20px">' + opts + '</select>'
+    + '<div style="display:flex;justify-content:flex-end;gap:8px">'
+      + '<button class="btn btn-ghost btn-sm" onclick="closeBrandMergeModal()">취소</button>'
+      + '<button class="btn btn-primary btn-sm" style="background:#c0392b" onclick="doBrandMerge(\'' + esc(sourceId) + '\')">병합 실행</button>'
+    + '</div></div>';
+  document.body.appendChild(ov);
+}
+function closeBrandMergeModal() {
+  var ov = $('brandMergeOverlay');
+  if (ov) ov.remove();
+}
+async function doBrandMerge(sourceId) {
+  var sel = $('brandMergeTarget');
+  var targetId = sel ? sel.value : '';
+  if (!targetId) { toast('대상 브랜드를 선택하세요', 'warn'); return; }
+  if (!confirm('정말 병합할까요?\n캠페인·신청 번호가 재발급되며 되돌릴 수 없습니다.')) return;
+  var result = await mergeBrands(sourceId, targetId);
+  if (!result.ok) { toast('병합 실패: ' + (result.error || '알 수 없는 오류'), 'error'); return; }
+  var d = result.data || {};
+  toast('병합 완료 — 캠페인 ' + (d.moved_campaigns || 0) + '건·신청 ' + (d.moved_apps || 0) + '건 이동');
+  closeBrandMergeModal();
   closeBrandDetailModal();
   if (typeof refreshPane === 'function') { await refreshPane('brands'); }
   else if (typeof loadBrandsPane === 'function') { await loadBrandsPane(); }

--- a/dev/js/admin-brand.js
+++ b/dev/js/admin-brand.js
@@ -1036,12 +1036,15 @@ async function openBrandDetailModal(id) {
   if (titleEl) titleEl.innerHTML = renderBrandDetailHeaderHtml(b);
   bodyEl.innerHTML = renderBrandDetailFormHtml(b, apps);
   renderBrandContactsRows();
-  // 삭제 버튼 — 연결(캠페인·신청) 0건 + campaign_admin 이상일 때만 노출. 연결 있으면 병합 기능(추후) 유도.
-  var canDeleteBrand = (apps.length === 0) && (campCount === 0)
-    && (typeof isCampaignAdminOrAbove === 'function' && isCampaignAdminOrAbove());
+  // 삭제(연결 0건만)·병합(연결 유무 무관) 버튼 — campaign_admin 이상만.
+  var isAdm = (typeof isCampaignAdminOrAbove === 'function' && isCampaignAdminOrAbove());
+  var canDeleteBrand = (apps.length === 0) && (campCount === 0) && isAdm;
   if (footerEl) footerEl.innerHTML = ''
     + (canDeleteBrand
         ? '<button class="btn btn-ghost btn-sm" onclick="deleteBrandConfirm()" style="display:inline-flex;align-items:center;gap:4px;color:#c0392b"><span class="material-icons-round notranslate" translate="no" style="font-size:14px">delete_outline</span>삭제</button>'
+        : '')
+    + (isAdm
+        ? '<button class="btn btn-ghost btn-sm" onclick="openBrandMergeModal(\'' + esc(id) + '\')" style="display:inline-flex;align-items:center;gap:4px;color:#c0392b"><span class="material-icons-round notranslate" translate="no" style="font-size:14px">merge</span>병합</button>'
         : '')
     + '<button class="btn btn-ghost btn-sm" onclick="closeBrandDetailModal();openNewBrandAppModal(\'' + esc(id) + '\')" style="display:inline-flex;align-items:center;gap:4px;margin-right:auto"><span class="material-icons-round notranslate" translate="no" style="font-size:14px">add</span>이 브랜드로 신규 신청</button>'
     + '<button class="btn btn-ghost btn-sm" onclick="closeBrandDetailModal()">닫기</button>'
@@ -1062,6 +1065,54 @@ async function deleteBrandConfirm() {
   var result = await deleteBrand(id);
   if (!result.ok) { toast('삭제 실패: ' + (result.error || '알 수 없는 오류'), 'error'); return; }
   toast('브랜드를 삭제했습니다');
+  closeBrandDetailModal();
+  if (typeof refreshPane === 'function') { await refreshPane('brands'); }
+  else if (typeof loadBrandsPane === 'function') { await loadBrandsPane(); }
+}
+
+// 브랜드 병합 모달 — 같은 회사 다른 활성 브랜드로 source 의 캠페인·신청 이동(채번 재발급). 원본 보관.
+async function openBrandMergeModal(sourceId) {
+  var src = (_brandsCache || []).find(function(b){ return b.id === sourceId; });
+  if (!src) return;
+  // 회사 미지정 브랜드는 병합 금지 (무관 브랜드 오병합 방지 — 서버 merge_brands 도 동일 가드)
+  if (!src.company_id) { toast('회사가 지정되지 않은 브랜드는 병합할 수 없습니다. 먼저 「회사」를 연결하세요.', 'warn'); return; }
+  var campCount = (typeof countCampaignsByBrand === 'function') ? await countCampaignsByBrand(sourceId) : 0;
+  var apps = (typeof fetchBrandApplicationsByBrand === 'function') ? (await fetchBrandApplicationsByBrand(sourceId) || []) : [];
+  var targets = (_brandsCache || []).filter(function(b){
+    return b.id !== sourceId && b.status === 'active' && b.company_id && b.company_id === src.company_id;
+  });
+  if (!targets.length) { toast('같은 회사에 병합할 다른 활성 브랜드가 없습니다', 'warn'); return; }
+  var opts = targets.map(function(b){
+    return '<option value="' + esc(b.id) + '">' + esc(b.name || b.brand_no || '브랜드') + (b.name_ja ? ' (' + esc(b.name_ja) + ')' : '') + ' · ' + esc(b.brand_no || '') + '</option>';
+  }).join('');
+  var ov = document.createElement('div');
+  ov.id = 'brandMergeOverlay';
+  ov.style.cssText = 'position:fixed;inset:0;background:rgba(0,0,0,.45);z-index:700;display:flex;align-items:center;justify-content:center';
+  ov.innerHTML = '<div style="background:#fff;border-radius:12px;width:480px;max-width:92vw;padding:24px;box-shadow:0 12px 48px rgba(0,0,0,.25)">'
+    + '<h3 style="margin:0 0 8px;font-size:16px;font-weight:700;color:var(--ink)">브랜드 병합</h3>'
+    + '<p style="margin:0 0 16px;font-size:12px;color:var(--muted);line-height:1.6">원본 「' + esc(src.name || src.brand_no || '') + '」의 <b>캠페인 ' + campCount + '건·신청 ' + apps.length + '건</b>을 아래 브랜드로 옮기고, 원본은 보관 처리합니다.<br>캠페인·신청 번호는 재발급되며(옛 번호는 보존) <b style="color:#c0392b">되돌릴 수 없습니다.</b></p>'
+    + '<label style="font-size:12px;font-weight:600;color:var(--ink);display:block;margin-bottom:6px">병합 대상 브랜드 (같은 회사)</label>'
+    + '<select id="brandMergeTarget" style="width:100%;padding:9px;border:1px solid var(--line);border-radius:8px;font-size:14px;margin-bottom:20px">' + opts + '</select>'
+    + '<div style="display:flex;justify-content:flex-end;gap:8px">'
+      + '<button class="btn btn-ghost btn-sm" onclick="closeBrandMergeModal()">취소</button>'
+      + '<button class="btn btn-primary btn-sm" style="background:#c0392b" onclick="doBrandMerge(\'' + esc(sourceId) + '\')">병합 실행</button>'
+    + '</div></div>';
+  document.body.appendChild(ov);
+}
+function closeBrandMergeModal() {
+  var ov = $('brandMergeOverlay');
+  if (ov) ov.remove();
+}
+async function doBrandMerge(sourceId) {
+  var sel = $('brandMergeTarget');
+  var targetId = sel ? sel.value : '';
+  if (!targetId) { toast('대상 브랜드를 선택하세요', 'warn'); return; }
+  if (!confirm('정말 병합할까요?\n캠페인·신청 번호가 재발급되며 되돌릴 수 없습니다.')) return;
+  var result = await mergeBrands(sourceId, targetId);
+  if (!result.ok) { toast('병합 실패: ' + (result.error || '알 수 없는 오류'), 'error'); return; }
+  var d = result.data || {};
+  toast('병합 완료 — 캠페인 ' + (d.moved_campaigns || 0) + '건·신청 ' + (d.moved_apps || 0) + '건 이동');
+  closeBrandMergeModal();
   closeBrandDetailModal();
   if (typeof refreshPane === 'function') { await refreshPane('brands'); }
   else if (typeof loadBrandsPane === 'function') { await loadBrandsPane(); }

--- a/dev/lib/storage.js
+++ b/dev/lib/storage.js
@@ -2074,6 +2074,19 @@ async function deleteBrand(brandId) {
   } catch(e) { console.error('[deleteBrand]', e); return {ok:false, error: e?.message || 'unknown', code: e?.code}; }
 }
 
+// 브랜드 병합 — source 신청·캠페인을 target 으로 이동 + 채번 재발급, 원본 archived. merge_brands RPC.
+async function mergeBrands(sourceId, targetId) {
+  if (!db) return {ok:false, error:'no_db'};
+  try {
+    const data = await retryWithRefresh(async () => {
+      const {data, error} = await db?.rpc('merge_brands', {p_source: sourceId, p_target: targetId});
+      if (error) throw error;
+      return data;
+    });
+    return {ok:true, data};
+  } catch(e) { console.error('[mergeBrands]', e); return {ok:false, error: e?.message || 'unknown', code: e?.code}; }
+}
+
 // 브랜드별 캠페인 수 일괄 집계 — 브랜드 목록 「캠페인 수」 컬럼용. {brand_id: count} 반환.
 // 1000행 캡 대응 range loop (대시보드 집계 패턴).
 async function fetchCampaignCountsByBrand() {

--- a/docs/specs/2026-06-09-brand-delete-merge.md
+++ b/docs/specs/2026-06-09-brand-delete-merge.md
@@ -62,4 +62,25 @@
 ### PR 2 (병합) — 미착수
 - merge_brands RPC + 병합 모달. PR 1 운영 배포 후.
 
-## 구현 결과 — PR 2 (개발 세션이 채울 것)
+## 구현 결과 — PR 2 (브랜드 병합)
+
+**구현일:** 2026-06-09
+**브랜치:** feature/brand-merge
+
+- 마이그레이션 **175** `merge_brands_rpc.sql` — `merge_brands(p_source, p_target)` RPC. 121 채번 패턴(`_accumulate_legacy_no`·`numbering_legacy_map` UPSERT·counter ON CONFLICT) 차용. 이동 순서 ①신청(A-seq 재발급) →②신청 파생 캠페인(C-seq) →③외부 캠페인(외부 C-seq) →④campaigns brand/brand_ja/brand_en 동기화(173 보완) →⑤원본 archived. advisory_xact_lock 2단·FOR UPDATE·멱등성. **같은 company_id 강제 + 둘 다 회사 지정 필수**(null 끼리 무관 브랜드 오병합 방지 — reviewer/expert 지적 반영). is_campaign_admin 가드. BEGIN/COMMIT 트랜잭션 래퍼.
+- `dev/lib/storage.js` — `mergeBrands(sourceId, targetId)` RPC 래퍼.
+- `dev/js/admin-brand.js` — 상세 모달 footer 병합 버튼(campaign_admin이면 연결 유무 무관 노출) + `openBrandMergeModal`(같은 회사 active 브랜드 대상 드롭다운 + 영향 캠페인·신청 수 + 되돌리기 불가 경고, 회사 미지정 source 차단) + `doBrandMerge`(confirm → mergeBrands → toast(이동 건수) → refreshPane).
+
+### 검증
+- reverb-supabase-expert 독립 재검증: 채번 정합·numbering_legacy_map·이동순서·보안·RAISE %·트리거 무관·sync_brand_application_stats 모두 통과. 경고: ①레거시 application_no(JFUN-...) 있으면 22023 롤백 → **운영/개발 적용 전 사전점검 SQL 필수** ②company_id null 가드(반영 완료) ③source 카운터 잔존(무해).
+- reverb-reviewer GO. confirm() 유지(기존 패턴).
+- ⚠️ DB 함수라 개발 DB 적용 후 **실제 병합 스모크 1회 검증 필수**(메모리 feedback_db_function_smoke_test).
+
+### 사전점검 SQL (병합 전 실행)
+```sql
+SELECT count(*) FROM public.brand_applications WHERE application_no NOT SIMILAR TO 'B[0-9]{4}-A[0-9]{3}';
+-- 0 이어야 안전. 1+ 면 레거시 번호 신청 — 병합 시 22023 롤백되므로 먼저 정리.
+```
+
+### 후속
+- CLAUDE.md 브랜드 관리 섹션에 삭제·병합 한 줄 추가(운영 배포 시).

--- a/index.html
+++ b/index.html
@@ -6105,6 +6105,19 @@ async function deleteBrand(brandId) {
   } catch(e) { console.error('[deleteBrand]', e); return {ok:false, error: e?.message || 'unknown', code: e?.code}; }
 }
 
+// 브랜드 병합 — source 신청·캠페인을 target 으로 이동 + 채번 재발급, 원본 archived. merge_brands RPC.
+async function mergeBrands(sourceId, targetId) {
+  if (!db) return {ok:false, error:'no_db'};
+  try {
+    const data = await retryWithRefresh(async () => {
+      const {data, error} = await db?.rpc('merge_brands', {p_source: sourceId, p_target: targetId});
+      if (error) throw error;
+      return data;
+    });
+    return {ok:true, data};
+  } catch(e) { console.error('[mergeBrands]', e); return {ok:false, error: e?.message || 'unknown', code: e?.code}; }
+}
+
 // 브랜드별 캠페인 수 일괄 집계 — 브랜드 목록 「캠페인 수」 컬럼용. {brand_id: count} 반환.
 // 1000행 캡 대응 range loop (대시보드 집계 패턴).
 async function fetchCampaignCountsByBrand() {

--- a/supabase/migrations/175_merge_brands_rpc.sql
+++ b/supabase/migrations/175_merge_brands_rpc.sql
@@ -1,0 +1,255 @@
+-- ============================================================
+-- 175: 브랜드 병합 RPC (merge_brands)
+--
+-- 원본 브랜드(p_source)의 신청·캠페인을 정식 브랜드(p_target)로 이동하고
+-- 채번을 p_target 기준으로 재발급(옛 번호 legacy_no 보존), 원본은 archived 처리.
+-- 121 link_campaign_to_application 의 재채번 패턴(_accumulate_legacy_no +
+-- numbering_legacy_map UPSERT + counter ON CONFLICT) 을 그대로 차용.
+--
+-- 이동 순서(채번 정합 필수):
+--   ① source 신청 → p_target.brand_id + A-seq 재발급
+--   ② ① 신청 파생 캠페인 → p_target.brand_id + C-seq 재발급 (B{t}-A{app}-C{new})
+--   ③ source 외부 캠페인(source_application_id NULL) → p_target + 외부 C-seq (B{t}-C{new})
+--   ④ 이동 campaigns.brand/brand_ja/brand_en → p_target 마스터값 (173 트리거 보완)
+--   ⑤ p_source.status='archived'
+--
+-- 사양서: docs/specs/2026-06-09-brand-delete-merge.md (PR 2)
+-- 의존: 088~090(채번), 121(_accumulate_legacy_no), 172·173(brand_ja/en), 174(delete_brand)
+-- 롤백: DROP FUNCTION IF EXISTS public.merge_brands(uuid, uuid);
+--   (※ 이미 실행된 병합은 함수 제거로 복원 안 됨 — 사전 스냅샷 필요)
+-- ============================================================
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.merge_brands(
+  p_source uuid,
+  p_target uuid
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_source        record;
+  v_target        record;
+
+  v_app           record;
+  v_old_app_no    text;
+  v_new_app_seq   integer;
+  v_new_app_no    text;
+
+  v_camp          record;
+  v_old_camp_no   text;
+  v_new_camp_no   text;
+  v_app_seq_parsed integer;
+  v_new_camp_seq  integer;
+  v_new_ext_seq   integer;
+  v_new_app_no_for_camp text;
+
+  v_moved_apps      integer := 0;
+  v_moved_campaigns integer := 0;
+BEGIN
+  -- 0. 권한 + 입력 검증
+  IF NOT public.is_campaign_admin() THEN
+    RAISE EXCEPTION '권한이 없습니다 (campaign_admin 이상 필요)' USING ERRCODE = '42501';
+  END IF;
+  IF p_source IS NULL OR p_target IS NULL THEN
+    RAISE EXCEPTION 'source_id 와 target_id 가 모두 필요합니다' USING ERRCODE = '22023';
+  END IF;
+  IF p_source = p_target THEN
+    RAISE EXCEPTION '원본과 대상이 같은 브랜드입니다' USING ERRCODE = '22023';
+  END IF;
+
+  -- 1. 잠금 2단 (uuid 작은 쪽 먼저 — 데드락 회피)
+  IF p_source < p_target THEN
+    PERFORM pg_advisory_xact_lock(hashtext(p_source::text)::bigint);
+    PERFORM pg_advisory_xact_lock(hashtext(p_target::text)::bigint);
+  ELSE
+    PERFORM pg_advisory_xact_lock(hashtext(p_target::text)::bigint);
+    PERFORM pg_advisory_xact_lock(hashtext(p_source::text)::bigint);
+  END IF;
+
+  -- 2. 브랜드 행 조회 (FOR UPDATE)
+  SELECT id, name, name_ja, name_en, company_id, brand_seq, status
+    INTO v_source FROM public.brands WHERE id = p_source FOR UPDATE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION '원본 브랜드를 찾을 수 없습니다: %', p_source USING ERRCODE = '22023';
+  END IF;
+
+  SELECT id, name, name_ja, name_en, company_id, brand_seq, status
+    INTO v_target FROM public.brands WHERE id = p_target FOR UPDATE;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION '대상 브랜드를 찾을 수 없습니다: %', p_target USING ERRCODE = '22023';
+  END IF;
+
+  -- 3. 회사 검증 — 둘 다 회사 지정돼 있고 같아야 함.
+  --    (회사 미지정 null 끼리는 "무관 브랜드"일 수 있어 병합 금지 — 회사 먼저 연결 유도)
+  IF v_source.company_id IS NULL OR v_target.company_id IS NULL THEN
+    RAISE EXCEPTION '회사가 지정되지 않은 브랜드는 병합할 수 없습니다. 먼저 회사를 연결하세요.'
+      USING ERRCODE = '22023';
+  END IF;
+  IF v_source.company_id IS DISTINCT FROM v_target.company_id THEN
+    RAISE EXCEPTION '원본과 대상의 소속 회사가 다릅니다 (company_id: % ≠ %)',
+      v_source.company_id::text, v_target.company_id::text
+      USING ERRCODE = '22023';
+  END IF;
+
+  -- 4. 멱등성 — source 이미 archived + 연결 0건이면 no-op
+  IF v_source.status = 'archived'
+     AND NOT EXISTS (SELECT 1 FROM public.brand_applications WHERE brand_id = p_source)
+     AND NOT EXISTS (SELECT 1 FROM public.campaigns          WHERE brand_id = p_source)
+  THEN
+    RETURN jsonb_build_object(
+      'source_id', p_source, 'target_id', p_target,
+      'moved_apps', 0, 'moved_campaigns', 0,
+      'source_archived', true, 'unchanged', true);
+  END IF;
+
+  -- 5. ① 신청 이동 + A-seq 재발급 (sync_brand_application_stats 트리거가 양쪽 집계 자동)
+  FOR v_app IN
+    SELECT id, application_no, legacy_no
+      FROM public.brand_applications
+     WHERE brand_id = p_source
+     ORDER BY created_at
+  LOOP
+    v_old_app_no := v_app.application_no;
+
+    INSERT INTO public.brand_application_counter (brand_id, last_seq)
+    VALUES (p_target, 1)
+    ON CONFLICT (brand_id)
+    DO UPDATE SET last_seq = public.brand_application_counter.last_seq + 1
+    RETURNING last_seq INTO v_new_app_seq;
+
+    IF v_new_app_seq > 999 THEN
+      RAISE EXCEPTION 'A-seq 오버플로 (>999): target brand_id=%', p_target USING ERRCODE = '22003';
+    END IF;
+
+    v_new_app_no := 'B' || lpad(v_target.brand_seq::text, 4, '0')
+                 || '-A' || lpad(v_new_app_seq::text, 3, '0');
+
+    UPDATE public.brand_applications
+       SET brand_id = p_target,
+           application_no = v_new_app_no,
+           legacy_no = public._accumulate_legacy_no(v_app.legacy_no, v_old_app_no)
+     WHERE id = v_app.id;
+
+    INSERT INTO public.numbering_legacy_map (entity_type, entity_id, legacy_no, new_no, migrated_at)
+    VALUES ('brand_application', v_app.id, COALESCE(v_app.legacy_no, v_old_app_no), v_new_app_no, now())
+    ON CONFLICT (entity_type, entity_id)
+    DO UPDATE SET new_no = EXCLUDED.new_no, migrated_at = now();
+
+    v_moved_apps := v_moved_apps + 1;
+  END LOOP;
+
+  -- 6. ② 신청 파생 캠페인 이동 + 재채번 (①로 신청 brand_id 이미 p_target)
+  FOR v_camp IN
+    SELECT c.id, c.campaign_no, c.legacy_no, c.source_application_id
+      FROM public.campaigns c
+      JOIN public.brand_applications ba ON ba.id = c.source_application_id
+     WHERE ba.brand_id = p_target
+       AND c.brand_id  = p_source
+     ORDER BY c.created_at
+  LOOP
+    v_old_camp_no := v_camp.campaign_no;
+
+    SELECT application_no INTO v_new_app_no_for_camp
+      FROM public.brand_applications WHERE id = v_camp.source_application_id;
+
+    IF v_new_app_no_for_camp SIMILAR TO 'B[0-9]{4}-A[0-9]{3}' THEN
+      v_app_seq_parsed := split_part(v_new_app_no_for_camp, '-A', 2)::integer;
+    ELSE
+      RAISE EXCEPTION '신청번호 형식이 예상과 다릅니다: % (기대값 B####-A###)', v_new_app_no_for_camp
+        USING ERRCODE = '22023';
+    END IF;
+
+    INSERT INTO public.application_campaign_counter (application_id, last_seq)
+    VALUES (v_camp.source_application_id, 1)
+    ON CONFLICT (application_id)
+    DO UPDATE SET last_seq = public.application_campaign_counter.last_seq + 1
+    RETURNING last_seq INTO v_new_camp_seq;
+
+    IF v_new_camp_seq > 999 THEN
+      RAISE EXCEPTION 'C-seq 오버플로 (>999): application_id=%', v_camp.source_application_id USING ERRCODE = '22003';
+    END IF;
+
+    v_new_camp_no := 'B' || lpad(v_target.brand_seq::text, 4, '0')
+                  || '-A' || lpad(v_app_seq_parsed::text, 3, '0')
+                  || '-C' || lpad(v_new_camp_seq::text, 3, '0');
+
+    UPDATE public.campaigns
+       SET brand_id = p_target,
+           campaign_no = v_new_camp_no,
+           legacy_no = public._accumulate_legacy_no(v_camp.legacy_no, v_old_camp_no),
+           updated_at = now()
+     WHERE id = v_camp.id;
+
+    INSERT INTO public.numbering_legacy_map (entity_type, entity_id, legacy_no, new_no, migrated_at)
+    VALUES ('campaign', v_camp.id, COALESCE(v_camp.legacy_no, v_old_camp_no), v_new_camp_no, now())
+    ON CONFLICT (entity_type, entity_id)
+    DO UPDATE SET new_no = EXCLUDED.new_no, migrated_at = now();
+
+    v_moved_campaigns := v_moved_campaigns + 1;
+  END LOOP;
+
+  -- 7. ③ 외부 캠페인(source_application_id NULL) 이동 + 재채번
+  FOR v_camp IN
+    SELECT id, campaign_no, legacy_no
+      FROM public.campaigns
+     WHERE brand_id = p_source AND source_application_id IS NULL
+     ORDER BY created_at
+  LOOP
+    v_old_camp_no := v_camp.campaign_no;
+
+    INSERT INTO public.brand_external_campaign_counter (brand_id, last_seq)
+    VALUES (p_target, 1)
+    ON CONFLICT (brand_id)
+    DO UPDATE SET last_seq = public.brand_external_campaign_counter.last_seq + 1
+    RETURNING last_seq INTO v_new_ext_seq;
+
+    IF v_new_ext_seq > 999 THEN
+      RAISE EXCEPTION '외부 C-seq 오버플로 (>999): target brand_id=%', p_target USING ERRCODE = '22003';
+    END IF;
+
+    v_new_camp_no := 'B' || lpad(v_target.brand_seq::text, 4, '0')
+                  || '-C' || lpad(v_new_ext_seq::text, 3, '0');
+
+    UPDATE public.campaigns
+       SET brand_id = p_target,
+           campaign_no = v_new_camp_no,
+           legacy_no = public._accumulate_legacy_no(v_camp.legacy_no, v_old_camp_no),
+           updated_at = now()
+     WHERE id = v_camp.id;
+
+    INSERT INTO public.numbering_legacy_map (entity_type, entity_id, legacy_no, new_no, migrated_at)
+    VALUES ('campaign', v_camp.id, COALESCE(v_camp.legacy_no, v_old_camp_no), v_new_camp_no, now())
+    ON CONFLICT (entity_type, entity_id)
+    DO UPDATE SET new_no = EXCLUDED.new_no, migrated_at = now();
+
+    v_moved_campaigns := v_moved_campaigns + 1;
+  END LOOP;
+
+  -- 8. ④ 이동된(+기존) target 캠페인 비정규화 컬럼 동기화 (173 트리거 보완)
+  UPDATE public.campaigns
+     SET brand = v_target.name, brand_ja = v_target.name_ja, brand_en = v_target.name_en,
+         updated_at = now()
+   WHERE brand_id = p_target;
+
+  -- 9. ⑤ 원본 보관 처리
+  UPDATE public.brands SET status = 'archived' WHERE id = p_source;
+
+  RETURN jsonb_build_object(
+    'source_id', p_source, 'target_id', p_target,
+    'moved_apps', v_moved_apps, 'moved_campaigns', v_moved_campaigns,
+    'source_archived', true, 'unchanged', false);
+END;
+$$;
+
+COMMENT ON FUNCTION public.merge_brands(uuid, uuid) IS
+  '[175] 브랜드 병합. source 신청·캠페인을 target 으로 이동 + 채번 재발급(legacy_no 보존). 같은 company_id 강제. is_campaign_admin 가드. 121 패턴 재사용. 원본 archived.';
+
+REVOKE ALL ON FUNCTION public.merge_brands(uuid, uuid) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.merge_brands(uuid, uuid) FROM anon;
+GRANT EXECUTE ON FUNCTION public.merge_brands(uuid, uuid) TO authenticated;
+
+COMMIT;


### PR DESCRIPTION
## 변경 요약
- 연결(캠페인·신청)이 있는 중복 브랜드를 같은 회사 정식 브랜드로 병합. 캠페인·신청을 이동하고 번호 재발급(옛 번호 보존), 원본은 보관 처리.
- 같은 회사만·회사 지정 필수. is_campaign_admin.

## DB 변경 (⚠️ 코드 배포 전 개발 DB 적용 + 사전점검)
- 마이그레이션 175 (merge_brands RPC). 적용 전 사전점검: 레거시 application_no 0건 확인.

## 관련 사양서
- docs/specs/2026-06-09-brand-delete-merge.md (PR 2)

## 검증
- supabase-expert 독립 재검증 통과 / reviewer GO / 빌드 통과 / qa 권장 light. ⚠️개발 DB 적용 후 실제 병합 스모크 필요

🤖 Generated with [Claude Code](https://claude.com/claude-code)