### PR TITLE
feat(deliverable): relax admin receipt edit to min 1 of 3 fields

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,7 +137,7 @@
 - **결과물 관리** (`/admin#deliverables`): 영수증/게시물 URL 통합 검수 페인. 필터(상태 기본 pending·캠페인·타입·인플루언서 검색) + 오래된 순 정렬. 상세 모달에 이력 타임라인 + 승인/반려/되돌리기. 반려 사유 템플릿(6종) + 자유입력. 낙관적 락(`version`) 기반 동시 처리 충돌 차단 — 후순위는 "이미 처리됨" 토스트
 - **인증 상태 컬럼**(목록 + 엑셀, 신청 1건 단위 3종, 위치=인플루언서 다음·영수증 앞): `인증성공`(리뷰어=영수증 승인+채널별 인증샷 모두 승인 / 시딩·방문=게시물 승인) · `인증샷 제출중`(검수중·반려·일부 미제출 등 진행 중) · `미제출`(아무것도 안 냄). 헬퍼 `computeCertStatus`/`certStatusBadge`(admin-deliverables.js), 엑셀은 `_excelCertStatus*`(admin-excel.js). 단일 캠페인 엑셀도 전체 상태 로드(`fetchDeliverables` status 필터 없음 + `fetchApplications({status:'approved'})` 조인으로 결과물 0건 승인 신청도 미제출 빈 행 포함) → 화면 목록·단일/다중 엑셀 모두 3종 정확 표시
 - **캠페인 진행현황**(캠페인 → 신청자 보기): 신청자 테이블에 OT 발송 체크박스(gifting/visit 승인 건만 활성) + 결과물 상태 요약(승인/검수대기/반려 건수 + 최신 상세 모달 링크)
-- **영수증 필수 필드**(리뷰어 monitor): 인플 폼에 `order_number` + `purchase_date` + `purchase_amount` 3종 필수. 관리자 검수 모달은 `renderReceiptInfoBlock(d)` 공통 헬퍼 + campaign_admin 이상 인플레이스 수정 + 「변경 이력 보기」 토글. `update_receipt_admin` RPC (SECURITY DEFINER, campaign_admin 가드, FOR UPDATE 행 잠금). 변경 시 `receipt_edit_history` 자동 INSERT
+- **영수증 필수 필드**(리뷰어 monitor): 인플 폼(제출)은 `order_number` + `purchase_date` + `purchase_amount` 3종 필수 유지. **관리자 검수 모달 인플레이스 수정은 3종 중 최소 1개만 입력하면 저장**(마이그레이션 178 — 운영자가 아는 정보만 부분 수정 가능, 인플 제출 경로와 무관). `renderReceiptInfoBlock(d)` 공통 헬퍼 + campaign_admin 이상 인플레이스 수정 + 「변경 이력 보기」 토글. `update_receipt_admin` RPC (SECURITY DEFINER, campaign_admin 가드, FOR UPDATE 행 잠금, 빈 항목 NULL 저장·3종 모두 빈값이면 거부). 변경 시 `receipt_edit_history` 자동 INSERT
 - **엑셀 내보내기**: 단일 캠페인은 더보기 메뉴 `결과물 엑셀`/`신청자 엑셀`, 다중 캠페인은 목록 체크박스 + 「선택 N개 …엑셀」. ExcelJS CDN lazy-load, 영수증 이미지 셀 임베드. 50개+ confirm() + 5초 쿨다운 + 동시 진행 lock. 시트1 「캠페인 정보」 + 시트2 「결과물/신청자」. 이름 한자/가나 분리, SNS 핸들 → 공식 전체 URL, 우편번호 별도 컬럼. 공용 헬퍼는 `_excel*` 시리즈
 
 ### 브랜드 서베이 (광고주 신청 관리)

