### PR TITLE
fix(apply): validate age before saving in age gate (qa-found)

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -12,7 +12,7 @@
 // 회귀(2026-05-12 PR #182 머지 직후 발생)를 방지하기 위한 자동 reload 가드.
 // sessionStorage 차단 환경(시크릿 모드 일부, 쿠키 차단)에서는 자연스럽게 skip.
 (function(){
-  var CURRENT_BUILD = 'v1781509399';
+  var CURRENT_BUILD = 'v1781513860';
   if (CURRENT_BUILD.indexOf('__') === 0) return; // 빌드 미적용 (dev/ 직접 열기) 시 skip
   try {
     var prev = sessionStorage.getItem('reverb.adminBuild');
@@ -2057,7 +2057,7 @@ input[type="date"].form-input::-webkit-calendar-picker-indicator{margin-left:aut
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-06-15 16:43 · 3bea067</span>
+          <span class="admin-build-text">2026-06-15 17:57 · 73d62f4</span>
         </div>
       </div>
     </aside>

--- a/dev/js/application.js
+++ b/dev/js/application.js
@@ -584,6 +584,20 @@ async function saveAgeGate() {
   }
   if (!gender) { showErr(t('authError.enterGender')); return; }
 
+  // ⚠️ 18세 미만은 DB 저장 없이 차단 — 생년월일 잠금 트리거(PR1)로 오타가 영구 고정되는 것 방지
+  //    (개인정보 최소수집 원칙). 18세 도달 후 재입력 시 저장됨(서버가 birthdate로 매번 판정).
+  const age = (typeof calcAgeFromBirthdate === 'function') ? calcAgeFromBirthdate(birthdate) : null;
+  if (age !== null && age < AGE_POLICY_MIN_AGE) {
+    closeAgeGate();
+    if (typeof openModal === 'function') {
+      $('alertModalMessage').textContent = t('ageGate.under18Apply');
+      openModal('alertModal');
+    } else {
+      toast(t('ageGate.under18Apply'), 'error');
+    }
+    return;
+  }
+
   const btn = $('ageGateSaveBtn');
   if (btn) { btn.disabled = true; btn.innerHTML = '<span class="spinner"></span>'; }
   try {
@@ -598,17 +612,7 @@ async function saveAgeGate() {
   }
   if (btn) { btn.disabled = false; btn.textContent = t('ageGate.save'); }
   closeAgeGate();
-  // 만 18세 미만이면 차단 안내, 이상이면 응모 흐름 재개
-  const age = (typeof calcAgeFromBirthdate === 'function') ? calcAgeFromBirthdate(birthdate) : null;
-  if (age !== null && age < AGE_POLICY_MIN_AGE) {
-    if (typeof openModal === 'function') {
-      $('alertModalMessage').textContent = t('ageGate.under18Apply');
-      openModal('alertModal');
-    } else {
-      toast(t('ageGate.under18Apply'), 'error');
-    }
-    return;
-  }
+  // 18세 이상 — 저장 완료, 응모 흐름 재개
   handleFloatApply();
 }
 

--- a/index.html
+++ b/index.html
@@ -9954,6 +9954,20 @@ async function saveAgeGate() {
   }
   if (!gender) { showErr(t('authError.enterGender')); return; }
 
+  // ⚠️ 18세 미만은 DB 저장 없이 차단 — 생년월일 잠금 트리거(PR1)로 오타가 영구 고정되는 것 방지
+  //    (개인정보 최소수집 원칙). 18세 도달 후 재입력 시 저장됨(서버가 birthdate로 매번 판정).
+  const age = (typeof calcAgeFromBirthdate === 'function') ? calcAgeFromBirthdate(birthdate) : null;
+  if (age !== null && age < AGE_POLICY_MIN_AGE) {
+    closeAgeGate();
+    if (typeof openModal === 'function') {
+      $('alertModalMessage').textContent = t('ageGate.under18Apply');
+      openModal('alertModal');
+    } else {
+      toast(t('ageGate.under18Apply'), 'error');
+    }
+    return;
+  }
+
   const btn = $('ageGateSaveBtn');
   if (btn) { btn.disabled = true; btn.innerHTML = '<span class="spinner"></span>'; }
   try {
@@ -9968,17 +9982,7 @@ async function saveAgeGate() {
   }
   if (btn) { btn.disabled = false; btn.textContent = t('ageGate.save'); }
   closeAgeGate();
-  // 만 18세 미만이면 차단 안내, 이상이면 응모 흐름 재개
-  const age = (typeof calcAgeFromBirthdate === 'function') ? calcAgeFromBirthdate(birthdate) : null;
-  if (age !== null && age < AGE_POLICY_MIN_AGE) {
-    if (typeof openModal === 'function') {
-      $('alertModalMessage').textContent = t('ageGate.under18Apply');
-      openModal('alertModal');
-    } else {
-      toast(t('ageGate.under18Apply'), 'error');
-    }
-    return;
-  }
+  // 18세 이상 — 저장 완료, 응모 흐름 재개
   handleFloatApply();
 }
 


### PR DESCRIPTION
## 변경 요약
- 연령 게이트(PR3) 버그 수정. qa 발견: `saveAgeGate`가 DB 저장 후 18세 미만 검증 → 18세 미만 생년월일이 영구 저장되고 잠금 트리거로 못 고침. **18세 미만 차단을 저장 전으로 이동**(미만이면 저장 없이 차단, 18세 이상만 저장). 개인정보 최소수집 원칙.

## 요청 외 추가 변경
- 없음

## 관련 사양서
- docs/specs/2026-05-27-age-minor-policy.md §0-1①

🤖 Generated with [Claude Code](https://claude.com/claude-code)