### PR TITLE
fix: 모바일 구매일 입력칸 가로 넘침 수정

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -12,7 +12,7 @@
 // 회귀(2026-05-12 PR #182 머지 직후 발생)를 방지하기 위한 자동 reload 가드.
 // sessionStorage 차단 환경(시크릿 모드 일부, 쿠키 차단)에서는 자연스럽게 skip.
 (function(){
-  var CURRENT_BUILD = 'v1781056041';
+  var CURRENT_BUILD = 'v1781056733';
   if (CURRENT_BUILD.indexOf('__') === 0) return; // 빌드 미적용 (dev/ 직접 열기) 시 skip
   try {
     var prev = sessionStorage.getItem('reverb.adminBuild');
@@ -179,8 +179,8 @@ img{display:block;max-width:100%}
 .form-input::placeholder{color:var(--on-surface-variant)}
 select.form-input{cursor:pointer;padding-right:36px;-webkit-appearance:none;appearance:none;background-image:url('data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 width=%2212%22 height=%228%22><path d=%22M1 1l5 5 5-5%22 fill=%22none%22 stroke=%22%23999%22 stroke-width=%221.5%22 stroke-linecap=%22round%22 stroke-linejoin=%22round%22/></svg>');background-repeat:no-repeat;background-position:right 12px center;background-size:12px}
 textarea.form-input{resize:vertical;min-height:80px}
-/* 모바일(iOS Safari) 날짜 입력칸 값 좌측 정렬 통일 (네이티브 달력 피커는 보존) */
-input[type="date"].form-input{text-align:left}
+/* 모바일(iOS Safari) 날짜 입력칸: 콘텐츠 기준 최소너비 강제로 부모를 넘치는 버그 방지 + 값 좌측 정렬 */
+input[type="date"].form-input{text-align:left;min-width:0;-webkit-min-logical-width:0;max-width:100%;box-sizing:border-box}
 input[type="date"].form-input::-webkit-date-and-time-value{text-align:left;margin:0}
 input[type="date"].form-input::-webkit-datetime-edit{text-align:left;padding:0}
 .pw-wrap{position:relative;display:block}
@@ -2030,7 +2030,7 @@ input[type="date"].form-input::-webkit-datetime-edit{text-align:left;padding:0}
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-06-10 10:47 · 9f7e36b</span>
+          <span class="admin-build-text">2026-06-10 10:58 · 9d95672</span>
         </div>
       </div>
     </aside>

--- a/dev/css/components.css
+++ b/dev/css/components.css
@@ -70,8 +70,8 @@
 .form-input::placeholder{color:var(--on-surface-variant)}
 select.form-input{cursor:pointer;padding-right:36px;-webkit-appearance:none;appearance:none;background-image:url('data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 width=%2212%22 height=%228%22><path d=%22M1 1l5 5 5-5%22 fill=%22none%22 stroke=%22%23999%22 stroke-width=%221.5%22 stroke-linecap=%22round%22 stroke-linejoin=%22round%22/></svg>');background-repeat:no-repeat;background-position:right 12px center;background-size:12px}
 textarea.form-input{resize:vertical;min-height:80px}
-/* 모바일(iOS Safari) 날짜 입력칸 값 좌측 정렬 통일 (네이티브 달력 피커는 보존) */
-input[type="date"].form-input{text-align:left}
+/* 모바일(iOS Safari) 날짜 입력칸: 콘텐츠 기준 최소너비 강제로 부모를 넘치는 버그 방지 + 값 좌측 정렬 */
+input[type="date"].form-input{text-align:left;min-width:0;-webkit-min-logical-width:0;max-width:100%;box-sizing:border-box}
 input[type="date"].form-input::-webkit-date-and-time-value{text-align:left;margin:0}
 input[type="date"].form-input::-webkit-datetime-edit{text-align:left;padding:0}
 .pw-wrap{position:relative;display:block}

--- a/index.html
+++ b/index.html
@@ -158,8 +158,8 @@ img{display:block;max-width:100%}
 .form-input::placeholder{color:var(--on-surface-variant)}
 select.form-input{cursor:pointer;padding-right:36px;-webkit-appearance:none;appearance:none;background-image:url('data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 width=%2212%22 height=%228%22><path d=%22M1 1l5 5 5-5%22 fill=%22none%22 stroke=%22%23999%22 stroke-width=%221.5%22 stroke-linecap=%22round%22 stroke-linejoin=%22round%22/></svg>');background-repeat:no-repeat;background-position:right 12px center;background-size:12px}
 textarea.form-input{resize:vertical;min-height:80px}
-/* 모바일(iOS Safari) 날짜 입력칸 값 좌측 정렬 통일 (네이티브 달력 피커는 보존) */
-input[type="date"].form-input{text-align:left}
+/* 모바일(iOS Safari) 날짜 입력칸: 콘텐츠 기준 최소너비 강제로 부모를 넘치는 버그 방지 + 값 좌측 정렬 */
+input[type="date"].form-input{text-align:left;min-width:0;-webkit-min-logical-width:0;max-width:100%;box-sizing:border-box}
 input[type="date"].form-input::-webkit-date-and-time-value{text-align:left;margin:0}
 input[type="date"].form-input::-webkit-datetime-edit{text-align:left;padding:0}
 .pw-wrap{position:relative;display:block}


### PR DESCRIPTION
아이폰에서 type=date 칸이 폼 영역을 벗어나던 문제(min-width:0). [via reviewer]