### PR TITLE
feat(admin): draggable non-modal image lightbox with zoom

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,7 +77,7 @@
 - 배포용: 루트 `index.html` (build.sh 로 생성)
 - 개발 폴더 구조:
   - `dev/js/` — 인플루언서: app, ui, campaign, application, auth, mypage, notifications, messaging
-    - 관리자(admin.js 페인 분리 완료, 2026-05-25): `admin.js`(캠페인 목록·폼만 잔류) + `admin-core.js`(공용 헬퍼: 페인 라우팅·다중필터·확인모달·라이트박스·태그입력) + `admin-notices.js` + `admin-faq.js` + `admin-influencers.js` + `admin-deliverables.js` + `admin-excel.js` + `admin-dashboard.js` + `admin-applications.js`(신청+신청자) + `admin-accounts.js`(내계정+관리자계정) + `admin-lookups.js`(기준데이터+번들3종+미니에디터) + `admin-errors.js`(오류 로그 페인 — 마이그레이션 165) + `admin-brand.js`/`admin-company.js`/`admin-brand-ops.js`/`admin-messaging.js`(브랜드 서베이)
+    - 관리자(admin.js 페인 분리 완료, 2026-05-25): `admin.js`(캠페인 목록·폼만 잔류) + `admin-core.js`(공용 헬퍼: 페인 라우팅·다중필터·확인모달·이미지 라이트박스[`#imageLightbox` — 배경 안 덮는 드래그·리사이즈 떠있는 창, 뒤 검수 모달 입력 가능]·모달 드래그/리사이즈 인프라·태그입력) + `admin-notices.js` + `admin-faq.js` + `admin-influencers.js` + `admin-deliverables.js` + `admin-excel.js` + `admin-dashboard.js` + `admin-applications.js`(신청+신청자) + `admin-accounts.js`(내계정+관리자계정) + `admin-lookups.js`(기준데이터+번들3종+미니에디터) + `admin-errors.js`(오류 로그 페인 — 마이그레이션 165) + `admin-brand.js`/`admin-company.js`/`admin-brand-ops.js`/`admin-messaging.js`(브랜드 서베이)
     - 빌드는 ES 모듈이 아니라 단순 이어붙이기(concat) — 전역 스코프 1개. `admin-core.js`가 다른 admin-* 파일보다 앞, `admin.js`가 페인 파일들보다 뒤, `admin/app.js`가 맨 마지막 (build.sh `ADMIN_JS_FILES` 순서)
   - `dev/css/` — base, components, campaign, auth, mypage, admin
   - `dev/lib/` — supabase(설정), shared(전역변수), storage(DB/Storage API)