--- a/admin/index.html
+++ b/admin/index.html
@@ -12,7 +12,7 @@
 // 회귀(2026-05-12 PR #182 머지 직후 발생)를 방지하기 위한 자동 reload 가드.
 // sessionStorage 차단 환경(시크릿 모드 일부, 쿠키 차단)에서는 자연스럽게 skip.
 (function(){
-  var CURRENT_BUILD = 'v1781004188';
+  var CURRENT_BUILD = 'v1781015206';
   if (CURRENT_BUILD.indexOf('__') === 0) return; // 빌드 미적용 (dev/ 직접 열기) 시 skip
   try {
     var prev = sessionStorage.getItem('reverb.adminBuild');
@@ -2012,7 +2012,7 @@ textarea.form-input{resize:vertical;min-height:80px}
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-06-09 20:23 · adbf48e</span>
+          <span class="admin-build-text">2026-06-09 23:26 · ae258ff</span>
         </div>
       </div>
     </aside>
@@ -19669,17 +19669,18 @@ function renderReceiptInfoBlock(d) {
     </div>`;
   const editHtml = canEdit ? `
     <div id="receiptInfoEdit-${esc(id)}" style="display:none;font-size:12px;margin-bottom:10px;padding:10px 12px;background:#FFF9E6;border:1px solid #F5C518;border-radius:8px">
-      <div style="font-weight:600;margin-bottom:8px">영수증 정보 수정</div>
+      <div style="font-weight:600;margin-bottom:4px">영수증 정보 수정</div>
+      <div style="font-size:11px;color:var(--muted);margin-bottom:8px">주문번호·구매일·구매금액 중 최소 1개만 입력해도 저장됩니다.</div>
       <div style="margin-bottom:6px">
-        <label style="display:block;color:var(--muted);margin-bottom:2px">주문번호 *</label>
+        <label style="display:block;color:var(--muted);margin-bottom:2px">주문번호</label>
         <input id="receiptEditOrder-${esc(id)}" type="text" maxlength="200" value="${esc(orderNo)}" style="width:100%;padding:5px 8px;border:1px solid var(--line);border-radius:4px;font-size:12px">
       </div>
       <div style="margin-bottom:6px">
-        <label style="display:block;color:var(--muted);margin-bottom:2px">구매일 *</label>
+        <label style="display:block;color:var(--muted);margin-bottom:2px">구매일</label>
         <input id="receiptEditDate-${esc(id)}" type="date" value="${esc(purchaseDate)}" style="width:100%;padding:5px 8px;border:1px solid var(--line);border-radius:4px;font-size:12px">
       </div>
       <div style="margin-bottom:8px">
-        <label style="display:block;color:var(--muted);margin-bottom:2px">구매금액 (엔) *</label>
+        <label style="display:block;color:var(--muted);margin-bottom:2px">구매금액 (엔)</label>
         <input id="receiptEditAmount-${esc(id)}" type="number" min="0" step="1" value="${(amt === null || !Number.isFinite(amt)) ? '' : amt}" style="width:100%;padding:5px 8px;border:1px solid var(--line);border-radius:4px;font-size:12px">
       </div>
       <div style="display:flex;gap:6px;justify-content:flex-end">
@@ -19709,18 +19710,22 @@ async function saveReceiptEdit(id) {
   const orderNo = (document.getElementById('receiptEditOrder-' + id)?.value || '').trim();
   const purchaseDate = document.getElementById('receiptEditDate-' + id)?.value || '';
   const rawAmount = document.getElementById('receiptEditAmount-' + id)?.value || '';
-  if (!orderNo) { toast('주문번호를 입력해주세요','error'); return; }
-  if (orderNo.length > 200) { toast('주문번호는 200자 이내로 입력해주세요','error'); return; }
-  if (!purchaseDate) { toast('구매일을 입력해주세요','error'); return; }
-  if (rawAmount === '' || rawAmount === null || rawAmount === undefined) {
-    toast('구매금액을 입력해주세요','error'); return;
+  // 관리자 수정: 3종 중 최소 1개만 있으면 저장 (인플루언서 제출 경로는 3종 필수 별도 유지)
+  const hasAmount = !(rawAmount === '' || rawAmount === null || rawAmount === undefined);
+  if (!orderNo && !purchaseDate && !hasAmount) {
+    toast('주문번호·구매일·구매금액 중 최소 1개는 입력해주세요','error'); return;
   }
-  const amount = Number(rawAmount);
-  if (!Number.isFinite(amount) || amount < 0) {
-    toast('구매금액은 0 이상의 숫자를 입력해주세요','error'); return;
+  if (orderNo.length > 200) { toast('주문번호는 200자 이내로 입력해주세요','error'); return; }
+  let amount = null;
+  if (hasAmount) {
+    amount = Number(rawAmount);
+    if (!Number.isFinite(amount) || amount < 0) {
+      toast('구매금액은 0 이상의 숫자를 입력해주세요','error'); return;
+    }
   }
   try {
-    await updateReceiptAdmin(id, orderNo, purchaseDate, amount);
+    // 빈 항목은 null 로 전달 (RPC 가 NULL 허용·최소 1개 검증)
+    await updateReceiptAdmin(id, orderNo || null, purchaseDate || null, amount);
     toast('영수증 정보를 수정했습니다','success');
     // 현재 열린 모달 재로딩 (통합 검수 모달 우선, 단일 상세 모달 후순)
     if (typeof _delivCombinedRefreshAppId !== 'undefined' && _delivCombinedRefreshAppId) {

--- a/dev/js/admin-deliverables.js
+++ b/dev/js/admin-deliverables.js
@@ -1190,17 +1190,18 @@ function renderReceiptInfoBlock(d) {
     </div>`;
   const editHtml = canEdit ? `
     <div id="receiptInfoEdit-${esc(id)}" style="display:none;font-size:12px;margin-bottom:10px;padding:10px 12px;background:#FFF9E6;border:1px solid #F5C518;border-radius:8px">
-      <div style="font-weight:600;margin-bottom:8px">영수증 정보 수정</div>
+      <div style="font-weight:600;margin-bottom:4px">영수증 정보 수정</div>
+      <div style="font-size:11px;color:var(--muted);margin-bottom:8px">주문번호·구매일·구매금액 중 최소 1개만 입력해도 저장됩니다.</div>
       <div style="margin-bottom:6px">
-        <label style="display:block;color:var(--muted);margin-bottom:2px">주문번호 *</label>
+        <label style="display:block;color:var(--muted);margin-bottom:2px">주문번호</label>
         <input id="receiptEditOrder-${esc(id)}" type="text" maxlength="200" value="${esc(orderNo)}" style="width:100%;padding:5px 8px;border:1px solid var(--line);border-radius:4px;font-size:12px">
       </div>
       <div style="margin-bottom:6px">
-        <label style="display:block;color:var(--muted);margin-bottom:2px">구매일 *</label>
+        <label style="display:block;color:var(--muted);margin-bottom:2px">구매일</label>
         <input id="receiptEditDate-${esc(id)}" type="date" value="${esc(purchaseDate)}" style="width:100%;padding:5px 8px;border:1px solid var(--line);border-radius:4px;font-size:12px">
       </div>
       <div style="margin-bottom:8px">
-        <label style="display:block;color:var(--muted);margin-bottom:2px">구매금액 (엔) *</label>
+        <label style="display:block;color:var(--muted);margin-bottom:2px">구매금액 (엔)</label>
         <input id="receiptEditAmount-${esc(id)}" type="number" min="0" step="1" value="${(amt === null || !Number.isFinite(amt)) ? '' : amt}" style="width:100%;padding:5px 8px;border:1px solid var(--line);border-radius:4px;font-size:12px">
       </div>
       <div style="display:flex;gap:6px;justify-content:flex-end">
@@ -1230,18 +1231,22 @@ async function saveReceiptEdit(id) {
   const orderNo = (document.getElementById('receiptEditOrder-' + id)?.value || '').trim();
   const purchaseDate = document.getElementById('receiptEditDate-' + id)?.value || '';
   const rawAmount = document.getElementById('receiptEditAmount-' + id)?.value || '';
-  if (!orderNo) { toast('주문번호를 입력해주세요','error'); return; }
-  if (orderNo.length > 200) { toast('주문번호는 200자 이내로 입력해주세요','error'); return; }
-  if (!purchaseDate) { toast('구매일을 입력해주세요','error'); return; }
-  if (rawAmount === '' || rawAmount === null || rawAmount === undefined) {
-    toast('구매금액을 입력해주세요','error'); return;
+  // 관리자 수정: 3종 중 최소 1개만 있으면 저장 (인플루언서 제출 경로는 3종 필수 별도 유지)
+  const hasAmount = !(rawAmount === '' || rawAmount === null || rawAmount === undefined);
+  if (!orderNo && !purchaseDate && !hasAmount) {
+    toast('주문번호·구매일·구매금액 중 최소 1개는 입력해주세요','error'); return;
   }
-  const amount = Number(rawAmount);
-  if (!Number.isFinite(amount) || amount < 0) {
-    toast('구매금액은 0 이상의 숫자를 입력해주세요','error'); return;
+  if (orderNo.length > 200) { toast('주문번호는 200자 이내로 입력해주세요','error'); return; }
+  let amount = null;
+  if (hasAmount) {
+    amount = Number(rawAmount);
+    if (!Number.isFinite(amount) || amount < 0) {
+      toast('구매금액은 0 이상의 숫자를 입력해주세요','error'); return;
+    }
   }
   try {
-    await updateReceiptAdmin(id, orderNo, purchaseDate, amount);
+    // 빈 항목은 null 로 전달 (RPC 가 NULL 허용·최소 1개 검증)
+    await updateReceiptAdmin(id, orderNo || null, purchaseDate || null, amount);
     toast('영수증 정보를 수정했습니다','success');
     // 현재 열린 모달 재로딩 (통합 검수 모달 우선, 단일 상세 모달 후순)
     if (typeof _delivCombinedRefreshAppId !== 'undefined' && _delivCombinedRefreshAppId) {

--- a/supabase/migrations/178_relax_update_receipt_admin.sql
+++ b/supabase/migrations/178_relax_update_receipt_admin.sql
@@ -1,0 +1,164 @@
+-- ============================================================
+-- migration: 178
+-- title: relax update_receipt_admin — 3종 필수 → 최소 1개
+-- date: 2026-06-09
+-- 128 대비 변경:
+--   [변경] 주문번호·구매일·구매금액 3종 모두 필수 → 최소 1개 있으면 저장 허용
+--   [신규] 3종 모두 빈값/NULL 인 경우 ERRCODE 22023 으로 차단
+--   [변경] order_number: 빈값(공백만) 차단 제거 → 빈값은 NULL 로 통일(NULLIF)
+--   [유지] order_number 값이 있을 때만 200자 초과 검증
+--   [유지] purchase_amount 값이 있을 때만(IS NOT NULL) < 0 검증
+--   [유지] 권한 가드(is_campaign_admin), FOR UPDATE 행 잠금, no-op 체크, 이력 기록
+-- 관리자 전용 함수(is_campaign_admin) — 인플루언서 제출 경로 무관
+--
+-- rollback (128 버전으로 되돌리기):
+--   supabase/migrations/128_receipt_required_fields.sql 의 4번 섹션(update_receipt_admin)을
+--   SQL Editor 에서 다시 실행하면 CREATE OR REPLACE 로 함수가 128 버전으로 교체됨.
+--   데이터·테이블·인덱스는 이 마이그레이션과 무관하므로 함수 교체만으로 완전 롤백됨.
+-- ============================================================
+
+BEGIN;
+
+-- ============================================================
+-- update_receipt_admin RPC (128 버전 교체)
+--
+-- 권한: campaign_admin 이상 (is_campaign_admin())
+-- 입력 검증:
+--   - 최소 1개 필수: order_number(공백 제거 후 비어있지 않음) / purchase_date / purchase_amount
+--     셋 모두 없으면 22023
+--   - order_number: 값이 있을 때만 200자 초과 검증. 빈값은 NULL 저장(NULLIF)
+--   - purchase_date: NULL 허용 (그대로 저장)
+--   - purchase_amount: NULL 허용. 값이 있을 때만 < 0 검증 (0원 허용)
+-- 대상 검증:
+--   - 존재하지 않는 deliverable_id → 에러
+--   - kind != 'receipt' → 에러
+-- no-op:
+--   - 저장값(order_number=NULLIF(trimmed,''), purchase_date, purchase_amount) 이
+--     기존값과 IS NOT DISTINCT FROM 모두 동일 → RETURN (이력 미기록)
+-- 부수 효과:
+--   - deliverables UPDATE
+--   - receipt_edit_history INSERT (prev/next 스냅샷)
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.update_receipt_admin(
+  p_deliverable_id  uuid,
+  p_order_number    text,
+  p_purchase_date   date,
+  p_purchase_amount numeric
+)
+  RETURNS void
+  LANGUAGE plpgsql
+  SECURITY DEFINER
+  SET search_path = ''
+AS $$
+DECLARE
+  v_prev          record;
+  v_admin_name    text;
+  v_trimmed_order text;
+  v_order_to_save text;  -- NULLIF(v_trimmed_order, '') — 저장에 사용할 최종값
+BEGIN
+  -- ── 권한 가드: campaign_admin 이상 ──────────────────────────
+  IF NOT public.is_campaign_admin() THEN
+    RAISE EXCEPTION '권한이 없습니다 (campaign_admin 이상 필요)' USING ERRCODE = '42501';
+  END IF;
+
+  -- ── 입력 정규화 ───────────────────────────────────────────
+  -- order_number 는 앞뒤 공백 제거 후 비교. NULL 과 빈값은 동일 처리
+  v_trimmed_order := btrim(COALESCE(p_order_number, ''));
+  -- 저장할 최종값: 빈 문자열이면 NULL 로 통일
+  v_order_to_save := NULLIF(v_trimmed_order, '');
+
+  -- ── 입력 검증: 최소 1개 필수 ─────────────────────────────
+  -- 3종 모두 빈값/NULL 이면 의미 없는 호출 — 차단
+  IF v_order_to_save IS NULL
+     AND p_purchase_date   IS NULL
+     AND p_purchase_amount IS NULL
+  THEN
+    RAISE EXCEPTION '주문번호·구매일·구매금액 중 최소 1개는 입력해야 합니다'
+      USING ERRCODE = '22023';
+  END IF;
+
+  -- ── 입력 검증: order_number — 값이 있을 때만 길이 검사 ────
+  IF v_order_to_save IS NOT NULL AND length(v_order_to_save) > 200 THEN
+    RAISE EXCEPTION '주문번호는 200자 이하여야 합니다' USING ERRCODE = '22023';
+  END IF;
+
+  -- ── 입력 검증: purchase_amount — 값이 있을 때만 음수 검사 ─
+  IF p_purchase_amount IS NOT NULL AND p_purchase_amount < 0 THEN
+    RAISE EXCEPTION '구매금액은 0 이상이어야 합니다' USING ERRCODE = '22023';
+  END IF;
+
+  -- ── 대상 행 조회 ──────────────────────────────────────────
+  SELECT order_number, purchase_date, purchase_amount, kind
+    INTO v_prev
+    FROM public.deliverables
+   WHERE id = p_deliverable_id
+   FOR UPDATE;  -- 동시 수정 충돌 방지를 위한 행 잠금
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION '결과물을 찾을 수 없습니다 (id: %)', p_deliverable_id USING ERRCODE = '02000';
+  END IF;
+
+  IF v_prev.kind != 'receipt' THEN
+    RAISE EXCEPTION '영수증 결과물만 수정 가능합니다 (kind=receipt 필요, 실제: %)', v_prev.kind
+      USING ERRCODE = '22023';
+  END IF;
+
+  -- ── no-op 체크: 저장값 기준으로 기존값과 모두 동일하면 이력 미기록 후 반환 ──
+  -- v_order_to_save: NULLIF 적용 후 값 (빈 문자열 → NULL 통일)
+  IF v_prev.order_number    IS NOT DISTINCT FROM v_order_to_save
+     AND v_prev.purchase_date   IS NOT DISTINCT FROM p_purchase_date
+     AND v_prev.purchase_amount IS NOT DISTINCT FROM p_purchase_amount
+  THEN
+    RETURN;
+  END IF;
+
+  -- ── 관리자 이름 스냅샷 ────────────────────────────────────
+  SELECT name INTO v_admin_name
+    FROM public.admins
+   WHERE auth_id = auth.uid()
+   LIMIT 1;
+
+  -- ── deliverables UPDATE ───────────────────────────────────
+  -- updated_at 은 trg_deliverables_updated_at BEFORE UPDATE 트리거가 자동 갱신
+  UPDATE public.deliverables
+     SET order_number    = v_order_to_save,
+         purchase_date   = p_purchase_date,
+         purchase_amount = p_purchase_amount
+   WHERE id = p_deliverable_id;
+
+  -- ── receipt_edit_history INSERT ───────────────────────────
+  -- next 값은 저장값(v_order_to_save, p_purchase_date, p_purchase_amount) 기준으로 기록
+  INSERT INTO public.receipt_edit_history (
+    deliverable_id,
+    changed_by,
+    changed_by_name,
+    order_number_prev,
+    order_number_next,
+    purchase_date_prev,
+    purchase_date_next,
+    purchase_amount_prev,
+    purchase_amount_next,
+    source
+  ) VALUES (
+    p_deliverable_id,
+    auth.uid(),
+    COALESCE(v_admin_name, '(이름미상)'),
+    v_prev.order_number,
+    v_order_to_save,
+    v_prev.purchase_date,
+    p_purchase_date,
+    v_prev.purchase_amount,
+    p_purchase_amount,
+    'admin_edit'
+  );
+END;
+$$;
+
+COMMENT ON FUNCTION public.update_receipt_admin(uuid, text, date, numeric) IS
+  '관리자가 deliverables(kind=receipt) 영수증 필드(주문번호·구매일·구매금액)를 수정하고 변경 이력을 기록하는 RPC. SECURITY DEFINER, campaign_admin 이상 필요. 128에서 178로 완화: 3종 모두 필수 → 최소 1개 입력. 178.';
+
+-- 권한 부여: 클라이언트(authenticated)에서 호출 가능 (128 과 동일)
+REVOKE ALL ON FUNCTION public.update_receipt_admin(uuid, text, date, numeric) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.update_receipt_admin(uuid, text, date, numeric) TO authenticated;
+
+COMMIT;


### PR DESCRIPTION
## 변경 요약
- 관리자 영수증 정보 인플레이스 수정 시 주문번호·구매일·구매금액 3종 필수 → 최소 1개로 완화
- 빈 항목은 NULL 저장, 3종 모두 비면 거부. 인플루언서 제출 경로는 3종 필수 유지
- 마이그레이션 178(update_receipt_admin 함수 교체) — 운영 DB 적용 완료

## 요청 외 추가 변경
- 없음

## 관련 사양서
- 없음 (CLAUDE.md 영수증 필수 필드 섹션 반영)

🤖 Generated with [Claude Code](https://claude.com/claude-code)