### PR TITLE
feat: auto-reject pending applications on campaign end/expire (silent)

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -10,7 +10,7 @@
     },
     "playwright": {
       "command": "npx",
-      "args": ["-y", "@playwright/mcp@latest", "--cdp-endpoint", "http://localhost:9222"]
+      "args": ["-y", "@playwright/mcp@latest", "--extension"]
     }
   }
 }

--- a/.mcp.json
+++ b/.mcp.json
@@ -10,7 +10,7 @@
     },
     "playwright": {
       "command": "npx",
-      "args": ["-y", "@playwright/mcp@latest", "--extension"]
+      "args": ["-y", "@playwright/mcp@latest", "--cdp-endpoint", "http://localhost:9222"]
     }
   }
 }

--- a/admin/index.html
+++ b/admin/index.html
@@ -12,7 +12,7 @@
 // 회귀(2026-05-12 PR #182 머지 직후 발생)를 방지하기 위한 자동 reload 가드.
 // sessionStorage 차단 환경(시크릿 모드 일부, 쿠키 차단)에서는 자연스럽게 skip.
 (function(){
-  var CURRENT_BUILD = 'v1780983226';
+  var CURRENT_BUILD = 'v1781000604';
   if (CURRENT_BUILD.indexOf('__') === 0) return; // 빌드 미적용 (dev/ 직접 열기) 시 skip
   try {
     var prev = sessionStorage.getItem('reverb.adminBuild');
@@ -2012,7 +2012,7 @@ textarea.form-input{resize:vertical;min-height:80px}
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-06-09 14:33 · c34d665</span>
+          <span class="admin-build-text">2026-06-09 19:23 · b5d64a5</span>
         </div>
       </div>
     </aside>
@@ -9234,7 +9234,7 @@ function getRecruitTypeBadgeKoSm(t) {
   return '';
 }
 
-function getStatusBadge(s) {
+function getStatusBadge(s, autoReason) {
   const labels = {
     pending: (typeof t === 'function' ? t('appHistory.pending') : '審査中'),
     approved: (typeof t === 'function' ? t('appHistory.approved') : '当選'),
@@ -9247,9 +9247,19 @@ function getStatusBadge(s) {
     rejected:  `<span class="badge badge-gray">${labels.rejected}</span>`,
     cancelled: `<span class="badge badge-gray">${labels.cancelled}</span>`
   };
-  return m[s] || s;
+  let html = m[s] || s;
+  // 캠페인 종료/노출마감으로 인한 자동 낙첨: 落選 옆에 작은 「募集終了」 보조 라벨
+  if (s === 'rejected' && autoReason) {
+    const endedLabel = (typeof t === 'function' ? t('appHistory.recruitEnded') : '募集終了');
+    html += `<span class="badge badge-gray" style="font-size:10px;opacity:.75">${endedLabel}</span>`;
+  }
+  return html;
 }
-function getStatusBadgeKo(s) {
+function getStatusBadgeKo(s, autoReason) {
+  // 캠페인 종료/노출마감 자동 낙첨은 "미승인"이 아니라 "캠페인 종료"로 표시
+  if (s === 'rejected' && autoReason) {
+    return '<span class="badge badge-gray">캠페인 종료</span>';
+  }
   const m = {
     pending:   '<span class="badge badge-gold">심사중</span>',
     approved:  '<span class="badge badge-green">승인</span>',
@@ -17949,7 +17959,7 @@ async function openInfluencerDetail(userId) {
       <td style="font-weight:600">${esc(camp.title)||esc(a.campaign_id)}</td>
       <td>${typeLabel}</td>
       <td style="font-size:12px;color:var(--muted)">${formatDate(a.created_at)}</td>
-      <td>${getStatusBadgeKo(a.status)}${a.status==='cancelled' && a.cancel_phase ? `<div style="font-size:10px;color:var(--muted);margin-top:2px">${esc(cancelPhaseLabelKo(a.cancel_phase))}</div>` : ''}</td>
+      <td>${getStatusBadgeKo(a.status, a.auto_reject_reason)}${a.status==='cancelled' && a.cancel_phase ? `<div style="font-size:10px;color:var(--muted);margin-top:2px">${esc(cancelPhaseLabelKo(a.cancel_phase))}</div>` : ''}</td>
     </tr>`;
     if (a.status !== 'cancelled') return mainRow;
     // 취소 사유 보조 행
@@ -22326,7 +22336,7 @@ function renderRecentAppsTable(apps, camps, users) {
       </td>
       <td>${msgCell(a.message, a)}</td>
       <td style="font-size:12px;color:var(--muted);white-space:nowrap">${formatDate(a.created_at)}</td>
-      <td>${getStatusBadgeKo(a.status)}</td>
+      <td>${getStatusBadgeKo(a.status, a.auto_reject_reason)}</td>
       <td style="white-space:nowrap">
         ${a.status==='pending'?`<div style="display:flex;gap:4px"><button class="btn btn-green btn-xs" ${_dRem<=0?'disabled style="background:var(--muted);opacity:.5;cursor:not-allowed"':''}onclick="updateAppStatus('${a.id}','approved')">승인</button><button class="btn btn-ghost btn-xs" style="color:var(--red);border-color:var(--red)" onclick="updateAppStatus('${a.id}','rejected')">미승인</button></div>`
         :`<div><div style="font-size:10px;color:var(--muted)">${esc(formatReviewer(a.reviewed_by))} ${a.reviewed_at?formatDateTime(a.reviewed_at):''}</div><button class="btn btn-ghost btn-xs" style="margin-top:4px;font-size:10px" onclick="updateAppStatus('${a.id}','pending')">되돌리기</button></div>`}
@@ -22735,7 +22745,7 @@ async function loadCampApplicants() {
     <td style="font-weight:700;color:var(--pink)">${totalF}</td>
     <td>${msgCell(a.message, a)}</td>
     <td style="font-size:12px;color:var(--muted)">${formatDate(a.created_at)}</td>
-    <td>${getStatusBadgeKo(a.status)}${a.status==='cancelled' && a.cancel_phase ? `<div style="font-size:10px;color:var(--muted);margin-top:2px">${esc(cancelPhaseLabelKo(a.cancel_phase))}</div>` : ''}</td>
+    <td>${getStatusBadgeKo(a.status, a.auto_reject_reason)}${a.status==='cancelled' && a.cancel_phase ? `<div style="font-size:10px;color:var(--muted);margin-top:2px">${esc(cancelPhaseLabelKo(a.cancel_phase))}</div>` : ''}</td>
     <td>${otCell}</td>
     <td>${delivCell}</td>
     <td style="white-space:nowrap">
@@ -23026,7 +23036,7 @@ async function renderAppCampList() {
       </td>
       <td>${msgCell(a.message, a)}</td>
       <td style="font-size:12px;color:var(--muted);white-space:nowrap">${formatDate(a.created_at)}</td>
-      <td>${getStatusBadgeKo(a.status)}${a.status==='cancelled' && a.cancel_phase ? `<div style="font-size:10px;color:var(--muted);margin-top:2px">${esc(cancelPhaseLabelKo(a.cancel_phase))}</div>` : ''}</td>
+      <td>${getStatusBadgeKo(a.status, a.auto_reject_reason)}${a.status==='cancelled' && a.cancel_phase ? `<div style="font-size:10px;color:var(--muted);margin-top:2px">${esc(cancelPhaseLabelKo(a.cancel_phase))}</div>` : ''}</td>
       <td style="white-space:nowrap">
         ${a.status==='pending'?`<div style="display:flex;gap:4px"><button class="btn btn-green btn-xs" ${_campRemaining<=0?'disabled style="background:var(--muted);opacity:.5;cursor:not-allowed"':''}onclick="updateAppStatus('${a.id}','approved')">승인</button><button class="btn btn-ghost btn-xs" style="color:var(--red);border-color:var(--red)" onclick="updateAppStatus('${a.id}','rejected')">미승인</button></div>`
         :a.status==='cancelled'?`<div style="font-size:10px;color:var(--muted)">${a.cancelled_at?formatDateTime(a.cancelled_at):'—'}</div>`

--- a/dev/js/admin-applications.js
+++ b/dev/js/admin-applications.js
@@ -110,7 +110,7 @@ async function loadCampApplicants() {
     <td style="font-weight:700;color:var(--pink)">${totalF}</td>
     <td>${msgCell(a.message, a)}</td>
     <td style="font-size:12px;color:var(--muted)">${formatDate(a.created_at)}</td>
-    <td>${getStatusBadgeKo(a.status)}${a.status==='cancelled' && a.cancel_phase ? `<div style="font-size:10px;color:var(--muted);margin-top:2px">${esc(cancelPhaseLabelKo(a.cancel_phase))}</div>` : ''}</td>
+    <td>${getStatusBadgeKo(a.status, a.auto_reject_reason)}${a.status==='cancelled' && a.cancel_phase ? `<div style="font-size:10px;color:var(--muted);margin-top:2px">${esc(cancelPhaseLabelKo(a.cancel_phase))}</div>` : ''}</td>
     <td>${otCell}</td>
     <td>${delivCell}</td>
     <td style="white-space:nowrap">
@@ -401,7 +401,7 @@ async function renderAppCampList() {
       </td>
       <td>${msgCell(a.message, a)}</td>
       <td style="font-size:12px;color:var(--muted);white-space:nowrap">${formatDate(a.created_at)}</td>
-      <td>${getStatusBadgeKo(a.status)}${a.status==='cancelled' && a.cancel_phase ? `<div style="font-size:10px;color:var(--muted);margin-top:2px">${esc(cancelPhaseLabelKo(a.cancel_phase))}</div>` : ''}</td>
+      <td>${getStatusBadgeKo(a.status, a.auto_reject_reason)}${a.status==='cancelled' && a.cancel_phase ? `<div style="font-size:10px;color:var(--muted);margin-top:2px">${esc(cancelPhaseLabelKo(a.cancel_phase))}</div>` : ''}</td>
       <td style="white-space:nowrap">
         ${a.status==='pending'?`<div style="display:flex;gap:4px"><button class="btn btn-green btn-xs" ${_campRemaining<=0?'disabled style="background:var(--muted);opacity:.5;cursor:not-allowed"':''}onclick="updateAppStatus('${a.id}','approved')">승인</button><button class="btn btn-ghost btn-xs" style="color:var(--red);border-color:var(--red)" onclick="updateAppStatus('${a.id}','rejected')">미승인</button></div>`
         :a.status==='cancelled'?`<div style="font-size:10px;color:var(--muted)">${a.cancelled_at?formatDateTime(a.cancelled_at):'—'}</div>`

--- a/dev/js/admin-dashboard.js
+++ b/dev/js/admin-dashboard.js
@@ -99,7 +99,7 @@ function renderRecentAppsTable(apps, camps, users) {
       </td>
       <td>${msgCell(a.message, a)}</td>
       <td style="font-size:12px;color:var(--muted);white-space:nowrap">${formatDate(a.created_at)}</td>
-      <td>${getStatusBadgeKo(a.status)}</td>
+      <td>${getStatusBadgeKo(a.status, a.auto_reject_reason)}</td>
       <td style="white-space:nowrap">
         ${a.status==='pending'?`<div style="display:flex;gap:4px"><button class="btn btn-green btn-xs" ${_dRem<=0?'disabled style="background:var(--muted);opacity:.5;cursor:not-allowed"':''}onclick="updateAppStatus('${a.id}','approved')">승인</button><button class="btn btn-ghost btn-xs" style="color:var(--red);border-color:var(--red)" onclick="updateAppStatus('${a.id}','rejected')">미승인</button></div>`
         :`<div><div style="font-size:10px;color:var(--muted)">${esc(formatReviewer(a.reviewed_by))} ${a.reviewed_at?formatDateTime(a.reviewed_at):''}</div><button class="btn btn-ghost btn-xs" style="margin-top:4px;font-size:10px" onclick="updateAppStatus('${a.id}','pending')">되돌리기</button></div>`}

--- a/dev/js/admin-influencers.js
+++ b/dev/js/admin-influencers.js
@@ -359,7 +359,7 @@ async function openInfluencerDetail(userId) {
       <td style="font-weight:600">${esc(camp.title)||esc(a.campaign_id)}</td>
       <td>${typeLabel}</td>
       <td style="font-size:12px;color:var(--muted)">${formatDate(a.created_at)}</td>
-      <td>${getStatusBadgeKo(a.status)}${a.status==='cancelled' && a.cancel_phase ? `<div style="font-size:10px;color:var(--muted);margin-top:2px">${esc(cancelPhaseLabelKo(a.cancel_phase))}</div>` : ''}</td>
+      <td>${getStatusBadgeKo(a.status, a.auto_reject_reason)}${a.status==='cancelled' && a.cancel_phase ? `<div style="font-size:10px;color:var(--muted);margin-top:2px">${esc(cancelPhaseLabelKo(a.cancel_phase))}</div>` : ''}</td>
     </tr>`;
     if (a.status !== 'cancelled') return mainRow;
     // 취소 사유 보조 행

--- a/dev/js/mypage.js
+++ b/dev/js/mypage.js
@@ -266,7 +266,7 @@ async function renderMyApplyList() {
       delivItemsHtml = items.join('');
     }
     // 응모 상태 배지(당첨/심사중 등) + 결과물 상태 배지를 카드 본문 맨 아래 가로 한 줄로 모음
-    const badgeRow = `<div class="apply-item-badges" style="display:flex;flex-wrap:wrap;gap:6px;align-items:center;margin-top:6px">${getStatusBadge(a.status)}${delivItemsHtml}</div>`;
+    const badgeRow = `<div class="apply-item-badges" style="display:flex;flex-wrap:wrap;gap:6px;align-items:center;margin-top:6px">${getStatusBadge(a.status, a.auto_reject_reason)}${delivItemsHtml}</div>`;
     const cautionLine = a.caution_agreed_at
       ? `<div class="apply-item-caution" style="font-size:11px;color:var(--green);margin-top:2px;display:inline-flex;align-items:center;gap:3px;flex-wrap:wrap"><span class="material-icons-round notranslate" translate="no" style="font-size:13px">check_circle</span>${t('appHistory.cautionAgreed')} ${formatDate(a.caution_agreed_at)}${cautionCompareButton(a, camp)}</div>`
       : '';

--- a/dev/js/ui.js
+++ b/dev/js/ui.js
@@ -246,7 +246,7 @@ function getRecruitTypeBadgeKoSm(t) {
   return '';
 }
 
-function getStatusBadge(s) {
+function getStatusBadge(s, autoReason) {
   const labels = {
     pending: (typeof t === 'function' ? t('appHistory.pending') : '審査中'),
     approved: (typeof t === 'function' ? t('appHistory.approved') : '当選'),
@@ -259,9 +259,19 @@ function getStatusBadge(s) {
     rejected:  `<span class="badge badge-gray">${labels.rejected}</span>`,
     cancelled: `<span class="badge badge-gray">${labels.cancelled}</span>`
   };
-  return m[s] || s;
+  let html = m[s] || s;
+  // 캠페인 종료/노출마감으로 인한 자동 낙첨: 落選 옆에 작은 「募集終了」 보조 라벨
+  if (s === 'rejected' && autoReason) {
+    const endedLabel = (typeof t === 'function' ? t('appHistory.recruitEnded') : '募集終了');
+    html += `<span class="badge badge-gray" style="font-size:10px;opacity:.75">${endedLabel}</span>`;
+  }
+  return html;
 }
-function getStatusBadgeKo(s) {
+function getStatusBadgeKo(s, autoReason) {
+  // 캠페인 종료/노출마감 자동 낙첨은 "미승인"이 아니라 "캠페인 종료"로 표시
+  if (s === 'rejected' && autoReason) {
+    return '<span class="badge badge-gray">캠페인 종료</span>';
+  }
   const m = {
     pending:   '<span class="badge badge-gold">심사중</span>',
     approved:  '<span class="badge badge-green">승인</span>',

--- a/dev/lib/i18n/ja.js
+++ b/dev/lib/i18n/ja.js
@@ -203,6 +203,7 @@ window.I18N_JA = {
     pending: '審査中',
     approved: '当選',
     rejected: '落選',
+    recruitEnded: '募集終了',
     cancelled: '取消',
     cancelledBadge: '取消済',
     cancelMenu: '取消',

--- a/dev/lib/i18n/ko.js
+++ b/dev/lib/i18n/ko.js
@@ -196,6 +196,7 @@ window.I18N_KO = {
     pending: '심사중',
     approved: '당첨',
     rejected: '낙첨',
+    recruitEnded: '모집종료',
     cancelled: '취소',
     cancelledBadge: '취소됨',
     cancelMenu: '응모 취소',

--- a/docs/specs/2026-06-09-campaign-end-auto-reject.md
+++ b/docs/specs/2026-06-09-campaign-end-auto-reject.md
@@ -1,0 +1,68 @@
+# 캠페인 종료 시 심사중 신청 자동 낙첨 (무알림)
+**작성일:** 2026-06-09
+
+## 요약
+캠페인 상태가 **종료(ended)** 또는 **노출마감(expired)** 으로 바뀌면, 그 캠페인의 **심사중(pending)** 신청을 자동으로 **낙첨(rejected)** 처리한다. 단 인플루언서에게 **알림이 가지 않게** 한다(앱 알림·메일 모두). 이번 누적분 일괄 정리(백필) + 향후 자동(데이터베이스 트리거).
+
+- 관리자 화면: 이 건들은 "미승인"이 아니라 **"캠페인 종료"** 로 표시
+- 인플루언서 화면: 「落選(낙첨)」 + 작은 「募集終了(모집종료)」 보조 라벨
+
+## 현재 상태 (2026-06-09 기준)
+
+### 관련 코드·DB·UI 진입점
+- 캠페인 status 전환(클라): `dev/lib/storage.js` `autoEndCampaigns`(closed→ended), `toggleCampaignVisibility`(노출 OFF→expired). 둘 다 `campaigns.status` 를 DB UPDATE → AFTER UPDATE OF status 트리거로 후킹 가능.
+- 신청 status 트리거 `trg_application_status_event`(마이그레이션 131·154): `NEW.status='approved'` 일 때만 notifications INSERT → **rejected 전이는 앱 알림 없음**. rejected 는 `application_events` 'reject' audit 만 남김.
+- 인플 일일 다이제스트 메일(`notify-influencer-daily-digest`): `status IN ('approved','rejected') AND reviewed_at >= 어제KST AND < 오늘KST`. **reviewed_at = NULL 이면 메일 제외.**
+- 인플 응모이력: `dev/js/mypage.js:269` → `getStatusBadge(a.status)` → `ui.js` rejected=「落選」.
+- 관리자 상태 배지: `getStatusBadgeKo`(ui.js). 호출처 `admin-applications.js`(신청관리·신청자 2곳)·`admin-influencers.js`(인플 상세 응모이력)·`admin-dashboard.js`(최근 신청).
+- applications 컬럼: status / reviewed_by(text) / reviewed_at(timestamptz NULL 가능) / reviewed_version(낙관적 락). reject_reason 없음.
+
+### 이 제안과 충돌 가능성 있는 기존 동작
+- 트리거 연쇄: 신규 트리거의 applications UPDATE 가 `trg_application_status_event` 를 발화 → application_events 'reject' audit(의도된 동작). 무한루프 없음(campaigns→applications 단방향).
+- `reviewed_version` 낙관적 락: 트리거/백필이 미변경이라 충돌 없음.
+- 마이그레이션 156 보호컬럼 락은 campaigns 만 대상, 신규 트리거는 applications 만 건드려 무관.
+
+## 의심·경우의 수
+1. **approved 보호(최중요)**: 트리거·백필 모두 `WHERE status='pending'` 만 → approved(당첨자) 절대 미변경.
+2. **closed 제외**: ended/expired 만 대상. closed(모집마감, 결과물 진행 중)는 제외.
+3. **운영자 노출 ON 복귀**: ended/expired→active 복귀 시 이미 낙첨된 건은 자동 복원 안 됨(DB 굳혀짐). 운영자가 신청관리에서 「되돌리기」로 수동 pending 복귀 가능(드문 케이스, 자동 복원은 과설계).
+4. **되돌리기 후 잔존**: 「되돌리기」로 pending 복귀 시 `auto_reject_reason` 값이 남지만 pending 상태라 화면엔 "심사중" 정상 표시(무해). 재낙첨되면 트리거가 다시 덮어씀.
+5. **메일 폭탄 방지**: 백필도 `reviewed_at=NULL` 이라 다음날 다이제스트 메일 제외.
+
+## 설계
+
+### DB (마이그레이션 2개)
+- **176 `auto_reject_pending_on_campaign_end.sql`**
+  - `applications.auto_reject_reason text` 컬럼 추가 (NULL=일반, 'campaign_ended'/'campaign_expired'=자동 낙첨 식별)
+  - 함수 `reject_pending_on_campaign_end()` (SECURITY DEFINER, search_path=''): `NEW.status IN ('ended','expired') AND COALESCE(OLD.status,'') NOT IN ('ended','expired')` 일 때 그 캠페인 pending → rejected, auto_reject_reason 세팅, reviewed_by='시스템(캠페인 종료)', reviewed_at=NULL
+  - 트리거 `trg_reject_pending_on_campaign_end` AFTER UPDATE OF status ON campaigns
+- **177 `auto_reject_pending_backfill.sql`**: 기존 ended/expired 캠페인의 pending 일괄 정리(동일 규칙, reviewed_at=NULL). 사전 확인 SELECT 주석 포함. 멱등.
+
+### 화면 (DB 변경 없이 식별 컬럼 기반 분기)
+- `ui.js`:
+  - `getStatusBadgeKo(s, autoReason)` — rejected+autoReason 이면 "캠페인 종료" 배지
+  - `getStatusBadge(s, autoReason)` — rejected+autoReason 이면 「落選」 + 작은 「募集終了」 보조 배지
+- 호출부에 `a.auto_reject_reason` 전달: `admin-applications.js`(2곳), `admin-influencers.js`, `admin-dashboard.js`, `mypage.js`
+- i18n: `appHistory.recruitEnded` (ja '募集終了' / ko '모집종료')
+- 관리자 처리 셀: 자동 낙첨 건은 status=rejected 라 기존 else 분기(reviewed_by 표시 + 되돌리기). reviewed_at=NULL 이라 날짜 미표시. reviewed_by='시스템(캠페인 종료)' 노출.
+
+## 사이드바 배지
+별도 작업 불필요 — 낙첨은 pending 이 아니므로 `fetchPendingApplicationCount`(status='pending' count)에서 자동 제외.
+
+## PR/배포 순서
+- DB(176·177) + 화면을 한 묶음으로 dev 배포 → 개발 DB 적용·스모크.
+- 운영: 마이그레이션 운영 DB 적용(백필 전 대상 건수 SELECT 확인) 후 dev→main 머지. **운영 데이터 변경(백필) 포함이라 사용자 최종 확인 필수.**
+
+## 구현 결과
+
+**구현일:** 2026-06-09
+**관련 커밋:** (dev 머지 후 기록)
+
+### 초안 대비 변경 사항
+- reviewed_at 회피값: 과거 고정값 대신 **NULL** 채택(화면에 이상한 날짜 미표시 + 메일 제외, 추적은 auto_reject_reason + reviewed_by 로 충분).
+- 식별: `auto_reject_reason text` 단일 컬럼으로 boolean+사유 통합('campaign_ended'/'campaign_expired').
+- 인플 화면: 「落選」 + 「募集終了」 보조 라벨(사용자 선택).
+
+### 구현 중 기술 결정 사항
+- 마이그레이션 번호 확정: 176(트리거+컬럼), 177(백필).
+- 관리자 일관성을 위해 신청관리 2곳 외 대시보드·인플 상세 응모이력에도 동일 배지 분기 적용.

--- a/docs/specs/2026-06-09-qa-cdp-remote-debugging.md
+++ b/docs/specs/2026-06-09-qa-cdp-remote-debugging.md
@@ -101,10 +101,14 @@ macOS 기준, **평소 크롬과 분리된 전용 프로필**로 띄움:
 **구현일:** 2026-06-09 (개발 세션 — `.mcp.json` 변경·검증 부분)
 **관련 커밋:** (dev 커밋 — `chore(mcp): connect playwright via cdp-endpoint to dedicated qa chrome`)
 
-### 초안 대비 변경 사항
-- **추가된 것:** 없음. 설계 §1 그대로 `.mcp.json` 한 줄 변경.
-  - 변경 전: `["-y", "@playwright/mcp@latest", "--extension"]`
-  - 변경 후: `["-y", "@playwright/mcp@latest", "--cdp-endpoint", "http://localhost:9222"]`
+### ⚠️ 초안 전제 오류 정정 (가장 중요 — 2026-06-09 검증 중 발견)
+- **인계 문서가 가리킨 파일이 틀렸음.** 설계 §1·영향파일은 "프로젝트 레포 `.mcp.json` 의 playwright 를 바꾸면 reverb-qa-tester 에 적용된다"고 전제했으나, **reverb-qa-tester 는 프로젝트 `.mcp.json` 이 아니라 클로드 ecc 플러그인의 playwright(`mcp__plugin_ecc_playwright__*`)를 쓴다.**
+  - 증거: 에이전트 정의 `tools:` 가 `mcp__plugin_ecc_playwright__browser_*` 고정 / `ToolSearch select:mcp__playwright__browser_navigate` → "없음"(프로젝트 `.mcp.json` 의 playwright 서버는 도구로 노출조차 안 됨) / qa-tester light 실행 시 내장 플러그인 사용·CDP 미반영 보고.
+- **실제 변경 대상 = ecc 플러그인 `.mcp.json` 2곳** (git 비추적, `~/.claude/` 하위):
+  - `~/.claude/plugins/marketplaces/ecc/.mcp.json`
+  - `~/.claude/plugins/cache/ecc/ecc/1.10.0/.mcp.json`
+  - 둘 다 `@playwright/mcp@0.0.69 --extension` → `--cdp-endpoint http://localhost:9222` 로 변경(0.0.69 도 `--help` 에 `--cdp-endpoint` 존재 확인).
+- **프로젝트 레포 `.mcp.json` 변경은 원복**(효과 없음 — `--extension` 으로 되돌림).
 - **빠진 것(개발 세션 범위 밖, 고문 세션 인계):** 거버넌스 규칙·에이전트·메모리 갱신(설계 §3) — `reverb-qa-tester.md`「실행 전 필수」/`multi-session.md`/`interaction.md`/`git.md`/`session-checklist.js`/`서비스점검.md`/`feedback_playwright_single_resource.md`. 이 파일들은 거버넌스 문서라 고문/기획 세션이 직접 수정(session-roles.md 경계).
 - **달라진 것:** 포트는 9222 그대로 확정. 사용자 크롤링과 충돌 우려(§95)는 **실측으로 해소** — 9222 점유 크롬이 크롤링용이 아니라 인계 문서가 지정한 전용 프로필(`--user-data-dir=$HOME/.chrome-reverb-qa`)이었음.
 
@@ -112,5 +116,7 @@ macOS 기준, **평소 크롬과 분리된 전용 프로필**로 띄움:
 - **9222 사전 점유 검증:** 변경 전 `lsof -i :9222` + `ps` 로 점유 프로세스 확인 → 전용 프로필 크롬(`.chrome-reverb-qa`)이 dev.globalreverb.com 로그인 상태로 떠 있음을 확인하고 진행(의심 4 보안 분리 충족).
 - **CDP 엔드포인트 응답 검증:** `curl http://localhost:9222/json/version` → Chrome/149, `webSocketDebuggerUrl` 존재 확인. `curl .../json` → 열린 탭이 `dev.globalreverb.com/#home`(로그인 상태)임 확인.
 - **JSON 유효성:** `python3 json.load` 로 `.mcp.json` 파싱 정상 확인.
-- **남은 검증(세션 재시작 필요):** `.mcp.json` 변경은 현재 세션의 이미 로드된 MCP 서버에 즉시 반영되지 않음 → **Claude Code 세션 재시작 후** `reverb-qa-tester` light 1회 실행으로 실제 연결·동작·로그인 유지·평소 크롬 무영향을 최종 확인해야 함(설계 §82). 이 세션에서는 CDP 응답까지만 검증.
-- **`.mcp.json` 은 git 추적 파일** → dev 커밋 대상. reverb 앱 코드·빌드 산출물이 아니라 MCP 서버 기동 설정이라 reverb-reviewer 정적검증 스코프 밖(JSON 유효성·CDP 응답으로 대체 검증).
+- **ecc 플러그인 파일은 git 비추적**(`~/.claude/` = 레포 밖, 사용자 로컬 환경 전용). 커밋 대상 아님. 프로젝트 `.mcp.json` 원복만 dev 커밋.
+- **전역 영향:** ecc playwright 변경은 REVERB뿐 아니라 **모든 프로젝트의 qa-tester**에 적용됨(사용자 단일 사용자라 전용 크롬 공유로 일관성은 오히려 양호).
+- **휘발성(중요):** ecc 플러그인 업데이트/재설치 시 `marketplaces/ecc/.mcp.json` 이 git pull 로 `--extension` 으로 **덮어쓰여짐** → 그때 본 변경 재적용 필요. 메모리에 재적용 절차 기록.
+- **남은 검증(세션 재시작 필요):** ecc 플러그인 `.mcp.json` 변경도 현재 세션의 이미 로드된 MCP 서버에 즉시 반영 안 됨 → **Claude Code 세션 재시작 후** `reverb-qa-tester` light 1회로 실제 연결·로그인 유지·평소 크롬 무영향 최종 확인. 이 세션에서는 ① 0.0.69 `--cdp-endpoint` 지원 ② CDP `:9222` 응답(Chrome149·dev 로그인 탭)까지만 검증.

--- a/docs/specs/2026-06-09-qa-cdp-remote-debugging.md
+++ b/docs/specs/2026-06-09-qa-cdp-remote-debugging.md
@@ -1,0 +1,116 @@
+# QA 자동 테스트 — Playwright 연결을 「확장 방식」 → 「원격 디버깅(CDP)」 전환
+
+**작성일:** 2026-06-09
+**작성:** 기획 세션 (설계·인계용 HANDOFF)
+**인계 대상:** 개발 세션(.mcp.json 변경·검증) + 고문 세션(거버넌스 규칙·메모리 갱신)
+
+---
+
+## 목적·배경
+
+사용자 요청: reverb 화면 자동 테스트(`reverb-qa-tester`, Playwright)가 크롬에 붙는 방식을 현재 **확장 프로그램 방식(`--extension`)**에서 **원격 디버깅 연결(`--cdp-endpoint`)**로 바꾼다.
+
+**동기(사용자 확인):**
+1. 자동 테스트가 **평소 쓰는 크롬을 차지**해서 작업이 방해됨 → 평소 크롬과 분리하고 싶음
+2. **이미 로그인된 상태 그대로** 테스트하고 싶음(매번 로그인 자동화 회피)
+3. 사용자가 **다른 프로젝트에서 크롤링(타 사이트 원격 접속·데이터 추출)에 원격 디버깅 패턴을 이미 사용** 중 → 손에 익은 방식으로 통일
+
+---
+
+## 현재 상태 (2026-06-09 확인 · planning.md 규칙 A)
+
+### 설정·옵션 (확인 완료)
+- `.mcp.json` (레포 루트): Playwright MCP 서버가 `["-y", "@playwright/mcp@latest", "--extension"]` 로 기동 — **확장 프로그램 방식**(사용자의 단일 크롬에 「Playwright Extension」으로 붙음).
+- `@playwright/mcp --help` 실측: **`--cdp-endpoint <endpoint>`** = "CDP endpoint to connect to" 옵션 존재. 동반 옵션 `--cdp-header`, `--cdp-timeout`(기본 30000ms). → **전환 가능 확인.**
+
+### 영향 파일 (전환 시 같이 고쳐야 함)
+- `.mcp.json` — 기동 인자 변경 (핵심)
+- `.claude/agents/reverb-qa-tester.md` — 「실행 전 필수」 절차(확장 연결 전제 → 전용 크롬 기동 전제)
+- `.claude/rules/multi-session.md` — 「Playwright(브라우저 테스트) 단일 자원」 섹션(`--extension` 명시)
+- `.claude/rules/interaction.md`, `.claude/rules/git.md` — qa-tester 호출 의무 문구 중 「--extension 모드」 언급
+- `.claude/hooks/session-checklist.js` — Playwright 안내 문구
+- `.claude/commands/서비스점검.md` — qa 관련 안내
+- 메모리 `feedback_playwright_single_resource.md` — `--extension` 전제 서술
+
+### 미해결 백로그·관련
+- 메모리 `feedback_playwright_single_resource.md`(단일 자원·동시 실행 금지) — **전환 후에도 유지**(아래 의심 3 참조)
+
+---
+
+## 의심·경우의 수 (planning.md 규칙 B)
+
+1. **크롬을 안 띄운 채 qa 호출 → 연결 실패**: 확장 방식은 평소 크롬에 자동으로 붙었지만, CDP 방식은 **사용자가 전용 크롬을 원격 디버깅 포트로 먼저 띄워둬야** MCP가 연결됨. 안 띄우면 qa 즉시 실패. → qa-tester 에이전트 「실행 전 필수」에 "전용 크롬 기동 확인" 단계 추가 필수.
+2. **평소 크롬 안 뺏김(동기 ①)은 전용 프로필이 있어야 성립**: 그냥 원격 디버깅을 켜고 평소 크롬에 붙이면 동일하게 방해받음. **반드시 별도 `--user-data-dir`(전용 프로필) 크롬**을 띄워야 ①이 실제로 해결됨.
+3. **동시 멀티세션 충돌은 그대로**: CDP로 바꿔도 같은 포트(예: 9222) = 같은 전용 크롬 1개를 공유하면 여전히 단일 자원. **「qa는 한 번에 한 세션만」 규칙 유지.** (세션마다 다른 포트/프로필로 띄우면 이론상 병렬 가능하나 관리 복잡·사고 위험 → 1차는 단일 유지 권장.)
+4. **보안 — 크롤링과의 분리 필수**: 사용자가 크롤링도 하므로, **reverb 테스트용 크롬과 크롤링용 크롬을 프로필(또는 별도 크롬)로 분리.** 한 크롬에 ⓐreverb 관리자 로그인 + ⓑ열린 디버깅 포트 + ⓒ크롤링 자동화가 섞이면 포트 경유로 관리자 세션이 조작될 위험. 또한 디버깅 포트는 **localhost 바인딩 유지**(외부 노출 금지 — `--host 0.0.0.0` 같은 외부 공개 금지).
+5. **확장 vs CDP 동작 차이**: 확장 방식은 사용자가 평소 크롬의 특정 탭을 공유. CDP 방식은 전용 크롬을 Playwright가 통째 제어 → 기존 qa 시나리오가 "사용자가 미리 열어둔 탭" 같은 전제를 깔고 있으면 점검 필요(현 시나리오는 navigate 부터 시작이라 대부분 무관 예상, 개발 세션 확인).
+6. **로그인 세션 만료**: 전용 크롬의 reverb 로그인이 만료되면 그 크롬에서 한 번 재로그인 필요(동기 ②의 유지보수 비용).
+7. **포트 점유 충돌**: 9222를 다른 프로세스가 쓰면 기동 실패 → 절차에 포트 확인 한 줄.
+
+---
+
+## 설계 / 변경 사항
+
+### 1. `.mcp.json` 변경 (개발 또는 고문 세션)
+```jsonc
+// 변경 전
+"playwright": { "command": "npx", "args": ["-y", "@playwright/mcp@latest", "--extension"] }
+// 변경 후
+"playwright": { "command": "npx", "args": ["-y", "@playwright/mcp@latest", "--cdp-endpoint", "http://localhost:9222"] }
+```
+- 포트(9222)는 표준값. 크롤링용과 겹치면 다른 포트로(예: 9333).
+
+### 2. 사용자 운영 절차 (전용 크롬 기동 — qa 돌리기 전 1회)
+macOS 기준, **평소 크롬과 분리된 전용 프로필**로 띄움:
+```bash
+"/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" \
+  --remote-debugging-port=9222 \
+  --user-data-dir="$HOME/.chrome-reverb-qa"
+```
+- 이 전용 크롬에서 **reverb 개발서버(dev.globalreverb.com) 로그인 1회** 해두면 세션 유지 → 이후 qa 가 로그인된 상태로 시작.
+- 이 크롬은 **reverb 테스트 전용** — 크롤링·개인 작업에 쓰지 말 것(의심 4).
+- 슬래시 명령 또는 짧은 셸 별칭(alias)으로 만들어 두면 편함(개발 세션이 제안).
+
+### 3. 거버넌스 규칙·메모리·에이전트 갱신 (고문 세션)
+- `reverb-qa-tester.md` 「실행 전 필수」: "전용 크롬이 `--remote-debugging-port`로 떠 있는지 + reverb 로그인 상태인지 확인. 안 떠 있으면 사용자에게 기동 요청 후 중단."
+- `multi-session.md` 「Playwright 단일 자원」: `--extension` → `--cdp-endpoint` 로 서술 갱신, **단일 세션 원칙 유지** 명시(의심 3).
+- `interaction.md`/`git.md`/`session-checklist.js`/`서비스점검.md`: `--extension` 언급 문구 갱신.
+- 메모리 `feedback_playwright_single_resource.md`: 방식 변경 반영(단일 자원·동시 금지 결론은 유지).
+
+---
+
+## 검증 방법 (전환 후, 단일 세션에서)
+1. 전용 크롬을 위 명령으로 띄우고 dev 로그인.
+2. `.mcp.json` 변경 후 Claude Code 세션 재시작(MCP 재로딩).
+3. qa-tester light 1회 실행 → 전용 크롬에서 동작·로그인 유지 확인, 평소 크롬은 영향 없음 확인.
+4. 크롬 안 띄운 채 호출 시 "연결 실패" 안내가 뜨는지(의심 1) 확인.
+
+---
+
+## 인계 — 누가 무엇을
+- **개발(또는 고문) 세션:** `.mcp.json` 변경 + 검증(3·4) + 사용자용 기동 별칭/명령 정리.
+- **고문 세션:** 거버넌스 규칙·메모리·에이전트 갱신(설계 3).
+- **사용자:** 전용 크롬 기동 절차 습관화 + 테스트/크롤링 크롬 분리.
+
+## 사용자 확인 필요
+- 포트 번호(9222 표준 vs 크롤링과 겹치면 변경) — 개발 세션이 사용자 크롤링 포트 확인 후 확정.
+- 동시 멀티세션 qa 병렬을 원하는지(권장: 1차는 단일 유지). 원하면 세션별 포트·프로필 분리 설계 추가.
+
+## 구현 결과
+
+**구현일:** 2026-06-09 (개발 세션 — `.mcp.json` 변경·검증 부분)
+**관련 커밋:** (dev 커밋 — `chore(mcp): connect playwright via cdp-endpoint to dedicated qa chrome`)
+
+### 초안 대비 변경 사항
+- **추가된 것:** 없음. 설계 §1 그대로 `.mcp.json` 한 줄 변경.
+  - 변경 전: `["-y", "@playwright/mcp@latest", "--extension"]`
+  - 변경 후: `["-y", "@playwright/mcp@latest", "--cdp-endpoint", "http://localhost:9222"]`
+- **빠진 것(개발 세션 범위 밖, 고문 세션 인계):** 거버넌스 규칙·에이전트·메모리 갱신(설계 §3) — `reverb-qa-tester.md`「실행 전 필수」/`multi-session.md`/`interaction.md`/`git.md`/`session-checklist.js`/`서비스점검.md`/`feedback_playwright_single_resource.md`. 이 파일들은 거버넌스 문서라 고문/기획 세션이 직접 수정(session-roles.md 경계).
+- **달라진 것:** 포트는 9222 그대로 확정. 사용자 크롤링과 충돌 우려(§95)는 **실측으로 해소** — 9222 점유 크롬이 크롤링용이 아니라 인계 문서가 지정한 전용 프로필(`--user-data-dir=$HOME/.chrome-reverb-qa`)이었음.
+
+### 구현 중 기술 결정 사항
+- **9222 사전 점유 검증:** 변경 전 `lsof -i :9222` + `ps` 로 점유 프로세스 확인 → 전용 프로필 크롬(`.chrome-reverb-qa`)이 dev.globalreverb.com 로그인 상태로 떠 있음을 확인하고 진행(의심 4 보안 분리 충족).
+- **CDP 엔드포인트 응답 검증:** `curl http://localhost:9222/json/version` → Chrome/149, `webSocketDebuggerUrl` 존재 확인. `curl .../json` → 열린 탭이 `dev.globalreverb.com/#home`(로그인 상태)임 확인.
+- **JSON 유효성:** `python3 json.load` 로 `.mcp.json` 파싱 정상 확인.
+- **남은 검증(세션 재시작 필요):** `.mcp.json` 변경은 현재 세션의 이미 로드된 MCP 서버에 즉시 반영되지 않음 → **Claude Code 세션 재시작 후** `reverb-qa-tester` light 1회 실행으로 실제 연결·동작·로그인 유지·평소 크롬 무영향을 최종 확인해야 함(설계 §82). 이 세션에서는 CDP 응답까지만 검증.
+- **`.mcp.json` 은 git 추적 파일** → dev 커밋 대상. reverb 앱 코드·빌드 산출물이 아니라 MCP 서버 기동 설정이라 reverb-reviewer 정적검증 스코프 밖(JSON 유효성·CDP 응답으로 대체 검증).

--- a/index.html
+++ b/index.html
@@ -2728,6 +2728,7 @@ window.I18N_JA = {
     pending: '審査中',
     approved: '当選',
     rejected: '落選',
+    recruitEnded: '募集終了',
     cancelled: '取消',
     cancelledBadge: '取消済',
     cancelMenu: '取消',
@@ -3390,6 +3391,7 @@ window.I18N_KO = {
     pending: '심사중',
     approved: '당첨',
     rejected: '낙첨',
+    recruitEnded: '모집종료',
     cancelled: '취소',
     cancelledBadge: '취소됨',
     cancelMenu: '응모 취소',
@@ -7726,7 +7728,7 @@ function getRecruitTypeBadgeKoSm(t) {
   return '';
 }
 
-function getStatusBadge(s) {
+function getStatusBadge(s, autoReason) {
   const labels = {
     pending: (typeof t === 'function' ? t('appHistory.pending') : '審査中'),
     approved: (typeof t === 'function' ? t('appHistory.approved') : '当選'),
@@ -7739,9 +7741,19 @@ function getStatusBadge(s) {
     rejected:  `<span class="badge badge-gray">${labels.rejected}</span>`,
     cancelled: `<span class="badge badge-gray">${labels.cancelled}</span>`
   };
-  return m[s] || s;
+  let html = m[s] || s;
+  // 캠페인 종료/노출마감으로 인한 자동 낙첨: 落選 옆에 작은 「募集終了」 보조 라벨
+  if (s === 'rejected' && autoReason) {
+    const endedLabel = (typeof t === 'function' ? t('appHistory.recruitEnded') : '募集終了');
+    html += `<span class="badge badge-gray" style="font-size:10px;opacity:.75">${endedLabel}</span>`;
+  }
+  return html;
 }
-function getStatusBadgeKo(s) {
+function getStatusBadgeKo(s, autoReason) {
+  // 캠페인 종료/노출마감 자동 낙첨은 "미승인"이 아니라 "캠페인 종료"로 표시
+  if (s === 'rejected' && autoReason) {
+    return '<span class="badge badge-gray">캠페인 종료</span>';
+  }
   const m = {
     pending:   '<span class="badge badge-gold">심사중</span>',
     approved:  '<span class="badge badge-green">승인</span>',
@@ -10886,7 +10898,7 @@ async function renderMyApplyList() {
       delivItemsHtml = items.join('');
     }
     // 응모 상태 배지(당첨/심사중 등) + 결과물 상태 배지를 카드 본문 맨 아래 가로 한 줄로 모음
-    const badgeRow = `<div class="apply-item-badges" style="display:flex;flex-wrap:wrap;gap:6px;align-items:center;margin-top:6px">${getStatusBadge(a.status)}${delivItemsHtml}</div>`;
+    const badgeRow = `<div class="apply-item-badges" style="display:flex;flex-wrap:wrap;gap:6px;align-items:center;margin-top:6px">${getStatusBadge(a.status, a.auto_reject_reason)}${delivItemsHtml}</div>`;
     const cautionLine = a.caution_agreed_at
       ? `<div class="apply-item-caution" style="font-size:11px;color:var(--green);margin-top:2px;display:inline-flex;align-items:center;gap:3px;flex-wrap:wrap"><span class="material-icons-round notranslate" translate="no" style="font-size:13px">check_circle</span>${t('appHistory.cautionAgreed')} ${formatDate(a.caution_agreed_at)}${cautionCompareButton(a, camp)}</div>`
       : '';

--- a/supabase/migrations/176_auto_reject_pending_on_campaign_end.sql
+++ b/supabase/migrations/176_auto_reject_pending_on_campaign_end.sql
@@ -1,0 +1,126 @@
+-- ============================================================
+-- 176_auto_reject_pending_on_campaign_end.sql
+-- 2026-06-09
+--
+-- 목적:
+--   캠페인 status 가 ended(종료) 또는 expired(노출마감) 로 변경될 때
+--   해당 캠페인의 pending 신청을 자동으로 rejected 처리한다.
+--   인플루언서 앱 알림·메일은 의도적으로 발생시키지 않는다.
+--
+-- 설계 근거:
+--   ① trg_application_status_event (마이그레이션 131·154):
+--       - applications.status 변경 시 발화. rejected 전이는 application_events
+--         'reject' audit 를 INSERT 함 (정상 기록, 무한루프 없음: campaigns → applications 단방향).
+--       - notifications INSERT 는 NEW.status='approved' 케이스에만 발생 → rejected 전이는 알림 없음.
+--   ② 인플루언서 일일 다이제스트 메일 (notify-influencer-daily-digest):
+--       - reviewed_at >= 어제KST 조건으로 잡음.
+--       - auto_reject 는 reviewed_at = NULL 로 두어 메일 자동 제외.
+--   ③ closed(모집마감)는 대상 아님 — 모집이 마감됐어도 심사는 가능(영업일 기준 처리).
+--       ended/expired 만 처리.
+--
+-- 변경 내용:
+--   (1) applications 테이블에 auto_reject_reason text 컬럼 추가
+--       NULL = 일반(수동 포함) / 'campaign_ended' / 'campaign_expired'
+--   (2) 트리거 함수 public.reject_pending_on_campaign_end() 생성
+--       AFTER UPDATE OF status ON campaigns 에서 발화 → pending 일괄 rejected
+--   (3) 트리거 trg_reject_pending_on_campaign_end 등록
+--
+-- 주의 포인트:
+--   - WHERE status='pending' 으로 approved/rejected/cancelled 행 절대 건드리지 않음.
+--     (당첨자를 낙첨 처리하는 사고 방지)
+--   - SECURITY DEFINER + SET search_path='' 필수 (.claude/rules/security.md)
+--   - reviewed_version(낙관적 락) 은 시스템 자동 처리라 갱신하지 않음.
+--   - 연쇄 트리거: campaigns UPDATE → applications UPDATE → trg_application_status_event
+--     → application_events INSERT ('reject' audit) 만 발생, 알림 없음.
+--
+-- 백필: 별도 177_auto_reject_pending_backfill.sql 참조.
+--
+-- 롤백:
+--   DROP TRIGGER IF EXISTS trg_reject_pending_on_campaign_end ON public.campaigns;
+--   DROP FUNCTION IF EXISTS public.reject_pending_on_campaign_end();
+--   ALTER TABLE public.applications DROP COLUMN IF EXISTS auto_reject_reason;
+-- ============================================================
+
+BEGIN;
+
+
+-- ============================================================
+-- (1) auto_reject_reason 컬럼 추가
+--     NULL     = 일반 신청 (관리자 수동 처리 포함)
+--     'campaign_ended'   = 캠페인 ended 전이로 인한 자동 낙첨
+--     'campaign_expired' = 캠페인 expired 전이로 인한 자동 낙첨
+-- ============================================================
+ALTER TABLE public.applications
+  ADD COLUMN IF NOT EXISTS auto_reject_reason text;
+
+COMMENT ON COLUMN public.applications.auto_reject_reason IS
+  '자동 낙첨 식별자. '
+  'NULL = 일반(관리자 수동 포함). '
+  '''campaign_ended'' = 캠페인 종료(ended) 전이로 인한 자동 낙첨. '
+  '''campaign_expired'' = 캠페인 노출마감(expired) 전이로 인한 자동 낙첨. '
+  '마이그레이션 176 추가.';
+
+
+-- ============================================================
+-- (2) 트리거 함수: reject_pending_on_campaign_end
+--     campaigns.status 가 ended/expired 로 변경될 때
+--     해당 캠페인의 pending 신청을 일괄 rejected 처리.
+--
+--     알림·메일 비발생 이유:
+--       - trg_application_status_event 는 rejected 전이에서 notifications INSERT 를 하지 않음.
+--       - reviewed_at = NULL 로 설정하여 인플루언서 일일 다이제스트 메일 조건(gte 어제KST)에서 제외.
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.reject_pending_on_campaign_end()
+  RETURNS trigger
+  LANGUAGE plpgsql
+  SECURITY DEFINER
+  SET search_path = ''
+AS $$
+BEGIN
+  -- ended 또는 expired 로 새로 전환된 경우에만 처리.
+  -- COALESCE(OLD.status,'') 로 OLD.status 가 NULL 인 엣지케이스도 안전하게 처리.
+  IF NEW.status IN ('ended', 'expired')
+     AND COALESCE(OLD.status, '') NOT IN ('ended', 'expired')
+  THEN
+    UPDATE public.applications
+      SET status             = 'rejected',
+          auto_reject_reason = CASE NEW.status
+                                 WHEN 'ended'   THEN 'campaign_ended'
+                                 ELSE                'campaign_expired'
+                               END,
+          reviewed_by        = '시스템(캠페인 종료)',
+          -- reviewed_at = NULL: 어제KST 비교 조건에서 자동 제외 → 다이제스트 메일 미발송.
+          reviewed_at        = NULL
+      WHERE campaign_id = NEW.id
+        AND status      = 'pending';
+        -- approved / rejected / cancelled 는 WHERE 조건으로 완전 보호.
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+COMMENT ON FUNCTION public.reject_pending_on_campaign_end() IS
+  '[176] campaigns.status 가 ended/expired 로 전환될 때 '
+  '해당 캠페인의 pending 신청을 자동으로 rejected 처리. '
+  'reviewed_at=NULL 로 인플루언서 다이제스트 메일 제외. '
+  'SECURITY DEFINER — 트리거에서만 호출.';
+
+
+-- ============================================================
+-- (3) 트리거 등록
+--     AFTER UPDATE OF status ON campaigns
+--     → 행 단위(FOR EACH ROW) 로 발화
+-- ============================================================
+DROP TRIGGER IF EXISTS trg_reject_pending_on_campaign_end ON public.campaigns;
+
+CREATE TRIGGER trg_reject_pending_on_campaign_end
+  AFTER UPDATE OF status ON public.campaigns
+  FOR EACH ROW
+  EXECUTE FUNCTION public.reject_pending_on_campaign_end();
+
+COMMENT ON TRIGGER trg_reject_pending_on_campaign_end ON public.campaigns IS
+  '[176] campaigns.status → ended/expired 전이 시 pending 신청 자동 낙첨 트리거.';
+
+
+COMMIT;

--- a/supabase/migrations/177_auto_reject_pending_backfill.sql
+++ b/supabase/migrations/177_auto_reject_pending_backfill.sql
@@ -1,0 +1,77 @@
+-- ============================================================
+-- 177_auto_reject_pending_backfill.sql
+-- 2026-06-09
+--
+-- 목적:
+--   176 트리거 도입 이전에 이미 ended/expired 상태인 캠페인의
+--   pending 신청을 소급하여 일괄 rejected 처리(백필).
+--
+-- 전제 조건:
+--   마이그레이션 176 (auto_reject_reason 컬럼 + 트리거 함수) 적용 완료.
+--
+-- 설계 근거 (176과 동일):
+--   ① rejected 전이는 trg_application_status_event 가 application_events
+--     'reject' audit 를 INSERT 함 (정상, 무한루프 없음).
+--   ② 알림(notifications) INSERT 없음 — rejected 전이는 알림 조건 불일치.
+--   ③ reviewed_at = NULL 로 인플루언서 일일 다이제스트 메일 제외 (필수).
+--
+-- 멱등성:
+--   WHERE a.status='pending' 조건으로 중복 실행 안전.
+--   이미 rejected/approved/cancelled 인 행은 절대 건드리지 않음.
+--
+-- 주의:
+--   - 운영 적용 전 반드시 아래 사전 확인 SELECT 를 먼저 실행하여 대상 건수 확인.
+--   - 대상 건수가 예상과 크게 다르면 즉시 멈추고 원인 파악.
+--
+-- 롤백:
+--   이 SQL 자체는 롤백이 의미 없음 (이미 누락 처리된 pending 행을 복구하는 것은
+--   비즈니스 판단이 필요). 만약 오적용이 발생했다면 개별 application_id 를 확인 후
+--   수동으로 status, auto_reject_reason, reviewed_by, reviewed_at 을 되돌릴 것.
+-- ============================================================
+
+
+-- ============================================================
+-- [운영 적용 전 반드시 실행] 사전 확인용 SELECT
+-- 이 쿼리를 먼저 실행해서 대상 건수를 확인한 뒤 아래 UPDATE 를 진행할 것.
+--
+-- SELECT count(*)
+--   FROM public.applications a
+--   JOIN public.campaigns c ON c.id = a.campaign_id
+--  WHERE c.status IN ('ended', 'expired')
+--    AND a.status = 'pending';
+-- ============================================================
+
+
+BEGIN;
+
+-- ============================================================
+-- 백필 UPDATE
+-- ended/expired 캠페인의 pending 신청 → rejected (자동 낙첨)
+-- ============================================================
+UPDATE public.applications a
+  SET status             = 'rejected',
+      auto_reject_reason = CASE c.status
+                             WHEN 'ended'   THEN 'campaign_ended'
+                             ELSE                'campaign_expired'
+                           END,
+      reviewed_by        = '시스템(캠페인 종료)',
+      -- reviewed_at = NULL: 다이제스트 메일 어제KST 비교 조건에서 자동 제외.
+      -- 이 행들을 메일에 포함시키면 운영 DB 적용 당일 인플루언서에게 낙첨 메일이 대량 발송됨.
+      reviewed_at        = NULL
+  FROM public.campaigns c
+ WHERE a.campaign_id = c.id
+   AND c.status IN ('ended', 'expired')
+   AND a.status = 'pending';
+
+-- ============================================================
+-- [사후 확인용 SELECT — UPDATE 직후 실행]
+-- 0 행이 나와야 정상 (남아있는 pending 이 없음).
+--
+-- SELECT count(*)
+--   FROM public.applications a
+--   JOIN public.campaigns c ON c.id = a.campaign_id
+--  WHERE c.status IN ('ended', 'expired')
+--    AND a.status = 'pending';
+-- ============================================================
+
+COMMIT;


### PR DESCRIPTION
## 변경 요약
- 캠페인이 종료(ended)/노출마감(expired)되면 그 캠페인의 심사중(pending) 신청을 자동 낙첨 처리 (무알림)
- 앱 알림 미발생(기존 트리거가 approved만 알림) + 심사일시 NULL로 일일 다이제스트 메일 제외
- 관리자 화면은 "캠페인 종료" 배지, 인플루언서 응모이력은 落選 + 募集終了 보조 라벨
- 마이그레이션 176(컬럼+트리거)·177(백필) — **운영 DB 적용 완료**: 기존 누적분 1,204건 백필 (남은 0건 확인)

## 요청 외 추가 변경
- .mcp.json qa 브라우저 도구 설정 커밋 2개(b5d64a5/3e25bc3) 동반 — 서로 상쇄, 개발 도구 설정이라 운영 사이트 무영향

## 관련 사양서
- docs/specs/2026-06-09-campaign-end-auto-reject.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)