### PR TITLE
fix: 영수증 이미지 재선택 시 OCR 값 새로 채움

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -12,7 +12,7 @@
 // 회귀(2026-05-12 PR #182 머지 직후 발생)를 방지하기 위한 자동 reload 가드.
 // sessionStorage 차단 환경(시크릿 모드 일부, 쿠키 차단)에서는 자연스럽게 skip.
 (function(){
-  var CURRENT_BUILD = 'v1781059457';
+  var CURRENT_BUILD = 'v1781060055';
   if (CURRENT_BUILD.indexOf('__') === 0) return; // 빌드 미적용 (dev/ 직접 열기) 시 skip
   try {
     var prev = sessionStorage.getItem('reverb.adminBuild');
@@ -2034,7 +2034,7 @@ input[type="date"].form-input::-webkit-calendar-picker-indicator{margin-left:aut
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-06-10 11:44 · 109f82f</span>
+          <span class="admin-build-text">2026-06-10 11:54 · 98aa601</span>
         </div>
       </div>
     </aside>

--- a/dev/js/application.js
+++ b/dev/js/application.js
@@ -1143,8 +1143,13 @@ function previewReceipt(input) {
   const file = input.files[0];
   if (!file) return;
   _receiptOcrFile = file;  // OCR 자동입력용 원본 파일 보관
-  // 이미지 새로 고르면 이전 OCR 안내 초기화
+  // 이미지 새로 고르면 이전 OCR 안내 초기화 + 이전 이미지로 OCR 자동입력한 칸 비움
+  // (손으로 직접 입력한 칸은 ocrFilled 표시가 없어 보존 → 새 이미지로 다시 자동입력 가능)
   const ocrStatus = $('receiptOcrStatus'); if (ocrStatus) { ocrStatus.style.display = 'none'; ocrStatus.textContent = ''; }
+  ['receiptOrderNumber', 'receiptDate', 'receiptAmount'].forEach(id => {
+    const el = $(id);
+    if (el && el.dataset.ocrFilled) { el.value = ''; el.style.background = ''; el.style.borderColor = ''; delete el.dataset.ocrFilled; }
+  });
   const reader = new FileReader();
   reader.onload = e => {
     _receiptImgData = e.target.result;
@@ -1193,12 +1198,14 @@ async function runReceiptAutofill() {
   }
 }
 
-// OCR 로 채운 칸 시각 표시 (녹색). 사용자가 다시 수정하면 표시 해제.
+// OCR 로 채운 칸 시각 표시 (녹색) + ocrFilled 표시(이미지 교체 시 이 칸만 비움 판단용).
+// 사용자가 직접 수정하면 손입력으로 간주 → 표시·녹색 해제(이후 이미지 교체해도 보존).
 function markOcrFilled(el) {
   if (!el) return;
   el.style.background = '#F0FDF4';
   el.style.borderColor = '#BBF7D0';
-  const clear = () => { el.style.background = ''; el.style.borderColor = ''; el.removeEventListener('input', clear); };
+  el.dataset.ocrFilled = '1';
+  const clear = () => { el.style.background = ''; el.style.borderColor = ''; delete el.dataset.ocrFilled; el.removeEventListener('input', clear); };
   el.addEventListener('input', clear);
 }
 

--- a/index.html
+++ b/index.html
@@ -10268,8 +10268,13 @@ function previewReceipt(input) {
   const file = input.files[0];
   if (!file) return;
   _receiptOcrFile = file;  // OCR 자동입력용 원본 파일 보관
-  // 이미지 새로 고르면 이전 OCR 안내 초기화
+  // 이미지 새로 고르면 이전 OCR 안내 초기화 + 이전 이미지로 OCR 자동입력한 칸 비움
+  // (손으로 직접 입력한 칸은 ocrFilled 표시가 없어 보존 → 새 이미지로 다시 자동입력 가능)
   const ocrStatus = $('receiptOcrStatus'); if (ocrStatus) { ocrStatus.style.display = 'none'; ocrStatus.textContent = ''; }
+  ['receiptOrderNumber', 'receiptDate', 'receiptAmount'].forEach(id => {
+    const el = $(id);
+    if (el && el.dataset.ocrFilled) { el.value = ''; el.style.background = ''; el.style.borderColor = ''; delete el.dataset.ocrFilled; }
+  });
   const reader = new FileReader();
   reader.onload = e => {
     _receiptImgData = e.target.result;
@@ -10318,12 +10323,14 @@ async function runReceiptAutofill() {
   }
 }
 
-// OCR 로 채운 칸 시각 표시 (녹색). 사용자가 다시 수정하면 표시 해제.
+// OCR 로 채운 칸 시각 표시 (녹색) + ocrFilled 표시(이미지 교체 시 이 칸만 비움 판단용).
+// 사용자가 직접 수정하면 손입력으로 간주 → 표시·녹색 해제(이후 이미지 교체해도 보존).
 function markOcrFilled(el) {
   if (!el) return;
   el.style.background = '#F0FDF4';
   el.style.borderColor = '#BBF7D0';
-  const clear = () => { el.style.background = ''; el.style.borderColor = ''; el.removeEventListener('input', clear); };
+  el.dataset.ocrFilled = '1';
+  const clear = () => { el.style.background = ''; el.style.borderColor = ''; delete el.dataset.ocrFilled; el.removeEventListener('input', clear); };
   el.addEventListener('input', clear);
 }
 


### PR DESCRIPTION
이미지를 다시 고르면 OCR로 채운 칸을 비워 새 영수증으로 다시 채움(손입력 보존). [via reviewer]