### PR TITLE
fix(deliverable): 채널 불일치 배지를 현재 정상 기준으로 (PR2)

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -12,7 +12,7 @@
 // 회귀(2026-05-12 PR #182 머지 직후 발생)를 방지하기 위한 자동 reload 가드.
 // sessionStorage 차단 환경(시크릿 모드 일부, 쿠키 차단)에서는 자연스럽게 skip.
 (function(){
-  var CURRENT_BUILD = 'v1781592085';
+  var CURRENT_BUILD = 'v1781592525';
   if (CURRENT_BUILD.indexOf('__') === 0) return; // 빌드 미적용 (dev/ 직접 열기) 시 skip
   try {
     var prev = sessionStorage.getItem('reverb.adminBuild');
@@ -2075,7 +2075,7 @@ tr.audit-row, .audit-row { background: #fff3e0 !important; }
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-06-16 15:41 · 14520aa</span>
+          <span class="admin-build-text">2026-06-16 15:48 · 68ec956</span>
         </div>
       </div>
     </aside>
@@ -19646,6 +19646,7 @@ function buildDeliverableGroups(delivs, campMap, opts) {
       }
     } else if (d.kind === 'post') {
       if (!g.result || subAt > (g.result.submitted_at || '')) g.result = d;
+      (g.posts = g.posts || []).push(d);  // 채널 불일치 배지 판정용 — 신청의 모든 post 보존 (result 는 최신 1건)
     }
     if (!g.latest_submitted_at || subAt > g.latest_submitted_at) g.latest_submitted_at = subAt;
   }
@@ -19744,10 +19745,15 @@ function renderDelivAppRow(g) {
   const infSub = infEmail + (infLine ? `<br>${infLine}` : '');
 
   const receiptCell = renderDelivStatusCell(g.receipt, 'receipt', rt);
+  // 같은 신청에 캠페인 채널과 일치하는 "승인된" 게시물이 있으면(현재 정상) 잘못된 채널 행 배지 숨김 (2026-06-16).
+  //   검수 모달 「채널 불일치 게시물」 박스(mismatchedBox)는 유지 → 거기서 잘못된 행 정리.
+  const hasValidApprovedPost = Array.isArray(g.posts) && g.posts.some(p =>
+    p.status === 'approved' && p.post_channel
+    && typeof postChannelMatchesCampaign === 'function' && postChannelMatchesCampaign(camp, p.post_channel));
   // monitor: 채널별 review_image N개 미니 행 / gifting·visit: 기존 g.result(post) 단일 셀
   const resultCell = (rt === 'monitor')
     ? renderDelivResultCellMonitor(g)
-    : renderDelivStatusCell(g.result, 'result', rt);
+    : renderDelivStatusCell(g.result, 'result', rt, { hasValidApprovedPost });
 
   // 영수증은 monitor(리뷰어) 캠페인에서만 사용. gifting/visit은 영수증 단계 없음.
   const useReceipt = rt === 'monitor';
@@ -19832,7 +19838,8 @@ function renderDelivResultCellMonitor(g) {
 }
 
 // 영수증·결과물 셀 — slot: 'receipt' | 'result', rt: campaign.recruit_type
-function renderDelivStatusCell(d, slot, rt) {
+//   opts.hasValidApprovedPost: 같은 신청에 캠페인 채널 일치 승인 게시물이 있으면 채널 불일치 배지 숨김
+function renderDelivStatusCell(d, slot, rt, opts) {
   // 영수증은 monitor에서만 사용. gifting/visit은 영수증 단계 없음 → 「-」 표시
   if (slot === 'receipt' && rt !== 'monitor') {
     return '<span style="font-size:11px;color:var(--muted)">—</span>';
@@ -19853,8 +19860,9 @@ function renderDelivStatusCell(d, slot, rt) {
       preview = `<a href="${esc(d.post_url)}" target="_blank" rel="noopener" onclick="event.stopPropagation()" style="font-size:10px;color:var(--dark-pink);text-decoration:none;display:inline-block;max-width:100px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;vertical-align:middle">${esc(host)}</a>`;
     }
     // 채널 불일치 경고 배지 (2026-06-16, 묶음2) — 캠페인 요구 채널에 없는 post_channel(예: 인스타 캠페인에 lips)
+    //   단 같은 신청에 캠페인 채널 일치 승인 게시물이 있으면(현재 정상) 숨김 (opts.hasValidApprovedPost).
     const camp = d.campaigns || (typeof allCampaigns !== 'undefined' && Array.isArray(allCampaigns) ? allCampaigns.find(c => c.id === d.campaign_id) : null);
-    if (d.post_channel && camp && !postChannelMatchesCampaign(camp, d.post_channel)) {
+    if (d.post_channel && camp && !postChannelMatchesCampaign(camp, d.post_channel) && !(opts && opts.hasValidApprovedPost)) {
       preview += ` <span class="notranslate" translate="no" style="background:#FFE4E4;color:#C33;font-size:10px;font-weight:700;padding:1px 6px;border-radius:3px;border:1px solid #C33" title="이 게시물 채널(${esc(d.post_channel)})이 캠페인 요구 채널에 없습니다. 잘못 저장된 행일 수 있습니다.">채널 불일치</span>`;
     }
   }

--- a/dev/js/admin-deliverables.js
+++ b/dev/js/admin-deliverables.js
@@ -471,6 +471,7 @@ function buildDeliverableGroups(delivs, campMap, opts) {
       }
     } else if (d.kind === 'post') {
       if (!g.result || subAt > (g.result.submitted_at || '')) g.result = d;
+      (g.posts = g.posts || []).push(d);  // 채널 불일치 배지 판정용 — 신청의 모든 post 보존 (result 는 최신 1건)
     }
     if (!g.latest_submitted_at || subAt > g.latest_submitted_at) g.latest_submitted_at = subAt;
   }
@@ -569,10 +570,15 @@ function renderDelivAppRow(g) {
   const infSub = infEmail + (infLine ? `<br>${infLine}` : '');
 
   const receiptCell = renderDelivStatusCell(g.receipt, 'receipt', rt);
+  // 같은 신청에 캠페인 채널과 일치하는 "승인된" 게시물이 있으면(현재 정상) 잘못된 채널 행 배지 숨김 (2026-06-16).
+  //   검수 모달 「채널 불일치 게시물」 박스(mismatchedBox)는 유지 → 거기서 잘못된 행 정리.
+  const hasValidApprovedPost = Array.isArray(g.posts) && g.posts.some(p =>
+    p.status === 'approved' && p.post_channel
+    && typeof postChannelMatchesCampaign === 'function' && postChannelMatchesCampaign(camp, p.post_channel));
   // monitor: 채널별 review_image N개 미니 행 / gifting·visit: 기존 g.result(post) 단일 셀
   const resultCell = (rt === 'monitor')
     ? renderDelivResultCellMonitor(g)
-    : renderDelivStatusCell(g.result, 'result', rt);
+    : renderDelivStatusCell(g.result, 'result', rt, { hasValidApprovedPost });
 
   // 영수증은 monitor(리뷰어) 캠페인에서만 사용. gifting/visit은 영수증 단계 없음.
   const useReceipt = rt === 'monitor';
@@ -657,7 +663,8 @@ function renderDelivResultCellMonitor(g) {
 }
 
 // 영수증·결과물 셀 — slot: 'receipt' | 'result', rt: campaign.recruit_type
-function renderDelivStatusCell(d, slot, rt) {
+//   opts.hasValidApprovedPost: 같은 신청에 캠페인 채널 일치 승인 게시물이 있으면 채널 불일치 배지 숨김
+function renderDelivStatusCell(d, slot, rt, opts) {
   // 영수증은 monitor에서만 사용. gifting/visit은 영수증 단계 없음 → 「-」 표시
   if (slot === 'receipt' && rt !== 'monitor') {
     return '<span style="font-size:11px;color:var(--muted)">—</span>';
@@ -678,8 +685,9 @@ function renderDelivStatusCell(d, slot, rt) {
       preview = `<a href="${esc(d.post_url)}" target="_blank" rel="noopener" onclick="event.stopPropagation()" style="font-size:10px;color:var(--dark-pink);text-decoration:none;display:inline-block;max-width:100px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;vertical-align:middle">${esc(host)}</a>`;
     }
     // 채널 불일치 경고 배지 (2026-06-16, 묶음2) — 캠페인 요구 채널에 없는 post_channel(예: 인스타 캠페인에 lips)
+    //   단 같은 신청에 캠페인 채널 일치 승인 게시물이 있으면(현재 정상) 숨김 (opts.hasValidApprovedPost).
     const camp = d.campaigns || (typeof allCampaigns !== 'undefined' && Array.isArray(allCampaigns) ? allCampaigns.find(c => c.id === d.campaign_id) : null);
-    if (d.post_channel && camp && !postChannelMatchesCampaign(camp, d.post_channel)) {
+    if (d.post_channel && camp && !postChannelMatchesCampaign(camp, d.post_channel) && !(opts && opts.hasValidApprovedPost)) {
       preview += ` <span class="notranslate" translate="no" style="background:#FFE4E4;color:#C33;font-size:10px;font-weight:700;padding:1px 6px;border-radius:3px;border:1px solid #C33" title="이 게시물 채널(${esc(d.post_channel)})이 캠페인 요구 채널에 없습니다. 잘못 저장된 행일 수 있습니다.">채널 불일치</span>`;
     }
   }


### PR DESCRIPTION
같은 신청에 캠페인 채널 일치 승인 게시물이 있으면 잘못된 채널 배지 숨김. 검수 모달 정리 박스는 유지. 빌더 g.posts 보존(공유 함수 미참조·회귀 없음). DB 무변경. reviewer GO. 사양서 docs/specs/2026-06-16-post-channel-validation-and-proxy-replace.md