### PR TITLE
feat(brand): 회사 무관 브랜드 병합 허용

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -12,7 +12,7 @@
 // 회귀(2026-05-12 PR #182 머지 직후 발생)를 방지하기 위한 자동 reload 가드.
 // sessionStorage 차단 환경(시크릿 모드 일부, 쿠키 차단)에서는 자연스럽게 skip.
 (function(){
-  var CURRENT_BUILD = 'v1780975793';
+  var CURRENT_BUILD = 'v1780976230';
   if (CURRENT_BUILD.indexOf('__') === 0) return; // 빌드 미적용 (dev/ 직접 열기) 시 skip
   try {
     var prev = sessionStorage.getItem('reverb.adminBuild');
@@ -2002,7 +2002,7 @@ textarea.form-input{resize:vertical;min-height:80px}
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-06-09 12:29 · 3b3c6fb</span>
+          <span class="admin-build-text">2026-06-09 12:37 · f3feb0e</span>
         </div>
       </div>
     </aside>
@@ -11723,24 +11723,25 @@ async function deleteBrandConfirm() {
 async function openBrandMergeModal(sourceId) {
   var src = (_brandsCache || []).find(function(b){ return b.id === sourceId; });
   if (!src) return;
-  // 회사 미지정 브랜드는 병합 금지 (무관 브랜드 오병합 방지 — 서버 merge_brands 도 동일 가드)
-  if (!src.company_id) { toast('회사가 지정되지 않은 브랜드는 병합할 수 없습니다. 먼저 「회사」를 연결하세요.', 'warn'); return; }
+  // 회사 무관 병합 허용(2026-06-09 — 회사 등록→연결→병합 단계 과다 해소). 오병합 방지는 모달 정보·확인으로.
   var campCount = (typeof countCampaignsByBrand === 'function') ? await countCampaignsByBrand(sourceId) : 0;
   var apps = (typeof fetchBrandApplicationsByBrand === 'function') ? (await fetchBrandApplicationsByBrand(sourceId) || []) : [];
+  var srcCo = (src.company_id && _brandCompanyMap[src.company_id]) || src.company_name || '회사 미등록';
   var targets = (_brandsCache || []).filter(function(b){
-    return b.id !== sourceId && b.status === 'active' && b.company_id && b.company_id === src.company_id;
+    return b.id !== sourceId && b.status === 'active';
   });
-  if (!targets.length) { toast('같은 회사에 병합할 다른 활성 브랜드가 없습니다', 'warn'); return; }
+  if (!targets.length) { toast('병합할 다른 활성 브랜드가 없습니다', 'warn'); return; }
   var opts = targets.map(function(b){
-    return '<option value="' + esc(b.id) + '">' + esc(b.name || b.brand_no || '브랜드') + (b.name_ja ? ' (' + esc(b.name_ja) + ')' : '') + ' · ' + esc(b.brand_no || '') + '</option>';
+    var co = (b.company_id && _brandCompanyMap[b.company_id]) || b.company_name || '회사 미등록';
+    return '<option value="' + esc(b.id) + '">' + esc(b.name || b.brand_no || '브랜드') + (b.name_ja ? ' (' + esc(b.name_ja) + ')' : '') + ' · ' + esc(b.brand_no || '') + ' · ' + esc(co) + '</option>';
   }).join('');
   var ov = document.createElement('div');
   ov.id = 'brandMergeOverlay';
   ov.style.cssText = 'position:fixed;inset:0;background:rgba(0,0,0,.45);z-index:700;display:flex;align-items:center;justify-content:center';
   ov.innerHTML = '<div style="background:#fff;border-radius:12px;width:480px;max-width:92vw;padding:24px;box-shadow:0 12px 48px rgba(0,0,0,.25)">'
     + '<h3 style="margin:0 0 8px;font-size:16px;font-weight:700;color:var(--ink)">브랜드 병합</h3>'
-    + '<p style="margin:0 0 16px;font-size:12px;color:var(--muted);line-height:1.6">원본 「' + esc(src.name || src.brand_no || '') + '」의 <b>캠페인 ' + campCount + '건·신청 ' + apps.length + '건</b>을 아래 브랜드로 옮기고, 원본은 보관 처리합니다.<br>캠페인·신청 번호는 재발급되며(옛 번호는 보존) <b style="color:#c0392b">되돌릴 수 없습니다.</b></p>'
-    + '<label style="font-size:12px;font-weight:600;color:var(--ink);display:block;margin-bottom:6px">병합 대상 브랜드 (같은 회사)</label>'
+    + '<p style="margin:0 0 16px;font-size:12px;color:var(--muted);line-height:1.6">원본 「' + esc(src.name || src.brand_no || '') + '」(' + esc(srcCo) + ')의 <b>캠페인 ' + campCount + '건·신청 ' + apps.length + '건</b>을 아래 브랜드로 옮기고, 원본은 보관 처리합니다.<br>캠페인·신청 번호는 재발급되며(옛 번호는 보존) <b style="color:#c0392b">되돌릴 수 없습니다.</b></p>'
+    + '<label style="font-size:12px;font-weight:600;color:var(--ink);display:block;margin-bottom:6px">병합 대상 브랜드 <span style="color:var(--muted);font-weight:400">(회사가 달라도 선택 가능 — 대상을 정확히 확인하세요)</span></label>'
     + '<select id="brandMergeTarget" style="width:100%;padding:9px;border:1px solid var(--line);border-radius:8px;font-size:14px;margin-bottom:20px">' + opts + '</select>'
     + '<div style="display:flex;justify-content:flex-end;gap:8px">'
       + '<button class="btn btn-ghost btn-sm" onclick="closeBrandMergeModal()">취소</button>'

--- a/dev/js/admin-brand.js
+++ b/dev/js/admin-brand.js
@@ -1079,24 +1079,25 @@ async function deleteBrandConfirm() {
 async function openBrandMergeModal(sourceId) {
   var src = (_brandsCache || []).find(function(b){ return b.id === sourceId; });
   if (!src) return;
-  // 회사 미지정 브랜드는 병합 금지 (무관 브랜드 오병합 방지 — 서버 merge_brands 도 동일 가드)
-  if (!src.company_id) { toast('회사가 지정되지 않은 브랜드는 병합할 수 없습니다. 먼저 「회사」를 연결하세요.', 'warn'); return; }
+  // 회사 무관 병합 허용(2026-06-09 — 회사 등록→연결→병합 단계 과다 해소). 오병합 방지는 모달 정보·확인으로.
   var campCount = (typeof countCampaignsByBrand === 'function') ? await countCampaignsByBrand(sourceId) : 0;
   var apps = (typeof fetchBrandApplicationsByBrand === 'function') ? (await fetchBrandApplicationsByBrand(sourceId) || []) : [];
+  var srcCo = (src.company_id && _brandCompanyMap[src.company_id]) || src.company_name || '회사 미등록';
   var targets = (_brandsCache || []).filter(function(b){
-    return b.id !== sourceId && b.status === 'active' && b.company_id && b.company_id === src.company_id;
+    return b.id !== sourceId && b.status === 'active';
   });
-  if (!targets.length) { toast('같은 회사에 병합할 다른 활성 브랜드가 없습니다', 'warn'); return; }
+  if (!targets.length) { toast('병합할 다른 활성 브랜드가 없습니다', 'warn'); return; }
   var opts = targets.map(function(b){
-    return '<option value="' + esc(b.id) + '">' + esc(b.name || b.brand_no || '브랜드') + (b.name_ja ? ' (' + esc(b.name_ja) + ')' : '') + ' · ' + esc(b.brand_no || '') + '</option>';
+    var co = (b.company_id && _brandCompanyMap[b.company_id]) || b.company_name || '회사 미등록';
+    return '<option value="' + esc(b.id) + '">' + esc(b.name || b.brand_no || '브랜드') + (b.name_ja ? ' (' + esc(b.name_ja) + ')' : '') + ' · ' + esc(b.brand_no || '') + ' · ' + esc(co) + '</option>';
   }).join('');
   var ov = document.createElement('div');
   ov.id = 'brandMergeOverlay';
   ov.style.cssText = 'position:fixed;inset:0;background:rgba(0,0,0,.45);z-index:700;display:flex;align-items:center;justify-content:center';
   ov.innerHTML = '<div style="background:#fff;border-radius:12px;width:480px;max-width:92vw;padding:24px;box-shadow:0 12px 48px rgba(0,0,0,.25)">'
     + '<h3 style="margin:0 0 8px;font-size:16px;font-weight:700;color:var(--ink)">브랜드 병합</h3>'
-    + '<p style="margin:0 0 16px;font-size:12px;color:var(--muted);line-height:1.6">원본 「' + esc(src.name || src.brand_no || '') + '」의 <b>캠페인 ' + campCount + '건·신청 ' + apps.length + '건</b>을 아래 브랜드로 옮기고, 원본은 보관 처리합니다.<br>캠페인·신청 번호는 재발급되며(옛 번호는 보존) <b style="color:#c0392b">되돌릴 수 없습니다.</b></p>'
-    + '<label style="font-size:12px;font-weight:600;color:var(--ink);display:block;margin-bottom:6px">병합 대상 브랜드 (같은 회사)</label>'
+    + '<p style="margin:0 0 16px;font-size:12px;color:var(--muted);line-height:1.6">원본 「' + esc(src.name || src.brand_no || '') + '」(' + esc(srcCo) + ')의 <b>캠페인 ' + campCount + '건·신청 ' + apps.length + '건</b>을 아래 브랜드로 옮기고, 원본은 보관 처리합니다.<br>캠페인·신청 번호는 재발급되며(옛 번호는 보존) <b style="color:#c0392b">되돌릴 수 없습니다.</b></p>'
+    + '<label style="font-size:12px;font-weight:600;color:var(--ink);display:block;margin-bottom:6px">병합 대상 브랜드 <span style="color:var(--muted);font-weight:400">(회사가 달라도 선택 가능 — 대상을 정확히 확인하세요)</span></label>'
     + '<select id="brandMergeTarget" style="width:100%;padding:9px;border:1px solid var(--line);border-radius:8px;font-size:14px;margin-bottom:20px">' + opts + '</select>'
     + '<div style="display:flex;justify-content:flex-end;gap:8px">'
       + '<button class="btn btn-ghost btn-sm" onclick="closeBrandMergeModal()">취소</button>'

--- a/supabase/migrations/175_merge_brands_rpc.sql
+++ b/supabase/migrations/175_merge_brands_rpc.sql
@@ -83,17 +83,9 @@ BEGIN
     RAISE EXCEPTION '대상 브랜드를 찾을 수 없습니다: %', p_target USING ERRCODE = '22023';
   END IF;
 
-  -- 3. 회사 검증 — 둘 다 회사 지정돼 있고 같아야 함.
-  --    (회사 미지정 null 끼리는 "무관 브랜드"일 수 있어 병합 금지 — 회사 먼저 연결 유도)
-  IF v_source.company_id IS NULL OR v_target.company_id IS NULL THEN
-    RAISE EXCEPTION '회사가 지정되지 않은 브랜드는 병합할 수 없습니다. 먼저 회사를 연결하세요.'
-      USING ERRCODE = '22023';
-  END IF;
-  IF v_source.company_id IS DISTINCT FROM v_target.company_id THEN
-    RAISE EXCEPTION '원본과 대상의 소속 회사가 다릅니다 (company_id: % ≠ %)',
-      v_source.company_id::text, v_target.company_id::text
-      USING ERRCODE = '22023';
-  END IF;
+  -- 3. 회사 검증 없음 (2026-06-09 정책: 회사 미등록·회사 불일치 브랜드도 병합 허용 —
+  --    회사 등록→연결→병합 단계 과다 해소. 오병합 방지는 UI 모달의 대상 회사·캠페인 수 표시 +
+  --    되돌리기 불가 확인으로 운영자가 판단). 캠페인·신청은 target.brand_id 로 귀속.
 
   -- 4. 멱등성 — source 이미 archived + 연결 0건이면 no-op
   IF v_source.status = 'archived'
@@ -246,7 +238,7 @@ END;
 $$;
 
 COMMENT ON FUNCTION public.merge_brands(uuid, uuid) IS
-  '[175] 브랜드 병합. source 신청·캠페인을 target 으로 이동 + 채번 재발급(legacy_no 보존). 같은 company_id 강제. is_campaign_admin 가드. 121 패턴 재사용. 원본 archived.';
+  '[175] 브랜드 병합. source 신청·캠페인을 target 으로 이동 + 채번 재발급(legacy_no 보존). 회사 불일치·미등록 브랜드도 허용. is_campaign_admin 가드. 121 패턴 재사용. 원본 archived.';
 
 REVOKE ALL ON FUNCTION public.merge_brands(uuid, uuid) FROM PUBLIC;
 REVOKE ALL ON FUNCTION public.merge_brands(uuid, uuid) FROM anon;


### PR DESCRIPTION
## 변경 요약
- 브랜드 병합의 회사 일치 강제 제거. 회사 미등록·회사 다른 브랜드도 병합 가능(등록→연결→병합 단계 과다 해소).
- 오병합 방지는 병합 모달의 대상 회사·캠페인 수 표시 + 되돌리기 불가 확인으로 이전.

## DB 변경 (⚠️ 개발 DB 175 재적용 — CREATE OR REPLACE)
- 마이그레이션 175 회사 검증 블록 제거 (운영 미배포라 175 수정)

## 검증
- supabase-expert 재검증(영향 없음) / reviewer GO / 빌드 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)