### PR TITLE
fix: OCR 모바일 회귀 복원(확대) + 날짜칸 정렬

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -12,7 +12,7 @@
 // 회귀(2026-05-12 PR #182 머지 직후 발생)를 방지하기 위한 자동 reload 가드.
 // sessionStorage 차단 환경(시크릿 모드 일부, 쿠키 차단)에서는 자연스럽게 skip.
 (function(){
-  var CURRENT_BUILD = 'v1781055436';
+  var CURRENT_BUILD = 'v1781056041';
   if (CURRENT_BUILD.indexOf('__') === 0) return; // 빌드 미적용 (dev/ 직접 열기) 시 skip
   try {
     var prev = sessionStorage.getItem('reverb.adminBuild');
@@ -179,8 +179,10 @@ img{display:block;max-width:100%}
 .form-input::placeholder{color:var(--on-surface-variant)}
 select.form-input{cursor:pointer;padding-right:36px;-webkit-appearance:none;appearance:none;background-image:url('data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 width=%2212%22 height=%228%22><path d=%22M1 1l5 5 5-5%22 fill=%22none%22 stroke=%22%23999%22 stroke-width=%221.5%22 stroke-linecap=%22round%22 stroke-linejoin=%22round%22/></svg>');background-repeat:no-repeat;background-position:right 12px center;background-size:12px}
 textarea.form-input{resize:vertical;min-height:80px}
-/* 모바일(iOS Safari) 날짜 입력칸 값이 우측/가운데로 치우치는 것 방지 — 다른 입력칸과 좌측 정렬 통일 */
+/* 모바일(iOS Safari) 날짜 입력칸 값 좌측 정렬 통일 (네이티브 달력 피커는 보존) */
+input[type="date"].form-input{text-align:left}
 input[type="date"].form-input::-webkit-date-and-time-value{text-align:left;margin:0}
+input[type="date"].form-input::-webkit-datetime-edit{text-align:left;padding:0}
 .pw-wrap{position:relative;display:block}
 .pw-wrap .form-input{width:100%;padding-right:44px;box-sizing:border-box}
 .pw-toggle{position:absolute;right:0;top:0;bottom:0;width:44px;background:transparent;border:none;cursor:pointer;color:var(--on-surface-variant);display:flex;align-items:center;justify-content:center;transition:color .2s}
@@ -2028,7 +2030,7 @@ input[type="date"].form-input::-webkit-date-and-time-value{text-align:left;margi
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-06-10 10:37 · 7c4d81a</span>
+          <span class="admin-build-text">2026-06-10 10:47 · 9f7e36b</span>
         </div>
       </div>
     </aside>
@@ -9052,11 +9054,11 @@ function preprocessReceiptImage(fileOrBlob) {
     const url = URL.createObjectURL(fileOrBlob);
     img.onload = () => {
       URL.revokeObjectURL(url);
-      // 다운스케일만 수행 (업스케일은 모바일 canvas 면적 한도에 걸려 이미지가 잘리거나
-      // 저화질로 다운샘플링돼 글자 인식이 저하됨 — PC는 한도가 커서 영향 없었음).
+      // 작은 모바일 스크린샷은 확대해야 글자가 읽힌다(업스케일 필수, 0.5~3배).
+      // 단 너무 커지면 모바일(iOS Safari) canvas 면적 한도에 걸려 잘리므로 MAX_AREA 로 cap.
       const target = 2000;
       const MAX_AREA = 4096 * 4096; // 모바일(iOS Safari) canvas 안전 면적
-      let scale = Math.min(target / img.naturalWidth, 1);
+      let scale = Math.max(0.5, Math.min(target / img.naturalWidth, 3));
       let w = Math.round(img.naturalWidth * scale), h = Math.round(img.naturalHeight * scale);
       if (w * h > MAX_AREA) { const f = Math.sqrt(MAX_AREA / (w * h)); w = Math.floor(w * f); h = Math.floor(h * f); }
       const c = document.createElement('canvas');

--- a/dev/css/components.css
+++ b/dev/css/components.css
@@ -70,8 +70,10 @@
 .form-input::placeholder{color:var(--on-surface-variant)}
 select.form-input{cursor:pointer;padding-right:36px;-webkit-appearance:none;appearance:none;background-image:url('data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 width=%2212%22 height=%228%22><path d=%22M1 1l5 5 5-5%22 fill=%22none%22 stroke=%22%23999%22 stroke-width=%221.5%22 stroke-linecap=%22round%22 stroke-linejoin=%22round%22/></svg>');background-repeat:no-repeat;background-position:right 12px center;background-size:12px}
 textarea.form-input{resize:vertical;min-height:80px}
-/* 모바일(iOS Safari) 날짜 입력칸 값이 우측/가운데로 치우치는 것 방지 — 다른 입력칸과 좌측 정렬 통일 */
+/* 모바일(iOS Safari) 날짜 입력칸 값 좌측 정렬 통일 (네이티브 달력 피커는 보존) */
+input[type="date"].form-input{text-align:left}
 input[type="date"].form-input::-webkit-date-and-time-value{text-align:left;margin:0}
+input[type="date"].form-input::-webkit-datetime-edit{text-align:left;padding:0}
 .pw-wrap{position:relative;display:block}
 .pw-wrap .form-input{width:100%;padding-right:44px;box-sizing:border-box}
 .pw-toggle{position:absolute;right:0;top:0;bottom:0;width:44px;background:transparent;border:none;cursor:pointer;color:var(--on-surface-variant);display:flex;align-items:center;justify-content:center;transition:color .2s}

--- a/dev/lib/ocr-receipt.js
+++ b/dev/lib/ocr-receipt.js
@@ -30,11 +30,11 @@ function preprocessReceiptImage(fileOrBlob) {
     const url = URL.createObjectURL(fileOrBlob);
     img.onload = () => {
       URL.revokeObjectURL(url);
-      // 다운스케일만 수행 (업스케일은 모바일 canvas 면적 한도에 걸려 이미지가 잘리거나
-      // 저화질로 다운샘플링돼 글자 인식이 저하됨 — PC는 한도가 커서 영향 없었음).
+      // 작은 모바일 스크린샷은 확대해야 글자가 읽힌다(업스케일 필수, 0.5~3배).
+      // 단 너무 커지면 모바일(iOS Safari) canvas 면적 한도에 걸려 잘리므로 MAX_AREA 로 cap.
       const target = 2000;
       const MAX_AREA = 4096 * 4096; // 모바일(iOS Safari) canvas 안전 면적
-      let scale = Math.min(target / img.naturalWidth, 1);
+      let scale = Math.max(0.5, Math.min(target / img.naturalWidth, 3));
       let w = Math.round(img.naturalWidth * scale), h = Math.round(img.naturalHeight * scale);
       if (w * h > MAX_AREA) { const f = Math.sqrt(MAX_AREA / (w * h)); w = Math.floor(w * f); h = Math.floor(h * f); }
       const c = document.createElement('canvas');

--- a/index.html
+++ b/index.html
@@ -158,8 +158,10 @@ img{display:block;max-width:100%}
 .form-input::placeholder{color:var(--on-surface-variant)}
 select.form-input{cursor:pointer;padding-right:36px;-webkit-appearance:none;appearance:none;background-image:url('data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 width=%2212%22 height=%228%22><path d=%22M1 1l5 5 5-5%22 fill=%22none%22 stroke=%22%23999%22 stroke-width=%221.5%22 stroke-linecap=%22round%22 stroke-linejoin=%22round%22/></svg>');background-repeat:no-repeat;background-position:right 12px center;background-size:12px}
 textarea.form-input{resize:vertical;min-height:80px}
-/* 모바일(iOS Safari) 날짜 입력칸 값이 우측/가운데로 치우치는 것 방지 — 다른 입력칸과 좌측 정렬 통일 */
+/* 모바일(iOS Safari) 날짜 입력칸 값 좌측 정렬 통일 (네이티브 달력 피커는 보존) */
+input[type="date"].form-input{text-align:left}
 input[type="date"].form-input::-webkit-date-and-time-value{text-align:left;margin:0}
+input[type="date"].form-input::-webkit-datetime-edit{text-align:left;padding:0}
 .pw-wrap{position:relative;display:block}
 .pw-wrap .form-input{width:100%;padding-right:44px;box-sizing:border-box}
 .pw-toggle{position:absolute;right:0;top:0;bottom:0;width:44px;background:transparent;border:none;cursor:pointer;color:var(--on-surface-variant);display:flex;align-items:center;justify-content:center;transition:color .2s}
@@ -4087,11 +4089,11 @@ function preprocessReceiptImage(fileOrBlob) {
     const url = URL.createObjectURL(fileOrBlob);
     img.onload = () => {
       URL.revokeObjectURL(url);
-      // 다운스케일만 수행 (업스케일은 모바일 canvas 면적 한도에 걸려 이미지가 잘리거나
-      // 저화질로 다운샘플링돼 글자 인식이 저하됨 — PC는 한도가 커서 영향 없었음).
+      // 작은 모바일 스크린샷은 확대해야 글자가 읽힌다(업스케일 필수, 0.5~3배).
+      // 단 너무 커지면 모바일(iOS Safari) canvas 면적 한도에 걸려 잘리므로 MAX_AREA 로 cap.
       const target = 2000;
       const MAX_AREA = 4096 * 4096; // 모바일(iOS Safari) canvas 안전 면적
-      let scale = Math.min(target / img.naturalWidth, 1);
+      let scale = Math.max(0.5, Math.min(target / img.naturalWidth, 3));
       let w = Math.round(img.naturalWidth * scale), h = Math.round(img.naturalHeight * scale);
       if (w * h > MAX_AREA) { const f = Math.sqrt(MAX_AREA / (w * h)); w = Math.floor(w * f); h = Math.floor(h * f); }
       const c = document.createElement('canvas');


### PR DESCRIPTION
## 변경 요약
- PR#475에서 확대 제거로 모바일 인식이 아예 안 되던 회귀 복원(확대 0.5~3배 + 면적 상한 유지)
- 모바일 날짜칸 값 좌측 정렬(달력 피커 보존)

[via reviewer]