--- a/admin/index.html
+++ b/admin/index.html
@@ -12,7 +12,7 @@
 // 회귀(2026-05-12 PR #182 머지 직후 발생)를 방지하기 위한 자동 reload 가드.
 // sessionStorage 차단 환경(시크릿 모드 일부, 쿠키 차단)에서는 자연스럽게 skip.
 (function(){
-  var CURRENT_BUILD = 'v1781018520';
+  var CURRENT_BUILD = 'v1781018967';
   if (CURRENT_BUILD.indexOf('__') === 0) return; // 빌드 미적용 (dev/ 직접 열기) 시 skip
   try {
     var prev = sessionStorage.getItem('reverb.adminBuild');
@@ -2026,7 +2026,7 @@ textarea.form-input{resize:vertical;min-height:80px}
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-06-10 00:22 · fe99644</span>
+          <span class="admin-build-text">2026-06-10 00:29 · 66cb70f</span>
         </div>
       </div>
     </aside>
@@ -4128,18 +4128,19 @@ textarea.form-input{resize:vertical;min-height:80px}
 
 <!-- 이미지 확대 라이트박스 -->
 <div class="modal-overlay" id="imageLightbox" style="z-index:900">
-  <div class="modal" style="padding:0;border-radius:16px;overflow:hidden">
-    <div class="modal-header" style="padding:10px 14px">
+  <div class="modal" style="padding:0;border-radius:16px">
+    <div class="modal-header" style="padding:10px 14px;border-radius:16px 16px 0 0">
       <span class="modal-title" style="font-size:14px">이미지 보기</span>
       <span class="modal-close material-icons-round notranslate" translate="no" onclick="closeModal('imageLightbox')" aria-label="닫기" style="font-size:18px">close</span>
     </div>
-    <div class="modal-body" style="padding:8px;display:flex;align-items:center;justify-content:center;background:#222;position:relative">
+    <div class="modal-body" style="padding:8px;display:flex;align-items:center;justify-content:center;background:#222;border-radius:0 0 16px 16px">
       <img id="imageLightboxImg" alt="이미지" style="max-width:100%;max-height:100%;width:auto;height:auto;object-fit:contain;display:block">
-      <div class="lightbox-zoom-ctrl">
-        <span class="material-icons-round notranslate" translate="no" onclick="lightboxZoom(-0.25)" title="축소">zoom_out</span>
-        <span id="lightboxZoomLabel" onclick="lightboxZoomReset()" title="원본 크기로">100%</span>
-        <span class="material-icons-round notranslate" translate="no" onclick="lightboxZoom(0.25)" title="확대">zoom_in</span>
-      </div>
+    </div>
+    <!-- 줌 컨트롤은 스크롤되는 modal-body 밖(.modal 직속)에 둬야 확대 스크롤 시 위치 고정 -->
+    <div class="lightbox-zoom-ctrl">
+      <span class="material-icons-round notranslate" translate="no" onclick="lightboxZoom(-0.25)" title="축소">zoom_out</span>
+      <span id="lightboxZoomLabel" onclick="lightboxZoomReset()" title="원본 크기로">100%</span>
+      <span class="material-icons-round notranslate" translate="no" onclick="lightboxZoom(0.25)" title="확대">zoom_in</span>
     </div>
   </div>
 </div>

--- a/admin/index.html
+++ b/admin/index.html
@@ -12,7 +12,7 @@
 // 회귀(2026-05-12 PR #182 머지 직후 발생)를 방지하기 위한 자동 reload 가드.
 // sessionStorage 차단 환경(시크릿 모드 일부, 쿠키 차단)에서는 자연스럽게 skip.
 (function(){
-  var CURRENT_BUILD = 'v1781017193';
+  var CURRENT_BUILD = 'v1781018520';
   if (CURRENT_BUILD.indexOf('__') === 0) return; // 빌드 미적용 (dev/ 직접 열기) 시 skip
   try {
     var prev = sessionStorage.getItem('reverb.adminBuild');
@@ -1828,6 +1828,13 @@ textarea.form-input{resize:vertical;min-height:80px}
 #imageLightbox .modal{pointer-events:auto}
 /* 크기는 CSS 로 — 드래그 초기화가 인라인 width/height 를 지우므로(인라인으로 주면 92vw 로 커짐) .draggable 에 기본 크기 지정 */
 #imageLightbox .modal.draggable{width:600px;height:600px;max-width:92vw;max-height:90vh}
+/* 줌(확대/축소) 시 이미지가 넘치면 스크롤 */
+#imageLightbox .modal-body{overflow:auto}
+/* 모달 중앙 하단 확대/축소 컨트롤 */
+.lightbox-zoom-ctrl{position:absolute;bottom:12px;left:50%;transform:translateX(-50%);display:flex;align-items:center;gap:10px;background:rgba(0,0,0,.65);border-radius:20px;padding:5px 12px;z-index:6}
+.lightbox-zoom-ctrl .material-icons-round{color:#fff;font-size:20px;cursor:pointer}
+.lightbox-zoom-ctrl .material-icons-round:hover{color:#FFD2E0}
+.lightbox-zoom-ctrl #lightboxZoomLabel{color:#fff;font-size:12px;min-width:40px;text-align:center;cursor:pointer;user-select:none}
 
 /* ── 관리자 모달 표준 구조 (2026-05-29 모달 구조 통일) ── */
 /* admin.css 는 관리자 빌드 전용(인플 빌드 CLIENT_CSS 에 미포함)이라 전역 정의해도 인플 영향 0. */
@@ -2019,7 +2026,7 @@ textarea.form-input{resize:vertical;min-height:80px}
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-06-09 23:59 · ee07a46</span>
+          <span class="admin-build-text">2026-06-10 00:22 · fe99644</span>
         </div>
       </div>
     </aside>
@@ -4126,8 +4133,13 @@ textarea.form-input{resize:vertical;min-height:80px}
       <span class="modal-title" style="font-size:14px">이미지 보기</span>
       <span class="modal-close material-icons-round notranslate" translate="no" onclick="closeModal('imageLightbox')" aria-label="닫기" style="font-size:18px">close</span>
     </div>
-    <div class="modal-body" style="padding:8px;display:flex;align-items:center;justify-content:center;background:#222">
+    <div class="modal-body" style="padding:8px;display:flex;align-items:center;justify-content:center;background:#222;position:relative">
       <img id="imageLightboxImg" alt="이미지" style="max-width:100%;max-height:100%;width:auto;height:auto;object-fit:contain;display:block">
+      <div class="lightbox-zoom-ctrl">
+        <span class="material-icons-round notranslate" translate="no" onclick="lightboxZoom(-0.25)" title="축소">zoom_out</span>
+        <span id="lightboxZoomLabel" onclick="lightboxZoomReset()" title="원본 크기로">100%</span>
+        <span class="material-icons-round notranslate" translate="no" onclick="lightboxZoom(0.25)" title="확대">zoom_in</span>
+      </div>
     </div>
   </div>
 </div>
@@ -10534,10 +10546,14 @@ let currentAdminInfo = null;
 //    빌드 이어붙이기 순서가 ui.js → admin-core.js 라 이 1인자 버전이 관리자 앱에서 우선 적용된다
 //    (분리 전 ui.js → admin.js 와 동일 동작). 관리자 호출처는 모두 1인자 형태. 단일화는 추후 검토.
 // ──────────────────────────────────────
+let _lbZoom = 1;
+const LB_ZOOM_MIN = 0.5, LB_ZOOM_MAX = 5;
 function openImageLightbox(url) {
   if (!url) return;
   const img = $('imageLightboxImg');
   if (img) img.src = url;
+  _lbZoom = 1;            // 열 때마다 배율 초기화
+  applyLightboxZoom();
   openModal('imageLightbox');
 }
 function closeImageLightbox() {
@@ -10545,6 +10561,31 @@ function closeImageLightbox() {
   const img = $('imageLightboxImg');
   if (img) img.src = '';
 }
+// 이미지 배율 적용 — 1배는 창에 맞춤(contain), 1배 초과는 width %로 키우고 넘치면 modal-body 스크롤
+function applyLightboxZoom() {
+  const img = $('imageLightboxImg');
+  if (!img) return;
+  const body = img.parentElement;
+  if (Math.abs(_lbZoom - 1) < 0.001) {
+    img.style.maxWidth = '100%'; img.style.maxHeight = '100%';
+    img.style.width = ''; img.style.height = '';
+    // 1배는 창 중앙
+    if (body) { body.style.alignItems = 'center'; body.style.justifyContent = 'center'; }
+  } else {
+    img.style.maxWidth = 'none'; img.style.maxHeight = 'none';
+    img.style.width = Math.round(_lbZoom * 100) + '%';
+    img.style.height = 'auto';
+    // 줌인 시 flex 중앙 정렬이 오버플로 상단·좌측을 잘라 스크롤 접근을 막으므로 시작점 정렬로 전환
+    if (body) { body.style.alignItems = 'flex-start'; body.style.justifyContent = 'flex-start'; }
+  }
+  const lbl = $('lightboxZoomLabel');
+  if (lbl) lbl.textContent = Math.round(_lbZoom * 100) + '%';
+}
+function lightboxZoom(delta) {
+  _lbZoom = Math.max(LB_ZOOM_MIN, Math.min(LB_ZOOM_MAX, Math.round((_lbZoom + delta) * 100) / 100));
+  applyLightboxZoom();
+}
+function lightboxZoomReset() { _lbZoom = 1; applyLightboxZoom(); }
 
 // ──────────────────────────────────────
 // 관리자 모달 드래그·리사이즈 (2026-05-29, 사양서 docs/specs/2026-05-28-admin-modal-draggable.md)

--- a/admin/index.html
+++ b/admin/index.html
@@ -12,7 +12,7 @@
 // 회귀(2026-05-12 PR #182 머지 직후 발생)를 방지하기 위한 자동 reload 가드.
 // sessionStorage 차단 환경(시크릿 모드 일부, 쿠키 차단)에서는 자연스럽게 skip.
 (function(){
-  var CURRENT_BUILD = 'v1781015206';
+  var CURRENT_BUILD = 'v1781017193';
   if (CURRENT_BUILD.indexOf('__') === 0) return; // 빌드 미적용 (dev/ 직접 열기) 시 skip
   try {
     var prev = sessionStorage.getItem('reverb.adminBuild');
@@ -1822,6 +1822,13 @@ textarea.form-input{resize:vertical;min-height:80px}
 .modal-rsz-se{bottom:0;right:0;width:14px;height:14px;cursor:nwse-resize}
 .modal-rsz-sw{bottom:0;left:0;width:14px;height:14px;cursor:nesw-resize}
 
+/* 이미지 확대 창(#imageLightbox): 배경을 덮지 않아 뒤 화면(검수 모달 입력 등) 조작 가능 + 드래그·리사이즈 떠있는 창.
+   overlay 는 클릭 통과(pointer-events:none), 창(.modal)만 잡힘. 배경 클릭 닫기 없음 — 닫기는 X·ESC. */
+#imageLightbox{background:transparent;pointer-events:none}
+#imageLightbox .modal{pointer-events:auto}
+/* 크기는 CSS 로 — 드래그 초기화가 인라인 width/height 를 지우므로(인라인으로 주면 92vw 로 커짐) .draggable 에 기본 크기 지정 */
+#imageLightbox .modal.draggable{width:600px;height:600px;max-width:92vw;max-height:90vh}
+
 /* ── 관리자 모달 표준 구조 (2026-05-29 모달 구조 통일) ── */
 /* admin.css 는 관리자 빌드 전용(인플 빌드 CLIENT_CSS 에 미포함)이라 전역 정의해도 인플 영향 0. */
 /* 미분리 모달 등은 #page-admin 밖(body 직속)이라 #page-admin 스코프가 안 먹음 → 전역으로 정의. */
@@ -2012,7 +2019,7 @@ textarea.form-input{resize:vertical;min-height:80px}
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-06-09 23:26 · ae258ff</span>
+          <span class="admin-build-text">2026-06-09 23:59 · ee07a46</span>
         </div>
       </div>
     </aside>
@@ -4113,9 +4120,16 @@ textarea.form-input{resize:vertical;min-height:80px}
 </div>
 
 <!-- 이미지 확대 라이트박스 -->
-<div class="modal-overlay" id="imageLightbox" style="z-index:900;background:rgba(0,0,0,.88)" onclick="closeModal('imageLightbox')">
-  <img id="imageLightboxImg" alt="증빙 이미지" style="max-width:92vw;max-height:92vh;object-fit:contain;margin:auto;display:block">
-  <button onclick="event.stopPropagation();closeModal('imageLightbox')" style="position:fixed;top:16px;right:16px;width:40px;height:40px;border-radius:50%;background:rgba(0,0,0,.55);color:#fff;border:none;cursor:pointer;font-size:22px;display:flex;align-items:center;justify-content:center" aria-label="닫기"><span class="material-icons-round notranslate" translate="no" style="font-size:22px">close</span></button>
+<div class="modal-overlay" id="imageLightbox" style="z-index:900">
+  <div class="modal" style="padding:0;border-radius:16px;overflow:hidden">
+    <div class="modal-header" style="padding:10px 14px">
+      <span class="modal-title" style="font-size:14px">이미지 보기</span>
+      <span class="modal-close material-icons-round notranslate" translate="no" onclick="closeModal('imageLightbox')" aria-label="닫기" style="font-size:18px">close</span>
+    </div>
+    <div class="modal-body" style="padding:8px;display:flex;align-items:center;justify-content:center;background:#222">
+      <img id="imageLightboxImg" alt="이미지" style="max-width:100%;max-height:100%;width:auto;height:auto;object-fit:contain;display:block">
+    </div>
+  </div>
 </div>
 
 <!-- 캠페인 상태 도움말 모달 -->
@@ -10554,6 +10568,8 @@ const DRAGGABLE_ADMIN_MODALS = new Set([
   'admMsgModal', 'admHideModal',
   // 일괄 발송 (PR 3) — 대상 선택·발송 상세는 내용이 길어 드래그·리사이즈 유용
   'bulkMessageModal', 'broadcastDetailModal',
+  // 이미지 확대 창 — 배경 안 덮고(뒤 화면 조작 가능) 드래그·리사이즈로 영수증 보며 입력
+  'imageLightbox',
 ]);
 
 function makeModalDraggableResizable(modalEl) {

--- a/dev/admin/index.html
+++ b/dev/admin/index.html
@@ -2241,8 +2241,13 @@
       <span class="modal-title" style="font-size:14px">이미지 보기</span>
       <span class="modal-close material-icons-round notranslate" translate="no" onclick="closeModal('imageLightbox')" aria-label="닫기" style="font-size:18px">close</span>
     </div>
-    <div class="modal-body" style="padding:8px;display:flex;align-items:center;justify-content:center;background:#222">
+    <div class="modal-body" style="padding:8px;display:flex;align-items:center;justify-content:center;background:#222;position:relative">
       <img id="imageLightboxImg" alt="이미지" style="max-width:100%;max-height:100%;width:auto;height:auto;object-fit:contain;display:block">
+      <div class="lightbox-zoom-ctrl">
+        <span class="material-icons-round notranslate" translate="no" onclick="lightboxZoom(-0.25)" title="축소">zoom_out</span>
+        <span id="lightboxZoomLabel" onclick="lightboxZoomReset()" title="원본 크기로">100%</span>
+        <span class="material-icons-round notranslate" translate="no" onclick="lightboxZoom(0.25)" title="확대">zoom_in</span>
+      </div>
     </div>
   </div>
 </div>

--- a/dev/admin/index.html
+++ b/dev/admin/index.html
@@ -2236,18 +2236,19 @@
 
 <!-- 이미지 확대 라이트박스 -->
 <div class="modal-overlay" id="imageLightbox" style="z-index:900">
-  <div class="modal" style="padding:0;border-radius:16px;overflow:hidden">
-    <div class="modal-header" style="padding:10px 14px">
+  <div class="modal" style="padding:0;border-radius:16px">
+    <div class="modal-header" style="padding:10px 14px;border-radius:16px 16px 0 0">
       <span class="modal-title" style="font-size:14px">이미지 보기</span>
       <span class="modal-close material-icons-round notranslate" translate="no" onclick="closeModal('imageLightbox')" aria-label="닫기" style="font-size:18px">close</span>
     </div>
-    <div class="modal-body" style="padding:8px;display:flex;align-items:center;justify-content:center;background:#222;position:relative">
+    <div class="modal-body" style="padding:8px;display:flex;align-items:center;justify-content:center;background:#222;border-radius:0 0 16px 16px">
       <img id="imageLightboxImg" alt="이미지" style="max-width:100%;max-height:100%;width:auto;height:auto;object-fit:contain;display:block">
-      <div class="lightbox-zoom-ctrl">
-        <span class="material-icons-round notranslate" translate="no" onclick="lightboxZoom(-0.25)" title="축소">zoom_out</span>
-        <span id="lightboxZoomLabel" onclick="lightboxZoomReset()" title="원본 크기로">100%</span>
-        <span class="material-icons-round notranslate" translate="no" onclick="lightboxZoom(0.25)" title="확대">zoom_in</span>
-      </div>
+    </div>
+    <!-- 줌 컨트롤은 스크롤되는 modal-body 밖(.modal 직속)에 둬야 확대 스크롤 시 위치 고정 -->
+    <div class="lightbox-zoom-ctrl">
+      <span class="material-icons-round notranslate" translate="no" onclick="lightboxZoom(-0.25)" title="축소">zoom_out</span>
+      <span id="lightboxZoomLabel" onclick="lightboxZoomReset()" title="원본 크기로">100%</span>
+      <span class="material-icons-round notranslate" translate="no" onclick="lightboxZoom(0.25)" title="확대">zoom_in</span>
     </div>
   </div>
 </div>

--- a/dev/admin/index.html
+++ b/dev/admin/index.html
@@ -2235,9 +2235,16 @@
 </div>
 
 <!-- 이미지 확대 라이트박스 -->
-<div class="modal-overlay" id="imageLightbox" style="z-index:900;background:rgba(0,0,0,.88)" onclick="closeModal('imageLightbox')">
-  <img id="imageLightboxImg" alt="증빙 이미지" style="max-width:92vw;max-height:92vh;object-fit:contain;margin:auto;display:block">
-  <button onclick="event.stopPropagation();closeModal('imageLightbox')" style="position:fixed;top:16px;right:16px;width:40px;height:40px;border-radius:50%;background:rgba(0,0,0,.55);color:#fff;border:none;cursor:pointer;font-size:22px;display:flex;align-items:center;justify-content:center" aria-label="닫기"><span class="material-icons-round notranslate" translate="no" style="font-size:22px">close</span></button>
+<div class="modal-overlay" id="imageLightbox" style="z-index:900">
+  <div class="modal" style="padding:0;border-radius:16px;overflow:hidden">
+    <div class="modal-header" style="padding:10px 14px">
+      <span class="modal-title" style="font-size:14px">이미지 보기</span>
+      <span class="modal-close material-icons-round notranslate" translate="no" onclick="closeModal('imageLightbox')" aria-label="닫기" style="font-size:18px">close</span>
+    </div>
+    <div class="modal-body" style="padding:8px;display:flex;align-items:center;justify-content:center;background:#222">
+      <img id="imageLightboxImg" alt="이미지" style="max-width:100%;max-height:100%;width:auto;height:auto;object-fit:contain;display:block">
+    </div>
+  </div>
 </div>
 
 <!-- 캠페인 상태 도움말 모달 -->

--- a/dev/css/admin.css
+++ b/dev/css/admin.css
@@ -1372,6 +1372,13 @@
 .modal-rsz-se{bottom:0;right:0;width:14px;height:14px;cursor:nwse-resize}
 .modal-rsz-sw{bottom:0;left:0;width:14px;height:14px;cursor:nesw-resize}
 
+/* 이미지 확대 창(#imageLightbox): 배경을 덮지 않아 뒤 화면(검수 모달 입력 등) 조작 가능 + 드래그·리사이즈 떠있는 창.
+   overlay 는 클릭 통과(pointer-events:none), 창(.modal)만 잡힘. 배경 클릭 닫기 없음 — 닫기는 X·ESC. */
+#imageLightbox{background:transparent;pointer-events:none}
+#imageLightbox .modal{pointer-events:auto}
+/* 크기는 CSS 로 — 드래그 초기화가 인라인 width/height 를 지우므로(인라인으로 주면 92vw 로 커짐) .draggable 에 기본 크기 지정 */
+#imageLightbox .modal.draggable{width:600px;height:600px;max-width:92vw;max-height:90vh}
+
 /* ── 관리자 모달 표준 구조 (2026-05-29 모달 구조 통일) ── */
 /* admin.css 는 관리자 빌드 전용(인플 빌드 CLIENT_CSS 에 미포함)이라 전역 정의해도 인플 영향 0. */
 /* 미분리 모달 등은 #page-admin 밖(body 직속)이라 #page-admin 스코프가 안 먹음 → 전역으로 정의. */

--- a/dev/css/admin.css
+++ b/dev/css/admin.css
@@ -1378,6 +1378,13 @@
 #imageLightbox .modal{pointer-events:auto}
 /* 크기는 CSS 로 — 드래그 초기화가 인라인 width/height 를 지우므로(인라인으로 주면 92vw 로 커짐) .draggable 에 기본 크기 지정 */
 #imageLightbox .modal.draggable{width:600px;height:600px;max-width:92vw;max-height:90vh}
+/* 줌(확대/축소) 시 이미지가 넘치면 스크롤 */
+#imageLightbox .modal-body{overflow:auto}
+/* 모달 중앙 하단 확대/축소 컨트롤 */
+.lightbox-zoom-ctrl{position:absolute;bottom:12px;left:50%;transform:translateX(-50%);display:flex;align-items:center;gap:10px;background:rgba(0,0,0,.65);border-radius:20px;padding:5px 12px;z-index:6}
+.lightbox-zoom-ctrl .material-icons-round{color:#fff;font-size:20px;cursor:pointer}
+.lightbox-zoom-ctrl .material-icons-round:hover{color:#FFD2E0}
+.lightbox-zoom-ctrl #lightboxZoomLabel{color:#fff;font-size:12px;min-width:40px;text-align:center;cursor:pointer;user-select:none}
 
 /* ── 관리자 모달 표준 구조 (2026-05-29 모달 구조 통일) ── */
 /* admin.css 는 관리자 빌드 전용(인플 빌드 CLIENT_CSS 에 미포함)이라 전역 정의해도 인플 영향 0. */

--- a/dev/js/admin-core.js
+++ b/dev/js/admin-core.js
@@ -617,10 +617,14 @@ let currentAdminInfo = null;
 //    빌드 이어붙이기 순서가 ui.js → admin-core.js 라 이 1인자 버전이 관리자 앱에서 우선 적용된다
 //    (분리 전 ui.js → admin.js 와 동일 동작). 관리자 호출처는 모두 1인자 형태. 단일화는 추후 검토.
 // ──────────────────────────────────────
+let _lbZoom = 1;
+const LB_ZOOM_MIN = 0.5, LB_ZOOM_MAX = 5;
 function openImageLightbox(url) {
   if (!url) return;
   const img = $('imageLightboxImg');
   if (img) img.src = url;
+  _lbZoom = 1;            // 열 때마다 배율 초기화
+  applyLightboxZoom();
   openModal('imageLightbox');
 }
 function closeImageLightbox() {
@@ -628,6 +632,31 @@ function closeImageLightbox() {
   const img = $('imageLightboxImg');
   if (img) img.src = '';
 }
+// 이미지 배율 적용 — 1배는 창에 맞춤(contain), 1배 초과는 width %로 키우고 넘치면 modal-body 스크롤
+function applyLightboxZoom() {
+  const img = $('imageLightboxImg');
+  if (!img) return;
+  const body = img.parentElement;
+  if (Math.abs(_lbZoom - 1) < 0.001) {
+    img.style.maxWidth = '100%'; img.style.maxHeight = '100%';
+    img.style.width = ''; img.style.height = '';
+    // 1배는 창 중앙
+    if (body) { body.style.alignItems = 'center'; body.style.justifyContent = 'center'; }
+  } else {
+    img.style.maxWidth = 'none'; img.style.maxHeight = 'none';
+    img.style.width = Math.round(_lbZoom * 100) + '%';
+    img.style.height = 'auto';
+    // 줌인 시 flex 중앙 정렬이 오버플로 상단·좌측을 잘라 스크롤 접근을 막으므로 시작점 정렬로 전환
+    if (body) { body.style.alignItems = 'flex-start'; body.style.justifyContent = 'flex-start'; }
+  }
+  const lbl = $('lightboxZoomLabel');
+  if (lbl) lbl.textContent = Math.round(_lbZoom * 100) + '%';
+}
+function lightboxZoom(delta) {
+  _lbZoom = Math.max(LB_ZOOM_MIN, Math.min(LB_ZOOM_MAX, Math.round((_lbZoom + delta) * 100) / 100));
+  applyLightboxZoom();
+}
+function lightboxZoomReset() { _lbZoom = 1; applyLightboxZoom(); }
 
 // ──────────────────────────────────────
 // 관리자 모달 드래그·리사이즈 (2026-05-29, 사양서 docs/specs/2026-05-28-admin-modal-draggable.md)

--- a/dev/js/admin-core.js
+++ b/dev/js/admin-core.js
@@ -651,6 +651,8 @@ const DRAGGABLE_ADMIN_MODALS = new Set([
   'admMsgModal', 'admHideModal',
   // 일괄 발송 (PR 3) — 대상 선택·발송 상세는 내용이 길어 드래그·리사이즈 유용
   'bulkMessageModal', 'broadcastDetailModal',
+  // 이미지 확대 창 — 배경 안 덮고(뒤 화면 조작 가능) 드래그·리사이즈로 영수증 보며 입력
+  'imageLightbox',
 ]);
 
 function makeModalDraggableResizable(modalEl) {


### PR DESCRIPTION
## 변경 요약
- 관리자 이미지 확대를 배경 안 덮는 드래그·리사이즈 떠있는 창으로 전환(뒤 검수 모달 입력 가능)
- 모달 중앙 하단 확대/축소(줌) 컨트롤 추가(50~500%, % 클릭 리셋, 넘치면 스크롤)
- 줌 컨트롤을 창 레벨로 고정(스크롤 시 위치 유지), overflow 클리핑 제거
- 데이터베이스 변경 없음

## 요청 외 추가 변경
- 없음

## 관련 사양서
- 없음 (CLAUDE.md admin-core 라이트박스 항목 반영)

🤖 Generated with [Claude Code](https://claude.com/claude-code)