### PR TITLE
feat(deliverable): pre-guide existing submissions in admin proxy modal

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -12,7 +12,7 @@
 // 회귀(2026-05-12 PR #182 머지 직후 발생)를 방지하기 위한 자동 reload 가드.
 // sessionStorage 차단 환경(시크릿 모드 일부, 쿠키 차단)에서는 자연스럽게 skip.
 (function(){
-  var CURRENT_BUILD = 'v1780979476';
+  var CURRENT_BUILD = 'v1780981452';
   if (CURRENT_BUILD.indexOf('__') === 0) return; // 빌드 미적용 (dev/ 직접 열기) 시 skip
   try {
     var prev = sessionStorage.getItem('reverb.adminBuild');
@@ -1761,6 +1761,20 @@ textarea.form-input{resize:vertical;min-height:80px}
 .admin-proxy-image-preview{margin-top:6px;max-width:180px;max-height:180px;border:1px solid var(--line);border-radius:6px;display:none}
 .admin-proxy-image-preview[src]{display:block}
 
+/* ─── 이미 제출된 결과물 사전 안내 박스 (대리 등록 모달) ────────── */
+.admin-proxy-existing-box{padding:12px 14px;background:#FEF3C7;border:1px solid #FBBF24;border-radius:8px;font-size:12px;line-height:1.55;color:#92400E}
+.admin-proxy-existing-box .pe-title{display:flex;align-items:center;gap:6px;font-weight:700;font-size:13px;margin-bottom:8px}
+.admin-proxy-existing-box .pe-list{list-style:none;margin:0 0 10px;padding:0;display:flex;flex-direction:column;gap:5px}
+.admin-proxy-existing-box .pe-list li{display:flex;align-items:center;gap:6px}
+.admin-proxy-existing-box .pe-kind{font-weight:600}
+.admin-proxy-existing-box .pe-status{font-size:11px;padding:1px 7px;border-radius:10px;background:#fff;border:1px solid #FBBF24;color:#92400E}
+.admin-proxy-existing-box .pe-status.pending{background:#FEF9C3;border-color:#EAB308;color:#854D0E}
+.admin-proxy-existing-box .pe-status.approved{background:#DCFCE7;border-color:#22C55E;color:#166534}
+.admin-proxy-existing-box .pe-status.rejected{background:#FEE2E2;border-color:#EF4444;color:#991B1B}
+.admin-proxy-existing-box .pe-guide{margin-bottom:10px}
+.admin-proxy-existing-box .pe-goto{display:inline-flex;align-items:center;gap:5px;padding:7px 14px;background:#92400E;color:#fff;border:none;border-radius:6px;font-size:12px;font-weight:600;cursor:pointer}
+.admin-proxy-existing-box .pe-goto:hover{background:#7C3209}
+
 /* 「대리 등록만 보기」 필터 토글 */
 .deliv-proxy-filter-label{display:inline-flex;align-items:center;gap:4px;font-size:12px;cursor:pointer;height:32px;color:var(--ink)}
 
@@ -2002,7 +2016,7 @@ textarea.form-input{resize:vertical;min-height:80px}
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-06-09 13:31 · 2e8e734</span>
+          <span class="admin-build-text">2026-06-09 14:04 · df1c1a1</span>
         </div>
       </div>
     </aside>
@@ -4601,6 +4615,9 @@ textarea.form-input{resize:vertical;min-height:80px}
           <span class="form-help">먼저 캠페인을 선택하세요. 그 캠페인의 승인된 인플루언서만 표시됩니다.</span>
         </div>
 
+        <!-- 1-c. 이미 제출된 결과물 사전 안내 (인플 선택 시 1건 이상이면 표시) -->
+        <div id="adminProxyExistingBox" class="admin-proxy-existing-box" style="display:none"></div>
+
         <!-- 2. 결과물 종류 선택 (캠페인 recruit_type 따라 노출) -->
         <div class="form-row required">
           <label>결과물 종류</label>
@@ -6613,6 +6630,20 @@ async function fetchDeliverablesByCampaign(campaignId) {
     if (error) throw error;
     return data || [];
   } catch(e) { console.error('[fetchDeliverablesByCampaign]', e); return []; }
+}
+
+// 응모건(application) 1건의 기존 결과물 조회 — 관리자 대리 등록 모달 사전 안내용 (is_admin SELECT)
+//   필요한 컬럼만 경량 조회. 인플 선택 시 1건만 부르므로 가벼움.
+async function fetchDeliverablesByApplication(applicationId) {
+  if (!db || !applicationId) return [];
+  try {
+    const {data, error} = await db?.from('deliverables')
+      .select('id, kind, status, post_channel, post_url, reject_reason, submitted_at, created_at')
+      .eq('application_id', applicationId)
+      .order('created_at', {ascending: false});
+    if (error) throw error;
+    return data || [];
+  } catch(e) { console.error('[fetchDeliverablesByApplication]', e); return []; }
 }
 
 // 인플루언서 본인 결과물 조회 (활동관리 화면)
@@ -19934,6 +19965,10 @@ function _resetAdminProxyForm() {
   _renderProxyEvidencePreview([]);
   // 내부 파일 목록 초기화
   _proxyEvidenceFiles = [];
+  // 이미 제출된 결과물 안내 박스 초기화
+  _adminProxyExistingDelivs = [];
+  const exBox = $('adminProxyExistingBox');
+  if (exBox) { exBox.style.display = 'none'; exBox.innerHTML = ''; }
 }
 
 // 마이그레이션 163: 증빙 파일 목록 (File 객체 배열, 최대 5장)
@@ -20203,6 +20238,69 @@ function selectAdminProxyInf(appId, silent) {
   const list = $('adminProxyInfList'); if (list) list.classList.remove('open');
   // 결과물 종류 옵션 활성화 (기존 onAdminProxyAppChange 로직 인라인)
   _refreshAdminProxyKindOptions(app);
+  // 이미 제출된 결과물 사전 안내 (응모건 1건만 비동기 조회 — fire-and-forget)
+  _loadAdminProxyExisting(appId);
+}
+
+// ── 이미 제출된 결과물 사전 안내 (대리 등록 전 멈춤 방지) ──────────────
+// 인플(응모건) 선택 시 그 application 의 기존 deliverables 를 조회해 안내 박스 + 채널 표식.
+let _adminProxyExistingDelivs = [];
+const _PROXY_KIND_LABEL = { receipt: '영수증', review_image: '리뷰이미지', post: '게시물' };
+const _PROXY_STATUS_LABEL = { pending: '검수대기', approved: '승인', rejected: '반려' };
+
+async function _loadAdminProxyExisting(appId) {
+  _adminProxyExistingDelivs = [];
+  _renderAdminProxyExistingBox();   // 이전 응모건 잔류 즉시 제거
+  if (!appId) return;
+  try {
+    _adminProxyExistingDelivs = await fetchDeliverablesByApplication(appId);
+  } catch (e) {
+    console.error('[admin-proxy] 기존 결과물 조회 실패', e);
+    _adminProxyExistingDelivs = [];
+  }
+  // 조회 후 현재 활성 종류의 채널 옵션도 갱신(표식·비활성 반영)
+  _renderAdminProxyExistingBox();
+  const kind = $('adminProxyKind')?.value;
+  if (kind === 'post') _populateAdminProxyPostChannelOptions();
+  else if (kind === 'review_image') _populateAdminProxyReviewChannelOptions();
+}
+
+function _renderAdminProxyExistingBox() {
+  const box = $('adminProxyExistingBox');
+  if (!box) return;
+  const list = _adminProxyExistingDelivs || [];
+  if (!list.length) { box.style.display = 'none'; box.innerHTML = ''; return; }
+
+  const receipts = list.filter(d => d.kind === 'receipt');
+  const others = list.filter(d => d.kind !== 'receipt');
+  const rows = [];
+  others.forEach(d => {
+    const kindLabel = _PROXY_KIND_LABEL[d.kind] || d.kind;
+    const ch = d.post_channel ? (_adminProxyChannels[d.post_channel] || d.post_channel) : '';
+    const st = _PROXY_STATUS_LABEL[d.status] || d.status;
+    const stClass = ['pending', 'approved', 'rejected'].includes(d.status) ? d.status : '';
+    rows.push(`<li><span class="pe-kind">${esc(kindLabel)}${ch ? '（' + esc(ch) + '）' : ''}</span><span class="pe-status ${stClass}">${esc(st)}</span></li>`);
+  });
+  if (receipts.length) {
+    // 영수증은 중복 허용 종류 → 총건수 + 검수대기 건수만 (개별 행 X)
+    const pendingN = receipts.filter(d => d.status === 'pending').length;
+    const stTxt = pendingN ? `검수대기 ${pendingN}건` : '';
+    rows.push(`<li><span class="pe-kind">영수증 (${receipts.length}건)</span>${stTxt ? `<span class="pe-status pending">${esc(stTxt)}</span>` : ''}</li>`);
+  }
+
+  const appId = $('adminProxyApp')?.value || '';
+  box.innerHTML =
+    `<div class="pe-title"><span class="material-icons-round notranslate" translate="no" style="font-size:18px">info</span>이미 제출된 결과물이 있습니다</div>` +
+    `<ul class="pe-list">${rows.join('')}</ul>` +
+    `<div class="pe-guide">이미 제출된 결과물은 대리 등록 대신 아래 「결과물 검수」에서 승인·반려해 주세요.</div>` +
+    `<button type="button" class="pe-goto" onclick="goToDelivReviewFromProxy('${esc(appId)}')"><span class="material-icons-round notranslate" translate="no" style="font-size:15px">fact_check</span>결과물 검수로 이동</button>`;
+  box.style.display = 'block';
+}
+
+function goToDelivReviewFromProxy(appId) {
+  if (!appId) return;
+  closeAdminProxyModal();
+  openDelivCombined(appId);
 }
 
 function _resetAdminProxyInfState() {
@@ -20213,6 +20311,10 @@ function _resetAdminProxyInfState() {
   const infList = $('adminProxyInfList'); if (infList) { infList.classList.remove('open'); infList.innerHTML = ''; }
   const kindSel = $('adminProxyKind');
   if (kindSel) { kindSel.innerHTML = '<option value="">— 먼저 인플루언서를 선택하세요 —</option>'; kindSel.disabled = true; }
+  // 안내 박스도 비움 (캠페인 변경 시 이전 응모건 잔류 방지)
+  _adminProxyExistingDelivs = [];
+  const exBox = $('adminProxyExistingBox');
+  if (exBox) { exBox.style.display = 'none'; exBox.innerHTML = ''; }
   onAdminProxyKindChange();
 }
 
@@ -20269,10 +20371,14 @@ function _populateAdminProxyPostChannelOptions() {
   const appId = $('adminProxyApp')?.value;
   const app = _adminProxyApps.find(a => a.id === appId);
   const channels = (app?.campaigns?.channel || '').split(',').map(s => s.trim()).filter(Boolean);
+  // 게시물은 URL 단위로 중복 판정(채널 아님) → 비활성하지 않고 표식만. 최종 가드는 RPC.
+  const taken = new Set((_adminProxyExistingDelivs || [])
+    .filter(d => d.kind === 'post' && d.post_channel)
+    .map(d => d.post_channel));
   const opts = ['<option value="">— 자동 판별 대기 (또는 수동 선택) —</option>'];
   channels.forEach(c => {
     const label = _adminProxyChannels[c] || c;
-    opts.push(`<option value="${esc(c)}">${esc(label)}</option>`);
+    opts.push(`<option value="${esc(c)}">${esc(label)}${taken.has(c) ? ' (이미 게시물 제출됨)' : ''}</option>`);
   });
   sel.innerHTML = opts.join('');
 }
@@ -20283,10 +20389,15 @@ function _populateAdminProxyReviewChannelOptions() {
   const appId = $('adminProxyApp')?.value;
   const app = _adminProxyApps.find(a => a.id === appId);
   const channels = (app?.campaigns?.channel || '').split(',').map(s => s.trim()).filter(Boolean);
+  // 리뷰이미지는 채널 단위로 중복 판정 → 이미 제출된 채널은 비활성(RPC·인덱스와 일치).
+  const taken = new Set((_adminProxyExistingDelivs || [])
+    .filter(d => d.kind === 'review_image' && d.post_channel)
+    .map(d => d.post_channel));
   const opts = ['<option value="">— 캠페인 채널 중 선택 —</option>'];
   channels.forEach(c => {
     const label = _adminProxyChannels[c] || c;
-    opts.push(`<option value="${esc(c)}">${esc(label)}</option>`);
+    const isTaken = taken.has(c);
+    opts.push(`<option value="${esc(c)}"${isTaken ? ' disabled' : ''}>${esc(label)}${isTaken ? ' (제출됨 — 검수에서 처리)' : ''}</option>`);
   });
   sel.innerHTML = opts.join('');
 }
@@ -20408,7 +20519,11 @@ async function submitAdminProxyDelivProxy() {
     else if (typeof renderDeliverablesList === 'function') await renderDeliverablesList();
   } catch (err) {
     console.error('[admin-proxy] RPC 실패', err);
-    toast('대리 등록 실패: ' + (err.message || err), 'error');
+    const raw = String(err.message || err || '');
+    // 중복(이미 제출됨) 에러는 다음 행동까지 안내 — 담당자가 멈추지 않도록
+    const isDup = err.code === '23505' || /이미 등록되어 있습니다|이미 등록되어 있습니다\.|리뷰 이미지가 이미 등록/.test(raw);
+    const extra = isDup ? ' 대리 등록 대신 「결과물 검수」에서 처리해 주세요.' : '';
+    toast('대리 등록 실패: ' + raw + extra, 'error');
   } finally {
     if (btn) { btn.disabled = false; btn.textContent = '대리 등록 및 자동 승인'; }
   }

--- a/admin/index.html
+++ b/admin/index.html
@@ -12,7 +12,7 @@
 // 회귀(2026-05-12 PR #182 머지 직후 발생)를 방지하기 위한 자동 reload 가드.
 // sessionStorage 차단 환경(시크릿 모드 일부, 쿠키 차단)에서는 자연스럽게 skip.
 (function(){
-  var CURRENT_BUILD = 'v1780981452';
+  var CURRENT_BUILD = 'v1780983226';
   if (CURRENT_BUILD.indexOf('__') === 0) return; // 빌드 미적용 (dev/ 직접 열기) 시 skip
   try {
     var prev = sessionStorage.getItem('reverb.adminBuild');
@@ -1767,10 +1767,6 @@ textarea.form-input{resize:vertical;min-height:80px}
 .admin-proxy-existing-box .pe-list{list-style:none;margin:0 0 10px;padding:0;display:flex;flex-direction:column;gap:5px}
 .admin-proxy-existing-box .pe-list li{display:flex;align-items:center;gap:6px}
 .admin-proxy-existing-box .pe-kind{font-weight:600}
-.admin-proxy-existing-box .pe-status{font-size:11px;padding:1px 7px;border-radius:10px;background:#fff;border:1px solid #FBBF24;color:#92400E}
-.admin-proxy-existing-box .pe-status.pending{background:#FEF9C3;border-color:#EAB308;color:#854D0E}
-.admin-proxy-existing-box .pe-status.approved{background:#DCFCE7;border-color:#22C55E;color:#166534}
-.admin-proxy-existing-box .pe-status.rejected{background:#FEE2E2;border-color:#EF4444;color:#991B1B}
 .admin-proxy-existing-box .pe-guide{margin-bottom:10px}
 .admin-proxy-existing-box .pe-goto{display:inline-flex;align-items:center;gap:5px;padding:7px 14px;background:#92400E;color:#fff;border:none;border-radius:6px;font-size:12px;font-weight:600;cursor:pointer}
 .admin-proxy-existing-box .pe-goto:hover{background:#7C3209}
@@ -2016,7 +2012,7 @@ textarea.form-input{resize:vertical;min-height:80px}
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-06-09 14:04 · df1c1a1</span>
+          <span class="admin-build-text">2026-06-09 14:33 · c34d665</span>
         </div>
       </div>
     </aside>
@@ -20246,7 +20242,6 @@ function selectAdminProxyInf(appId, silent) {
 // 인플(응모건) 선택 시 그 application 의 기존 deliverables 를 조회해 안내 박스 + 채널 표식.
 let _adminProxyExistingDelivs = [];
 const _PROXY_KIND_LABEL = { receipt: '영수증', review_image: '리뷰이미지', post: '게시물' };
-const _PROXY_STATUS_LABEL = { pending: '검수대기', approved: '승인', rejected: '반려' };
 
 async function _loadAdminProxyExisting(appId) {
   _adminProxyExistingDelivs = [];
@@ -20268,31 +20263,29 @@ async function _loadAdminProxyExisting(appId) {
 function _renderAdminProxyExistingBox() {
   const box = $('adminProxyExistingBox');
   if (!box) return;
-  const list = _adminProxyExistingDelivs || [];
-  if (!list.length) { box.style.display = 'none'; box.innerHTML = ''; return; }
+  // 목적 = 아직 처리 안 된(검수대기) 결과물을 검수로 보내기. 이미 승인·반려된 지난 내역은
+  // 대리 등록 판단에 불필요 → 검수대기(pending) 만 노출.
+  const pending = (_adminProxyExistingDelivs || []).filter(d => d.status === 'pending');
+  if (!pending.length) { box.style.display = 'none'; box.innerHTML = ''; return; }
 
-  const receipts = list.filter(d => d.kind === 'receipt');
-  const others = list.filter(d => d.kind !== 'receipt');
+  const receipts = pending.filter(d => d.kind === 'receipt');
+  const others = pending.filter(d => d.kind !== 'receipt');
   const rows = [];
   others.forEach(d => {
     const kindLabel = _PROXY_KIND_LABEL[d.kind] || d.kind;
     const ch = d.post_channel ? (_adminProxyChannels[d.post_channel] || d.post_channel) : '';
-    const st = _PROXY_STATUS_LABEL[d.status] || d.status;
-    const stClass = ['pending', 'approved', 'rejected'].includes(d.status) ? d.status : '';
-    rows.push(`<li><span class="pe-kind">${esc(kindLabel)}${ch ? '（' + esc(ch) + '）' : ''}</span><span class="pe-status ${stClass}">${esc(st)}</span></li>`);
+    rows.push(`<li><span class="pe-kind">${esc(kindLabel)}${ch ? '（' + esc(ch) + '）' : ''}</span></li>`);
   });
   if (receipts.length) {
-    // 영수증은 중복 허용 종류 → 총건수 + 검수대기 건수만 (개별 행 X)
-    const pendingN = receipts.filter(d => d.status === 'pending').length;
-    const stTxt = pendingN ? `검수대기 ${pendingN}건` : '';
-    rows.push(`<li><span class="pe-kind">영수증 (${receipts.length}건)</span>${stTxt ? `<span class="pe-status pending">${esc(stTxt)}</span>` : ''}</li>`);
+    // 영수증은 중복 허용 종류 → 검수대기 건수만 (개별 행 X)
+    rows.push(`<li><span class="pe-kind">영수증${receipts.length > 1 ? ' (' + receipts.length + '건)' : ''}</span></li>`);
   }
 
   const appId = $('adminProxyApp')?.value || '';
   box.innerHTML =
-    `<div class="pe-title"><span class="material-icons-round notranslate" translate="no" style="font-size:18px">info</span>이미 제출된 결과물이 있습니다</div>` +
+    `<div class="pe-title"><span class="material-icons-round notranslate" translate="no" style="font-size:18px">info</span>검수 대기 중인 결과물이 있습니다</div>` +
     `<ul class="pe-list">${rows.join('')}</ul>` +
-    `<div class="pe-guide">이미 제출된 결과물은 대리 등록 대신 아래 「결과물 검수」에서 승인·반려해 주세요.</div>` +
+    `<div class="pe-guide">이미 제출되어 검수 대기 중입니다. 대리 등록 대신 아래 「결과물 검수」에서 승인·반려해 주세요.</div>` +
     `<button type="button" class="pe-goto" onclick="goToDelivReviewFromProxy('${esc(appId)}')"><span class="material-icons-round notranslate" translate="no" style="font-size:15px">fact_check</span>결과물 검수로 이동</button>`;
   box.style.display = 'block';
 }

--- a/dev/admin/index.html
+++ b/dev/admin/index.html
@@ -2733,6 +2733,9 @@
           <span class="form-help">먼저 캠페인을 선택하세요. 그 캠페인의 승인된 인플루언서만 표시됩니다.</span>
         </div>
 
+        <!-- 1-c. 이미 제출된 결과물 사전 안내 (인플 선택 시 1건 이상이면 표시) -->
+        <div id="adminProxyExistingBox" class="admin-proxy-existing-box" style="display:none"></div>
+
         <!-- 2. 결과물 종류 선택 (캠페인 recruit_type 따라 노출) -->
         <div class="form-row required">
           <label>결과물 종류</label>

--- a/dev/css/admin.css
+++ b/dev/css/admin.css
@@ -1317,10 +1317,6 @@
 .admin-proxy-existing-box .pe-list{list-style:none;margin:0 0 10px;padding:0;display:flex;flex-direction:column;gap:5px}
 .admin-proxy-existing-box .pe-list li{display:flex;align-items:center;gap:6px}
 .admin-proxy-existing-box .pe-kind{font-weight:600}
-.admin-proxy-existing-box .pe-status{font-size:11px;padding:1px 7px;border-radius:10px;background:#fff;border:1px solid #FBBF24;color:#92400E}
-.admin-proxy-existing-box .pe-status.pending{background:#FEF9C3;border-color:#EAB308;color:#854D0E}
-.admin-proxy-existing-box .pe-status.approved{background:#DCFCE7;border-color:#22C55E;color:#166534}
-.admin-proxy-existing-box .pe-status.rejected{background:#FEE2E2;border-color:#EF4444;color:#991B1B}
 .admin-proxy-existing-box .pe-guide{margin-bottom:10px}
 .admin-proxy-existing-box .pe-goto{display:inline-flex;align-items:center;gap:5px;padding:7px 14px;background:#92400E;color:#fff;border:none;border-radius:6px;font-size:12px;font-weight:600;cursor:pointer}
 .admin-proxy-existing-box .pe-goto:hover{background:#7C3209}

--- a/dev/css/admin.css
+++ b/dev/css/admin.css
@@ -1311,6 +1311,20 @@
 .admin-proxy-image-preview{margin-top:6px;max-width:180px;max-height:180px;border:1px solid var(--line);border-radius:6px;display:none}
 .admin-proxy-image-preview[src]{display:block}
 
+/* ─── 이미 제출된 결과물 사전 안내 박스 (대리 등록 모달) ────────── */
+.admin-proxy-existing-box{padding:12px 14px;background:#FEF3C7;border:1px solid #FBBF24;border-radius:8px;font-size:12px;line-height:1.55;color:#92400E}
+.admin-proxy-existing-box .pe-title{display:flex;align-items:center;gap:6px;font-weight:700;font-size:13px;margin-bottom:8px}
+.admin-proxy-existing-box .pe-list{list-style:none;margin:0 0 10px;padding:0;display:flex;flex-direction:column;gap:5px}
+.admin-proxy-existing-box .pe-list li{display:flex;align-items:center;gap:6px}
+.admin-proxy-existing-box .pe-kind{font-weight:600}
+.admin-proxy-existing-box .pe-status{font-size:11px;padding:1px 7px;border-radius:10px;background:#fff;border:1px solid #FBBF24;color:#92400E}
+.admin-proxy-existing-box .pe-status.pending{background:#FEF9C3;border-color:#EAB308;color:#854D0E}
+.admin-proxy-existing-box .pe-status.approved{background:#DCFCE7;border-color:#22C55E;color:#166534}
+.admin-proxy-existing-box .pe-status.rejected{background:#FEE2E2;border-color:#EF4444;color:#991B1B}
+.admin-proxy-existing-box .pe-guide{margin-bottom:10px}
+.admin-proxy-existing-box .pe-goto{display:inline-flex;align-items:center;gap:5px;padding:7px 14px;background:#92400E;color:#fff;border:none;border-radius:6px;font-size:12px;font-weight:600;cursor:pointer}
+.admin-proxy-existing-box .pe-goto:hover{background:#7C3209}
+
 /* 「대리 등록만 보기」 필터 토글 */
 .deliv-proxy-filter-label{display:inline-flex;align-items:center;gap:4px;font-size:12px;cursor:pointer;height:32px;color:var(--ink)}
 

--- a/dev/js/admin-deliverables.js
+++ b/dev/js/admin-deliverables.js
@@ -1493,6 +1493,10 @@ function _resetAdminProxyForm() {
   _renderProxyEvidencePreview([]);
   // 내부 파일 목록 초기화
   _proxyEvidenceFiles = [];
+  // 이미 제출된 결과물 안내 박스 초기화
+  _adminProxyExistingDelivs = [];
+  const exBox = $('adminProxyExistingBox');
+  if (exBox) { exBox.style.display = 'none'; exBox.innerHTML = ''; }
 }
 
 // 마이그레이션 163: 증빙 파일 목록 (File 객체 배열, 최대 5장)
@@ -1762,6 +1766,69 @@ function selectAdminProxyInf(appId, silent) {
   const list = $('adminProxyInfList'); if (list) list.classList.remove('open');
   // 결과물 종류 옵션 활성화 (기존 onAdminProxyAppChange 로직 인라인)
   _refreshAdminProxyKindOptions(app);
+  // 이미 제출된 결과물 사전 안내 (응모건 1건만 비동기 조회 — fire-and-forget)
+  _loadAdminProxyExisting(appId);
+}
+
+// ── 이미 제출된 결과물 사전 안내 (대리 등록 전 멈춤 방지) ──────────────
+// 인플(응모건) 선택 시 그 application 의 기존 deliverables 를 조회해 안내 박스 + 채널 표식.
+let _adminProxyExistingDelivs = [];
+const _PROXY_KIND_LABEL = { receipt: '영수증', review_image: '리뷰이미지', post: '게시물' };
+const _PROXY_STATUS_LABEL = { pending: '검수대기', approved: '승인', rejected: '반려' };
+
+async function _loadAdminProxyExisting(appId) {
+  _adminProxyExistingDelivs = [];
+  _renderAdminProxyExistingBox();   // 이전 응모건 잔류 즉시 제거
+  if (!appId) return;
+  try {
+    _adminProxyExistingDelivs = await fetchDeliverablesByApplication(appId);
+  } catch (e) {
+    console.error('[admin-proxy] 기존 결과물 조회 실패', e);
+    _adminProxyExistingDelivs = [];
+  }
+  // 조회 후 현재 활성 종류의 채널 옵션도 갱신(표식·비활성 반영)
+  _renderAdminProxyExistingBox();
+  const kind = $('adminProxyKind')?.value;
+  if (kind === 'post') _populateAdminProxyPostChannelOptions();
+  else if (kind === 'review_image') _populateAdminProxyReviewChannelOptions();
+}
+
+function _renderAdminProxyExistingBox() {
+  const box = $('adminProxyExistingBox');
+  if (!box) return;
+  const list = _adminProxyExistingDelivs || [];
+  if (!list.length) { box.style.display = 'none'; box.innerHTML = ''; return; }
+
+  const receipts = list.filter(d => d.kind === 'receipt');
+  const others = list.filter(d => d.kind !== 'receipt');
+  const rows = [];
+  others.forEach(d => {
+    const kindLabel = _PROXY_KIND_LABEL[d.kind] || d.kind;
+    const ch = d.post_channel ? (_adminProxyChannels[d.post_channel] || d.post_channel) : '';
+    const st = _PROXY_STATUS_LABEL[d.status] || d.status;
+    const stClass = ['pending', 'approved', 'rejected'].includes(d.status) ? d.status : '';
+    rows.push(`<li><span class="pe-kind">${esc(kindLabel)}${ch ? '（' + esc(ch) + '）' : ''}</span><span class="pe-status ${stClass}">${esc(st)}</span></li>`);
+  });
+  if (receipts.length) {
+    // 영수증은 중복 허용 종류 → 총건수 + 검수대기 건수만 (개별 행 X)
+    const pendingN = receipts.filter(d => d.status === 'pending').length;
+    const stTxt = pendingN ? `검수대기 ${pendingN}건` : '';
+    rows.push(`<li><span class="pe-kind">영수증 (${receipts.length}건)</span>${stTxt ? `<span class="pe-status pending">${esc(stTxt)}</span>` : ''}</li>`);
+  }
+
+  const appId = $('adminProxyApp')?.value || '';
+  box.innerHTML =
+    `<div class="pe-title"><span class="material-icons-round notranslate" translate="no" style="font-size:18px">info</span>이미 제출된 결과물이 있습니다</div>` +
+    `<ul class="pe-list">${rows.join('')}</ul>` +
+    `<div class="pe-guide">이미 제출된 결과물은 대리 등록 대신 아래 「결과물 검수」에서 승인·반려해 주세요.</div>` +
+    `<button type="button" class="pe-goto" onclick="goToDelivReviewFromProxy('${esc(appId)}')"><span class="material-icons-round notranslate" translate="no" style="font-size:15px">fact_check</span>결과물 검수로 이동</button>`;
+  box.style.display = 'block';
+}
+
+function goToDelivReviewFromProxy(appId) {
+  if (!appId) return;
+  closeAdminProxyModal();
+  openDelivCombined(appId);
 }
 
 function _resetAdminProxyInfState() {
@@ -1772,6 +1839,10 @@ function _resetAdminProxyInfState() {
   const infList = $('adminProxyInfList'); if (infList) { infList.classList.remove('open'); infList.innerHTML = ''; }
   const kindSel = $('adminProxyKind');
   if (kindSel) { kindSel.innerHTML = '<option value="">— 먼저 인플루언서를 선택하세요 —</option>'; kindSel.disabled = true; }
+  // 안내 박스도 비움 (캠페인 변경 시 이전 응모건 잔류 방지)
+  _adminProxyExistingDelivs = [];
+  const exBox = $('adminProxyExistingBox');
+  if (exBox) { exBox.style.display = 'none'; exBox.innerHTML = ''; }
   onAdminProxyKindChange();
 }
 
@@ -1828,10 +1899,14 @@ function _populateAdminProxyPostChannelOptions() {
   const appId = $('adminProxyApp')?.value;
   const app = _adminProxyApps.find(a => a.id === appId);
   const channels = (app?.campaigns?.channel || '').split(',').map(s => s.trim()).filter(Boolean);
+  // 게시물은 URL 단위로 중복 판정(채널 아님) → 비활성하지 않고 표식만. 최종 가드는 RPC.
+  const taken = new Set((_adminProxyExistingDelivs || [])
+    .filter(d => d.kind === 'post' && d.post_channel)
+    .map(d => d.post_channel));
   const opts = ['<option value="">— 자동 판별 대기 (또는 수동 선택) —</option>'];
   channels.forEach(c => {
     const label = _adminProxyChannels[c] || c;
-    opts.push(`<option value="${esc(c)}">${esc(label)}</option>`);
+    opts.push(`<option value="${esc(c)}">${esc(label)}${taken.has(c) ? ' (이미 게시물 제출됨)' : ''}</option>`);
   });
   sel.innerHTML = opts.join('');
 }
@@ -1842,10 +1917,15 @@ function _populateAdminProxyReviewChannelOptions() {
   const appId = $('adminProxyApp')?.value;
   const app = _adminProxyApps.find(a => a.id === appId);
   const channels = (app?.campaigns?.channel || '').split(',').map(s => s.trim()).filter(Boolean);
+  // 리뷰이미지는 채널 단위로 중복 판정 → 이미 제출된 채널은 비활성(RPC·인덱스와 일치).
+  const taken = new Set((_adminProxyExistingDelivs || [])
+    .filter(d => d.kind === 'review_image' && d.post_channel)
+    .map(d => d.post_channel));
   const opts = ['<option value="">— 캠페인 채널 중 선택 —</option>'];
   channels.forEach(c => {
     const label = _adminProxyChannels[c] || c;
-    opts.push(`<option value="${esc(c)}">${esc(label)}</option>`);
+    const isTaken = taken.has(c);
+    opts.push(`<option value="${esc(c)}"${isTaken ? ' disabled' : ''}>${esc(label)}${isTaken ? ' (제출됨 — 검수에서 처리)' : ''}</option>`);
   });
   sel.innerHTML = opts.join('');
 }
@@ -1967,7 +2047,11 @@ async function submitAdminProxyDelivProxy() {
     else if (typeof renderDeliverablesList === 'function') await renderDeliverablesList();
   } catch (err) {
     console.error('[admin-proxy] RPC 실패', err);
-    toast('대리 등록 실패: ' + (err.message || err), 'error');
+    const raw = String(err.message || err || '');
+    // 중복(이미 제출됨) 에러는 다음 행동까지 안내 — 담당자가 멈추지 않도록
+    const isDup = err.code === '23505' || /이미 등록되어 있습니다|이미 등록되어 있습니다\.|리뷰 이미지가 이미 등록/.test(raw);
+    const extra = isDup ? ' 대리 등록 대신 「결과물 검수」에서 처리해 주세요.' : '';
+    toast('대리 등록 실패: ' + raw + extra, 'error');
   } finally {
     if (btn) { btn.disabled = false; btn.textContent = '대리 등록 및 자동 승인'; }
   }

--- a/dev/js/admin-deliverables.js
+++ b/dev/js/admin-deliverables.js
@@ -1774,7 +1774,6 @@ function selectAdminProxyInf(appId, silent) {
 // 인플(응모건) 선택 시 그 application 의 기존 deliverables 를 조회해 안내 박스 + 채널 표식.
 let _adminProxyExistingDelivs = [];
 const _PROXY_KIND_LABEL = { receipt: '영수증', review_image: '리뷰이미지', post: '게시물' };
-const _PROXY_STATUS_LABEL = { pending: '검수대기', approved: '승인', rejected: '반려' };
 
 async function _loadAdminProxyExisting(appId) {
   _adminProxyExistingDelivs = [];
@@ -1796,31 +1795,29 @@ async function _loadAdminProxyExisting(appId) {
 function _renderAdminProxyExistingBox() {
   const box = $('adminProxyExistingBox');
   if (!box) return;
-  const list = _adminProxyExistingDelivs || [];
-  if (!list.length) { box.style.display = 'none'; box.innerHTML = ''; return; }
+  // 목적 = 아직 처리 안 된(검수대기) 결과물을 검수로 보내기. 이미 승인·반려된 지난 내역은
+  // 대리 등록 판단에 불필요 → 검수대기(pending) 만 노출.
+  const pending = (_adminProxyExistingDelivs || []).filter(d => d.status === 'pending');
+  if (!pending.length) { box.style.display = 'none'; box.innerHTML = ''; return; }
 
-  const receipts = list.filter(d => d.kind === 'receipt');
-  const others = list.filter(d => d.kind !== 'receipt');
+  const receipts = pending.filter(d => d.kind === 'receipt');
+  const others = pending.filter(d => d.kind !== 'receipt');
   const rows = [];
   others.forEach(d => {
     const kindLabel = _PROXY_KIND_LABEL[d.kind] || d.kind;
     const ch = d.post_channel ? (_adminProxyChannels[d.post_channel] || d.post_channel) : '';
-    const st = _PROXY_STATUS_LABEL[d.status] || d.status;
-    const stClass = ['pending', 'approved', 'rejected'].includes(d.status) ? d.status : '';
-    rows.push(`<li><span class="pe-kind">${esc(kindLabel)}${ch ? '（' + esc(ch) + '）' : ''}</span><span class="pe-status ${stClass}">${esc(st)}</span></li>`);
+    rows.push(`<li><span class="pe-kind">${esc(kindLabel)}${ch ? '（' + esc(ch) + '）' : ''}</span></li>`);
   });
   if (receipts.length) {
-    // 영수증은 중복 허용 종류 → 총건수 + 검수대기 건수만 (개별 행 X)
-    const pendingN = receipts.filter(d => d.status === 'pending').length;
-    const stTxt = pendingN ? `검수대기 ${pendingN}건` : '';
-    rows.push(`<li><span class="pe-kind">영수증 (${receipts.length}건)</span>${stTxt ? `<span class="pe-status pending">${esc(stTxt)}</span>` : ''}</li>`);
+    // 영수증은 중복 허용 종류 → 검수대기 건수만 (개별 행 X)
+    rows.push(`<li><span class="pe-kind">영수증${receipts.length > 1 ? ' (' + receipts.length + '건)' : ''}</span></li>`);
   }
 
   const appId = $('adminProxyApp')?.value || '';
   box.innerHTML =
-    `<div class="pe-title"><span class="material-icons-round notranslate" translate="no" style="font-size:18px">info</span>이미 제출된 결과물이 있습니다</div>` +
+    `<div class="pe-title"><span class="material-icons-round notranslate" translate="no" style="font-size:18px">info</span>검수 대기 중인 결과물이 있습니다</div>` +
     `<ul class="pe-list">${rows.join('')}</ul>` +
-    `<div class="pe-guide">이미 제출된 결과물은 대리 등록 대신 아래 「결과물 검수」에서 승인·반려해 주세요.</div>` +
+    `<div class="pe-guide">이미 제출되어 검수 대기 중입니다. 대리 등록 대신 아래 「결과물 검수」에서 승인·반려해 주세요.</div>` +
     `<button type="button" class="pe-goto" onclick="goToDelivReviewFromProxy('${esc(appId)}')"><span class="material-icons-round notranslate" translate="no" style="font-size:15px">fact_check</span>결과물 검수로 이동</button>`;
   box.style.display = 'block';
 }

--- a/dev/lib/storage.js
+++ b/dev/lib/storage.js
@@ -808,6 +808,20 @@ async function fetchDeliverablesByCampaign(campaignId) {
   } catch(e) { console.error('[fetchDeliverablesByCampaign]', e); return []; }
 }
 
+// 응모건(application) 1건의 기존 결과물 조회 — 관리자 대리 등록 모달 사전 안내용 (is_admin SELECT)
+//   필요한 컬럼만 경량 조회. 인플 선택 시 1건만 부르므로 가벼움.
+async function fetchDeliverablesByApplication(applicationId) {
+  if (!db || !applicationId) return [];
+  try {
+    const {data, error} = await db?.from('deliverables')
+      .select('id, kind, status, post_channel, post_url, reject_reason, submitted_at, created_at')
+      .eq('application_id', applicationId)
+      .order('created_at', {ascending: false});
+    if (error) throw error;
+    return data || [];
+  } catch(e) { console.error('[fetchDeliverablesByApplication]', e); return []; }
+}
+
 // 인플루언서 본인 결과물 조회 (활동관리 화면)
 async function fetchDeliverablesForUser(filters) {
   if (!db) return [];

--- a/docs/specs/2026-06-09-admin-proxy-duplicate-guidance.md
+++ b/docs/specs/2026-06-09-admin-proxy-duplicate-guidance.md
@@ -123,6 +123,7 @@
 - **빠진 것:** 없음.
 - **달라진 것:**
   - 사양서는 게시물 채널 비활성 여부를 "개발 세션 확정"으로 열어뒀음 → **게시물 채널은 비활성하지 않고 「(이미 게시물 제출됨)」 표식만**으로 확정. 리뷰이미지 채널만 비활성.
+  - **안내 박스는 검수대기(pending) 결과물만 노출**(2026-06-09 사용자 피드백 반영). 초안은 "제출 1건 이상이면 종류·채널·상태 요약"이었으나, 박스 목적이 "아직 처리 안 된 것을 검수로 보내기"라 이미 승인·반려된 지난 내역은 제외. 상태 칩도 제거(모두 검수대기라 불필요). 채널 드롭다운 비활성/표식은 중복 방지 목적이라 상태 무관하게 전체 deliverables 기준 유지.
 
 ### 구현 중 기술 결정 사항
 - **게시물 중복 판정 단위 = URL 단위 확정.** 현행 인덱스 `uidx_deliverables_post_url ON deliverables(application_id, kind, post_url) WHERE kind='post'` (마이그레이션 035) + RPC `admin_create_deliverable_proxy` (마이그레이션 163) 의 post 가드가 `(application_id, kind='post', post_url)` 로 막음. 채널 단위가 아님. 게시물 P0 핫픽스(`project_deliverable_post_url_dup_bug`)는 인플 재제출 로직만 바꿨고 인덱스/RPC 중복 단위는 URL 그대로.

--- a/docs/specs/2026-06-09-admin-proxy-duplicate-guidance.md
+++ b/docs/specs/2026-06-09-admin-proxy-duplicate-guidance.md
@@ -1,0 +1,140 @@
+# 관리자 결과물 대리 등록 — 이미 제출된 결과물 사전 안내
+
+**작성일:** 2026-06-09
+**작성:** 기획 세션
+**관련 기능:** 관리자 결과물 대리 등록 (`/admin#deliverables` → 「대리 등록」 모달)
+
+---
+
+## 배경 (사용자 보고)
+
+운영 담당자가 **제출기간이 지난 응모건**에 대해 "인플루언서가 못 냈겠지" 생각하고 게시물 결과물을 대리 등록하려 했으나, 사실 **인플루언서가 이미 그 게시물을 검수대기 상태로 제출**해 둔 상태였다. 대리 등록 마지막 단계에서 **「대리 등록 실패: 같은 게시물 URL이 이미 등록되어 있습니다.」** 토스트만 뜨고, 담당자는 **그다음 무엇을 해야 할지 몰라 멈췄다.**
+
+핵심: 에러가 "막힌 이유"만 알려주고 "다음 행동"을 안내하지 않는다. 게다가 **다 입력한 뒤 맨 끝에서야** 막힌다. (비개발자 담당자에게 가장 흔한 막힘)
+
+---
+
+## 현재 상태 (2026-06-09 기준 · planning.md 규칙 A)
+
+### 관련 코드·DB·UI 진입점
+
+**모달 로직** — `dev/js/admin-deliverables.js`
+- `openAdminProxyModal(presetAppId)` (1413줄): 모달 열 때 **승인된 신청 + 캠페인 + 인플루언서만** 로드. **기존 제출 결과물(`deliverables`)은 조회하지 않음.**
+- `_loadAdminProxyApprovedApps()` (1570줄): `applications` status='approved' 전건 + 캠페인·인플 클라이언트 join. deliverables 미포함.
+- `selectAdminProxyInf(appId, silent)` (1755줄): 인플루언서(=응모건) 선택 → `_refreshAdminProxyKindOptions(app)` 호출. 종류 드롭다운만 채움(recruit_type 기준), **이미 제출 여부 확인 안 함.**
+- `_refreshAdminProxyKindOptions(app)` (1778줄): monitor → 영수증·리뷰이미지 / 그 외 → 게시물 URL 옵션 생성.
+- 검수 모달 진입 함수 `openDelivCombined(applicationId)` (865줄)은 **응모건 ID 하나로 검수 모달을 연다** (목록 「검수」 버튼이 이미 이렇게 호출, 563줄). 역방향 `openAdminProxyFromCombined()` (1445줄)도 이미 존재 → **「검수로 이동」 버튼은 같은 패턴으로 구현 가능, 충돌 없음.**
+
+**서버 가드(중복 판정)** — `supabase/migrations/163_admin_proxy_evidence.sql` (현행 RPC `admin_create_deliverable_proxy`)
+- `kind='post'` (215~225줄): 같은 `application_id` + `kind='post'` + **같은 `post_url`** 이 이미 있으면 `RAISE EXCEPTION '같은 게시물 URL이 이미 등록되어 있습니다.'` (23505)
+- `kind='review_image'` (237~247줄): 같은 `application_id` + `kind='review_image'` + **같은 `post_channel`** 이 이미 있으면 `RAISE EXCEPTION '해당 채널(%)의 리뷰 이미지가 이미 등록되어 있습니다.'` (23505)
+- `kind='receipt'`: **중복 가드 없음** (영수증은 여러 건 허용). 즉 영수증은 이 에러가 안 남.
+
+→ **중복 판정 단위가 종류마다 다름**: 게시물=URL 단위, 리뷰이미지=채널 단위, 영수증=막지 않음.
+
+### 이 제안과 충돌 가능성 있는 기존 동작
+- **충돌 없음 — 확인 완료.** 신규 동작은 모달에 "조회 + 안내" 단계를 추가할 뿐, 기존 등록 흐름·RPC·DB는 그대로. 「검수로 이동」도 기존 `openDelivCombined` 재사용.
+- DB 변경 없음(조회만).
+
+### 미해결 백로그·관련 작업
+- `project_admin_proxy_deliverable.md` (대리 등록 운영 출시 완료, 마이그레이션 160·161·163)
+- `project_deliverable_post_url_dup_bug.md` (게시물 채널별 1건·재제출=같은 채널 교체. ⚠️후속: 채널별 유니크 정리·중복 정리 — **본 사양의 "중복 판정 단위"는 그 후속 작업의 현 상태에 맞춰 개발 세션이 확정**)
+
+---
+
+## 의심·경우의 수 (planning.md 규칙 B)
+
+1. **부분 제출** (가장 중요): 리뷰어(monitor) 캠페인은 영수증 + 리뷰이미지 2종. **영수증만 냈고 리뷰이미지는 안 냈으면 리뷰이미지 대리 등록은 정상적으로 필요.** → "인플루언서 통째로 막기" 금지, **종류·채널 단위 판정** 필수.
+2. **이미 낸 건의 상태**(검수대기/반려/승인)에 따라 담당자 행동이 다름 → 안내에 **상태 같이 표시.**
+3. **빈 상태**: 제출 0건이면 안내 박스 미표시 + 정상 진행 (대리 등록 본래 용도 — 막으면 안 됨).
+4. **채널 단위**: 게시물·리뷰이미지는 채널마다 1건. 인스타는 냈고 X는 안 냈으면 **X는 대리 등록 가능**해야 함.
+5. **영수증은 중복 미차단**: 영수증은 RPC가 안 막으므로 드롭다운 비활성 대상 아님. 단 "이미 영수증 N건 제출됨" 안내는 노출(담당자 인지용).
+6. **진입 경로 차이**: 검수 모달에서 「대리 등록」으로 들어온 경우(`openAdminProxyFromCombined`)는 거의 항상 결과물이 있는 응모건 → 안내 박스가 자연스럽게 뜸. 결과물 페인 상단 버튼으로 직접 진입하면 응모건을 새로 고르므로 0건일 수도.
+7. **stale 가능성**: 모달 여는 동안 다른 관리자가 결과물을 추가/삭제하면 안내가 과거 상태일 수 있음. → RPC가 최종 방어선이므로 안내는 "사전 보조"일 뿐, 실패 토스트는 그대로 유지(보강).
+
+---
+
+## 제안 / 설계
+
+### 동작 (사용자 확정: "안내 + 「검수로 이동」 버튼까지")
+
+대리 등록 모달에서 **인플루언서(응모건)를 선택한 직후**, 그 `application_id`의 기존 `deliverables`를 조회해 다음을 처리:
+
+#### 1. 안내 박스 (응모건에 제출 결과물이 1건 이상일 때만 표시)
+- 위치: 종류 선택 드롭다운 위(또는 인플루언서 입력 아래) 모달 본문 상단.
+- 내용:
+  - 헤더: 「이미 제출된 결과물이 있습니다」 (경고 톤, 노랑/주황 배너)
+  - 종류·채널·상태 요약 목록. 예:
+    - 「게시물(Instagram) — 검수대기」
+    - 「리뷰이미지(X) — 반려」
+    - 「영수증 — 검수대기 (2건)」
+  - 행동 안내 한 줄: 「이미 제출된 결과물은 대리 등록 대신 아래 [결과물 검수]에서 승인·반려해 주세요.」
+  - **「검수로 이동」 버튼**: `closeAdminProxyModal()` → `openDelivCombined(appId)` (기존 함수 재사용).
+- 0건이면 박스 미표시, 기존 흐름 그대로.
+
+#### 2. 종류·채널 드롭다운 표식·비활성 (중복으로 막히는 종류만)
+- **게시물**: 이미 제출된 게시물의 **점유 단위**(현행 RPC 기준 = 같은 채널/URL)는 채널 옵션에 「제출됨」 표식 + 비활성. (실제 판정 단위는 개발 세션이 현행 인덱스·RPC에 맞춰 확정 — `post_url` vs 채널)
+- **리뷰이미지**: 이미 제출된 **채널**은 채널 옵션에 「제출됨」 표식 + 비활성.
+- **영수증**: 중복 미차단 종류 → 비활성 안 함. 안내 박스에만 "N건 제출됨" 표시.
+- 모든 채널/종류가 이미 점유되어 더 등록할 게 없으면, 종류 드롭다운에 그 사실 안내(예: 「추가로 대리 등록할 항목 없음 — 검수에서 처리」).
+
+#### 3. 실패 토스트 보강 (최종 방어선)
+- 만에 하나 안내를 지나쳐(또는 동시 처리로) RPC 중복 에러가 나도, 토스트 문구에 행동 안내를 덧붙임:
+  - 현행: 「같은 게시물 URL이 이미 등록되어 있습니다.」
+  - 보강: 「…이미 등록되어 있습니다. 대리 등록 대신 [결과물 검수]에서 처리해 주세요.」 (클라이언트 토스트에서 덧붙이거나 RPC 메시지 수정 중 택1 — RPC 메시지 수정은 마이그레이션 동반이므로, **1차는 클라이언트 토스트에서 덧붙이는 쪽 권장**)
+
+### 데이터 조회
+- 신규 또는 재사용 조회 함수(`dev/lib/storage.js`): `application_id` 로 `deliverables` 의 `kind, status, post_channel, post_url, created_at` SELECT. RLS는 `is_admin()` SELECT 허용(기존). DB 변경 없음.
+- 모달 로드 시점에 모든 응모건의 deliverables를 미리 받지 말 것(대량). **인플루언서 선택 시 그 응모건 1건만 조회**(가벼움).
+
+### DB 변경
+- **없음.** 조회(SELECT)만 추가. (3번 토스트 보강을 RPC 메시지 수정으로 하면 마이그레이션 1개 추가되지만, 1차 권장안은 클라이언트 처리라 DB 무변경.)
+
+### 영향 파일
+- `dev/js/admin-deliverables.js` — 인플루언서 선택 시 조회·안내 박스 렌더·드롭다운 표식, 「검수로 이동」 핸들러
+- `dev/lib/storage.js` — 응모건 deliverables 조회 함수 (없으면 추가)
+- `dev/admin/index.html` (또는 빌드 전 dev HTML) — 안내 박스 컨테이너 요소
+- 빌드: `bash dev/build.sh`
+
+---
+
+## PR 분할
+
+단일 PR로 충분 (조회 + 안내 + 드롭다운 표식 + 검수 이동 버튼 + 토스트 보강 한 세트). DB 무변경.
+
+---
+
+## 사용자 확인 필요 (개발 착수 전 점검)
+
+- (확정됨) 안내 수준 = **안내 박스 + 「검수로 이동」 버튼**.
+- (개발 세션 판단) 게시물 중복 판정 단위(URL vs 채널) — 현행 인덱스·RPC 상태에 맞춰 확정. `project_deliverable_post_url_dup_bug.md` 후속(채널별 유니크) 진행 여부에 영향받음.
+
+---
+
+## 구현 결과
+
+**구현일:** 2026-06-09
+**관련 커밋:** (dev 커밋 예정 — `feat(deliverable): pre-guide existing submissions in admin proxy modal`)
+
+### 초안 대비 변경 사항
+- **추가된 것:**
+  - `storage.js` 에 `fetchDeliverablesByApplication(appId)` 신규 함수 (기존 `fetchDeliverablesForUser({application_id})` 는 `select('*')`+인플 본인 맥락 이름이라 재사용 대신 관리자용 경량 전용 함수 추가).
+  - 안내 박스 CSS(`.admin-proxy-existing-box` 외) — 기존 모달 노랑 경고 박스 톤(`#FEF3C7`/`#FBBF24`) 재사용.
+- **빠진 것:** 없음.
+- **달라진 것:**
+  - 사양서는 게시물 채널 비활성 여부를 "개발 세션 확정"으로 열어뒀음 → **게시물 채널은 비활성하지 않고 「(이미 게시물 제출됨)」 표식만**으로 확정. 리뷰이미지 채널만 비활성.
+
+### 구현 중 기술 결정 사항
+- **게시물 중복 판정 단위 = URL 단위 확정.** 현행 인덱스 `uidx_deliverables_post_url ON deliverables(application_id, kind, post_url) WHERE kind='post'` (마이그레이션 035) + RPC `admin_create_deliverable_proxy` (마이그레이션 163) 의 post 가드가 `(application_id, kind='post', post_url)` 로 막음. 채널 단위가 아님. 게시물 P0 핫픽스(`project_deliverable_post_url_dup_bug`)는 인플 재제출 로직만 바꿨고 인덱스/RPC 중복 단위는 URL 그대로.
+  - → 게시물 채널 드롭다운을 비활성하면 "같은 채널 다른 URL"(RPC 가 허용하는 동작)까지 UI 가 과차단하므로, **표식만** 하고 비활성은 안 함. 최종 가드는 RPC.
+- **리뷰이미지 = 채널 단위 확정.** 인덱스 `deliverables_review_image_app_channel_uniq ON (application_id, post_channel) WHERE kind='review_image'` (마이그레이션 158) + RPC 가드와 일치 → 이미 제출된 채널 **드롭다운 비활성**.
+- **영수증 = 중복 가드 없음** → 비활성·표식 안 함. 안내 박스에 "N건 (검수대기 M건)" 만 표시.
+- **조회 시점:** 인플(응모건) 선택 직후 1건만 비동기 조회(fire-and-forget). 모달 전체 응모건 prefetch 안 함(대량 방지). `selectAdminProxyInf` 는 동기 유지하고 `_loadAdminProxyExisting` 만 async.
+- **stale 대비:** 안내는 사전 보조일 뿐, RPC 23505 가 최종 방어선. 실패 토스트에 "「결과물 검수」에서 처리" 행동 안내를 덧붙여 보강.
+- **DB 변경 없음.**
+
+### 영향 파일
+- `dev/lib/storage.js` — `fetchDeliverablesByApplication` 추가
+- `dev/js/admin-deliverables.js` — `_loadAdminProxyExisting`/`_renderAdminProxyExistingBox`/`goToDelivReviewFromProxy` 추가, `selectAdminProxyInf`·채널 옵션 2종·폼 리셋 2종·실패 토스트 수정
+- `dev/admin/index.html` — `#adminProxyExistingBox` 컨테이너 추가
+- `dev/css/admin.css` — `.admin-proxy-existing-box` 스타일 추가

--- a/index.html
+++ b/index.html
@@ -4839,6 +4839,20 @@ async function fetchDeliverablesByCampaign(campaignId) {
   } catch(e) { console.error('[fetchDeliverablesByCampaign]', e); return []; }
 }
 
+// 응모건(application) 1건의 기존 결과물 조회 — 관리자 대리 등록 모달 사전 안내용 (is_admin SELECT)
+//   필요한 컬럼만 경량 조회. 인플 선택 시 1건만 부르므로 가벼움.
+async function fetchDeliverablesByApplication(applicationId) {
+  if (!db || !applicationId) return [];
+  try {
+    const {data, error} = await db?.from('deliverables')
+      .select('id, kind, status, post_channel, post_url, reject_reason, submitted_at, created_at')
+      .eq('application_id', applicationId)
+      .order('created_at', {ascending: false});
+    if (error) throw error;
+    return data || [];
+  } catch(e) { console.error('[fetchDeliverablesByApplication]', e); return []; }
+}
+
 // 인플루언서 본인 결과물 조회 (활동관리 화면)
 async function fetchDeliverablesForUser(filters) {
   if (!db) return [];


### PR DESCRIPTION
## 변경 요약
- 관리자 결과물 대리 등록 모달에서, 인플루언서(응모건) 선택 시 그 응모건의 **검수대기 결과물**을 사전 안내(노랑 박스 + 「결과물 검수로 이동」 버튼)
- 담당자가 이미 제출된 결과물을 모르고 대리 등록하다 "같은 URL 이미 등록" 토스트만 보고 멈추던 문제 해결
- 리뷰이미지: 이미 제출된 채널 드롭다운 비활성 / 게시물: 「(이미 게시물 제출됨)」 표식만(URL 단위 중복, RPC가 최종 가드) / 영수증: 안내 박스 건수만
- 안내 박스는 검수대기(pending)만 노출 — 이미 승인·반려된 지난 내역은 제외

## 요청 외 추가 변경
- 없음

## 관련 사양서
- docs/specs/2026-06-09-admin-proxy-duplicate-guidance.md (구현 결과 섹션 작성됨)

## 검증
- DB 무변경 (조회 함수 1개 추가, 기존 deliverables RLS is_admin SELECT)
- [via reviewer] 정적 검증 GO (stale 잔류 없음·XSS 안전·중복 판정 단위 정합)
- [via supabase-expert] RLS OK, 마이그레이션 불필요

🤖 Generated with [Claude Code](https://claude.com/claude-code)