### PR TITLE
fix(error-log): filter iOS Safari extension noise

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -12,7 +12,7 @@
 // 회귀(2026-05-12 PR #182 머지 직후 발생)를 방지하기 위한 자동 reload 가드.
 // sessionStorage 차단 환경(시크릿 모드 일부, 쿠키 차단)에서는 자연스럽게 skip.
 (function(){
-  var CURRENT_BUILD = 'v1780977987';
+  var CURRENT_BUILD = 'v1780979476';
   if (CURRENT_BUILD.indexOf('__') === 0) return; // 빌드 미적용 (dev/ 직접 열기) 시 skip
   try {
     var prev = sessionStorage.getItem('reverb.adminBuild');
@@ -2002,7 +2002,7 @@ textarea.form-input{resize:vertical;min-height:80px}
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-06-09 13:06 · 79ba7dd</span>
+          <span class="admin-build-text">2026-06-09 13:31 · 2e8e734</span>
         </div>
       </div>
     </aside>

--- a/dev/js/error-report.js
+++ b/dev/js/error-report.js
@@ -20,6 +20,8 @@
     /NetworkError|Failed to fetch/i,   // 사용자 네트워크 끊김
     /Non-Error promise rejection/i,
     /chrome-extension|moz-extension|safari-extension/i,
+    /browser\.runtime/i,               // 아이폰 Safari 확장이 주입한 확장 API 접근 에러 (앱 코드 아님)
+    /webkit-masked-url/i,              // Safari 가 확장 스크립트 출처를 가린 URL (스택에만 등장)
   ];
 
   function _toMessage(v) {

--- a/index.html
+++ b/index.html
@@ -7358,6 +7358,8 @@ async function renderLegalPage() {
     /NetworkError|Failed to fetch/i,   // 사용자 네트워크 끊김
     /Non-Error promise rejection/i,
     /chrome-extension|moz-extension|safari-extension/i,
+    /browser\.runtime/i,               // 아이폰 Safari 확장이 주입한 확장 API 접근 에러 (앱 코드 아님)
+    /webkit-masked-url/i,              // Safari 가 확장 스크립트 출처를 가린 URL (스택에만 등장)
   ];
 
   function _toMessage(v) {


### PR DESCRIPTION
## 변경 요약
- 사용자 폰 Safari 확장(번역기·비번관리자 등)이 낸 에러가 관리자 오류 로그 페인에 노이즈로 유입되던 것을 수집 단계에서 차단
- `dev/js/error-report.js` NOISE 배열에 정규식 2줄 추가: `/browser\.runtime/i`, `/webkit-masked-url/i`

## 요청 외 추가 변경
- 없음

## 관련 사양서
- 없음 (정규식 2줄, 사양서 불필요 소규모 변경)

## 검증
- 코드 매칭 실증: 실제 확장 에러 → 차단(true) / 앱 진짜 버그 → 수집(false), 오탐 없음
- [via reviewer] 정적 검증 GO, qa skip (상수 2줄, 로직 흐름 무변경)
- DB 무영향

🤖 Generated with [Claude Code](https://claude.com/claude-code)