### PR TITLE
fix(brand): 브랜드 이름 중복 에러를 친절한 한국어로

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -12,7 +12,7 @@
 // 회귀(2026-05-12 PR #182 머지 직후 발생)를 방지하기 위한 자동 reload 가드.
 // sessionStorage 차단 환경(시크릿 모드 일부, 쿠키 차단)에서는 자연스럽게 skip.
 (function(){
-  var CURRENT_BUILD = 'v1780976230';
+  var CURRENT_BUILD = 'v1780977987';
   if (CURRENT_BUILD.indexOf('__') === 0) return; // 빌드 미적용 (dev/ 직접 열기) 시 skip
   try {
     var prev = sessionStorage.getItem('reverb.adminBuild');
@@ -2002,7 +2002,7 @@ textarea.form-input{resize:vertical;min-height:80px}
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-06-09 12:37 · f3feb0e</span>
+          <span class="admin-build-text">2026-06-09 13:06 · 79ba7dd</span>
         </div>
       </div>
     </aside>
@@ -12199,7 +12199,15 @@ async function saveBrandDetail() {
   var patch = _collectBrandFormPatch();
   if (!patch.name) { toast('브랜드명을 입력하세요.', 'warn'); return; }
   var result = await updateBrand(_brandsCurrentId, patch);
-  if (!result.ok) { toast('저장 실패: ' + (result.error || '알 수 없는 오류'), 'error'); return; }
+  if (!result.ok) {
+    var em = result.error || '';
+    if (em.indexOf('duplicate') >= 0 || em.indexOf('unique') >= 0 || em.indexOf('name_normalized') >= 0) {
+      toast('이미 같은 이름의 브랜드가 등록돼 있습니다. (띄어쓰기·대소문자는 같은 것으로 봅니다)', 'error');
+    } else {
+      toast('저장 실패: ' + (em || '알 수 없는 오류'), 'error');
+    }
+    return;
+  }
   toast('저장되었습니다.');
   closeBrandDetailModal();
   await refreshPane('brands');
@@ -12234,10 +12242,11 @@ async function submitNewBrand() {
   patch.created_by = currentUser?.id || null;
   var result = await insertBrand(patch);
   if (!result.ok) {
-    if ((result.error || '').indexOf('duplicate') >= 0 || (result.error || '').indexOf('unique') >= 0) {
-      toast('동일한 정규화 이름의 브랜드가 이미 있습니다.', 'error');
+    var em = result.error || '';
+    if (em.indexOf('duplicate') >= 0 || em.indexOf('unique') >= 0 || em.indexOf('name_normalized') >= 0) {
+      toast('이미 같은 이름의 브랜드가 등록돼 있습니다. (띄어쓰기·대소문자는 같은 것으로 봅니다)', 'error');
     } else {
-      toast('등록 실패: ' + (result.error || '알 수 없는 오류'), 'error');
+      toast('등록 실패: ' + (em || '알 수 없는 오류'), 'error');
     }
     return;
   }

--- a/dev/js/admin-brand.js
+++ b/dev/js/admin-brand.js
@@ -1555,7 +1555,15 @@ async function saveBrandDetail() {
   var patch = _collectBrandFormPatch();
   if (!patch.name) { toast('브랜드명을 입력하세요.', 'warn'); return; }
   var result = await updateBrand(_brandsCurrentId, patch);
-  if (!result.ok) { toast('저장 실패: ' + (result.error || '알 수 없는 오류'), 'error'); return; }
+  if (!result.ok) {
+    var em = result.error || '';
+    if (em.indexOf('duplicate') >= 0 || em.indexOf('unique') >= 0 || em.indexOf('name_normalized') >= 0) {
+      toast('이미 같은 이름의 브랜드가 등록돼 있습니다. (띄어쓰기·대소문자는 같은 것으로 봅니다)', 'error');
+    } else {
+      toast('저장 실패: ' + (em || '알 수 없는 오류'), 'error');
+    }
+    return;
+  }
   toast('저장되었습니다.');
   closeBrandDetailModal();
   await refreshPane('brands');
@@ -1590,10 +1598,11 @@ async function submitNewBrand() {
   patch.created_by = currentUser?.id || null;
   var result = await insertBrand(patch);
   if (!result.ok) {
-    if ((result.error || '').indexOf('duplicate') >= 0 || (result.error || '').indexOf('unique') >= 0) {
-      toast('동일한 정규화 이름의 브랜드가 이미 있습니다.', 'error');
+    var em = result.error || '';
+    if (em.indexOf('duplicate') >= 0 || em.indexOf('unique') >= 0 || em.indexOf('name_normalized') >= 0) {
+      toast('이미 같은 이름의 브랜드가 등록돼 있습니다. (띄어쓰기·대소문자는 같은 것으로 봅니다)', 'error');
     } else {
-      toast('등록 실패: ' + (result.error || '알 수 없는 오류'), 'error');
+      toast('등록 실패: ' + (em || '알 수 없는 오류'), 'error');
     }
     return;
   }


### PR DESCRIPTION
## 변경 요약
- 브랜드 저장(편집·생성) 시 이름 중복 에러가 영어 데이터베이스 원문으로 나오던 것을 「이미 같은 이름의 브랜드가 등록돼 있습니다」로 변환. 편집 저장엔 처리가 아예 없었고, 생성은 '정규화' 전문용어 사용 → 통일·쉬운 말로.

## DB 변경
- 없음

## 검증
- reviewer GO / 빌드 통과 / qa skip

🤖 Generated with [Claude Code](https://claude.com/claude-code)