### PR TITLE
feat(deliverable): 게시물 URL 오타 보정 + 잘못된 채널 행 정리 (운영 핫픽스)

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -12,7 +12,7 @@
 // 회귀(2026-05-12 PR #182 머지 직후 발생)를 방지하기 위한 자동 reload 가드.
 // sessionStorage 차단 환경(시크릿 모드 일부, 쿠키 차단)에서는 자연스럽게 skip.
 (function(){
-  var CURRENT_BUILD = 'v1781580865';
+  var CURRENT_BUILD = 'v1781587728';
   if (CURRENT_BUILD.indexOf('__') === 0) return; // 빌드 미적용 (dev/ 직접 열기) 시 skip
   try {
     var prev = sessionStorage.getItem('reverb.adminBuild');
@@ -2043,7 +2043,7 @@ input[type="date"].form-input::-webkit-calendar-picker-indicator{margin-left:aut
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-06-16 12:34 · c060f7f</span>
+          <span class="admin-build-text">2026-06-16 14:28 · 67c2e14</span>
         </div>
       </div>
     </aside>
@@ -5523,6 +5523,38 @@ function postChannelMatchesCampaign(camp, postChannel) {
   return list.includes(String(postChannel).trim().toLowerCase());
 }
 
+// 결과물 게시물 URL 입력 오타 자동 보정 (2026-06-16). 인플 제출·관리자 대리 등록 공통.
+//   명백한 오타만 고치고, 위험 스킴은 차단, 나머지는 그대로 검증.
+//   - 앞뒤 공백 제거
+//   - 흔한 스킴 오타(ttp:// · ttps:// · htp:// · htps:// · http// · http:/ 등) → https://
+//     (SNS 게시물은 https 가 표준이라 https 로 통일)
+//   - 스킴 없으면(instagram.com/...) https:// 자동 추가
+//   - 위험 스킴(javascript: · data: · vbscript: · file: · blob:) → null 차단(XSS 방지)
+//   - 최종 new URL 로 검증, http/https + 호스트 있는 것만 통과
+//   반환: {url, changed} | null(빈값·위험 스킴·형식 오류). changed=보정 발생 여부(화면 안내용)
+// 사양서: docs/specs/2026-06-16-post-channel-validation-and-proxy-replace.md
+function normalizeUrlInput(raw) {
+  let s = String(raw || '').trim();
+  if (!s) return null;
+  const orig = s;
+  if (/^(javascript|data|vbscript|file|blob):/i.test(s)) return null; // 위험 스킴 차단
+  if (/^https?:\/\//i.test(s)) {
+    // 이미 정상 스킴 — 그대로
+  } else if (/^h?t{1,2}ps?:?\/{1,2}/i.test(s)) {
+    s = s.replace(/^h?t{1,2}ps?:?\/{1,2}/i, 'https://'); // 흔한 스킴 오타 → https://
+  } else if (/^[a-z][a-z0-9+.\-]*:\/\//i.test(s)) {
+    return null; // 알 수 없는 스킴 차단
+  } else {
+    s = 'https://' + s; // 스킴 없음 → https:// 추가
+  }
+  try {
+    const u = new URL(s);
+    if (u.protocol !== 'https:' && u.protocol !== 'http:') return null;
+    if (!u.hostname) return null;
+  } catch (e) { return null; }
+  return { url: s, changed: s !== orig };
+}
+
 // raw 입력값(URL 또는 핸들)에서 핸들만 뽑아 반환. 실패 시 trim된 원본 반환.
 // 저장 정책: 핸들만(@ 없이) 저장. 표시 시 UI에서 @ prefix 부여.
 function extractSnsHandle(channel, raw) {
@@ -6929,6 +6961,23 @@ async function deleteLegacyReviewImage(deliverableId, reason) {
   let ok = false;
   await retryWithRefresh(async () => {
     const {error} = await db.rpc('delete_legacy_review_image', {
+      p_deliverable_id: deliverableId,
+      p_reason:         reason || null
+    });
+    if (error) throw error;
+    ok = true;
+  });
+  return ok;
+}
+
+// 잘못된 채널 게시물(post) 결과물 삭제 (super_admin, 마이그레이션 183).
+//   캠페인 요구 채널과 다른 채널로 잘못 저장된 post 행 정리. 서버에서 채널 불일치·승인 보호 재검증.
+async function deleteMismatchedPostDeliverable(deliverableId, reason) {
+  if (!db) throw new Error('DB 미연결');
+  if (!deliverableId) throw new Error('deliverableId 누락');
+  let ok = false;
+  await retryWithRefresh(async () => {
+    const {error} = await db.rpc('delete_mismatched_post_deliverable', {
       p_deliverable_id: deliverableId,
       p_reason:         reason || null
     });
@@ -19495,6 +19544,11 @@ function renderDelivStatusCell(d, slot, rt) {
       try { host = new URL(d.post_url).hostname.replace(/^www\./, ''); } catch(e) { host = d.post_url; }
       preview = `<a href="${esc(d.post_url)}" target="_blank" rel="noopener" onclick="event.stopPropagation()" style="font-size:10px;color:var(--dark-pink);text-decoration:none;display:inline-block;max-width:100px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;vertical-align:middle">${esc(host)}</a>`;
     }
+    // 채널 불일치 경고 배지 (2026-06-16, 묶음2) — 캠페인 요구 채널에 없는 post_channel(예: 인스타 캠페인에 lips)
+    const camp = d.campaigns || (typeof allCampaigns !== 'undefined' && Array.isArray(allCampaigns) ? allCampaigns.find(c => c.id === d.campaign_id) : null);
+    if (d.post_channel && camp && !postChannelMatchesCampaign(camp, d.post_channel)) {
+      preview += ` <span class="notranslate" translate="no" style="background:#FFE4E4;color:#C33;font-size:10px;font-weight:700;padding:1px 6px;border-radius:3px;border:1px solid #C33" title="이 게시물 채널(${esc(d.post_channel)})이 캠페인 요구 채널에 없습니다. 잘못 저장된 행일 수 있습니다.">채널 불일치</span>`;
+    }
   }
   // 마이그레이션 160: 대리 등록 행은 status 배지를 「대리 등록」으로 교체 (자동 승인이라 "승인" 표기 무의미)
   // 사용자 결정 2026-05-28: 「승인 + 작은 대리 마커」 중복 → 단일 「대리 등록」 배지로 통합
@@ -19992,6 +20046,18 @@ async function deleteLegacyReviewImageRow(deliverableId) {
   } catch(e) { toast(e?.message || '삭제 중 오류가 발생했습니다', 'error'); }
 }
 
+// 채널 불일치 게시물(post) 삭제 (super_admin, 마이그레이션 183, 묶음2). 되돌릴 수 없으므로 확인 모달.
+async function deleteMismatchedPostRow(deliverableId) {
+  const ok = await showConfirm('캠페인 요구 채널과 다른 채널로 저장된 게시물입니다. 삭제하면 되돌릴 수 없습니다. 진행하시겠습니까?');
+  if (!ok) return;
+  try {
+    await deleteMismatchedPostDeliverable(deliverableId, '관리자 수동 삭제 (채널 불일치 게시물)');
+    toast('삭제했습니다', 'success');
+    if (_delivCombinedRefreshAppId) await renderDelivCombinedBody(_delivCombinedRefreshAppId);
+    if (typeof refreshPane === 'function') await refreshPane('deliverables');
+  } catch(e) { toast(e?.message || '삭제 중 오류가 발생했습니다', 'error'); }
+}
+
 // ─── 영수증 정보 블록 (마이그레이션 128) ─────────────────────
 // kind='receipt' 결과물의 주문번호·구매일·구매금액을 노출.
 // campaign_admin 이상은 인플레이스 수정 폼 + 변경 이력 토글 사용.
@@ -20282,6 +20348,10 @@ function renderDelivPanelContent(d, events) {
     return '<div style="text-align:center;color:var(--muted);padding:40px;font-size:13px">아직 제출되지 않았습니다.</div>';
   }
   let html = '';
+  // 채널 불일치 판정 (2026-06-16, 묶음2) — post 행이 캠페인 요구 채널에 없는지
+  const _panelCamp = d.campaigns || (typeof allCampaigns !== 'undefined' && Array.isArray(allCampaigns) ? allCampaigns.find(c => c.id === d.campaign_id) : null);
+  const isPostChannelMismatch = !!(d.kind === 'post' && d.post_channel && _panelCamp
+    && typeof postChannelMatchesCampaign === 'function' && !postChannelMatchesCampaign(_panelCamp, d.post_channel));
   // 관리자 대리 등록 행 (마이그레이션 160) — 상단 안내 박스 + 회수 버튼은 하단 별도 영역
   if (d.submitted_by_admin) {
     const reasonLabel = _proxyReasonLabelKo(d.submitted_by_admin_reason_code);
@@ -20312,7 +20382,7 @@ function renderDelivPanelContent(d, events) {
     }
   } else {
     html += `<div style="font-size:13px;line-height:1.7;margin-bottom:10px">
-      <div><span style="color:var(--muted)">채널</span> · <strong>${esc(d.post_channel || '—')}</strong></div>
+      <div><span style="color:var(--muted)">채널</span> · <strong>${esc(d.post_channel || '—')}</strong>${isPostChannelMismatch ? ` <span class="notranslate" translate="no" style="background:#FFE4E4;color:#C33;font-size:10px;font-weight:700;padding:1px 6px;border-radius:3px;border:1px solid #C33" title="캠페인 요구 채널에 없는 채널입니다">채널 불일치</span>` : ''}</div>
       <div style="margin-top:6px"><span style="color:var(--muted)">URL</span> · ${d.post_url ? `<a href="${esc(d.post_url)}" target="_blank" rel="noopener" style="color:var(--dark-pink);word-break:break-all">${esc(d.post_url)}</a>` : '—'}</div>
       ${(Array.isArray(d.post_submissions) && d.post_submissions.length) ? `<div style="margin-top:8px;font-size:11px;color:var(--muted)">제출 이력 ${d.post_submissions.length}건</div>` : ''}
     </div>`;
@@ -20328,6 +20398,13 @@ function renderDelivPanelContent(d, events) {
   // 대리 등록 행은 일반 「되돌리기」 비활성 + super_admin 전용 「대리 등록 회수」 버튼 (사용자 결정 2026-05-28)
   const isProxy = !!d.submitted_by_admin;
   const isSuperAdmin = (typeof currentAdminInfo !== 'undefined' && currentAdminInfo?.role === 'super_admin');
+  // 채널 불일치 게시물 삭제 (super_admin, 묶음2) — 잘못된 채널로 저장된 행 정리. 승인 행은 서버가 거부.
+  if (isPostChannelMismatch && isSuperAdmin && d.status !== 'approved') {
+    html += `<div style="margin-top:10px;padding:10px 12px;background:#FFF4F4;border:1px solid #F0C0C0;border-radius:8px">
+      <div style="font-size:11px;color:#C33;margin-bottom:6px">이 게시물은 캠페인 요구 채널과 다른 채널(<span class="notranslate" translate="no">${esc(d.post_channel)}</span>)로 저장됐습니다. 잘못 등록된 행이면 삭제하세요. 되돌릴 수 없습니다.</div>
+      <button class="btn btn-ghost btn-sm" style="color:#C33;border-color:#C33;font-size:11px;padding:4px 10px" onclick="deleteMismatchedPostRow('${esc(d.id)}')">채널 불일치 게시물 삭제</button>
+    </div>`;
+  }
   if (d.status === 'pending') {
     html += `<div style="display:flex;gap:6px;margin-top:12px;justify-content:flex-end;align-items:center">`;
     if (isProxy && isSuperAdmin) {
@@ -20906,8 +20983,11 @@ function _adminDetectChannelFromUrl(url) {
 }
 
 function onAdminProxyPostUrlInput() {
-  const url = $('adminProxyPostUrl')?.value || '';
-  if (!url) return;
+  const raw = $('adminProxyPostUrl')?.value || '';
+  if (!raw) return;
+  // 보정된 주소로 채널 자동 판별 (저장 시 submitAdminProxyDelivProxy 가 실제 보정)
+  const norm = normalizeUrlInput(raw);
+  const url = norm ? norm.url : raw;
   const guess = _adminDetectChannelFromUrl(url);
   if (!guess) return;
   const sel = $('adminProxyPostChannel');
@@ -20958,9 +21038,14 @@ async function submitAdminProxyDelivProxy() {
       payload.purchaseDate = date;
       payload.purchaseAmount = parseFloat(amount);
     } else if (kind === 'post') {
-      const url = ($('adminProxyPostUrl')?.value || '').trim();
+      const rawUrl = ($('adminProxyPostUrl')?.value || '').trim();
       const channel = $('adminProxyPostChannel')?.value;
-      if (!url) return toast('게시물 URL을 입력하세요', 'error');
+      if (!rawUrl) return toast('게시물 URL을 입력하세요', 'error');
+      // URL 오타 자동 보정 (2026-06-16) — ttp:// 등 흔한 실수·스킴 누락 교정, 위험 스킴 차단
+      const norm = normalizeUrlInput(rawUrl);
+      if (!norm) return toast('URL 형식이 올바르지 않습니다', 'error');
+      const url = norm.url;
+      if (norm.changed) toast('URL을 수정했습니다: ' + url, 'success');
       if (!channel) return toast('채널을 선택하세요 (자동 판별 실패 시 수동)', 'error');
       // 방어: 캠페인 요구 채널과 일치 확인 (2026-06-16). 드롭다운이 이미 캠페인 채널만이나 이중 가드.
       // proxyApp 미탐지(목록 비동기 리로드 등) 시에는 서버 함수(admin_create_deliverable_proxy) 가드에 위임.

--- a/dev/js/admin-deliverables.js
+++ b/dev/js/admin-deliverables.js
@@ -673,6 +673,11 @@ function renderDelivStatusCell(d, slot, rt) {
       try { host = new URL(d.post_url).hostname.replace(/^www\./, ''); } catch(e) { host = d.post_url; }
       preview = `<a href="${esc(d.post_url)}" target="_blank" rel="noopener" onclick="event.stopPropagation()" style="font-size:10px;color:var(--dark-pink);text-decoration:none;display:inline-block;max-width:100px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;vertical-align:middle">${esc(host)}</a>`;
     }
+    // 채널 불일치 경고 배지 (2026-06-16, 묶음2) — 캠페인 요구 채널에 없는 post_channel(예: 인스타 캠페인에 lips)
+    const camp = d.campaigns || (typeof allCampaigns !== 'undefined' && Array.isArray(allCampaigns) ? allCampaigns.find(c => c.id === d.campaign_id) : null);
+    if (d.post_channel && camp && !postChannelMatchesCampaign(camp, d.post_channel)) {
+      preview += ` <span class="notranslate" translate="no" style="background:#FFE4E4;color:#C33;font-size:10px;font-weight:700;padding:1px 6px;border-radius:3px;border:1px solid #C33" title="이 게시물 채널(${esc(d.post_channel)})이 캠페인 요구 채널에 없습니다. 잘못 저장된 행일 수 있습니다.">채널 불일치</span>`;
+    }
   }
   // 마이그레이션 160: 대리 등록 행은 status 배지를 「대리 등록」으로 교체 (자동 승인이라 "승인" 표기 무의미)
   // 사용자 결정 2026-05-28: 「승인 + 작은 대리 마커」 중복 → 단일 「대리 등록」 배지로 통합
@@ -1170,6 +1175,18 @@ async function deleteLegacyReviewImageRow(deliverableId) {
   } catch(e) { toast(e?.message || '삭제 중 오류가 발생했습니다', 'error'); }
 }
 
+// 채널 불일치 게시물(post) 삭제 (super_admin, 마이그레이션 183, 묶음2). 되돌릴 수 없으므로 확인 모달.
+async function deleteMismatchedPostRow(deliverableId) {
+  const ok = await showConfirm('캠페인 요구 채널과 다른 채널로 저장된 게시물입니다. 삭제하면 되돌릴 수 없습니다. 진행하시겠습니까?');
+  if (!ok) return;
+  try {
+    await deleteMismatchedPostDeliverable(deliverableId, '관리자 수동 삭제 (채널 불일치 게시물)');
+    toast('삭제했습니다', 'success');
+    if (_delivCombinedRefreshAppId) await renderDelivCombinedBody(_delivCombinedRefreshAppId);
+    if (typeof refreshPane === 'function') await refreshPane('deliverables');
+  } catch(e) { toast(e?.message || '삭제 중 오류가 발생했습니다', 'error'); }
+}
+
 // ─── 영수증 정보 블록 (마이그레이션 128) ─────────────────────
 // kind='receipt' 결과물의 주문번호·구매일·구매금액을 노출.
 // campaign_admin 이상은 인플레이스 수정 폼 + 변경 이력 토글 사용.
@@ -1460,6 +1477,10 @@ function renderDelivPanelContent(d, events) {
     return '<div style="text-align:center;color:var(--muted);padding:40px;font-size:13px">아직 제출되지 않았습니다.</div>';
   }
   let html = '';
+  // 채널 불일치 판정 (2026-06-16, 묶음2) — post 행이 캠페인 요구 채널에 없는지
+  const _panelCamp = d.campaigns || (typeof allCampaigns !== 'undefined' && Array.isArray(allCampaigns) ? allCampaigns.find(c => c.id === d.campaign_id) : null);
+  const isPostChannelMismatch = !!(d.kind === 'post' && d.post_channel && _panelCamp
+    && typeof postChannelMatchesCampaign === 'function' && !postChannelMatchesCampaign(_panelCamp, d.post_channel));
   // 관리자 대리 등록 행 (마이그레이션 160) — 상단 안내 박스 + 회수 버튼은 하단 별도 영역
   if (d.submitted_by_admin) {
     const reasonLabel = _proxyReasonLabelKo(d.submitted_by_admin_reason_code);
@@ -1490,7 +1511,7 @@ function renderDelivPanelContent(d, events) {
     }
   } else {
     html += `<div style="font-size:13px;line-height:1.7;margin-bottom:10px">
-      <div><span style="color:var(--muted)">채널</span> · <strong>${esc(d.post_channel || '—')}</strong></div>
+      <div><span style="color:var(--muted)">채널</span> · <strong>${esc(d.post_channel || '—')}</strong>${isPostChannelMismatch ? ` <span class="notranslate" translate="no" style="background:#FFE4E4;color:#C33;font-size:10px;font-weight:700;padding:1px 6px;border-radius:3px;border:1px solid #C33" title="캠페인 요구 채널에 없는 채널입니다">채널 불일치</span>` : ''}</div>
       <div style="margin-top:6px"><span style="color:var(--muted)">URL</span> · ${d.post_url ? `<a href="${esc(d.post_url)}" target="_blank" rel="noopener" style="color:var(--dark-pink);word-break:break-all">${esc(d.post_url)}</a>` : '—'}</div>
       ${(Array.isArray(d.post_submissions) && d.post_submissions.length) ? `<div style="margin-top:8px;font-size:11px;color:var(--muted)">제출 이력 ${d.post_submissions.length}건</div>` : ''}
     </div>`;
@@ -1506,6 +1527,13 @@ function renderDelivPanelContent(d, events) {
   // 대리 등록 행은 일반 「되돌리기」 비활성 + super_admin 전용 「대리 등록 회수」 버튼 (사용자 결정 2026-05-28)
   const isProxy = !!d.submitted_by_admin;
   const isSuperAdmin = (typeof currentAdminInfo !== 'undefined' && currentAdminInfo?.role === 'super_admin');
+  // 채널 불일치 게시물 삭제 (super_admin, 묶음2) — 잘못된 채널로 저장된 행 정리. 승인 행은 서버가 거부.
+  if (isPostChannelMismatch && isSuperAdmin && d.status !== 'approved') {
+    html += `<div style="margin-top:10px;padding:10px 12px;background:#FFF4F4;border:1px solid #F0C0C0;border-radius:8px">
+      <div style="font-size:11px;color:#C33;margin-bottom:6px">이 게시물은 캠페인 요구 채널과 다른 채널(<span class="notranslate" translate="no">${esc(d.post_channel)}</span>)로 저장됐습니다. 잘못 등록된 행이면 삭제하세요. 되돌릴 수 없습니다.</div>
+      <button class="btn btn-ghost btn-sm" style="color:#C33;border-color:#C33;font-size:11px;padding:4px 10px" onclick="deleteMismatchedPostRow('${esc(d.id)}')">채널 불일치 게시물 삭제</button>
+    </div>`;
+  }
   if (d.status === 'pending') {
     html += `<div style="display:flex;gap:6px;margin-top:12px;justify-content:flex-end;align-items:center">`;
     if (isProxy && isSuperAdmin) {
@@ -2084,8 +2112,11 @@ function _adminDetectChannelFromUrl(url) {
 }
 
 function onAdminProxyPostUrlInput() {
-  const url = $('adminProxyPostUrl')?.value || '';
-  if (!url) return;
+  const raw = $('adminProxyPostUrl')?.value || '';
+  if (!raw) return;
+  // 보정된 주소로 채널 자동 판별 (저장 시 submitAdminProxyDelivProxy 가 실제 보정)
+  const norm = normalizeUrlInput(raw);
+  const url = norm ? norm.url : raw;
   const guess = _adminDetectChannelFromUrl(url);
   if (!guess) return;
   const sel = $('adminProxyPostChannel');
@@ -2136,9 +2167,14 @@ async function submitAdminProxyDelivProxy() {
       payload.purchaseDate = date;
       payload.purchaseAmount = parseFloat(amount);
     } else if (kind === 'post') {
-      const url = ($('adminProxyPostUrl')?.value || '').trim();
+      const rawUrl = ($('adminProxyPostUrl')?.value || '').trim();
       const channel = $('adminProxyPostChannel')?.value;
-      if (!url) return toast('게시물 URL을 입력하세요', 'error');
+      if (!rawUrl) return toast('게시물 URL을 입력하세요', 'error');
+      // URL 오타 자동 보정 (2026-06-16) — ttp:// 등 흔한 실수·스킴 누락 교정, 위험 스킴 차단
+      const norm = normalizeUrlInput(rawUrl);
+      if (!norm) return toast('URL 형식이 올바르지 않습니다', 'error');
+      const url = norm.url;
+      if (norm.changed) toast('URL을 수정했습니다: ' + url, 'success');
       if (!channel) return toast('채널을 선택하세요 (자동 판별 실패 시 수동)', 'error');
       // 방어: 캠페인 요구 채널과 일치 확인 (2026-06-16). 드롭다운이 이미 캠페인 채널만이나 이중 가드.
       // proxyApp 미탐지(목록 비동기 리로드 등) 시에는 서버 함수(admin_create_deliverable_proxy) 가드에 위임.

--- a/dev/js/application.js
+++ b/dev/js/application.js
@@ -744,14 +744,17 @@ function populatePostChannelManualOptions() {
 }
 
 function onPostUrlInputChange() {
-  const url = $('postUrlInput')?.value || '';
+  const raw = $('postUrlInput')?.value || '';
   const detectedLbl = $('postChannelDetected');
   const manualWrap = $('postChannelManualWrap');
-  if (!url.trim()) {
+  if (!raw.trim()) {
     if (detectedLbl) detectedLbl.textContent = '';
     if (manualWrap) manualWrap.style.display = 'none';
     return;
   }
+  // 보정된 주소로 채널 판별 (ttp:// 등 오타가 있어도 채널 인식 — 저장 시 addDraftUrl 이 실제 보정)
+  const norm = normalizeUrlInput(raw);
+  const url = norm ? norm.url : raw;
   const ch = detectChannelFromUrl(url);
   if (ch) {
     if (detectedLbl) detectedLbl.textContent = t('activity.postChannelDetected').replace('{channel}', getChannelLabelLocal(ch));
@@ -1254,9 +1257,13 @@ function previewReviewImage(input, channel) {
 // Draft URL 추가 (gifting/visit — SNS 게시 URL 제출)
 async function addDraftUrl() {
   if (!currentUser) { toast(t('apply.needLogin'),'error'); return; }
-  const url = ($('postUrlInput')?.value || '').trim();
-  if (!url) { toast(t('activity.needUrl'), 'error'); return; }
-  try { new URL(url); } catch(e) { toast(t('activity.badUrlFormat'),'error'); return; }
+  const rawUrl = ($('postUrlInput')?.value || '').trim();
+  if (!rawUrl) { toast(t('activity.needUrl'), 'error'); return; }
+  // URL 오타 자동 보정 (2026-06-16) — ttp:// 등 흔한 실수·스킴 누락 교정, 위험 스킴 차단
+  const norm = normalizeUrlInput(rawUrl);
+  if (!norm) { toast(t('activity.badUrlFormat'),'error'); return; }
+  const url = norm.url;
+  if (norm.changed) toast(t('activity.urlFixed').replace('{url}', url), 'success');
 
   const camp = _activityCamp || {};
   const submissionEnd = camp.submission_end;

--- a/dev/lib/i18n/ja.js
+++ b/dev/lib/i18n/ja.js
@@ -479,6 +479,7 @@ window.I18N_JA = {
     submitCountLabel: '提出回数: {n}回',
     needUrl: 'URLを入力してください',
     badUrlFormat: 'URLの形式が正しくありません',
+    urlFixed: 'URLを修正しました：{url}',
     needChannel: 'チャンネルを選択してください',
     channelMismatch: 'このキャンペーンは「{channels}」の投稿が必要です。正しいチャンネルのリンク（URL）を貼ってください。',
     afterDeadline: '提出期限が過ぎたため、登録できません',

--- a/dev/lib/i18n/ko.js
+++ b/dev/lib/i18n/ko.js
@@ -464,6 +464,7 @@ window.I18N_KO = {
     submitCountLabel: '제출 횟수: {n}회',
     needUrl: 'URL을 입력해주세요',
     badUrlFormat: 'URL 형식이 올바르지 않습니다',
+    urlFixed: 'URL을 수정했습니다: {url}',
     needChannel: '채널을 선택해주세요',
     channelMismatch: '이 캠페인은 「{channels}」 게시물이 필요합니다. 올바른 채널의 링크(URL)를 붙여넣어 주세요.',
     afterDeadline: '제출 기한이 지나 등록할 수 없습니다',

--- a/dev/lib/shared.js
+++ b/dev/lib/shared.js
@@ -322,6 +322,38 @@ function postChannelMatchesCampaign(camp, postChannel) {
   return list.includes(String(postChannel).trim().toLowerCase());
 }
 
+// 결과물 게시물 URL 입력 오타 자동 보정 (2026-06-16). 인플 제출·관리자 대리 등록 공통.
+//   명백한 오타만 고치고, 위험 스킴은 차단, 나머지는 그대로 검증.
+//   - 앞뒤 공백 제거
+//   - 흔한 스킴 오타(ttp:// · ttps:// · htp:// · htps:// · http// · http:/ 등) → https://
+//     (SNS 게시물은 https 가 표준이라 https 로 통일)
+//   - 스킴 없으면(instagram.com/...) https:// 자동 추가
+//   - 위험 스킴(javascript: · data: · vbscript: · file: · blob:) → null 차단(XSS 방지)
+//   - 최종 new URL 로 검증, http/https + 호스트 있는 것만 통과
+//   반환: {url, changed} | null(빈값·위험 스킴·형식 오류). changed=보정 발생 여부(화면 안내용)
+// 사양서: docs/specs/2026-06-16-post-channel-validation-and-proxy-replace.md
+function normalizeUrlInput(raw) {
+  let s = String(raw || '').trim();
+  if (!s) return null;
+  const orig = s;
+  if (/^(javascript|data|vbscript|file|blob):/i.test(s)) return null; // 위험 스킴 차단
+  if (/^https?:\/\//i.test(s)) {
+    // 이미 정상 스킴 — 그대로
+  } else if (/^h?t{1,2}ps?:?\/{1,2}/i.test(s)) {
+    s = s.replace(/^h?t{1,2}ps?:?\/{1,2}/i, 'https://'); // 흔한 스킴 오타 → https://
+  } else if (/^[a-z][a-z0-9+.\-]*:\/\//i.test(s)) {
+    return null; // 알 수 없는 스킴 차단
+  } else {
+    s = 'https://' + s; // 스킴 없음 → https:// 추가
+  }
+  try {
+    const u = new URL(s);
+    if (u.protocol !== 'https:' && u.protocol !== 'http:') return null;
+    if (!u.hostname) return null;
+  } catch (e) { return null; }
+  return { url: s, changed: s !== orig };
+}
+
 // raw 입력값(URL 또는 핸들)에서 핸들만 뽑아 반환. 실패 시 trim된 원본 반환.
 // 저장 정책: 핸들만(@ 없이) 저장. 표시 시 UI에서 @ prefix 부여.
 function extractSnsHandle(channel, raw) {

--- a/dev/lib/storage.js
+++ b/dev/lib/storage.js
@@ -1054,6 +1054,23 @@ async function deleteLegacyReviewImage(deliverableId, reason) {
   return ok;
 }
 
+// 잘못된 채널 게시물(post) 결과물 삭제 (super_admin, 마이그레이션 183).
+//   캠페인 요구 채널과 다른 채널로 잘못 저장된 post 행 정리. 서버에서 채널 불일치·승인 보호 재검증.
+async function deleteMismatchedPostDeliverable(deliverableId, reason) {
+  if (!db) throw new Error('DB 미연결');
+  if (!deliverableId) throw new Error('deliverableId 누락');
+  let ok = false;
+  await retryWithRefresh(async () => {
+    const {error} = await db.rpc('delete_mismatched_post_deliverable', {
+      p_deliverable_id: deliverableId,
+      p_reason:         reason || null
+    });
+    if (error) throw error;
+    ok = true;
+  });
+  return ok;
+}
+
 // 영수증 변경 이력 조회 (모든 관리자 SELECT 가능)
 async function fetchReceiptEditHistory(deliverableId) {
   if (!db || !deliverableId) return [];

--- a/index.html
+++ b/index.html
@@ -2193,6 +2193,38 @@ function postChannelMatchesCampaign(camp, postChannel) {
   return list.includes(String(postChannel).trim().toLowerCase());
 }
 
+// 결과물 게시물 URL 입력 오타 자동 보정 (2026-06-16). 인플 제출·관리자 대리 등록 공통.
+//   명백한 오타만 고치고, 위험 스킴은 차단, 나머지는 그대로 검증.
+//   - 앞뒤 공백 제거
+//   - 흔한 스킴 오타(ttp:// · ttps:// · htp:// · htps:// · http// · http:/ 등) → https://
+//     (SNS 게시물은 https 가 표준이라 https 로 통일)
+//   - 스킴 없으면(instagram.com/...) https:// 자동 추가
+//   - 위험 스킴(javascript: · data: · vbscript: · file: · blob:) → null 차단(XSS 방지)
+//   - 최종 new URL 로 검증, http/https + 호스트 있는 것만 통과
+//   반환: {url, changed} | null(빈값·위험 스킴·형식 오류). changed=보정 발생 여부(화면 안내용)
+// 사양서: docs/specs/2026-06-16-post-channel-validation-and-proxy-replace.md
+function normalizeUrlInput(raw) {
+  let s = String(raw || '').trim();
+  if (!s) return null;
+  const orig = s;
+  if (/^(javascript|data|vbscript|file|blob):/i.test(s)) return null; // 위험 스킴 차단
+  if (/^https?:\/\//i.test(s)) {
+    // 이미 정상 스킴 — 그대로
+  } else if (/^h?t{1,2}ps?:?\/{1,2}/i.test(s)) {
+    s = s.replace(/^h?t{1,2}ps?:?\/{1,2}/i, 'https://'); // 흔한 스킴 오타 → https://
+  } else if (/^[a-z][a-z0-9+.\-]*:\/\//i.test(s)) {
+    return null; // 알 수 없는 스킴 차단
+  } else {
+    s = 'https://' + s; // 스킴 없음 → https:// 추가
+  }
+  try {
+    const u = new URL(s);
+    if (u.protocol !== 'https:' && u.protocol !== 'http:') return null;
+    if (!u.hostname) return null;
+  } catch (e) { return null; }
+  return { url: s, changed: s !== orig };
+}
+
 // raw 입력값(URL 또는 핸들)에서 핸들만 뽑아 반환. 실패 시 trim된 원본 반환.
 // 저장 정책: 핸들만(@ 없이) 저장. 표시 시 UI에서 @ prefix 부여.
 function extractSnsHandle(channel, raw) {
@@ -3033,6 +3065,7 @@ window.I18N_JA = {
     submitCountLabel: '提出回数: {n}回',
     needUrl: 'URLを入力してください',
     badUrlFormat: 'URLの形式が正しくありません',
+    urlFixed: 'URLを修正しました：{url}',
     needChannel: 'チャンネルを選択してください',
     channelMismatch: 'このキャンペーンは「{channels}」の投稿が必要です。正しいチャンネルのリンク（URL）を貼ってください。',
     afterDeadline: '提出期限が過ぎたため、登録できません',
@@ -3698,6 +3731,7 @@ window.I18N_KO = {
     submitCountLabel: '제출 횟수: {n}회',
     needUrl: 'URL을 입력해주세요',
     badUrlFormat: 'URL 형식이 올바르지 않습니다',
+    urlFixed: 'URL을 수정했습니다: {url}',
     needChannel: '채널을 선택해주세요',
     channelMismatch: '이 캠페인은 「{channels}」 게시물이 필요합니다. 올바른 채널의 링크(URL)를 붙여넣어 주세요.',
     afterDeadline: '제출 기한이 지나 등록할 수 없습니다',
@@ -5263,6 +5297,23 @@ async function deleteLegacyReviewImage(deliverableId, reason) {
   let ok = false;
   await retryWithRefresh(async () => {
     const {error} = await db.rpc('delete_legacy_review_image', {
+      p_deliverable_id: deliverableId,
+      p_reason:         reason || null
+    });
+    if (error) throw error;
+    ok = true;
+  });
+  return ok;
+}
+
+// 잘못된 채널 게시물(post) 결과물 삭제 (super_admin, 마이그레이션 183).
+//   캠페인 요구 채널과 다른 채널로 잘못 저장된 post 행 정리. 서버에서 채널 불일치·승인 보호 재검증.
+async function deleteMismatchedPostDeliverable(deliverableId, reason) {
+  if (!db) throw new Error('DB 미연결');
+  if (!deliverableId) throw new Error('deliverableId 누락');
+  let ok = false;
+  await retryWithRefresh(async () => {
+    const {error} = await db.rpc('delete_mismatched_post_deliverable', {
       p_deliverable_id: deliverableId,
       p_reason:         reason || null
     });
@@ -9908,14 +9959,17 @@ function populatePostChannelManualOptions() {
 }
 
 function onPostUrlInputChange() {
-  const url = $('postUrlInput')?.value || '';
+  const raw = $('postUrlInput')?.value || '';
   const detectedLbl = $('postChannelDetected');
   const manualWrap = $('postChannelManualWrap');
-  if (!url.trim()) {
+  if (!raw.trim()) {
     if (detectedLbl) detectedLbl.textContent = '';
     if (manualWrap) manualWrap.style.display = 'none';
     return;
   }
+  // 보정된 주소로 채널 판별 (ttp:// 등 오타가 있어도 채널 인식 — 저장 시 addDraftUrl 이 실제 보정)
+  const norm = normalizeUrlInput(raw);
+  const url = norm ? norm.url : raw;
   const ch = detectChannelFromUrl(url);
   if (ch) {
     if (detectedLbl) detectedLbl.textContent = t('activity.postChannelDetected').replace('{channel}', getChannelLabelLocal(ch));
@@ -10418,9 +10472,13 @@ function previewReviewImage(input, channel) {
 // Draft URL 추가 (gifting/visit — SNS 게시 URL 제출)
 async function addDraftUrl() {
   if (!currentUser) { toast(t('apply.needLogin'),'error'); return; }
-  const url = ($('postUrlInput')?.value || '').trim();
-  if (!url) { toast(t('activity.needUrl'), 'error'); return; }
-  try { new URL(url); } catch(e) { toast(t('activity.badUrlFormat'),'error'); return; }
+  const rawUrl = ($('postUrlInput')?.value || '').trim();
+  if (!rawUrl) { toast(t('activity.needUrl'), 'error'); return; }
+  // URL 오타 자동 보정 (2026-06-16) — ttp:// 등 흔한 실수·스킴 누락 교정, 위험 스킴 차단
+  const norm = normalizeUrlInput(rawUrl);
+  if (!norm) { toast(t('activity.badUrlFormat'),'error'); return; }
+  const url = norm.url;
+  if (norm.changed) toast(t('activity.urlFixed').replace('{url}', url), 'success');
 
   const camp = _activityCamp || {};
   const submissionEnd = camp.submission_end;

--- a/supabase/migrations/183_delete_mismatched_post.sql
+++ b/supabase/migrations/183_delete_mismatched_post.sql
@@ -1,0 +1,241 @@
+-- =============================================================================
+-- 마이그레이션 183: delete_mismatched_post_deliverable RPC
+-- 제목    : 캠페인 채널과 불일치하는 게시물(post) 결과물을 super_admin 이 삭제
+-- 의존    : 035 (deliverables / deliverable_events, ON DELETE CASCADE)
+--           162 (deliverable_events.action CHECK 9종 — admin_proxy_revoke 포함)
+--           182 (캠페인 채널 검증 패턴 참고 — string_to_array + ANY)
+-- 대상    : 개발서버 + 운영서버
+-- 날짜    : 2026-06-16
+-- 사양서  : docs/specs/2026-06-16-post-channel-validation-and-proxy-replace.md
+-- 위험도  : 낮음 — 신규 RPC 1개. 테이블 구조·기존 RLS·기존 함수 무변경.
+-- 멱등성  : DROP FUNCTION IF EXISTS + CREATE OR REPLACE FUNCTION
+--
+-- 목적:
+--   캠페인 요구 채널과 다른 채널로 잘못 저장된 게시물(post) 결과물 행을
+--   super_admin 이 직접 삭제할 수 있는 RPC.
+--
+--   서버 재검증(채널 불일치 시에만 삭제 허용)을 통해 오삭제를 방지하고,
+--   승인(approved) 상태 행을 보호한다.
+--
+-- 설계 결정:
+--   - audit INSERT(admin_proxy_revoke 재사용): deliverable_events.ON DELETE CASCADE
+--     (마이그레이션 035) 로 audit 이벤트도 행 삭제와 함께 소멸하는 한계는
+--     마이그레이션 162 delete_legacy_review_image, 160 admin_proxy_revoke 와 동일.
+--     새 action 을 추가하지 않고 기존 admin_proxy_revoke 를 재사용한다
+--     ("기존 방식 감수" 결정 — 별도 영구 audit 테이블은 현재 미구현).
+--   - Storage 없음: post 결과물은 post_url(외부 URL)만 보유. Storage 파일 삭제 불필요.
+--
+-- 한계 사항:
+--   deliverable_events.deliverable_id 에 ON DELETE CASCADE (마이그레이션 035) 가 걸려 있어
+--   이 RPC 가 deliverables 행을 DELETE 하면 직전에 INSERT 한 audit 이벤트도 함께 삭제됨.
+--   영구 감사가 필요하다면 별도 audit 테이블 분리를 권장 (현재 미구현).
+--
+-- 롤백 방법:
+--   DROP FUNCTION IF EXISTS public.delete_mismatched_post_deliverable(uuid, text);
+-- =============================================================================
+
+BEGIN;
+
+-- ============================================================
+-- RPC: delete_mismatched_post_deliverable
+--
+--   목적  : post_channel 이 캠페인 channel 콤마 목록에 없는 게시물(post) 결과물 행을
+--           super_admin 이 삭제한다. 정상 채널이거나 승인된 행은 거부한다.
+--
+--   인수  : p_deliverable_id — 삭제할 deliverable UUID
+--           p_reason         — 삭제 사유 (기록용, NULL 허용)
+--   반환  : void
+--   권한  : is_super_admin() 전용
+-- ============================================================
+
+DROP FUNCTION IF EXISTS public.delete_mismatched_post_deliverable(uuid, text);
+
+CREATE OR REPLACE FUNCTION public.delete_mismatched_post_deliverable(
+  p_deliverable_id  uuid,
+  p_reason          text   -- 삭제 사유 (기록용, NULL 허용)
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_kind        text;
+  v_post_channel text;
+  v_status      text;
+  v_campaign_id uuid;
+  v_camp_channel text;
+  v_camp_list   text[];
+BEGIN
+
+  -- ① 권한 가드: super_admin 전용
+  IF NOT public.is_super_admin() THEN
+    RAISE EXCEPTION '권한이 없습니다. super_admin 권한이 필요합니다.'
+      USING ERRCODE = '42501';
+  END IF;
+
+  -- ② 대상 행 검증 + 행 잠금 (동시 삭제 직렬화)
+  SELECT kind, post_channel, status, campaign_id
+    INTO v_kind, v_post_channel, v_status, v_campaign_id
+    FROM public.deliverables
+   WHERE id = p_deliverable_id
+   FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION '결과물을 찾을 수 없습니다.'
+      USING ERRCODE = 'P0002';
+  END IF;
+
+  -- ③ post 행만 허용 (receipt / review_image 오삭제 방지)
+  IF v_kind <> 'post' THEN
+    RAISE EXCEPTION '게시물(post) 결과물만 삭제할 수 있습니다. 현재 종류: %', v_kind
+      USING ERRCODE = 'P0001';
+  END IF;
+
+  -- ④ 승인 행 보호: approved 는 삭제 불가 (반려·검수중·draft 만 허용)
+  IF v_status = 'approved' THEN
+    RAISE EXCEPTION '승인된 게시물은 삭제할 수 없습니다.'
+      USING ERRCODE = 'P0001';
+  END IF;
+
+  -- ④-b post_channel 미판별(NULL/빈값) 행 보호:
+  --   채널이 없는 행은 "잘못된 채널" 이 아니라 "채널 미판별 레거시" 이므로
+  --   이 RPC(채널 불일치 정리)의 대상이 아니다. 오삭제 방지.
+  IF v_post_channel IS NULL OR trim(v_post_channel) = '' THEN
+    RAISE EXCEPTION '채널 정보가 없는 게시물은 채널 불일치 삭제 대상이 아닙니다.'
+      USING ERRCODE = 'P0001';
+  END IF;
+
+  -- ⑤ 채널 불일치 서버 재검증 (핵심 안전장치)
+  --
+  --   캠페인의 channel 콤마 목록(공백 제거 + 소문자)에 post_channel 이 포함되면
+  --   "정상 채널" 로 간주하여 삭제를 거부한다.
+  --
+  --   campaigns.channel 이 NULL 이거나 빈 문자열이면 배열이 빈 배열({})이 되어
+  --   ANY 검사가 false → 삭제 거부 (레거시 캠페인 보호).
+  --   이는 shared.js postChannelMatchesCampaign 의 "빈 값이면 true(정상)" 와 동일한 의미.
+  --
+  --   즉 삭제가 허용되는 조건은:
+  --     1) campaigns.channel 이 비어있지 않고
+  --     2) post_channel 이 그 목록에 포함되지 않는 경우(불일치)
+  --
+  SELECT channel
+    INTO v_camp_channel
+    FROM public.campaigns
+   WHERE id = v_campaign_id;
+
+  -- 공백 제거 후 콤마 분리 (182 채널 검증 패턴과 동일)
+  v_camp_list := string_to_array(
+    lower(replace(COALESCE(v_camp_channel, ''), ' ', '')),
+    ','
+  );
+
+  -- 캠페인 채널이 비어있거나, post_channel 이 목록에 있으면 → 정상 채널 → 삭제 거부
+  IF array_length(v_camp_list, 1) IS NULL
+     OR lower(trim(COALESCE(v_post_channel, ''))) = ANY(v_camp_list)
+  THEN
+    RAISE EXCEPTION '정상 채널 게시물은 삭제할 수 없습니다.'
+      ' (캠페인 채널이 비어있거나, post_channel 이 캠페인 채널 목록에 포함됩니다.'
+      ' 현재 post_channel: %, 캠페인 채널: %)',
+      COALESCE(v_post_channel, '(NULL)'),
+      COALESCE(v_camp_channel, '(NULL)')
+      USING ERRCODE = 'P0001';
+  END IF;
+
+  -- ⑥ audit: deliverable_events INSERT
+  --
+  --   신규 action 없이 기존 admin_proxy_revoke 재사용 (새 action 추가하지 않음 — 기존 방식 감수).
+  --   from_status = 삭제 전 status(단 CHECK 허용값 pending/rejected 만 — draft 는 NULL),
+  --   to_status = NULL (행이 삭제되어 도달 상태 없음).
+  --   ⚠️ deliverable_events.from_status/to_status CHECK 는 ('pending','approved','rejected') 만
+  --      허용(035) → draft 를 그대로 넣으면 제약 위반. draft 면 NULL 로 기록.
+  --
+  --   ⚠️ 한계: deliverable_events.deliverable_id 에 ON DELETE CASCADE (마이그레이션 035) 가
+  --   걸려 있어, 아래 DELETE 실행과 동시에 이 audit 행도 소멸함.
+  --   영구 감사가 필요하면 별도 테이블 분리 권장 (마이그레이션 162 섹션 3, 160 과 동일 한계).
+  INSERT INTO public.deliverable_events (
+    deliverable_id,
+    actor_id,
+    action,
+    from_status,
+    to_status,
+    reason
+  )
+  VALUES (
+    p_deliverable_id,
+    auth.uid(),
+    'admin_proxy_revoke',   -- 기존 9종 중 삭제에 가장 가까운 값 재사용
+    CASE WHEN v_status IN ('pending','rejected') THEN v_status ELSE NULL END,  -- from_status: draft 면 NULL(CHECK 보호)
+    NULL,                   -- to_status: 행 삭제로 도달 상태 없음
+    COALESCE(p_reason, '채널 불일치 게시물 삭제')
+  );
+
+  -- ⑦ DELETE: deliverables 행 삭제
+  --   ON DELETE CASCADE (마이그레이션 035) 로 deliverable_events 도 함께 삭제됨.
+  --   Storage 파일 없음 — post 결과물은 post_url(외부 URL)만 보유.
+  DELETE FROM public.deliverables
+   WHERE id = p_deliverable_id;
+
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.delete_mismatched_post_deliverable(uuid, text) FROM PUBLIC;
+GRANT  EXECUTE ON FUNCTION public.delete_mismatched_post_deliverable(uuid, text) TO authenticated;
+
+COMMENT ON FUNCTION public.delete_mismatched_post_deliverable IS
+  '[183] 캠페인 채널과 불일치하는 게시물(post) 결과물을 super_admin 이 삭제한다.'
+  ' approved 행 및 정상 채널(캠페인 channel 목록에 있는) 행은 거부.'
+  ' 주의: deliverable_events ON DELETE CASCADE(035)로 audit 이벤트도 함께 삭제됨.';
+
+
+COMMIT;
+
+-- =============================================================================
+-- 적용 후 검증 SQL (SQL Editor에서 1단계씩 순차 실행)
+--
+-- ★ 개발 DB에서만 실행.
+--
+-- [1단계] RPC 시그니처 확인
+-- SELECT proname, pg_get_function_arguments(oid)
+--   FROM pg_proc
+--  WHERE proname = 'delete_mismatched_post_deliverable';
+-- 기대: 1행 반환 (p_deliverable_id uuid, p_reason text)
+--
+-- [2단계] 채널 불일치 post 행 확인 (1단계 이후)
+-- SELECT d.id, d.post_channel, d.status, c.channel AS camp_channel
+--   FROM public.deliverables d
+--   JOIN public.campaigns c ON c.id = d.campaign_id
+--  WHERE d.kind = 'post'
+--    AND d.status <> 'approved'
+--    AND c.channel IS NOT NULL
+--    AND c.channel <> ''
+--    AND NOT (
+--      lower(trim(COALESCE(d.post_channel, '')))
+--      = ANY(string_to_array(lower(replace(c.channel,' ','')), ','))
+--    )
+--  LIMIT 5;
+-- 기대: 삭제 후보 행 목록 (없으면 테스트 데이터 생성 필요)
+--
+-- [3단계] 스모크 — 정상 채널 게시물 삭제 거부 확인 (2단계 이후)
+--   (post 이고 캠페인 채널과 일치하는 pending 행 UUID 사용)
+-- SELECT public.delete_mismatched_post_deliverable('<정상채널_uuid>', '테스트');
+-- 기대: ERROR P0001 (정상 채널 게시물 삭제 불가)
+--
+-- [4단계] 스모크 — approved 행 삭제 거부 확인 (3단계 이후)
+--   (kind='post', status='approved' 인 UUID 사용)
+-- SELECT public.delete_mismatched_post_deliverable('<approved_uuid>', '테스트');
+-- 기대: ERROR P0001 (승인된 게시물 삭제 불가)
+--
+-- [5단계] 스모크 — 채널 불일치 행 삭제 정상 동작 (4단계 이후)
+--   (2단계에서 찾은 채널 불일치 UUID 사용)
+-- SELECT public.delete_mismatched_post_deliverable('<불일치_uuid>', '채널 불일치 삭제 테스트');
+-- 기대: 오류 없이 반환
+-- 확인:
+-- SELECT id FROM public.deliverables WHERE id = '<불일치_uuid>';
+-- 기대: 0행 (삭제됨)
+--
+-- [6단계] 권한 없는 사용자 차단 확인 (5단계 이후)
+--   (campaign_admin 또는 인플루언서 계정으로 실행)
+-- SELECT public.delete_mismatched_post_deliverable('<임의_uuid>', NULL);
+-- 기대: ERROR 42501 (super_admin 권한 필요)
+-- =============================================================================


### PR DESCRIPTION
## 변경 요약
- 게시물 URL 오타 자동 보정(ttp:// 등 → https://, 위험 스킴 차단) — 인플·관리자 공통
- 검수 화면 「채널 불일치」 경고 배지 + super_admin 잘못된 채널 게시물 삭제(마이그183)

## 운영 핫픽스 (재빌드 패턴)
dev 보류 기능(연령 180·감사용 179/181) 미혼입을 위해 main 기준 cherry-pick 소스 적용 + 운영 재빌드. index.html/admin/index.html 에 ageGateOverlay·auditBadgeHtml 0건 검증.

## DB
- 마이그레이션 183 — 035/162 기존 객체만 의존, 운영 DB 단독 적용 가능. **PR 머지 전 운영 SQL Editor 실행 필요**

## 검증
- 동일 변경 dev 선반영(PR #503) + qa light PASS
- reverb-reviewer GO (재적용·보류 기능 미혼입)
- reverb-supabase-expert 마이그183 작성·수정 GO

## 관련 사양서
- docs/specs/2026-06-16-post-channel-validation-and-proxy-replace.md (dev 존재)