### PR TITLE
feat(admin): 감사용 인플루언서 계정 기능 운영 출시

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -12,7 +12,7 @@
 // 회귀(2026-05-12 PR #182 머지 직후 발생)를 방지하기 위한 자동 reload 가드.
 // sessionStorage 차단 환경(시크릿 모드 일부, 쿠키 차단)에서는 자연스럽게 skip.
 (function(){
-  var CURRENT_BUILD = 'v1781597973';
+  var CURRENT_BUILD = 'v1781600429';
   if (CURRENT_BUILD.indexOf('__') === 0) return; // 빌드 미적용 (dev/ 직접 열기) 시 skip
   try {
     var prev = sessionStorage.getItem('reverb.adminBuild');
@@ -1968,6 +1968,24 @@ input[type="date"].form-input::-webkit-calendar-picker-indicator{margin-left:aut
 #brandContactsHeader, .brand-contact-row { min-width: 0; }
 .brand-contact-row > input { min-width: 0; width: 100%; box-sizing: border-box; }
 
+/* 감사용 계정 배지 — 통계·산출물에서 격리된 운영팀 시뮬레이션 계정 표시.
+   모든 인플·응모·결과물 행에 auditBadgeHtml() 로 강제 노출. 주황 톤(경고 아닌 식별용). */
+.audit-badge {
+  display: inline-block;
+  padding: 2px 7px;
+  margin-left: 5px;
+  background: #ff9800;
+  color: #fff;
+  font-size: 11px;
+  font-weight: 700;
+  line-height: 1.4;
+  border-radius: 3px;
+  vertical-align: middle;
+  white-space: nowrap;
+}
+/* 감사용 행 — 행 배경도 옅게 강조해 목록에서 즉시 식별 */
+tr.audit-row, .audit-row { background: #fff3e0 !important; }
+
 </style>
 </head>
 <body style="background:#F8F5F8">
@@ -2043,7 +2061,7 @@ input[type="date"].form-input::-webkit-calendar-picker-indicator{margin-left:aut
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-06-16 17:19 · 6111fdc</span>
+          <span class="admin-build-text">2026-06-16 18:00 · f9aa0e2</span>
         </div>
       </div>
     </aside>
@@ -5555,6 +5573,34 @@ function normalizeUrlInput(raw) {
   return { url: s, changed: s !== orig };
 }
 
+// 감사용 계정 「감사용」 배지 HTML.
+// inf: influencers 행(is_audit) 또는 is_audit 불리언을 가진 객체.
+// 감사용이 아니면 빈 문자열 — 일반 인플루언서 행에는 아무것도 출력 안 함.
+// 통계·산출물에서 격리된 계정임을 운영자가 한눈에 구분하도록 모든 인플·응모·결과물 행에 호출.
+function auditBadgeHtml(inf) {
+  if (!inf || !inf.is_audit) return '';
+  return '<span class="audit-badge" title="감사용 계정 — 통계·산출물에서 격리됨" translate="no">감사용</span>';
+}
+
+// 감사용 계정(is_audit) 회원번호(influencers.id) 집합 생성.
+// 관리자 화면에서 클라가 직접 응모 건수를 셀 때(빈자리·승인 차단) 감사용을 격리하기 위한 헬퍼.
+// applications 행에는 is_audit 가 없으므로 users(fetchInfluencers, is_audit 포함)에서 만든 집합을
+// user_id 로 대조한다(이메일 매칭보다 NULL·불일치·성능 위험이 없음).
+function buildAuditIdSet(users) {
+  return new Set((users || []).filter(u => u && u.is_audit).map(u => u.id));
+}
+
+// 특정 캠페인의 승인(approved) 응모 수를 감사용 제외로 계산.
+//   apps: applications 배열, campId: 캠페인 id(null 이면 전체), auditIds: buildAuditIdSet 결과.
+// 감사용 응모는 모집 슬롯·빈자리 집계에서 빠져야 한다(설계 격리, 마이그레이션 179·181).
+function countNonAuditApproved(apps, campId, auditIds) {
+  return (apps || []).filter(a =>
+    a.status === 'approved'
+    && (campId == null || a.campaign_id === campId)
+    && !(auditIds && auditIds.has(a.user_id))
+  ).length;
+}
+
 // raw 입력값(URL 또는 핸들)에서 핸들만 뽑아 반환. 실패 시 trim된 원본 반환.
 // 저장 정책: 핸들만(@ 없이) 저장. 표시 시 UI에서 @ prefix 부여.
 function extractSnsHandle(channel, raw) {
@@ -6181,12 +6227,17 @@ async function incrementViewCount(campId) {
 }
 
 // ── Influencers ──
-async function fetchInfluencers() {
+// includeAudit 기본 true = 기존 동작 보존(전건 반환).
+// 통계·엑셀 등 실수 집계가 필요한 호출처만 { includeAudit: false } 를 명시 전달(PR D/F에서).
+async function fetchInfluencers(opts = {}) {
   if (!db) return [];
+  const { includeAudit = true } = opts;
   try {
-    return await fetchAllPaged(() =>
-      db.from('influencers').select('*').order('created_at', {ascending: true})
-    );
+    return await fetchAllPaged(() => {
+      let q = db.from('influencers').select('*').order('created_at', {ascending: true});
+      if (!includeAudit) q = q.eq('is_audit', false);
+      return q;
+    });
   } catch(e) {
     return [];
   }
@@ -7093,7 +7144,7 @@ async function fetchInfluencersByIds(userIds) {
   if (!db || !userIds?.length) return {};
   try {
     const {data, error} = await db?.from('influencers')
-      .select('id, name, name_kana, email, primary_sns, line_id, is_verified, verified_at, is_blacklisted, blacklisted_at, blacklist_reason_code, blacklist_reason_note')
+      .select('id, name, name_kana, email, primary_sns, line_id, is_verified, verified_at, is_blacklisted, blacklisted_at, blacklist_reason_code, blacklist_reason_note, is_audit')
       .in('id', userIds);
     if (error) throw error;
     const map = {};
@@ -9115,6 +9166,124 @@ async function resolveClientError(id, status, note) {
     });
     return true;
   } catch (e) { console.error('[resolveClientError]', e); return false; }
+}
+
+// ── 감사용 계정 흔적 제거 (super_admin 한정, 마이그레이션 179) ──
+//
+// ⚠️ Storage 삭제 메모
+//   - 메시지 첨부(message_attachments): RPC가 반환하는 값이 이미 버킷 상대 경로({appId}/{uuid}.jpg)이므로
+//     그대로 db.storage.from('application-message-attachments').remove([...paths]) 로 삭제.
+//   - 영수증 이미지(receipt_images): receipt_url 컬럼에는 Supabase 공개 전체 URL이 저장됨
+//     (https://{project}.supabase.co/storage/v1/object/public/campaign-images/receipts/...).
+//     db.storage.remove()는 버킷 내 상대 경로를 요구하므로, URL에서
+//     '/storage/v1/object/public/campaign-images/' 접두사를 제거해 상대 경로를 추출한다.
+//     변환 실패 시(접두사 불일치 등) 그 파일만 건너뛰고 나머지는 계속 처리.
+
+// Supabase 공개 URL → campaign-images 버킷 상대 경로 변환 헬퍼
+// 예: 'https://xxx.supabase.co/storage/v1/object/public/campaign-images/receipts/abc.jpg'
+//     → 'receipts/abc.jpg'
+// 변환 불가(형식 불일치)면 null 반환.
+function _receiptUrlToStoragePath(url) {
+  if (!url || typeof url !== 'string') return null;
+  const MARKER = '/storage/v1/object/public/campaign-images/';
+  const idx = url.indexOf(MARKER);
+  if (idx === -1) return null;
+  const path = url.slice(idx + MARKER.length);
+  return path || null;
+}
+
+// Storage 파일 삭제 공통 헬퍼.
+// bucket: 버킷명, paths: 상대 경로 배열 (빈 배열이면 즉시 반환).
+// 삭제 실패 시 에러를 throw 하지 않고 {ok, failedPaths} 형태로 반환
+// (일부 경로 삭제 실패가 흔적 제거 전체를 막지 않도록).
+async function _deleteStorageFiles(bucket, paths) {
+  if (!db || !Array.isArray(paths) || paths.length === 0) return { ok: true, failedPaths: [] };
+  try {
+    const { error } = await db.storage.from(bucket).remove(paths);
+    if (error) {
+      console.warn(`[_deleteStorageFiles] ${bucket} 삭제 실패:`, error);
+      return { ok: false, failedPaths: paths };
+    }
+    return { ok: true, failedPaths: [] };
+  } catch (e) {
+    console.warn(`[_deleteStorageFiles] ${bucket} 예외:`, e);
+    return { ok: false, failedPaths: paths };
+  }
+}
+
+// 모든 감사용 계정 흔적 제거.
+// RPC 성공 후 Storage 파일(메시지 첨부 + 영수증 이미지)도 후속 삭제.
+// 반환: { rpc, storageResult } — 호출처가 삭제 결과를 사용자에게 표시할 수 있도록.
+async function purgeAuditDataAll() {
+  if (!db) throw new Error('DB 미연결');
+  return await retryWithRefresh(async () => {
+    const { data, error } = await db.rpc('purge_audit_data_all');
+    if (error) throw error;
+
+    // RPC 결과가 'no_audit_account' 이면 삭제할 Storage 파일도 없음
+    if (!data || data.status === 'no_audit_account') {
+      return { rpc: data, storageResult: null };
+    }
+
+    const storagePaths = data.storage_paths_to_delete || {};
+
+    // 메시지 첨부: 이미 버킷 상대 경로
+    const msgPaths = Array.isArray(storagePaths.message_attachments)
+      ? storagePaths.message_attachments.filter(Boolean)
+      : [];
+
+    // 영수증: 전체 URL → 버킷 상대 경로 변환 (변환 불가 항목 제외)
+    const receiptPaths = Array.isArray(storagePaths.receipt_images)
+      ? storagePaths.receipt_images.map(_receiptUrlToStoragePath).filter(Boolean)
+      : [];
+
+    const [msgResult, receiptResult] = await Promise.all([
+      _deleteStorageFiles(MSG_ATTACH_BUCKET, msgPaths),
+      _deleteStorageFiles('campaign-images', receiptPaths),
+    ]);
+
+    return {
+      rpc: data,
+      storageResult: { msgResult, receiptResult },
+    };
+  });
+}
+
+// 특정 캠페인의 감사용 계정 흔적 제거.
+// 반환: { rpc, storageResult }
+async function purgeAuditDataForCampaign(campaignId) {
+  if (!db) throw new Error('DB 미연결');
+  return await retryWithRefresh(async () => {
+    const { data, error } = await db.rpc('purge_audit_data_for_campaign', {
+      p_campaign_id: campaignId,
+    });
+    if (error) throw error;
+
+    // 응모건 0건 케이스: storage_paths_to_delete 키 자체가 없을 수 있음
+    if (!data || data.status === 'no_audit_account' || !data.storage_paths_to_delete) {
+      return { rpc: data, storageResult: null };
+    }
+
+    const storagePaths = data.storage_paths_to_delete;
+
+    const msgPaths = Array.isArray(storagePaths.message_attachments)
+      ? storagePaths.message_attachments.filter(Boolean)
+      : [];
+
+    const receiptPaths = Array.isArray(storagePaths.receipt_images)
+      ? storagePaths.receipt_images.map(_receiptUrlToStoragePath).filter(Boolean)
+      : [];
+
+    const [msgResult, receiptResult] = await Promise.all([
+      _deleteStorageFiles(MSG_ATTACH_BUCKET, msgPaths),
+      _deleteStorageFiles('campaign-images', receiptPaths),
+    ]);
+
+    return {
+      rpc: data,
+      storageResult: { msgResult, receiptResult },
+    };
+  });
 }
 
 
@@ -15394,18 +15563,24 @@ async function loadBrandOpsDetail() {
   }
   if (body) body.innerHTML = '<div style="text-align:center;color:var(--muted);padding:48px"><span class="spinner" style="width:22px;height:22px;border-width:2px;border-color:rgba(200,120,163,.2);border-top-color:var(--pink)"></span></div>';
 
-  var results = await Promise.all([getBrandOpsDetail(_brandOpsDetailId), fetchApplications()]);
+  // 감사용 계정 id 집합(소수) — 폴백 승인 집계에서 격리. 전체 회원 로드 없이 가볍게 조회.
+  var results = await Promise.all([
+    getBrandOpsDetail(_brandOpsDetailId),
+    fetchApplications(),
+    db ? db.from('influencers').select('id').eq('is_audit', true) : Promise.resolve({data: []}),
+  ]);
   var detail = results[0];
   var apps = results[1] || [];
+  var _auditIds = new Set((((results[2] && results[2].data) || [])).map(function(r){ return r.id; }));
   _brandOpsDetailData = detail;
   if (!detail || !detail.brand) {
     if (body) body.innerHTML = '<div style="text-align:center;color:var(--muted);padding:48px">브랜드 정보를 불러올 수 없습니다</div>';
     return;
   }
-  // 캠페인별 승인 수 집계 (인플루언서 응모 = applications, status approved)
+  // 캠페인별 승인 수 집계 (인플루언서 응모 = applications, status approved). 감사용 제외(격리).
   _brandOpsApprByCamp = {};
   apps.forEach(function(a){
-    if (a.status === 'approved') _brandOpsApprByCamp[a.campaign_id] = (_brandOpsApprByCamp[a.campaign_id] || 0) + 1;
+    if (a.status === 'approved' && !_auditIds.has(a.user_id)) _brandOpsApprByCamp[a.campaign_id] = (_brandOpsApprByCamp[a.campaign_id] || 0) + 1;
   });
   renderBrandOpsDetail(detail);
 }
@@ -16029,7 +16204,7 @@ function renderInboxThreadList() {
     return `<button type="button" class="inbox-thread-item ${active}" onclick="openInboxThread('${esc(t.application_id)}')">
       <span class="inbox-thread-main">
         ${campLabel}
-        <span class="inbox-thread-name">${kanji}${kana ? `<span class="inbox-thread-kana">${kana}</span>` : ''}</span>
+        <span class="inbox-thread-name">${kanji}${auditBadgeHtml(inf)}${kana ? `<span class="inbox-thread-kana">${kana}</span>` : ''}</span>
         ${email ? `<span class="inbox-thread-email">${email}</span>` : ''}
         ${previewHtml}
       </span>
@@ -18232,8 +18407,8 @@ function buildInfRowAll(u) {
     return `<div style="max-width:140px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap" title="${safe}">${inner}</div>`;
   };
   const ellip = (s, w=140) => `<div style="max-width:${w}px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap" title="${esc(s||'')}">${esc(s)||'—'}</div>`;
-  return `<tr data-id="${esc(u.id)}"${u.is_blacklisted?' style="opacity:.55"':''}>
-    <td><div style="font-weight:600;color:var(--pink);cursor:pointer" onclick="openInfluencerDetail('${u.id}')">${esc(u.name_kanji||u.name)||'—'}${adminBadge(u.email)}${influencerStatusBadges(u)}</div><div style="font-size:11px;color:var(--muted)">${esc(u.email)}</div></td>
+  return `<tr data-id="${esc(u.id)}" class="${u.is_audit?'audit-row':''}"${u.is_blacklisted?' style="opacity:.55"':''}>
+    <td><div style="font-weight:600;color:var(--pink);cursor:pointer" onclick="openInfluencerDetail('${u.id}')">${esc(u.name_kanji||u.name)||'—'}${auditBadgeHtml(u)}${adminBadge(u.email)}${influencerStatusBadges(u)}</div><div style="font-size:11px;color:var(--muted)">${esc(u.email)}</div></td>
     <td>${snsCell('instagram', u.ig)}<div style="font-size:11px;color:var(--muted)">${igF}명</div></td>
     <td>${snsCell('x', u.x)}<div style="font-size:11px;color:var(--muted)">${xF}명</div></td>
     <td>${snsCell('tiktok', u.tiktok)}<div style="font-size:11px;color:var(--muted)">${ttF}명</div></td>
@@ -18378,7 +18553,49 @@ async function openInfluencerDetail(userId) {
     </td></tr>`;
   }).join('') : '<tr><td colspan="4" style="text-align:center;color:var(--muted);padding:24px">신청 이력 없음</td></tr>';
 
+  // 감사용 흔적 청소 — super_admin + 감사용 계정(is_audit=true)일 때만 노출.
+  // 일반 인플 상세에는 절대 렌더하지 않음(매번 innerHTML 초기화로 stale 방지).
+  const auditBox = $('infDetailAuditPurge');
+  if (auditBox) {
+    const isSuper = currentAdminInfo?.role === 'super_admin';
+    if (isSuper && u.is_audit === true) {
+      auditBox.innerHTML = `
+        <div class="admin-card" style="border:1px solid var(--line)">
+          <div class="admin-card-header"><span class="admin-card-title">감사용 흔적 청소</span></div>
+          <div style="padding:16px">
+            <p style="font-size:13px;color:var(--muted);margin:0 0 12px">모든 감사용 계정의 응모·결과물·메시지·알림을 한 번에 삭제합니다. 감사용 계정 자체는 유지됩니다.</p>
+            <button class="btn btn-sm" style="background:#C62828;color:#fff;border:none" onclick="purgeAllAuditData()"><span class="material-icons-round notranslate" translate="no" style="font-size:16px;vertical-align:middle;margin-right:4px">cleaning_services</span>전체 흔적 청소</button>
+          </div>
+        </div>`;
+    } else {
+      auditBox.innerHTML = '';
+    }
+  }
+
   openModal('influencerFullDetailModal');
+}
+
+// 전체 감사용 흔적 청소 — super_admin 전용.
+// 모든 감사용 계정(is_audit=true)의 응모·결과물·메시지·알림을 삭제(계정 자체는 유지).
+async function purgeAllAuditData() {
+  if (currentAdminInfo?.role !== 'super_admin') return;
+  const ok = await showConfirm('모든 감사용 계정의 응모·결과물·메시지·알림을 삭제합니다. 감사용 계정 자체는 유지됩니다. 되돌릴 수 없습니다. 진행할까요?');
+  if (!ok) return;
+  try {
+    const res = await purgeAuditDataAll();
+    const rpc = res?.rpc;
+    if (!rpc || rpc.status === 'no_audit_account' || !rpc.deleted || (rpc.deleted.applications || 0) === 0) {
+      toast('삭제할 감사용 데이터 없음', '');
+    } else {
+      const n = rpc.deleted.applications || 0;
+      toast(`감사용 응모 ${n}건·결과물 등 삭제됨`, 'success');
+    }
+    closeModal('influencerFullDetailModal');
+    await refreshPane('influencers');
+  } catch (e) {
+    console.error('[purgeAllAuditData]', e);
+    toast('감사용 흔적 청소 실패: ' + (e?.message || e), 'error');
+  }
 }
 
 // 상태 관리 패널 — 인증 토글 + 블랙리스트 등록/해제 + 사유 입력
@@ -19474,12 +19691,12 @@ function renderDelivAppRow(g) {
   const pe = (rt === 'monitor') ? camp.purchase_end
            : (rt === 'visit')   ? camp.visit_end    : '';
 
-  return `<tr data-app-id="${esc(g.application_id)}" style="${rowStyle}">
+  return `<tr data-app-id="${esc(g.application_id)}" class="${inf.is_audit ? 'audit-row' : ''}" style="${rowStyle}">
     <td>${rtBadge}</td>
     <td>${campNoBadge}<div>${esc(camp.title || '—')}</div><div style="font-size:10px;color:var(--muted)">${esc(brandLabelAdmin(camp))}</div></td>
     <td style="font-size:11px;color:var(--ink);white-space:nowrap">${periodRangeCell(ps, pe)}</td>
     <td style="font-size:11px;color:var(--ink);white-space:nowrap">${periodSingleCell(camp.submission_end)}</td>
-    <td><div style="font-weight:600;color:var(--pink);cursor:pointer" onclick="openInfluencerModal('${esc(inf.id||'')}')">${infName}${(typeof influencerStatusBadges === 'function') ? influencerStatusBadges(inf) : ''}</div>${infSub ? `<div style="font-size:10px;color:var(--muted)">${infSub}</div>` : ''}<div style="margin-top:4px">${renderApplicantMsgBtn({id: g.application_id, campaign_id: (camp && camp.id) || ''})}</div></td>
+    <td><div style="font-weight:600;color:var(--pink);cursor:pointer" onclick="openInfluencerModal('${esc(inf.id||'')}')">${infName}${auditBadgeHtml(inf)}${(typeof influencerStatusBadges === 'function') ? influencerStatusBadges(inf) : ''}</div>${infSub ? `<div style="font-size:10px;color:var(--muted)">${infSub}</div>` : ''}<div style="margin-top:4px">${renderApplicantMsgBtn({id: g.application_id, campaign_id: (camp && camp.id) || ''})}</div></td>
     <td>${certStatusBadge(g)}</td>
     <td>${receiptCell}</td>
     <td>${resultCell}</td>
@@ -21555,6 +21772,89 @@ function _confirmLargeExport(n) {
   });
 }
 
+// ──────────────────────────────────────────────────────────────────
+// 감사용 계정(influencers.is_audit) 격리 — 엑셀 산출물 보호 (PR D)
+//   광고주에게 전달하는 엑셀에 운영팀 시뮬레이션용 감사용 행이 섞이지 않도록
+//   다운로드 직전 「감사용 포함/제외」 확인 모달을 거치게 한다.
+//   confirmAuditExport(auditCount) → Promise<'include'|'exclude'|null>
+//     · auditCount<=0: 모달 없이 즉시 'exclude' (감사용 없으니 격리 무관)
+//     · null: 취소 (다운로드 중단)
+//   세션 동안 '다음부터 묻지 않음' 선택은 캐시 (페이지 새로고침 시 초기화)
+// ──────────────────────────────────────────────────────────────────
+var _auditExportChoiceCache = null; // null | 'include' | 'exclude'
+
+function confirmAuditExport(auditCount) {
+  if (!auditCount || auditCount <= 0) return Promise.resolve('exclude');
+  if (_auditExportChoiceCache) return Promise.resolve(_auditExportChoiceCache);
+
+  return new Promise(function(resolve) {
+    // 기존 잔존 모달 정리 (중복 클릭 대비)
+    var prev = document.getElementById('auditExportModal');
+    if (prev) prev.remove();
+
+    var overlay = document.createElement('div');
+    overlay.className = 'modal-overlay';
+    overlay.id = 'auditExportModal';
+    overlay.style.zIndex = '665'; // admMsgLightbox(660) 위 — 라이트박스 열린 채 다운로드 대비
+    overlay.innerHTML =
+      '<div class="modal" style="max-width:460px;border-radius:20px;margin:auto">' +
+        '<div class="modal-body" style="padding:24px 24px 20px">' +
+          '<div style="font-size:15px;font-weight:700;color:var(--ink);margin-bottom:10px">감사용 계정 포함 여부</div>' +
+          '<div style="font-size:13px;line-height:1.7;color:var(--ink)">' +
+            '현재 결과에 <b>감사용 계정 ' + esc(String(auditCount)) + '명</b>이 포함되어 있습니다.<br>' +
+            '감사용 계정은 운영팀 시뮬레이션용이라, 광고주에게 전달하는 산출물에는 제외하는 것을 권장합니다.' +
+          '</div>' +
+          '<div style="margin-top:16px;display:flex;flex-direction:column;gap:10px">' +
+            '<label style="display:flex;align-items:flex-start;gap:8px;font-size:13px;color:var(--ink);cursor:pointer">' +
+              '<input type="radio" name="auditExportChoice" value="exclude" checked style="margin-top:2px">' +
+              '<span><b>감사용 제외</b> (광고주 전달용)<br><span style="font-size:12px;color:var(--ink-light,#888)">감사용 ' + esc(String(auditCount)) + '명을 빼고 내보냅니다.</span></span>' +
+            '</label>' +
+            '<label style="display:flex;align-items:flex-start;gap:8px;font-size:13px;color:var(--ink);cursor:pointer">' +
+              '<input type="radio" name="auditExportChoice" value="include" style="margin-top:2px">' +
+              '<span><b>감사용 포함</b> (운영 내부 확인용)<br><span style="font-size:12px;color:var(--ink-light,#888)">감사용 ' + esc(String(auditCount)) + '명을 포함해 내보냅니다.</span></span>' +
+            '</label>' +
+          '</div>' +
+          '<label style="display:flex;align-items:center;gap:8px;margin-top:14px;font-size:12px;color:var(--ink-light,#888);cursor:pointer">' +
+            '<input type="checkbox" id="auditExportRemember"> 다음부터 묻지 않음 (현재 세션)' +
+          '</label>' +
+          '<div style="display:flex;gap:10px;margin-top:20px;justify-content:flex-end">' +
+            '<button class="btn btn-ghost" style="min-width:90px" data-audit-action="cancel">취소</button>' +
+            '<button class="btn btn-primary" style="min-width:120px" data-audit-action="ok">엑셀 다운로드</button>' +
+          '</div>' +
+        '</div>' +
+      '</div>';
+    document.body.appendChild(overlay);
+
+    var settled = false;
+    function done(result) {
+      if (settled) return;
+      settled = true;
+      document.removeEventListener('keydown', onEscAudit);
+      overlay.remove();
+      resolve(result);
+    }
+    function onEscAudit(e) {
+      if (e.key === 'Escape') done(null);
+    }
+    document.addEventListener('keydown', onEscAudit);
+    overlay.addEventListener('click', function(e) {
+      var action = e.target && e.target.getAttribute && e.target.getAttribute('data-audit-action');
+      if (action === 'cancel') { done(null); return; }
+      if (action === 'ok') {
+        var sel = overlay.querySelector('input[name="auditExportChoice"]:checked');
+        var choice = (sel && sel.value === 'include') ? 'include' : 'exclude';
+        var remember = overlay.querySelector('#auditExportRemember');
+        if (remember && remember.checked) _auditExportChoiceCache = choice;
+        done(choice);
+        return;
+      }
+      // 오버레이 바깥(배경) 클릭은 취소로 처리
+      if (e.target === overlay) { done(null); }
+    });
+    overlay.classList.add('open');
+  });
+}
+
 // 캠페인 다중 선택 신청자 엑셀 — 시트1 캠페인 정보 + 시트2 통합 신청자 리스트
 //   idsOverride: 인자로 직접 ids 배열 받기 가능 (단일 캠페인 더보기 메뉴 호출용)
 async function exportSelectedCampaignsApplicants(idsOverride) {
@@ -21582,6 +21882,16 @@ async function exportSelectedCampaignsApplicants(idsOverride) {
       var apps = await fetchApplications({ campaign_id: c.id });
       appsByCampId[c.id] = apps || [];
       (apps || []).forEach(function(a){ a._campMeta = c; allCampApps.push(a); });
+    }
+
+    // 감사용 계정 격리 — 이 엑셀에 실제 들어갈 신청자 중 감사용 인플 수 계산 후 포함/제외 확인
+    var auditEmails = {};
+    allCampApps.forEach(function(a){ var u = userByEmail[a.user_email]; if (u && u.is_audit && a.user_email) auditEmails[a.user_email] = true; });
+    var auditCount = Object.keys(auditEmails).length;
+    var auditChoice = await confirmAuditExport(auditCount);
+    if (auditChoice === null) return; // 취소 — finally 에서 _markExportEnd
+    if (auditChoice === 'exclude') {
+      allCampApps = allCampApps.filter(function(a){ var u = userByEmail[a.user_email]; return !(u && u.is_audit); });
     }
 
     var wb = new ExcelJS.Workbook();
@@ -21719,6 +22029,17 @@ async function exportSelectedCampaignsDeliverables(idsOverride) {
     // 인플루언서 id 매핑 (단일 함수와 동일 패턴)
     var usersById = {};
     (users || []).forEach(function(u){ if (u && u.id) usersById[u.id] = u; });
+
+    // 감사용 계정 격리 — 이 엑셀에 실제 들어갈 결과물 중 감사용 인플 수 계산 후 포함/제외 확인
+    var auditUserIds = {};
+    allDelivs.forEach(function(d){ var u = usersById[d.user_id]; if (u && u.is_audit && d.user_id) auditUserIds[d.user_id] = true; });
+    var auditCount = Object.keys(auditUserIds).length;
+    var auditChoice = await confirmAuditExport(auditCount);
+    if (auditChoice === null) return; // 취소 — finally 에서 _markExportEnd
+    if (auditChoice === 'exclude') {
+      allDelivs = allDelivs.filter(function(d){ var u = usersById[d.user_id]; return !(u && u.is_audit); });
+      if (allDelivs.length === 0) { toast('감사용 제외 후 남은 결과물이 없습니다', 'warn'); return; }
+    }
 
     // 영수증·리뷰 이미지 Image→Canvas→JPEG 재인코딩 (CORS·포맷 호환성)
     var imgBuffers = {};
@@ -21993,6 +22314,17 @@ async function exportCampaignApplicationsExcel(campId) {
     var userByEmail = {};
     (users || []).forEach(function(u){ if (u.email) userByEmail[u.email] = u; });
 
+    // 감사용 계정 격리 — 이 엑셀에 실제 들어갈 신청자 중 감사용 인플 수 계산 후 포함/제외 확인
+    var auditEmails = {};
+    apps.forEach(function(a){ var u = userByEmail[a.user_email]; if (u && u.is_audit && a.user_email) auditEmails[a.user_email] = true; });
+    var auditCount = Object.keys(auditEmails).length;
+    var auditChoice = await confirmAuditExport(auditCount);
+    if (auditChoice === null) return; // 취소 — finally 에서 _markExportEnd
+    if (auditChoice === 'exclude') {
+      apps = apps.filter(function(a){ var u = userByEmail[a.user_email]; return !(u && u.is_audit); });
+      if (!apps.length) { toast('감사용 제외 후 남은 신청자가 없습니다', 'warn'); return; }
+    }
+
     var statusLabel = function(s) {
       if (s === 'approved') return '승인';
       if (s === 'pending') return '심사중';
@@ -22147,6 +22479,20 @@ async function exportCampaignDeliverables(campId) {
     var users = await fetchInfluencers();
     var userById = {};
     (users || []).forEach(function(u){ if (u && u.id) userById[u.id] = u; });
+
+    // 감사용 계정 격리 — 이 엑셀에 실제 들어갈 결과물·승인신청 중 감사용 인플 수 계산 후 포함/제외 확인
+    //   (multi-channel monitor 위임 경로보다 먼저 처리해 양쪽 모두 적용)
+    var auditUserIds = {};
+    delivs.forEach(function(d){ var u = userById[d.user_id]; if (u && u.is_audit && d.user_id) auditUserIds[d.user_id] = true; });
+    (approvedApps || []).forEach(function(app){ var u = userById[app.user_id]; if (u && u.is_audit && app.user_id) auditUserIds[app.user_id] = true; });
+    var auditCount = Object.keys(auditUserIds).length;
+    var auditChoice = await confirmAuditExport(auditCount);
+    if (auditChoice === null) return; // 취소 — finally 에서 _markExportEnd
+    if (auditChoice === 'exclude') {
+      delivs = (delivs || []).filter(function(d){ var u = userById[d.user_id]; return !(u && u.is_audit); });
+      approvedApps = (approvedApps || []).filter(function(app){ var u = userById[app.user_id]; return !(u && u.is_audit); });
+      if (!delivs.length && !approvedApps.length) { toast('감사용 제외 후 남은 결과물이 없습니다', 'warn'); return; }
+    }
 
     // 3-1) monitor + 캠페인 채널 N개면 채널별 결과물 컬럼 펼침 (사양 2 PR 3, 2026-05-28)
     //   gifting/visit·채널 없는 레거시 monitor는 기존 22컬럼 단일 결과물 코드 그대로.
@@ -22875,6 +23221,15 @@ async function exportInfluencersExcel() {
 
   _markExportStart();
   try {
+    // 감사용 계정 격리 — 현재 필터 결과 중 감사용 인플 수 계산 후 포함/제외 확인
+    var auditCount = rows.filter(function(u){ return u && u.is_audit; }).length;
+    var auditChoice = await confirmAuditExport(auditCount);
+    if (auditChoice === null) return; // 취소 — finally 에서 _markExportEnd
+    if (auditChoice === 'exclude') {
+      rows = rows.filter(function(u){ return !(u && u.is_audit); });
+      if (!rows.length) { toast('감사용 제외 후 남은 인플루언서가 없습니다', 'warn'); return; }
+    }
+
     await loadExcelJS();
     var wb = new ExcelJS.Workbook();
     var ws = wb.addWorksheet('인플루언서');
@@ -23005,23 +23360,32 @@ async function loadAdminData(preloaded) {
       showAdminUnreadNoticesIfAny();
     }
   }).catch(()=>{});
-  const approved = apps.filter(a=>a.status==='approved');
-  const pending = apps.filter(a=>a.status==='pending');
+  // 감사용 계정(is_audit) 격리 — KPI·통계·차트에서 제외 (광고주 보고용 수치 오염 방지).
+  // users 는 전건으로 받아 통계용 statsUsers / statsApps 만 따로 거른다.
+  // applications.user_id = influencers.id 이므로 user_id 단일 기준으로 격리 (user_email 컬럼 없음).
+  const _auditIds = new Set(users.filter(u=>u.is_audit).map(u=>u.id));
+  const statsUsers = users.filter(u=>!u.is_audit);
+  const statsApps = apps.filter(a=>!_auditIds.has(a.user_id));
+
+  const approved = statsApps.filter(a=>a.status==='approved');
+  // pending 은 사이드바 신청 배지에도 쓰임 — 감사용 제외(처리 대상 아님).
+  // 신청 관리 페인은 감사용을 표시하므로 배지<페인 카운트 불일치가 생길 수 있으나 의도된 격리.
+  const pending = statsApps.filter(a=>a.status==='pending');
 
   $('kpiCampaigns').textContent = camps.length;
-  $('kpiInfluencers').textContent = users.length;
-  $('kpiApplications').textContent = apps.length;
+  $('kpiInfluencers').textContent = statsUsers.length;
+  $('kpiApplications').textContent = statsApps.length;
   $('kpiApproved').textContent = approved.length;
   renderCampaignBreakdown(camps);
   // 목록 페인(loadAdminCampaigns/loadAdminInfluencers)은 해당 pane 진입 시에만 로드
 
-  // 회원가입 차트 + KPI
-  _allUsers = users;
-  renderSignupKPIs(users);
-  renderSignupChart(users, 30);
-  renderProfileCompletion(users);
-  // 배송지 분포(도도부현 Top N) — 이미 fetch한 users 재사용 (중복 쿼리 방지)
-  renderAddressDistribution(users);
+  // 회원가입 차트 + KPI (감사용 제외)
+  _allUsers = statsUsers;
+  renderSignupKPIs(statsUsers);
+  renderSignupChart(statsUsers, 30);
+  renderProfileCompletion(statsUsers);
+  // 배송지 분포(도도부현 Top N) — 통계용 statsUsers 재사용 (중복 쿼리 방지)
+  renderAddressDistribution(statsUsers);
   // 대시보드는 apps 전건을 KPI용으로 이미 보유 → 추가 count 쿼리 없이 인라인 계산.
   // 그 외 경로(부트의 대시보드 외 페인)는 refreshApplySidebarBadge() 가 가벼운 count 로 갱신.
   if ($('adminApplySi')) $('adminApplySi').innerHTML = `<span class="si-icon material-icons-round notranslate" translate="no">assignment</span><span class="si-text">신청 관리</span>${pending.length>0?`<span class="admin-si-badge">${pending.length>999?'999+':pending.length}</span>`:''}`;
@@ -23033,13 +23397,15 @@ async function loadAdminData(preloaded) {
 function renderRecentAppsTable(apps, camps, users) {
   if (!$('recentAppsBody')) return;
   const recent = apps.slice().sort((a,b)=>new Date(b.created_at)-new Date(a.created_at)).slice(0,8);
+  const _auditIds = buildAuditIdSet(users);  // 감사용 응모는 빈자리 집계에서 제외
   $('recentAppsBody').innerHTML = recent.length ? recent.map(a=>{
     const camp = camps.find(c=>c.id===a.campaign_id)||{};
-    const _dRem = Math.max((camp.slots||0)-apps.filter(x=>x.campaign_id===camp.id&&x.status==='approved').length,0);
+    const _dRem = Math.max((camp.slots||0)-countNonAuditApproved(apps, camp.id, _auditIds),0);
     const imgs = [camp.img1,camp.img2,camp.img3,camp.img4,camp.img5,camp.img6,camp.img7,camp.img8,camp.image_url].filter(Boolean).filter((v,i,arr)=>arr.indexOf(v)===i);
     const thumbUrl = imgs[0] || '';
     const typeLabel = getRecruitTypeBadgeKoSm(camp.recruit_type);
-    return `<tr>
+    const _u = users.find(u=>u.email===a.user_email) || {};
+    return `<tr class="${_u.is_audit?'audit-row':''}">
       <td>
         <div style="display:flex;align-items:center;gap:10px">
           <div style="position:relative;width:40px;height:40px;flex-shrink:0;border-radius:6px;overflow:hidden;background:var(--surface-dim)">
@@ -23054,14 +23420,14 @@ function renderRecentAppsTable(apps, camps, users) {
         </div>
       </td>
       <td>
-        <div style="font-weight:600;color:var(--pink);cursor:pointer" onclick="openInfluencerModal('${users.find(u=>u.email===a.user_email)?.id||''}')">${esc(a.user_name)||'—'}${influencerStatusBadges(users.find(u=>u.email===a.user_email)||{})}</div>
+        <div style="font-weight:600;color:var(--pink);cursor:pointer" onclick="openInfluencerModal('${_u.id||''}')">${esc(a.user_name)||'—'}${auditBadgeHtml(_u)}${influencerStatusBadges(_u)}</div>
         <div style="font-size:11px;color:var(--muted)">${esc(a.user_email)}</div>
       </td>
       <td>${msgCell(a.message, a)}</td>
       <td style="font-size:12px;color:var(--muted);white-space:nowrap">${formatDate(a.created_at)}</td>
       <td>${getStatusBadgeKo(a.status, a.auto_reject_reason)}</td>
       <td style="white-space:nowrap">
-        ${a.status==='pending'?`<div style="display:flex;gap:4px"><button class="btn btn-green btn-xs" ${_dRem<=0?'disabled style="background:var(--muted);opacity:.5;cursor:not-allowed"':''}onclick="updateAppStatus('${a.id}','approved')">승인</button><button class="btn btn-ghost btn-xs" style="color:var(--red);border-color:var(--red)" onclick="updateAppStatus('${a.id}','rejected')">미승인</button></div>`
+        ${a.status==='pending'?`<div style="display:flex;gap:4px"><button class="btn btn-green btn-xs" ${(_dRem<=0 && !_u.is_audit)?'disabled style="background:var(--muted);opacity:.5;cursor:not-allowed"':''}onclick="updateAppStatus('${a.id}','approved')">승인</button><button class="btn btn-ghost btn-xs" style="color:var(--red);border-color:var(--red)" onclick="updateAppStatus('${a.id}','rejected')">미승인</button></div>`
         :`<div><div style="font-size:10px;color:var(--muted)">${esc(formatReviewer(a.reviewed_by))} ${a.reviewed_at?formatDateTime(a.reviewed_at):''}</div><button class="btn btn-ghost btn-xs" style="margin-top:4px;font-size:10px" onclick="updateAppStatus('${a.id}','pending')">되돌리기</button></div>`}
       </td>
     </tr>`;
@@ -23406,16 +23772,17 @@ async function loadCampApplicants() {
   const searchQ = ($('campAppSearch')?.value || '').trim().toLowerCase();
   await loadApplicantMsgUnread();  // 응모건 메시지 본인 미열람 배지 맵
   let apps = await fetchApplications({campaign_id: currentCampApplicantId});
+  const _users = await fetchInfluencers();            // 행 렌더 + 감사용 격리 공용 (1회 로드)
+  const _auditIds = buildAuditIdSet(_users);          // 감사용 응모는 빈자리·모집현황 집계에서 제외
   const allApps = apps.slice();  // 필터 적용 전 전체 — 상단 요약 카드 집계용
   const total = apps.length;
-  const allApproved = apps.filter(a => a.status === 'approved').length;
-  const allPending = apps.filter(a => a.status === 'pending').length;
+  const allApproved = countNonAuditApproved(apps, null, _auditIds);  // 감사용 제외 승인 수(빈자리·진행바용)
+  const allPending = apps.filter(a => a.status === 'pending' && !_auditIds.has(a.user_id)).length;
   if (filter) apps = apps.filter(a=>a.status===filter);
   if (searchQ) {
-    const users = await fetchInfluencers();
     // 단어 단위 AND 매칭 (matchSearchTokens, 전각/반각 공백 무관)
     apps = apps.filter(a => {
-      const u = users.find(x => x.email === a.user_email) || {};
+      const u = _users.find(x => x.email === a.user_email) || {};
       return matchSearchTokens(searchQ, [
         a.user_name, a.user_email,
         u.name_kanji, u.name, u.name_kana,
@@ -23448,7 +23815,6 @@ async function loadCampApplicants() {
     <span style="color:var(--gold)">심사중 ${pending}명</span>
   `;
 
-  const _users = await fetchInfluencers();
   // Stage 4: 이 캠페인의 모든 결과물을 한 번에 받아 application_id로 그룹핑
   const allDelivs = await fetchDeliverablesByCampaign(currentCampApplicantId);
   // 상단 요약 카드 (개요 + 모집/결과물 현황 + 비용)
@@ -23480,9 +23846,9 @@ async function loadCampApplicants() {
     const totalF = ((_u.ig_followers||0)+(_u.x_followers||0)+(_u.tiktok_followers||0)+(_u.youtube_followers||0)).toLocaleString();
     const otCell = renderOtCell(a, isPostType);
     const delivCell = renderDelivCell(delivByApp[a.id] || [], a.status, selectedChannels, channelMatch, isPostType);
-    return `<tr data-id="${esc(a.id)}">
+    return `<tr data-id="${esc(a.id)}" class="${_u.is_audit?'audit-row':''}">
     <td>
-      <div style="font-weight:600;color:var(--pink);cursor:pointer" onclick="openInfluencerModal('${_u.id||''}')">${esc(a.user_name)||'—'}${adminBadge(a.user_email)}${influencerStatusBadges(_u)}</div>
+      <div style="font-weight:600;color:var(--pink);cursor:pointer" onclick="openInfluencerModal('${_u.id||''}')">${esc(a.user_name)||'—'}${auditBadgeHtml(_u)}${adminBadge(a.user_email)}${influencerStatusBadges(_u)}</div>
       <div style="font-size:11px;color:var(--muted)">${esc(a.user_email)||''}</div>${_u.line_id?`<div style="font-size:11px;color:var(--muted)">LINE: ${esc(_u.line_id)}</div>`:''}
       <div style="margin-top:4px">${renderApplicantMsgBtn(a)}</div>
     </td>
@@ -23497,7 +23863,7 @@ async function loadCampApplicants() {
     <td>${otCell}</td>
     <td>${delivCell}</td>
     <td style="white-space:nowrap">
-      ${a.status==='pending'?`<div style="display:flex;gap:4px"><button class="btn btn-green btn-xs" ${remaining<=0?'disabled style="background:var(--muted);opacity:.5;cursor:not-allowed"':''}onclick="updateAppStatus('${a.id}','approved')">승인</button><button class="btn btn-ghost btn-xs" style="color:var(--red);border-color:var(--red)" onclick="updateAppStatus('${a.id}','rejected')">미승인</button></div>`
+      ${a.status==='pending'?`<div style="display:flex;gap:4px"><button class="btn btn-green btn-xs" ${(remaining<=0 && !_u.is_audit)?'disabled style="background:var(--muted);opacity:.5;cursor:not-allowed"':''}onclick="updateAppStatus('${a.id}','approved')">승인</button><button class="btn btn-ghost btn-xs" style="color:var(--red);border-color:var(--red)" onclick="updateAppStatus('${a.id}','rejected')">미승인</button></div>`
       :a.status==='cancelled'?`<div style="font-size:10px;color:var(--muted)">${a.cancelled_at?formatDateTime(a.cancelled_at):'—'}</div>`
       :`<div><div style="font-size:10px;color:var(--muted)">${esc(formatReviewer(a.reviewed_by))} ${a.reviewed_at?formatDateTime(a.reviewed_at):''}</div><button class="btn btn-ghost btn-xs" style="margin-top:4px;font-size:10px" onclick="updateAppStatus('${a.id}','pending')">되돌리기</button></div>`}
     </td>
@@ -23766,6 +24132,7 @@ async function renderAppCampList() {
   const allAppsRaw = _appListCache.allAppsRaw;
   let apps = allAppsRaw.slice();
   const users = _appListCache.users;
+  const _auditIds = buildAuditIdSet(users);  // 감사용 응모는 빈자리 집계에서 제외
 
   // 캠페인 ↔ 타입 쌍별 연동: 현재 선택값 스냅샷
   const typeValsRaw = getMultiFilterValues('appTypeMulti');
@@ -23867,7 +24234,7 @@ async function renderAppCampList() {
   const renderAppRow = (a) => {
     const camp = camps.find(c => c.id === a.campaign_id) || {};
     const u = users.find(u => u.email === a.user_email) || {};
-    const _campRemaining = Math.max((camp.slots||0)-allAppsRaw.filter(x=>x.campaign_id===camp.id&&x.status==='approved').length,0);
+    const _campRemaining = Math.max((camp.slots||0)-countNonAuditApproved(allAppsRaw, camp.id, _auditIds),0);
     const imgs = [camp.img1,camp.img2,camp.img3,camp.img4,camp.img5,camp.img6,camp.img7,camp.img8,camp.image_url].filter(Boolean).filter((v,i,arr)=>arr.indexOf(v)===i);
     const thumbUrl = imgs[0] || '';
     const typeLabel = getRecruitTypeBadgeKoSm(camp.recruit_type);
@@ -23877,7 +24244,7 @@ async function renderAppCampList() {
     const productSub     = (camp.product_ko && camp.product && camp.product_ko !== camp.product) ? camp.product : '';
     const recruitStart   = camp.recruit_start ? formatDate(camp.recruit_start) : '';
     const recruitEnd     = camp.deadline ? formatDate(camp.deadline) : '';
-    return `<tr data-id="${esc(a.id)}">
+    return `<tr data-id="${esc(a.id)}" class="${u.is_audit?'audit-row':''}">
       <td style="max-width:260px">
         <div style="display:flex;align-items:center;gap:10px">
           <div style="position:relative;width:40px;height:40px;flex-shrink:0;border-radius:6px;overflow:hidden;background:var(--surface-dim)">
@@ -23886,7 +24253,7 @@ async function renderAppCampList() {
           <div style="min-width:0;flex:1">
             <div>${typeLabel}</div>
             <strong style="font-size:13px;cursor:pointer;display:block;word-break:break-word;line-height:1.4" onclick="openCampPreviewModal('${camp.id}')">${esc(camp.title)||'—'}</strong>
-            ${camp.slots?(()=>{const _r=Math.max(camp.slots-allAppsRaw.filter(x=>x.campaign_id===camp.id&&x.status==='approved').length,0);return `<div style="font-size:10px;color:var(--muted);margin-top:2px">모집 ${camp.slots}명 · 빈자리 <span style="color:${_r>0?'var(--green)':'var(--red)'};font-weight:600">${_r>0?_r+'건':'없음'}</span></div>`;})():''}
+            ${camp.slots?(()=>{const _r=Math.max(camp.slots-countNonAuditApproved(allAppsRaw, camp.id, _auditIds),0);return `<div style="font-size:10px;color:var(--muted);margin-top:2px">모집 ${camp.slots}명 · 빈자리 <span style="color:${_r>0?'var(--green)':'var(--red)'};font-weight:600">${_r>0?_r+'건':'없음'}</span></div>`;})():''}
           </div>
         </div>
       </td>
@@ -23903,7 +24270,7 @@ async function renderAppCampList() {
         <div style="color:var(--ink)">~ ${recruitEnd||'—'}</div>
       </td>
       <td>
-        <div style="font-weight:600;color:var(--pink);cursor:pointer" onclick="openInfluencerModal('${u.id||''}')">${esc(a.user_name)||'—'}${influencerStatusBadges(u)}</div>
+        <div style="font-weight:600;color:var(--pink);cursor:pointer" onclick="openInfluencerModal('${u.id||''}')">${esc(a.user_name)||'—'}${auditBadgeHtml(u)}${influencerStatusBadges(u)}</div>
         <div style="font-size:11px;color:var(--muted)">${esc(a.user_email)||''}</div>${u.line_id?`<div style="font-size:11px;color:var(--muted)">LINE: ${esc(u.line_id)}</div>`:''}
         <div style="margin-top:4px">${renderApplicantMsgBtn(a)}</div>
       </td>
@@ -23911,7 +24278,7 @@ async function renderAppCampList() {
       <td style="font-size:12px;color:var(--muted);white-space:nowrap">${formatDate(a.created_at)}</td>
       <td>${getStatusBadgeKo(a.status, a.auto_reject_reason)}${a.status==='cancelled' && a.cancel_phase ? `<div style="font-size:10px;color:var(--muted);margin-top:2px">${esc(cancelPhaseLabelKo(a.cancel_phase))}</div>` : ''}</td>
       <td style="white-space:nowrap">
-        ${a.status==='pending'?`<div style="display:flex;gap:4px"><button class="btn btn-green btn-xs" ${_campRemaining<=0?'disabled style="background:var(--muted);opacity:.5;cursor:not-allowed"':''}onclick="updateAppStatus('${a.id}','approved')">승인</button><button class="btn btn-ghost btn-xs" style="color:var(--red);border-color:var(--red)" onclick="updateAppStatus('${a.id}','rejected')">미승인</button></div>`
+        ${a.status==='pending'?`<div style="display:flex;gap:4px"><button class="btn btn-green btn-xs" ${(_campRemaining<=0 && !u.is_audit)?'disabled style="background:var(--muted);opacity:.5;cursor:not-allowed"':''}onclick="updateAppStatus('${a.id}','approved')">승인</button><button class="btn btn-ghost btn-xs" style="color:var(--red);border-color:var(--red)" onclick="updateAppStatus('${a.id}','rejected')">미승인</button></div>`
         :a.status==='cancelled'?`<div style="font-size:10px;color:var(--muted)">${a.cancelled_at?formatDateTime(a.cancelled_at):'—'}</div>`
         :`<div><div style="font-size:10px;color:var(--muted)">${esc(formatReviewer(a.reviewed_by))} ${a.reviewed_at?formatDateTime(a.reviewed_at):''}</div><button class="btn btn-ghost btn-xs" style="margin-top:4px;font-size:10px" onclick="updateAppStatus('${a.id}','pending')">되돌리기</button></div>`}
       </td>
@@ -23935,15 +24302,29 @@ async function updateAppStatus(appId, status) {
   try {
     // 승인 시 모집인원 초과 체크
     if (status === 'approved') {
-      const {data: app} = await db?.from('applications').select('campaign_id').eq('id', appId).maybeSingle();
+      const {data: app} = await db?.from('applications').select('campaign_id, user_id').eq('id', appId).maybeSingle();
       if (app) {
-        const {data: camp} = await db?.from('campaigns').select('slots').eq('id', app.campaign_id).maybeSingle();
-        const approvedApps = await fetchApplications({campaign_id: app.campaign_id, status: 'approved'});
-        const slots = camp?.slots || 0;
-        if (slots > 0 && approvedApps.length >= slots) {
-          $('alertModalMessage').innerHTML = `이 캠페인의 모집 정원은 <strong>${esc(String(slots))}명</strong>으로<br>이미 모두 찼습니다.`;
-          openModal('alertModal');
-          return;
+        // 감사용 응모는 정원과 무관하게 승인 허용 (격리 — 마이그레이션 179·181)
+        const {data: applicant} = await db?.from('influencers').select('is_audit').eq('id', app.user_id).maybeSingle();
+        if (!applicant?.is_audit) {
+          const {data: camp} = await db?.from('campaigns').select('slots').eq('id', app.campaign_id).maybeSingle();
+          const slots = camp?.slots || 0;
+          if (slots > 0) {
+            const approvedApps = await fetchApplications({campaign_id: app.campaign_id, status: 'approved'});
+            // 승인된 감사용 응모는 정원 카운트에서 제외
+            const ids = approvedApps.map(a => a.user_id).filter(Boolean);
+            let auditSet = new Set();
+            if (ids.length) {
+              const {data: auditRows} = await db?.from('influencers').select('id').eq('is_audit', true).in('id', ids) || {};
+              auditSet = new Set((auditRows || []).map(r => r.id));
+            }
+            const nonAuditApproved = approvedApps.filter(a => !auditSet.has(a.user_id)).length;
+            if (nonAuditApproved >= slots) {
+              $('alertModalMessage').innerHTML = `이 캠페인의 모집 정원은 <strong>${esc(String(slots))}명</strong>으로<br>이미 모두 찼습니다.`;
+              openModal('alertModal');
+              return;
+            }
+          }
         }
       }
     }
@@ -28003,10 +28384,13 @@ function toggleCampMoreMenu(e, btnEl, campId, campTitle) {
   const rect = btnEl.getBoundingClientRect();
   const menu = document.createElement('div');
   menu.className = 'camp-more-menu';
-  // 변경 이력 항목은 super_admin 한정 (audit 데이터, 일반 매니저 노출 X)
+  // 변경 이력·감사용 흔적 청소 항목은 super_admin 한정 (audit 데이터, 일반 매니저 노출 X)
   const isSuper = currentAdminInfo?.role === 'super_admin';
   const historyItem = isSuper
     ? `<div class="camp-more-item" onclick="openCautionHistoryModal('${campId}')"><span class="material-icons-round notranslate" translate="no" style="font-size:16px">history</span>변경 이력</div>`
+    : '';
+  const auditPurgeItem = isSuper
+    ? `<div class="camp-more-item camp-more-danger" onclick="purgeCampaignAuditData('${campId}')"><span class="material-icons-round notranslate" translate="no" style="font-size:16px">cleaning_services</span>감사용 흔적 청소</div>`
     : '';
   menu.innerHTML = `
     <div class="camp-more-item" onclick="openEditCampaign('${campId}')"><span class="material-icons-round notranslate" translate="no" style="font-size:16px">edit</span>편집</div>
@@ -28014,6 +28398,7 @@ function toggleCampMoreMenu(e, btnEl, campId, campTitle) {
     <div class="camp-more-item" onclick="exportCampaignDeliverables('${campId}')"><span class="material-icons-round notranslate" translate="no" style="font-size:16px">download</span>결과물 엑셀</div>
     <div class="camp-more-item" onclick="exportCampaignApplicationsExcel('${campId}')"><span class="material-icons-round notranslate" translate="no" style="font-size:16px">download</span>신청자 엑셀</div>
     ${historyItem}
+    ${auditPurgeItem}
     <div class="camp-more-item camp-more-danger" data-camp-title="${esc(campTitle)}" onclick="deleteCampaign('${campId}',this.dataset.campTitle)"><span class="material-icons-round notranslate" translate="no" style="font-size:16px">delete</span>삭제</div>
   `;
   document.body.appendChild(menu);
@@ -28028,6 +28413,31 @@ function toggleCampMoreMenu(e, btnEl, campId, campTitle) {
       }
     });
   }, 0);
+}
+
+// 캠페인별 감사용 흔적 청소 — super_admin 전용.
+// 이 캠페인에서 감사용 계정(is_audit=true)이 만든 응모·결과물·메시지를 모두 삭제한다.
+async function purgeCampaignAuditData(campId) {
+  document.querySelectorAll('.camp-more-menu').forEach(d => d.remove());
+  if (currentAdminInfo?.role !== 'super_admin') return;
+  const ok = await showConfirm('이 캠페인에서 감사용 계정이 만든 응모·결과물·메시지를 모두 삭제합니다. 되돌릴 수 없습니다. 진행할까요?');
+  if (!ok) return;
+  try {
+    const res = await purgeAuditDataForCampaign(campId);
+    const rpc = res?.rpc;
+    if (!rpc || rpc.status === 'no_audit_account' || !rpc.deleted || (rpc.deleted.applications || 0) === 0) {
+      toast('삭제할 감사용 데이터 없음', '');
+    } else {
+      const n = rpc.deleted.applications || 0;
+      toast(`감사용 응모 ${n}건·결과물 등 삭제됨`, 'success');
+    }
+    // 진행현황 페인이 열려 있으면 그쪽을, 아니면 캠페인 목록 갱신
+    const applicantsPaneActive = $('adminPane-camp-applicants')?.classList.contains('on');
+    await refreshPane(applicantsPaneActive ? 'camp-applicants' : 'campaigns');
+  } catch (e) {
+    console.error('[purgeCampaignAuditData]', e);
+    toast('감사용 흔적 청소 실패: ' + (e?.message || e), 'error');
+  }
 }
 
 function toggleStatusDropdown(badgeEl) {

--- a/dev/css/admin.css
+++ b/dev/css/admin.css
@@ -1509,3 +1509,21 @@
    input 의 기본 min-width:auto 때문에 좁은 모달에서 행이 넘쳐 대표·삭제 버튼이 잘리던 문제 방지. */
 #brandContactsHeader, .brand-contact-row { min-width: 0; }
 .brand-contact-row > input { min-width: 0; width: 100%; box-sizing: border-box; }
+
+/* 감사용 계정 배지 — 통계·산출물에서 격리된 운영팀 시뮬레이션 계정 표시.
+   모든 인플·응모·결과물 행에 auditBadgeHtml() 로 강제 노출. 주황 톤(경고 아닌 식별용). */
+.audit-badge {
+  display: inline-block;
+  padding: 2px 7px;
+  margin-left: 5px;
+  background: #ff9800;
+  color: #fff;
+  font-size: 11px;
+  font-weight: 700;
+  line-height: 1.4;
+  border-radius: 3px;
+  vertical-align: middle;
+  white-space: nowrap;
+}
+/* 감사용 행 — 행 배경도 옅게 강조해 목록에서 즉시 식별 */
+tr.audit-row, .audit-row { background: #fff3e0 !important; }

--- a/dev/js/admin-applications.js
+++ b/dev/js/admin-applications.js
@@ -48,16 +48,17 @@ async function loadCampApplicants() {
   const searchQ = ($('campAppSearch')?.value || '').trim().toLowerCase();
   await loadApplicantMsgUnread();  // 응모건 메시지 본인 미열람 배지 맵
   let apps = await fetchApplications({campaign_id: currentCampApplicantId});
+  const _users = await fetchInfluencers();            // 행 렌더 + 감사용 격리 공용 (1회 로드)
+  const _auditIds = buildAuditIdSet(_users);          // 감사용 응모는 빈자리·모집현황 집계에서 제외
   const allApps = apps.slice();  // 필터 적용 전 전체 — 상단 요약 카드 집계용
   const total = apps.length;
-  const allApproved = apps.filter(a => a.status === 'approved').length;
-  const allPending = apps.filter(a => a.status === 'pending').length;
+  const allApproved = countNonAuditApproved(apps, null, _auditIds);  // 감사용 제외 승인 수(빈자리·진행바용)
+  const allPending = apps.filter(a => a.status === 'pending' && !_auditIds.has(a.user_id)).length;
   if (filter) apps = apps.filter(a=>a.status===filter);
   if (searchQ) {
-    const users = await fetchInfluencers();
     // 단어 단위 AND 매칭 (matchSearchTokens, 전각/반각 공백 무관)
     apps = apps.filter(a => {
-      const u = users.find(x => x.email === a.user_email) || {};
+      const u = _users.find(x => x.email === a.user_email) || {};
       return matchSearchTokens(searchQ, [
         a.user_name, a.user_email,
         u.name_kanji, u.name, u.name_kana,
@@ -90,7 +91,6 @@ async function loadCampApplicants() {
     <span style="color:var(--gold)">심사중 ${pending}명</span>
   `;
 
-  const _users = await fetchInfluencers();
   // Stage 4: 이 캠페인의 모든 결과물을 한 번에 받아 application_id로 그룹핑
   const allDelivs = await fetchDeliverablesByCampaign(currentCampApplicantId);
   // 상단 요약 카드 (개요 + 모집/결과물 현황 + 비용)
@@ -122,9 +122,9 @@ async function loadCampApplicants() {
     const totalF = ((_u.ig_followers||0)+(_u.x_followers||0)+(_u.tiktok_followers||0)+(_u.youtube_followers||0)).toLocaleString();
     const otCell = renderOtCell(a, isPostType);
     const delivCell = renderDelivCell(delivByApp[a.id] || [], a.status, selectedChannels, channelMatch, isPostType);
-    return `<tr data-id="${esc(a.id)}">
+    return `<tr data-id="${esc(a.id)}" class="${_u.is_audit?'audit-row':''}">
     <td>
-      <div style="font-weight:600;color:var(--pink);cursor:pointer" onclick="openInfluencerModal('${_u.id||''}')">${esc(a.user_name)||'—'}${adminBadge(a.user_email)}${influencerStatusBadges(_u)}</div>
+      <div style="font-weight:600;color:var(--pink);cursor:pointer" onclick="openInfluencerModal('${_u.id||''}')">${esc(a.user_name)||'—'}${auditBadgeHtml(_u)}${adminBadge(a.user_email)}${influencerStatusBadges(_u)}</div>
       <div style="font-size:11px;color:var(--muted)">${esc(a.user_email)||''}</div>${_u.line_id?`<div style="font-size:11px;color:var(--muted)">LINE: ${esc(_u.line_id)}</div>`:''}
       <div style="margin-top:4px">${renderApplicantMsgBtn(a)}</div>
     </td>
@@ -139,7 +139,7 @@ async function loadCampApplicants() {
     <td>${otCell}</td>
     <td>${delivCell}</td>
     <td style="white-space:nowrap">
-      ${a.status==='pending'?`<div style="display:flex;gap:4px"><button class="btn btn-green btn-xs" ${remaining<=0?'disabled style="background:var(--muted);opacity:.5;cursor:not-allowed"':''}onclick="updateAppStatus('${a.id}','approved')">승인</button><button class="btn btn-ghost btn-xs" style="color:var(--red);border-color:var(--red)" onclick="updateAppStatus('${a.id}','rejected')">미승인</button></div>`
+      ${a.status==='pending'?`<div style="display:flex;gap:4px"><button class="btn btn-green btn-xs" ${(remaining<=0 && !_u.is_audit)?'disabled style="background:var(--muted);opacity:.5;cursor:not-allowed"':''}onclick="updateAppStatus('${a.id}','approved')">승인</button><button class="btn btn-ghost btn-xs" style="color:var(--red);border-color:var(--red)" onclick="updateAppStatus('${a.id}','rejected')">미승인</button></div>`
       :a.status==='cancelled'?`<div style="font-size:10px;color:var(--muted)">${a.cancelled_at?formatDateTime(a.cancelled_at):'—'}</div>`
       :`<div><div style="font-size:10px;color:var(--muted)">${esc(formatReviewer(a.reviewed_by))} ${a.reviewed_at?formatDateTime(a.reviewed_at):''}</div><button class="btn btn-ghost btn-xs" style="margin-top:4px;font-size:10px" onclick="updateAppStatus('${a.id}','pending')">되돌리기</button></div>`}
     </td>
@@ -408,6 +408,7 @@ async function renderAppCampList() {
   const allAppsRaw = _appListCache.allAppsRaw;
   let apps = allAppsRaw.slice();
   const users = _appListCache.users;
+  const _auditIds = buildAuditIdSet(users);  // 감사용 응모는 빈자리 집계에서 제외
 
   // 캠페인 ↔ 타입 쌍별 연동: 현재 선택값 스냅샷
   const typeValsRaw = getMultiFilterValues('appTypeMulti');
@@ -509,7 +510,7 @@ async function renderAppCampList() {
   const renderAppRow = (a) => {
     const camp = camps.find(c => c.id === a.campaign_id) || {};
     const u = users.find(u => u.email === a.user_email) || {};
-    const _campRemaining = Math.max((camp.slots||0)-allAppsRaw.filter(x=>x.campaign_id===camp.id&&x.status==='approved').length,0);
+    const _campRemaining = Math.max((camp.slots||0)-countNonAuditApproved(allAppsRaw, camp.id, _auditIds),0);
     const imgs = [camp.img1,camp.img2,camp.img3,camp.img4,camp.img5,camp.img6,camp.img7,camp.img8,camp.image_url].filter(Boolean).filter((v,i,arr)=>arr.indexOf(v)===i);
     const thumbUrl = imgs[0] || '';
     const typeLabel = getRecruitTypeBadgeKoSm(camp.recruit_type);
@@ -519,7 +520,7 @@ async function renderAppCampList() {
     const productSub     = (camp.product_ko && camp.product && camp.product_ko !== camp.product) ? camp.product : '';
     const recruitStart   = camp.recruit_start ? formatDate(camp.recruit_start) : '';
     const recruitEnd     = camp.deadline ? formatDate(camp.deadline) : '';
-    return `<tr data-id="${esc(a.id)}">
+    return `<tr data-id="${esc(a.id)}" class="${u.is_audit?'audit-row':''}">
       <td style="max-width:260px">
         <div style="display:flex;align-items:center;gap:10px">
           <div style="position:relative;width:40px;height:40px;flex-shrink:0;border-radius:6px;overflow:hidden;background:var(--surface-dim)">
@@ -528,7 +529,7 @@ async function renderAppCampList() {
           <div style="min-width:0;flex:1">
             <div>${typeLabel}</div>
             <strong style="font-size:13px;cursor:pointer;display:block;word-break:break-word;line-height:1.4" onclick="openCampPreviewModal('${camp.id}')">${esc(camp.title)||'—'}</strong>
-            ${camp.slots?(()=>{const _r=Math.max(camp.slots-allAppsRaw.filter(x=>x.campaign_id===camp.id&&x.status==='approved').length,0);return `<div style="font-size:10px;color:var(--muted);margin-top:2px">모집 ${camp.slots}명 · 빈자리 <span style="color:${_r>0?'var(--green)':'var(--red)'};font-weight:600">${_r>0?_r+'건':'없음'}</span></div>`;})():''}
+            ${camp.slots?(()=>{const _r=Math.max(camp.slots-countNonAuditApproved(allAppsRaw, camp.id, _auditIds),0);return `<div style="font-size:10px;color:var(--muted);margin-top:2px">모집 ${camp.slots}명 · 빈자리 <span style="color:${_r>0?'var(--green)':'var(--red)'};font-weight:600">${_r>0?_r+'건':'없음'}</span></div>`;})():''}
           </div>
         </div>
       </td>
@@ -545,7 +546,7 @@ async function renderAppCampList() {
         <div style="color:var(--ink)">~ ${recruitEnd||'—'}</div>
       </td>
       <td>
-        <div style="font-weight:600;color:var(--pink);cursor:pointer" onclick="openInfluencerModal('${u.id||''}')">${esc(a.user_name)||'—'}${influencerStatusBadges(u)}</div>
+        <div style="font-weight:600;color:var(--pink);cursor:pointer" onclick="openInfluencerModal('${u.id||''}')">${esc(a.user_name)||'—'}${auditBadgeHtml(u)}${influencerStatusBadges(u)}</div>
         <div style="font-size:11px;color:var(--muted)">${esc(a.user_email)||''}</div>${u.line_id?`<div style="font-size:11px;color:var(--muted)">LINE: ${esc(u.line_id)}</div>`:''}
         <div style="margin-top:4px">${renderApplicantMsgBtn(a)}</div>
       </td>
@@ -553,7 +554,7 @@ async function renderAppCampList() {
       <td style="font-size:12px;color:var(--muted);white-space:nowrap">${formatDate(a.created_at)}</td>
       <td>${getStatusBadgeKo(a.status, a.auto_reject_reason)}${a.status==='cancelled' && a.cancel_phase ? `<div style="font-size:10px;color:var(--muted);margin-top:2px">${esc(cancelPhaseLabelKo(a.cancel_phase))}</div>` : ''}</td>
       <td style="white-space:nowrap">
-        ${a.status==='pending'?`<div style="display:flex;gap:4px"><button class="btn btn-green btn-xs" ${_campRemaining<=0?'disabled style="background:var(--muted);opacity:.5;cursor:not-allowed"':''}onclick="updateAppStatus('${a.id}','approved')">승인</button><button class="btn btn-ghost btn-xs" style="color:var(--red);border-color:var(--red)" onclick="updateAppStatus('${a.id}','rejected')">미승인</button></div>`
+        ${a.status==='pending'?`<div style="display:flex;gap:4px"><button class="btn btn-green btn-xs" ${(_campRemaining<=0 && !u.is_audit)?'disabled style="background:var(--muted);opacity:.5;cursor:not-allowed"':''}onclick="updateAppStatus('${a.id}','approved')">승인</button><button class="btn btn-ghost btn-xs" style="color:var(--red);border-color:var(--red)" onclick="updateAppStatus('${a.id}','rejected')">미승인</button></div>`
         :a.status==='cancelled'?`<div style="font-size:10px;color:var(--muted)">${a.cancelled_at?formatDateTime(a.cancelled_at):'—'}</div>`
         :`<div><div style="font-size:10px;color:var(--muted)">${esc(formatReviewer(a.reviewed_by))} ${a.reviewed_at?formatDateTime(a.reviewed_at):''}</div><button class="btn btn-ghost btn-xs" style="margin-top:4px;font-size:10px" onclick="updateAppStatus('${a.id}','pending')">되돌리기</button></div>`}
       </td>
@@ -577,15 +578,29 @@ async function updateAppStatus(appId, status) {
   try {
     // 승인 시 모집인원 초과 체크
     if (status === 'approved') {
-      const {data: app} = await db?.from('applications').select('campaign_id').eq('id', appId).maybeSingle();
+      const {data: app} = await db?.from('applications').select('campaign_id, user_id').eq('id', appId).maybeSingle();
       if (app) {
-        const {data: camp} = await db?.from('campaigns').select('slots').eq('id', app.campaign_id).maybeSingle();
-        const approvedApps = await fetchApplications({campaign_id: app.campaign_id, status: 'approved'});
-        const slots = camp?.slots || 0;
-        if (slots > 0 && approvedApps.length >= slots) {
-          $('alertModalMessage').innerHTML = `이 캠페인의 모집 정원은 <strong>${esc(String(slots))}명</strong>으로<br>이미 모두 찼습니다.`;
-          openModal('alertModal');
-          return;
+        // 감사용 응모는 정원과 무관하게 승인 허용 (격리 — 마이그레이션 179·181)
+        const {data: applicant} = await db?.from('influencers').select('is_audit').eq('id', app.user_id).maybeSingle();
+        if (!applicant?.is_audit) {
+          const {data: camp} = await db?.from('campaigns').select('slots').eq('id', app.campaign_id).maybeSingle();
+          const slots = camp?.slots || 0;
+          if (slots > 0) {
+            const approvedApps = await fetchApplications({campaign_id: app.campaign_id, status: 'approved'});
+            // 승인된 감사용 응모는 정원 카운트에서 제외
+            const ids = approvedApps.map(a => a.user_id).filter(Boolean);
+            let auditSet = new Set();
+            if (ids.length) {
+              const {data: auditRows} = await db?.from('influencers').select('id').eq('is_audit', true).in('id', ids) || {};
+              auditSet = new Set((auditRows || []).map(r => r.id));
+            }
+            const nonAuditApproved = approvedApps.filter(a => !auditSet.has(a.user_id)).length;
+            if (nonAuditApproved >= slots) {
+              $('alertModalMessage').innerHTML = `이 캠페인의 모집 정원은 <strong>${esc(String(slots))}명</strong>으로<br>이미 모두 찼습니다.`;
+              openModal('alertModal');
+              return;
+            }
+          }
         }
       }
     }

--- a/dev/js/admin-brand-ops.js
+++ b/dev/js/admin-brand-ops.js
@@ -203,18 +203,24 @@ async function loadBrandOpsDetail() {
   }
   if (body) body.innerHTML = '<div style="text-align:center;color:var(--muted);padding:48px"><span class="spinner" style="width:22px;height:22px;border-width:2px;border-color:rgba(200,120,163,.2);border-top-color:var(--pink)"></span></div>';
 
-  var results = await Promise.all([getBrandOpsDetail(_brandOpsDetailId), fetchApplications()]);
+  // 감사용 계정 id 집합(소수) — 폴백 승인 집계에서 격리. 전체 회원 로드 없이 가볍게 조회.
+  var results = await Promise.all([
+    getBrandOpsDetail(_brandOpsDetailId),
+    fetchApplications(),
+    db ? db.from('influencers').select('id').eq('is_audit', true) : Promise.resolve({data: []}),
+  ]);
   var detail = results[0];
   var apps = results[1] || [];
+  var _auditIds = new Set((((results[2] && results[2].data) || [])).map(function(r){ return r.id; }));
   _brandOpsDetailData = detail;
   if (!detail || !detail.brand) {
     if (body) body.innerHTML = '<div style="text-align:center;color:var(--muted);padding:48px">브랜드 정보를 불러올 수 없습니다</div>';
     return;
   }
-  // 캠페인별 승인 수 집계 (인플루언서 응모 = applications, status approved)
+  // 캠페인별 승인 수 집계 (인플루언서 응모 = applications, status approved). 감사용 제외(격리).
   _brandOpsApprByCamp = {};
   apps.forEach(function(a){
-    if (a.status === 'approved') _brandOpsApprByCamp[a.campaign_id] = (_brandOpsApprByCamp[a.campaign_id] || 0) + 1;
+    if (a.status === 'approved' && !_auditIds.has(a.user_id)) _brandOpsApprByCamp[a.campaign_id] = (_brandOpsApprByCamp[a.campaign_id] || 0) + 1;
   });
   renderBrandOpsDetail(detail);
 }

--- a/dev/js/admin-dashboard.js
+++ b/dev/js/admin-dashboard.js
@@ -45,23 +45,32 @@ async function loadAdminData(preloaded) {
       showAdminUnreadNoticesIfAny();
     }
   }).catch(()=>{});
-  const approved = apps.filter(a=>a.status==='approved');
-  const pending = apps.filter(a=>a.status==='pending');
+  // 감사용 계정(is_audit) 격리 — KPI·통계·차트에서 제외 (광고주 보고용 수치 오염 방지).
+  // users 는 전건으로 받아 통계용 statsUsers / statsApps 만 따로 거른다.
+  // applications.user_id = influencers.id 이므로 user_id 단일 기준으로 격리 (user_email 컬럼 없음).
+  const _auditIds = new Set(users.filter(u=>u.is_audit).map(u=>u.id));
+  const statsUsers = users.filter(u=>!u.is_audit);
+  const statsApps = apps.filter(a=>!_auditIds.has(a.user_id));
+
+  const approved = statsApps.filter(a=>a.status==='approved');
+  // pending 은 사이드바 신청 배지에도 쓰임 — 감사용 제외(처리 대상 아님).
+  // 신청 관리 페인은 감사용을 표시하므로 배지<페인 카운트 불일치가 생길 수 있으나 의도된 격리.
+  const pending = statsApps.filter(a=>a.status==='pending');
 
   $('kpiCampaigns').textContent = camps.length;
-  $('kpiInfluencers').textContent = users.length;
-  $('kpiApplications').textContent = apps.length;
+  $('kpiInfluencers').textContent = statsUsers.length;
+  $('kpiApplications').textContent = statsApps.length;
   $('kpiApproved').textContent = approved.length;
   renderCampaignBreakdown(camps);
   // 목록 페인(loadAdminCampaigns/loadAdminInfluencers)은 해당 pane 진입 시에만 로드
 
-  // 회원가입 차트 + KPI
-  _allUsers = users;
-  renderSignupKPIs(users);
-  renderSignupChart(users, 30);
-  renderProfileCompletion(users);
-  // 배송지 분포(도도부현 Top N) — 이미 fetch한 users 재사용 (중복 쿼리 방지)
-  renderAddressDistribution(users);
+  // 회원가입 차트 + KPI (감사용 제외)
+  _allUsers = statsUsers;
+  renderSignupKPIs(statsUsers);
+  renderSignupChart(statsUsers, 30);
+  renderProfileCompletion(statsUsers);
+  // 배송지 분포(도도부현 Top N) — 통계용 statsUsers 재사용 (중복 쿼리 방지)
+  renderAddressDistribution(statsUsers);
   // 대시보드는 apps 전건을 KPI용으로 이미 보유 → 추가 count 쿼리 없이 인라인 계산.
   // 그 외 경로(부트의 대시보드 외 페인)는 refreshApplySidebarBadge() 가 가벼운 count 로 갱신.
   if ($('adminApplySi')) $('adminApplySi').innerHTML = `<span class="si-icon material-icons-round notranslate" translate="no">assignment</span><span class="si-text">신청 관리</span>${pending.length>0?`<span class="admin-si-badge">${pending.length>999?'999+':pending.length}</span>`:''}`;
@@ -73,13 +82,15 @@ async function loadAdminData(preloaded) {
 function renderRecentAppsTable(apps, camps, users) {
   if (!$('recentAppsBody')) return;
   const recent = apps.slice().sort((a,b)=>new Date(b.created_at)-new Date(a.created_at)).slice(0,8);
+  const _auditIds = buildAuditIdSet(users);  // 감사용 응모는 빈자리 집계에서 제외
   $('recentAppsBody').innerHTML = recent.length ? recent.map(a=>{
     const camp = camps.find(c=>c.id===a.campaign_id)||{};
-    const _dRem = Math.max((camp.slots||0)-apps.filter(x=>x.campaign_id===camp.id&&x.status==='approved').length,0);
+    const _dRem = Math.max((camp.slots||0)-countNonAuditApproved(apps, camp.id, _auditIds),0);
     const imgs = [camp.img1,camp.img2,camp.img3,camp.img4,camp.img5,camp.img6,camp.img7,camp.img8,camp.image_url].filter(Boolean).filter((v,i,arr)=>arr.indexOf(v)===i);
     const thumbUrl = imgs[0] || '';
     const typeLabel = getRecruitTypeBadgeKoSm(camp.recruit_type);
-    return `<tr>
+    const _u = users.find(u=>u.email===a.user_email) || {};
+    return `<tr class="${_u.is_audit?'audit-row':''}">
       <td>
         <div style="display:flex;align-items:center;gap:10px">
           <div style="position:relative;width:40px;height:40px;flex-shrink:0;border-radius:6px;overflow:hidden;background:var(--surface-dim)">
@@ -94,14 +105,14 @@ function renderRecentAppsTable(apps, camps, users) {
         </div>
       </td>
       <td>
-        <div style="font-weight:600;color:var(--pink);cursor:pointer" onclick="openInfluencerModal('${users.find(u=>u.email===a.user_email)?.id||''}')">${esc(a.user_name)||'—'}${influencerStatusBadges(users.find(u=>u.email===a.user_email)||{})}</div>
+        <div style="font-weight:600;color:var(--pink);cursor:pointer" onclick="openInfluencerModal('${_u.id||''}')">${esc(a.user_name)||'—'}${auditBadgeHtml(_u)}${influencerStatusBadges(_u)}</div>
         <div style="font-size:11px;color:var(--muted)">${esc(a.user_email)}</div>
       </td>
       <td>${msgCell(a.message, a)}</td>
       <td style="font-size:12px;color:var(--muted);white-space:nowrap">${formatDate(a.created_at)}</td>
       <td>${getStatusBadgeKo(a.status, a.auto_reject_reason)}</td>
       <td style="white-space:nowrap">
-        ${a.status==='pending'?`<div style="display:flex;gap:4px"><button class="btn btn-green btn-xs" ${_dRem<=0?'disabled style="background:var(--muted);opacity:.5;cursor:not-allowed"':''}onclick="updateAppStatus('${a.id}','approved')">승인</button><button class="btn btn-ghost btn-xs" style="color:var(--red);border-color:var(--red)" onclick="updateAppStatus('${a.id}','rejected')">미승인</button></div>`
+        ${a.status==='pending'?`<div style="display:flex;gap:4px"><button class="btn btn-green btn-xs" ${(_dRem<=0 && !_u.is_audit)?'disabled style="background:var(--muted);opacity:.5;cursor:not-allowed"':''}onclick="updateAppStatus('${a.id}','approved')">승인</button><button class="btn btn-ghost btn-xs" style="color:var(--red);border-color:var(--red)" onclick="updateAppStatus('${a.id}','rejected')">미승인</button></div>`
         :`<div><div style="font-size:10px;color:var(--muted)">${esc(formatReviewer(a.reviewed_by))} ${a.reviewed_at?formatDateTime(a.reviewed_at):''}</div><button class="btn btn-ghost btn-xs" style="margin-top:4px;font-size:10px" onclick="updateAppStatus('${a.id}','pending')">되돌리기</button></div>`}
       </td>
     </tr>`;

--- a/dev/js/admin-deliverables.js
+++ b/dev/js/admin-deliverables.js
@@ -603,12 +603,12 @@ function renderDelivAppRow(g) {
   const pe = (rt === 'monitor') ? camp.purchase_end
            : (rt === 'visit')   ? camp.visit_end    : '';
 
-  return `<tr data-app-id="${esc(g.application_id)}" style="${rowStyle}">
+  return `<tr data-app-id="${esc(g.application_id)}" class="${inf.is_audit ? 'audit-row' : ''}" style="${rowStyle}">
     <td>${rtBadge}</td>
     <td>${campNoBadge}<div>${esc(camp.title || '—')}</div><div style="font-size:10px;color:var(--muted)">${esc(brandLabelAdmin(camp))}</div></td>
     <td style="font-size:11px;color:var(--ink);white-space:nowrap">${periodRangeCell(ps, pe)}</td>
     <td style="font-size:11px;color:var(--ink);white-space:nowrap">${periodSingleCell(camp.submission_end)}</td>
-    <td><div style="font-weight:600;color:var(--pink);cursor:pointer" onclick="openInfluencerModal('${esc(inf.id||'')}')">${infName}${(typeof influencerStatusBadges === 'function') ? influencerStatusBadges(inf) : ''}</div>${infSub ? `<div style="font-size:10px;color:var(--muted)">${infSub}</div>` : ''}<div style="margin-top:4px">${renderApplicantMsgBtn({id: g.application_id, campaign_id: (camp && camp.id) || ''})}</div></td>
+    <td><div style="font-weight:600;color:var(--pink);cursor:pointer" onclick="openInfluencerModal('${esc(inf.id||'')}')">${infName}${auditBadgeHtml(inf)}${(typeof influencerStatusBadges === 'function') ? influencerStatusBadges(inf) : ''}</div>${infSub ? `<div style="font-size:10px;color:var(--muted)">${infSub}</div>` : ''}<div style="margin-top:4px">${renderApplicantMsgBtn({id: g.application_id, campaign_id: (camp && camp.id) || ''})}</div></td>
     <td>${certStatusBadge(g)}</td>
     <td>${receiptCell}</td>
     <td>${resultCell}</td>

--- a/dev/js/admin-excel.js
+++ b/dev/js/admin-excel.js
@@ -318,6 +318,89 @@ function _confirmLargeExport(n) {
   });
 }
 
+// ──────────────────────────────────────────────────────────────────
+// 감사용 계정(influencers.is_audit) 격리 — 엑셀 산출물 보호 (PR D)
+//   광고주에게 전달하는 엑셀에 운영팀 시뮬레이션용 감사용 행이 섞이지 않도록
+//   다운로드 직전 「감사용 포함/제외」 확인 모달을 거치게 한다.
+//   confirmAuditExport(auditCount) → Promise<'include'|'exclude'|null>
+//     · auditCount<=0: 모달 없이 즉시 'exclude' (감사용 없으니 격리 무관)
+//     · null: 취소 (다운로드 중단)
+//   세션 동안 '다음부터 묻지 않음' 선택은 캐시 (페이지 새로고침 시 초기화)
+// ──────────────────────────────────────────────────────────────────
+var _auditExportChoiceCache = null; // null | 'include' | 'exclude'
+
+function confirmAuditExport(auditCount) {
+  if (!auditCount || auditCount <= 0) return Promise.resolve('exclude');
+  if (_auditExportChoiceCache) return Promise.resolve(_auditExportChoiceCache);
+
+  return new Promise(function(resolve) {
+    // 기존 잔존 모달 정리 (중복 클릭 대비)
+    var prev = document.getElementById('auditExportModal');
+    if (prev) prev.remove();
+
+    var overlay = document.createElement('div');
+    overlay.className = 'modal-overlay';
+    overlay.id = 'auditExportModal';
+    overlay.style.zIndex = '665'; // admMsgLightbox(660) 위 — 라이트박스 열린 채 다운로드 대비
+    overlay.innerHTML =
+      '<div class="modal" style="max-width:460px;border-radius:20px;margin:auto">' +
+        '<div class="modal-body" style="padding:24px 24px 20px">' +
+          '<div style="font-size:15px;font-weight:700;color:var(--ink);margin-bottom:10px">감사용 계정 포함 여부</div>' +
+          '<div style="font-size:13px;line-height:1.7;color:var(--ink)">' +
+            '현재 결과에 <b>감사용 계정 ' + esc(String(auditCount)) + '명</b>이 포함되어 있습니다.<br>' +
+            '감사용 계정은 운영팀 시뮬레이션용이라, 광고주에게 전달하는 산출물에는 제외하는 것을 권장합니다.' +
+          '</div>' +
+          '<div style="margin-top:16px;display:flex;flex-direction:column;gap:10px">' +
+            '<label style="display:flex;align-items:flex-start;gap:8px;font-size:13px;color:var(--ink);cursor:pointer">' +
+              '<input type="radio" name="auditExportChoice" value="exclude" checked style="margin-top:2px">' +
+              '<span><b>감사용 제외</b> (광고주 전달용)<br><span style="font-size:12px;color:var(--ink-light,#888)">감사용 ' + esc(String(auditCount)) + '명을 빼고 내보냅니다.</span></span>' +
+            '</label>' +
+            '<label style="display:flex;align-items:flex-start;gap:8px;font-size:13px;color:var(--ink);cursor:pointer">' +
+              '<input type="radio" name="auditExportChoice" value="include" style="margin-top:2px">' +
+              '<span><b>감사용 포함</b> (운영 내부 확인용)<br><span style="font-size:12px;color:var(--ink-light,#888)">감사용 ' + esc(String(auditCount)) + '명을 포함해 내보냅니다.</span></span>' +
+            '</label>' +
+          '</div>' +
+          '<label style="display:flex;align-items:center;gap:8px;margin-top:14px;font-size:12px;color:var(--ink-light,#888);cursor:pointer">' +
+            '<input type="checkbox" id="auditExportRemember"> 다음부터 묻지 않음 (현재 세션)' +
+          '</label>' +
+          '<div style="display:flex;gap:10px;margin-top:20px;justify-content:flex-end">' +
+            '<button class="btn btn-ghost" style="min-width:90px" data-audit-action="cancel">취소</button>' +
+            '<button class="btn btn-primary" style="min-width:120px" data-audit-action="ok">엑셀 다운로드</button>' +
+          '</div>' +
+        '</div>' +
+      '</div>';
+    document.body.appendChild(overlay);
+
+    var settled = false;
+    function done(result) {
+      if (settled) return;
+      settled = true;
+      document.removeEventListener('keydown', onEscAudit);
+      overlay.remove();
+      resolve(result);
+    }
+    function onEscAudit(e) {
+      if (e.key === 'Escape') done(null);
+    }
+    document.addEventListener('keydown', onEscAudit);
+    overlay.addEventListener('click', function(e) {
+      var action = e.target && e.target.getAttribute && e.target.getAttribute('data-audit-action');
+      if (action === 'cancel') { done(null); return; }
+      if (action === 'ok') {
+        var sel = overlay.querySelector('input[name="auditExportChoice"]:checked');
+        var choice = (sel && sel.value === 'include') ? 'include' : 'exclude';
+        var remember = overlay.querySelector('#auditExportRemember');
+        if (remember && remember.checked) _auditExportChoiceCache = choice;
+        done(choice);
+        return;
+      }
+      // 오버레이 바깥(배경) 클릭은 취소로 처리
+      if (e.target === overlay) { done(null); }
+    });
+    overlay.classList.add('open');
+  });
+}
+
 // 캠페인 다중 선택 신청자 엑셀 — 시트1 캠페인 정보 + 시트2 통합 신청자 리스트
 //   idsOverride: 인자로 직접 ids 배열 받기 가능 (단일 캠페인 더보기 메뉴 호출용)
 async function exportSelectedCampaignsApplicants(idsOverride) {
@@ -345,6 +428,16 @@ async function exportSelectedCampaignsApplicants(idsOverride) {
       var apps = await fetchApplications({ campaign_id: c.id });
       appsByCampId[c.id] = apps || [];
       (apps || []).forEach(function(a){ a._campMeta = c; allCampApps.push(a); });
+    }
+
+    // 감사용 계정 격리 — 이 엑셀에 실제 들어갈 신청자 중 감사용 인플 수 계산 후 포함/제외 확인
+    var auditEmails = {};
+    allCampApps.forEach(function(a){ var u = userByEmail[a.user_email]; if (u && u.is_audit && a.user_email) auditEmails[a.user_email] = true; });
+    var auditCount = Object.keys(auditEmails).length;
+    var auditChoice = await confirmAuditExport(auditCount);
+    if (auditChoice === null) return; // 취소 — finally 에서 _markExportEnd
+    if (auditChoice === 'exclude') {
+      allCampApps = allCampApps.filter(function(a){ var u = userByEmail[a.user_email]; return !(u && u.is_audit); });
     }
 
     var wb = new ExcelJS.Workbook();
@@ -482,6 +575,17 @@ async function exportSelectedCampaignsDeliverables(idsOverride) {
     // 인플루언서 id 매핑 (단일 함수와 동일 패턴)
     var usersById = {};
     (users || []).forEach(function(u){ if (u && u.id) usersById[u.id] = u; });
+
+    // 감사용 계정 격리 — 이 엑셀에 실제 들어갈 결과물 중 감사용 인플 수 계산 후 포함/제외 확인
+    var auditUserIds = {};
+    allDelivs.forEach(function(d){ var u = usersById[d.user_id]; if (u && u.is_audit && d.user_id) auditUserIds[d.user_id] = true; });
+    var auditCount = Object.keys(auditUserIds).length;
+    var auditChoice = await confirmAuditExport(auditCount);
+    if (auditChoice === null) return; // 취소 — finally 에서 _markExportEnd
+    if (auditChoice === 'exclude') {
+      allDelivs = allDelivs.filter(function(d){ var u = usersById[d.user_id]; return !(u && u.is_audit); });
+      if (allDelivs.length === 0) { toast('감사용 제외 후 남은 결과물이 없습니다', 'warn'); return; }
+    }
 
     // 영수증·리뷰 이미지 Image→Canvas→JPEG 재인코딩 (CORS·포맷 호환성)
     var imgBuffers = {};
@@ -756,6 +860,17 @@ async function exportCampaignApplicationsExcel(campId) {
     var userByEmail = {};
     (users || []).forEach(function(u){ if (u.email) userByEmail[u.email] = u; });
 
+    // 감사용 계정 격리 — 이 엑셀에 실제 들어갈 신청자 중 감사용 인플 수 계산 후 포함/제외 확인
+    var auditEmails = {};
+    apps.forEach(function(a){ var u = userByEmail[a.user_email]; if (u && u.is_audit && a.user_email) auditEmails[a.user_email] = true; });
+    var auditCount = Object.keys(auditEmails).length;
+    var auditChoice = await confirmAuditExport(auditCount);
+    if (auditChoice === null) return; // 취소 — finally 에서 _markExportEnd
+    if (auditChoice === 'exclude') {
+      apps = apps.filter(function(a){ var u = userByEmail[a.user_email]; return !(u && u.is_audit); });
+      if (!apps.length) { toast('감사용 제외 후 남은 신청자가 없습니다', 'warn'); return; }
+    }
+
     var statusLabel = function(s) {
       if (s === 'approved') return '승인';
       if (s === 'pending') return '심사중';
@@ -910,6 +1025,20 @@ async function exportCampaignDeliverables(campId) {
     var users = await fetchInfluencers();
     var userById = {};
     (users || []).forEach(function(u){ if (u && u.id) userById[u.id] = u; });
+
+    // 감사용 계정 격리 — 이 엑셀에 실제 들어갈 결과물·승인신청 중 감사용 인플 수 계산 후 포함/제외 확인
+    //   (multi-channel monitor 위임 경로보다 먼저 처리해 양쪽 모두 적용)
+    var auditUserIds = {};
+    delivs.forEach(function(d){ var u = userById[d.user_id]; if (u && u.is_audit && d.user_id) auditUserIds[d.user_id] = true; });
+    (approvedApps || []).forEach(function(app){ var u = userById[app.user_id]; if (u && u.is_audit && app.user_id) auditUserIds[app.user_id] = true; });
+    var auditCount = Object.keys(auditUserIds).length;
+    var auditChoice = await confirmAuditExport(auditCount);
+    if (auditChoice === null) return; // 취소 — finally 에서 _markExportEnd
+    if (auditChoice === 'exclude') {
+      delivs = (delivs || []).filter(function(d){ var u = userById[d.user_id]; return !(u && u.is_audit); });
+      approvedApps = (approvedApps || []).filter(function(app){ var u = userById[app.user_id]; return !(u && u.is_audit); });
+      if (!delivs.length && !approvedApps.length) { toast('감사용 제외 후 남은 결과물이 없습니다', 'warn'); return; }
+    }
 
     // 3-1) monitor + 캠페인 채널 N개면 채널별 결과물 컬럼 펼침 (사양 2 PR 3, 2026-05-28)
     //   gifting/visit·채널 없는 레거시 monitor는 기존 22컬럼 단일 결과물 코드 그대로.
@@ -1638,6 +1767,15 @@ async function exportInfluencersExcel() {
 
   _markExportStart();
   try {
+    // 감사용 계정 격리 — 현재 필터 결과 중 감사용 인플 수 계산 후 포함/제외 확인
+    var auditCount = rows.filter(function(u){ return u && u.is_audit; }).length;
+    var auditChoice = await confirmAuditExport(auditCount);
+    if (auditChoice === null) return; // 취소 — finally 에서 _markExportEnd
+    if (auditChoice === 'exclude') {
+      rows = rows.filter(function(u){ return !(u && u.is_audit); });
+      if (!rows.length) { toast('감사용 제외 후 남은 인플루언서가 없습니다', 'warn'); return; }
+    }
+
     await loadExcelJS();
     var wb = new ExcelJS.Workbook();
     var ws = wb.addWorksheet('인플루언서');

--- a/dev/js/admin-influencers.js
+++ b/dev/js/admin-influencers.js
@@ -239,8 +239,8 @@ function buildInfRowAll(u) {
     return `<div style="max-width:140px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap" title="${safe}">${inner}</div>`;
   };
   const ellip = (s, w=140) => `<div style="max-width:${w}px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap" title="${esc(s||'')}">${esc(s)||'—'}</div>`;
-  return `<tr data-id="${esc(u.id)}"${u.is_blacklisted?' style="opacity:.55"':''}>
-    <td><div style="font-weight:600;color:var(--pink);cursor:pointer" onclick="openInfluencerDetail('${u.id}')">${esc(u.name_kanji||u.name)||'—'}${adminBadge(u.email)}${influencerStatusBadges(u)}</div><div style="font-size:11px;color:var(--muted)">${esc(u.email)}</div></td>
+  return `<tr data-id="${esc(u.id)}" class="${u.is_audit?'audit-row':''}"${u.is_blacklisted?' style="opacity:.55"':''}>
+    <td><div style="font-weight:600;color:var(--pink);cursor:pointer" onclick="openInfluencerDetail('${u.id}')">${esc(u.name_kanji||u.name)||'—'}${auditBadgeHtml(u)}${adminBadge(u.email)}${influencerStatusBadges(u)}</div><div style="font-size:11px;color:var(--muted)">${esc(u.email)}</div></td>
     <td>${snsCell('instagram', u.ig)}<div style="font-size:11px;color:var(--muted)">${igF}명</div></td>
     <td>${snsCell('x', u.x)}<div style="font-size:11px;color:var(--muted)">${xF}명</div></td>
     <td>${snsCell('tiktok', u.tiktok)}<div style="font-size:11px;color:var(--muted)">${ttF}명</div></td>
@@ -385,7 +385,49 @@ async function openInfluencerDetail(userId) {
     </td></tr>`;
   }).join('') : '<tr><td colspan="4" style="text-align:center;color:var(--muted);padding:24px">신청 이력 없음</td></tr>';
 
+  // 감사용 흔적 청소 — super_admin + 감사용 계정(is_audit=true)일 때만 노출.
+  // 일반 인플 상세에는 절대 렌더하지 않음(매번 innerHTML 초기화로 stale 방지).
+  const auditBox = $('infDetailAuditPurge');
+  if (auditBox) {
+    const isSuper = currentAdminInfo?.role === 'super_admin';
+    if (isSuper && u.is_audit === true) {
+      auditBox.innerHTML = `
+        <div class="admin-card" style="border:1px solid var(--line)">
+          <div class="admin-card-header"><span class="admin-card-title">감사용 흔적 청소</span></div>
+          <div style="padding:16px">
+            <p style="font-size:13px;color:var(--muted);margin:0 0 12px">모든 감사용 계정의 응모·결과물·메시지·알림을 한 번에 삭제합니다. 감사용 계정 자체는 유지됩니다.</p>
+            <button class="btn btn-sm" style="background:#C62828;color:#fff;border:none" onclick="purgeAllAuditData()"><span class="material-icons-round notranslate" translate="no" style="font-size:16px;vertical-align:middle;margin-right:4px">cleaning_services</span>전체 흔적 청소</button>
+          </div>
+        </div>`;
+    } else {
+      auditBox.innerHTML = '';
+    }
+  }
+
   openModal('influencerFullDetailModal');
+}
+
+// 전체 감사용 흔적 청소 — super_admin 전용.
+// 모든 감사용 계정(is_audit=true)의 응모·결과물·메시지·알림을 삭제(계정 자체는 유지).
+async function purgeAllAuditData() {
+  if (currentAdminInfo?.role !== 'super_admin') return;
+  const ok = await showConfirm('모든 감사용 계정의 응모·결과물·메시지·알림을 삭제합니다. 감사용 계정 자체는 유지됩니다. 되돌릴 수 없습니다. 진행할까요?');
+  if (!ok) return;
+  try {
+    const res = await purgeAuditDataAll();
+    const rpc = res?.rpc;
+    if (!rpc || rpc.status === 'no_audit_account' || !rpc.deleted || (rpc.deleted.applications || 0) === 0) {
+      toast('삭제할 감사용 데이터 없음', '');
+    } else {
+      const n = rpc.deleted.applications || 0;
+      toast(`감사용 응모 ${n}건·결과물 등 삭제됨`, 'success');
+    }
+    closeModal('influencerFullDetailModal');
+    await refreshPane('influencers');
+  } catch (e) {
+    console.error('[purgeAllAuditData]', e);
+    toast('감사용 흔적 청소 실패: ' + (e?.message || e), 'error');
+  }
 }
 
 // 상태 관리 패널 — 인증 토글 + 블랙리스트 등록/해제 + 사유 입력

--- a/dev/js/admin-messaging.js
+++ b/dev/js/admin-messaging.js
@@ -341,7 +341,7 @@ function renderInboxThreadList() {
     return `<button type="button" class="inbox-thread-item ${active}" onclick="openInboxThread('${esc(t.application_id)}')">
       <span class="inbox-thread-main">
         ${campLabel}
-        <span class="inbox-thread-name">${kanji}${kana ? `<span class="inbox-thread-kana">${kana}</span>` : ''}</span>
+        <span class="inbox-thread-name">${kanji}${auditBadgeHtml(inf)}${kana ? `<span class="inbox-thread-kana">${kana}</span>` : ''}</span>
         ${email ? `<span class="inbox-thread-email">${email}</span>` : ''}
         ${previewHtml}
       </span>

--- a/dev/js/admin.js
+++ b/dev/js/admin.js
@@ -2275,10 +2275,13 @@ function toggleCampMoreMenu(e, btnEl, campId, campTitle) {
   const rect = btnEl.getBoundingClientRect();
   const menu = document.createElement('div');
   menu.className = 'camp-more-menu';
-  // 변경 이력 항목은 super_admin 한정 (audit 데이터, 일반 매니저 노출 X)
+  // 변경 이력·감사용 흔적 청소 항목은 super_admin 한정 (audit 데이터, 일반 매니저 노출 X)
   const isSuper = currentAdminInfo?.role === 'super_admin';
   const historyItem = isSuper
     ? `<div class="camp-more-item" onclick="openCautionHistoryModal('${campId}')"><span class="material-icons-round notranslate" translate="no" style="font-size:16px">history</span>변경 이력</div>`
+    : '';
+  const auditPurgeItem = isSuper
+    ? `<div class="camp-more-item camp-more-danger" onclick="purgeCampaignAuditData('${campId}')"><span class="material-icons-round notranslate" translate="no" style="font-size:16px">cleaning_services</span>감사용 흔적 청소</div>`
     : '';
   menu.innerHTML = `
     <div class="camp-more-item" onclick="openEditCampaign('${campId}')"><span class="material-icons-round notranslate" translate="no" style="font-size:16px">edit</span>편집</div>
@@ -2286,6 +2289,7 @@ function toggleCampMoreMenu(e, btnEl, campId, campTitle) {
     <div class="camp-more-item" onclick="exportCampaignDeliverables('${campId}')"><span class="material-icons-round notranslate" translate="no" style="font-size:16px">download</span>결과물 엑셀</div>
     <div class="camp-more-item" onclick="exportCampaignApplicationsExcel('${campId}')"><span class="material-icons-round notranslate" translate="no" style="font-size:16px">download</span>신청자 엑셀</div>
     ${historyItem}
+    ${auditPurgeItem}
     <div class="camp-more-item camp-more-danger" data-camp-title="${esc(campTitle)}" onclick="deleteCampaign('${campId}',this.dataset.campTitle)"><span class="material-icons-round notranslate" translate="no" style="font-size:16px">delete</span>삭제</div>
   `;
   document.body.appendChild(menu);
@@ -2300,6 +2304,31 @@ function toggleCampMoreMenu(e, btnEl, campId, campTitle) {
       }
     });
   }, 0);
+}
+
+// 캠페인별 감사용 흔적 청소 — super_admin 전용.
+// 이 캠페인에서 감사용 계정(is_audit=true)이 만든 응모·결과물·메시지를 모두 삭제한다.
+async function purgeCampaignAuditData(campId) {
+  document.querySelectorAll('.camp-more-menu').forEach(d => d.remove());
+  if (currentAdminInfo?.role !== 'super_admin') return;
+  const ok = await showConfirm('이 캠페인에서 감사용 계정이 만든 응모·결과물·메시지를 모두 삭제합니다. 되돌릴 수 없습니다. 진행할까요?');
+  if (!ok) return;
+  try {
+    const res = await purgeAuditDataForCampaign(campId);
+    const rpc = res?.rpc;
+    if (!rpc || rpc.status === 'no_audit_account' || !rpc.deleted || (rpc.deleted.applications || 0) === 0) {
+      toast('삭제할 감사용 데이터 없음', '');
+    } else {
+      const n = rpc.deleted.applications || 0;
+      toast(`감사용 응모 ${n}건·결과물 등 삭제됨`, 'success');
+    }
+    // 진행현황 페인이 열려 있으면 그쪽을, 아니면 캠페인 목록 갱신
+    const applicantsPaneActive = $('adminPane-camp-applicants')?.classList.contains('on');
+    await refreshPane(applicantsPaneActive ? 'camp-applicants' : 'campaigns');
+  } catch (e) {
+    console.error('[purgeCampaignAuditData]', e);
+    toast('감사용 흔적 청소 실패: ' + (e?.message || e), 'error');
+  }
 }
 
 function toggleStatusDropdown(badgeEl) {

--- a/dev/lib/shared.js
+++ b/dev/lib/shared.js
@@ -354,6 +354,34 @@ function normalizeUrlInput(raw) {
   return { url: s, changed: s !== orig };
 }
 
+// 감사용 계정 「감사용」 배지 HTML.
+// inf: influencers 행(is_audit) 또는 is_audit 불리언을 가진 객체.
+// 감사용이 아니면 빈 문자열 — 일반 인플루언서 행에는 아무것도 출력 안 함.
+// 통계·산출물에서 격리된 계정임을 운영자가 한눈에 구분하도록 모든 인플·응모·결과물 행에 호출.
+function auditBadgeHtml(inf) {
+  if (!inf || !inf.is_audit) return '';
+  return '<span class="audit-badge" title="감사용 계정 — 통계·산출물에서 격리됨" translate="no">감사용</span>';
+}
+
+// 감사용 계정(is_audit) 회원번호(influencers.id) 집합 생성.
+// 관리자 화면에서 클라가 직접 응모 건수를 셀 때(빈자리·승인 차단) 감사용을 격리하기 위한 헬퍼.
+// applications 행에는 is_audit 가 없으므로 users(fetchInfluencers, is_audit 포함)에서 만든 집합을
+// user_id 로 대조한다(이메일 매칭보다 NULL·불일치·성능 위험이 없음).
+function buildAuditIdSet(users) {
+  return new Set((users || []).filter(u => u && u.is_audit).map(u => u.id));
+}
+
+// 특정 캠페인의 승인(approved) 응모 수를 감사용 제외로 계산.
+//   apps: applications 배열, campId: 캠페인 id(null 이면 전체), auditIds: buildAuditIdSet 결과.
+// 감사용 응모는 모집 슬롯·빈자리 집계에서 빠져야 한다(설계 격리, 마이그레이션 179·181).
+function countNonAuditApproved(apps, campId, auditIds) {
+  return (apps || []).filter(a =>
+    a.status === 'approved'
+    && (campId == null || a.campaign_id === campId)
+    && !(auditIds && auditIds.has(a.user_id))
+  ).length;
+}
+
 // raw 입력값(URL 또는 핸들)에서 핸들만 뽑아 반환. 실패 시 trim된 원본 반환.
 // 저장 정책: 핸들만(@ 없이) 저장. 표시 시 UI에서 @ prefix 부여.
 function extractSnsHandle(channel, raw) {

--- a/dev/lib/storage.js
+++ b/dev/lib/storage.js
@@ -265,12 +265,17 @@ async function incrementViewCount(campId) {
 }
 
 // ── Influencers ──
-async function fetchInfluencers() {
+// includeAudit 기본 true = 기존 동작 보존(전건 반환).
+// 통계·엑셀 등 실수 집계가 필요한 호출처만 { includeAudit: false } 를 명시 전달(PR D/F에서).
+async function fetchInfluencers(opts = {}) {
   if (!db) return [];
+  const { includeAudit = true } = opts;
   try {
-    return await fetchAllPaged(() =>
-      db.from('influencers').select('*').order('created_at', {ascending: true})
-    );
+    return await fetchAllPaged(() => {
+      let q = db.from('influencers').select('*').order('created_at', {ascending: true});
+      if (!includeAudit) q = q.eq('is_audit', false);
+      return q;
+    });
   } catch(e) {
     return [];
   }
@@ -1177,7 +1182,7 @@ async function fetchInfluencersByIds(userIds) {
   if (!db || !userIds?.length) return {};
   try {
     const {data, error} = await db?.from('influencers')
-      .select('id, name, name_kana, email, primary_sns, line_id, is_verified, verified_at, is_blacklisted, blacklisted_at, blacklist_reason_code, blacklist_reason_note')
+      .select('id, name, name_kana, email, primary_sns, line_id, is_verified, verified_at, is_blacklisted, blacklisted_at, blacklist_reason_code, blacklist_reason_note, is_audit')
       .in('id', userIds);
     if (error) throw error;
     const map = {};
@@ -3199,5 +3204,123 @@ async function resolveClientError(id, status, note) {
     });
     return true;
   } catch (e) { console.error('[resolveClientError]', e); return false; }
+}
+
+// ── 감사용 계정 흔적 제거 (super_admin 한정, 마이그레이션 179) ──
+//
+// ⚠️ Storage 삭제 메모
+//   - 메시지 첨부(message_attachments): RPC가 반환하는 값이 이미 버킷 상대 경로({appId}/{uuid}.jpg)이므로
+//     그대로 db.storage.from('application-message-attachments').remove([...paths]) 로 삭제.
+//   - 영수증 이미지(receipt_images): receipt_url 컬럼에는 Supabase 공개 전체 URL이 저장됨
+//     (https://{project}.supabase.co/storage/v1/object/public/campaign-images/receipts/...).
+//     db.storage.remove()는 버킷 내 상대 경로를 요구하므로, URL에서
+//     '/storage/v1/object/public/campaign-images/' 접두사를 제거해 상대 경로를 추출한다.
+//     변환 실패 시(접두사 불일치 등) 그 파일만 건너뛰고 나머지는 계속 처리.
+
+// Supabase 공개 URL → campaign-images 버킷 상대 경로 변환 헬퍼
+// 예: 'https://xxx.supabase.co/storage/v1/object/public/campaign-images/receipts/abc.jpg'
+//     → 'receipts/abc.jpg'
+// 변환 불가(형식 불일치)면 null 반환.
+function _receiptUrlToStoragePath(url) {
+  if (!url || typeof url !== 'string') return null;
+  const MARKER = '/storage/v1/object/public/campaign-images/';
+  const idx = url.indexOf(MARKER);
+  if (idx === -1) return null;
+  const path = url.slice(idx + MARKER.length);
+  return path || null;
+}
+
+// Storage 파일 삭제 공통 헬퍼.
+// bucket: 버킷명, paths: 상대 경로 배열 (빈 배열이면 즉시 반환).
+// 삭제 실패 시 에러를 throw 하지 않고 {ok, failedPaths} 형태로 반환
+// (일부 경로 삭제 실패가 흔적 제거 전체를 막지 않도록).
+async function _deleteStorageFiles(bucket, paths) {
+  if (!db || !Array.isArray(paths) || paths.length === 0) return { ok: true, failedPaths: [] };
+  try {
+    const { error } = await db.storage.from(bucket).remove(paths);
+    if (error) {
+      console.warn(`[_deleteStorageFiles] ${bucket} 삭제 실패:`, error);
+      return { ok: false, failedPaths: paths };
+    }
+    return { ok: true, failedPaths: [] };
+  } catch (e) {
+    console.warn(`[_deleteStorageFiles] ${bucket} 예외:`, e);
+    return { ok: false, failedPaths: paths };
+  }
+}
+
+// 모든 감사용 계정 흔적 제거.
+// RPC 성공 후 Storage 파일(메시지 첨부 + 영수증 이미지)도 후속 삭제.
+// 반환: { rpc, storageResult } — 호출처가 삭제 결과를 사용자에게 표시할 수 있도록.
+async function purgeAuditDataAll() {
+  if (!db) throw new Error('DB 미연결');
+  return await retryWithRefresh(async () => {
+    const { data, error } = await db.rpc('purge_audit_data_all');
+    if (error) throw error;
+
+    // RPC 결과가 'no_audit_account' 이면 삭제할 Storage 파일도 없음
+    if (!data || data.status === 'no_audit_account') {
+      return { rpc: data, storageResult: null };
+    }
+
+    const storagePaths = data.storage_paths_to_delete || {};
+
+    // 메시지 첨부: 이미 버킷 상대 경로
+    const msgPaths = Array.isArray(storagePaths.message_attachments)
+      ? storagePaths.message_attachments.filter(Boolean)
+      : [];
+
+    // 영수증: 전체 URL → 버킷 상대 경로 변환 (변환 불가 항목 제외)
+    const receiptPaths = Array.isArray(storagePaths.receipt_images)
+      ? storagePaths.receipt_images.map(_receiptUrlToStoragePath).filter(Boolean)
+      : [];
+
+    const [msgResult, receiptResult] = await Promise.all([
+      _deleteStorageFiles(MSG_ATTACH_BUCKET, msgPaths),
+      _deleteStorageFiles('campaign-images', receiptPaths),
+    ]);
+
+    return {
+      rpc: data,
+      storageResult: { msgResult, receiptResult },
+    };
+  });
+}
+
+// 특정 캠페인의 감사용 계정 흔적 제거.
+// 반환: { rpc, storageResult }
+async function purgeAuditDataForCampaign(campaignId) {
+  if (!db) throw new Error('DB 미연결');
+  return await retryWithRefresh(async () => {
+    const { data, error } = await db.rpc('purge_audit_data_for_campaign', {
+      p_campaign_id: campaignId,
+    });
+    if (error) throw error;
+
+    // 응모건 0건 케이스: storage_paths_to_delete 키 자체가 없을 수 있음
+    if (!data || data.status === 'no_audit_account' || !data.storage_paths_to_delete) {
+      return { rpc: data, storageResult: null };
+    }
+
+    const storagePaths = data.storage_paths_to_delete;
+
+    const msgPaths = Array.isArray(storagePaths.message_attachments)
+      ? storagePaths.message_attachments.filter(Boolean)
+      : [];
+
+    const receiptPaths = Array.isArray(storagePaths.receipt_images)
+      ? storagePaths.receipt_images.map(_receiptUrlToStoragePath).filter(Boolean)
+      : [];
+
+    const [msgResult, receiptResult] = await Promise.all([
+      _deleteStorageFiles(MSG_ATTACH_BUCKET, msgPaths),
+      _deleteStorageFiles('campaign-images', receiptPaths),
+    ]);
+
+    return {
+      rpc: data,
+      storageResult: { msgResult, receiptResult },
+    };
+  });
 }
 

--- a/index.html
+++ b/index.html
@@ -2225,6 +2225,34 @@ function normalizeUrlInput(raw) {
   return { url: s, changed: s !== orig };
 }
 
+// 감사용 계정 「감사용」 배지 HTML.
+// inf: influencers 행(is_audit) 또는 is_audit 불리언을 가진 객체.
+// 감사용이 아니면 빈 문자열 — 일반 인플루언서 행에는 아무것도 출력 안 함.
+// 통계·산출물에서 격리된 계정임을 운영자가 한눈에 구분하도록 모든 인플·응모·결과물 행에 호출.
+function auditBadgeHtml(inf) {
+  if (!inf || !inf.is_audit) return '';
+  return '<span class="audit-badge" title="감사용 계정 — 통계·산출물에서 격리됨" translate="no">감사용</span>';
+}
+
+// 감사용 계정(is_audit) 회원번호(influencers.id) 집합 생성.
+// 관리자 화면에서 클라가 직접 응모 건수를 셀 때(빈자리·승인 차단) 감사용을 격리하기 위한 헬퍼.
+// applications 행에는 is_audit 가 없으므로 users(fetchInfluencers, is_audit 포함)에서 만든 집합을
+// user_id 로 대조한다(이메일 매칭보다 NULL·불일치·성능 위험이 없음).
+function buildAuditIdSet(users) {
+  return new Set((users || []).filter(u => u && u.is_audit).map(u => u.id));
+}
+
+// 특정 캠페인의 승인(approved) 응모 수를 감사용 제외로 계산.
+//   apps: applications 배열, campId: 캠페인 id(null 이면 전체), auditIds: buildAuditIdSet 결과.
+// 감사용 응모는 모집 슬롯·빈자리 집계에서 빠져야 한다(설계 격리, 마이그레이션 179·181).
+function countNonAuditApproved(apps, campId, auditIds) {
+  return (apps || []).filter(a =>
+    a.status === 'approved'
+    && (campId == null || a.campaign_id === campId)
+    && !(auditIds && auditIds.has(a.user_id))
+  ).length;
+}
+
 // raw 입력값(URL 또는 핸들)에서 핸들만 뽑아 반환. 실패 시 trim된 원본 반환.
 // 저장 정책: 핸들만(@ 없이) 저장. 표시 시 UI에서 @ prefix 부여.
 function extractSnsHandle(channel, raw) {
@@ -4517,12 +4545,17 @@ async function incrementViewCount(campId) {
 }
 
 // ── Influencers ──
-async function fetchInfluencers() {
+// includeAudit 기본 true = 기존 동작 보존(전건 반환).
+// 통계·엑셀 등 실수 집계가 필요한 호출처만 { includeAudit: false } 를 명시 전달(PR D/F에서).
+async function fetchInfluencers(opts = {}) {
   if (!db) return [];
+  const { includeAudit = true } = opts;
   try {
-    return await fetchAllPaged(() =>
-      db.from('influencers').select('*').order('created_at', {ascending: true})
-    );
+    return await fetchAllPaged(() => {
+      let q = db.from('influencers').select('*').order('created_at', {ascending: true});
+      if (!includeAudit) q = q.eq('is_audit', false);
+      return q;
+    });
   } catch(e) {
     return [];
   }
@@ -5429,7 +5462,7 @@ async function fetchInfluencersByIds(userIds) {
   if (!db || !userIds?.length) return {};
   try {
     const {data, error} = await db?.from('influencers')
-      .select('id, name, name_kana, email, primary_sns, line_id, is_verified, verified_at, is_blacklisted, blacklisted_at, blacklist_reason_code, blacklist_reason_note')
+      .select('id, name, name_kana, email, primary_sns, line_id, is_verified, verified_at, is_blacklisted, blacklisted_at, blacklist_reason_code, blacklist_reason_note, is_audit')
       .in('id', userIds);
     if (error) throw error;
     const map = {};
@@ -7451,6 +7484,124 @@ async function resolveClientError(id, status, note) {
     });
     return true;
   } catch (e) { console.error('[resolveClientError]', e); return false; }
+}
+
+// ── 감사용 계정 흔적 제거 (super_admin 한정, 마이그레이션 179) ──
+//
+// ⚠️ Storage 삭제 메모
+//   - 메시지 첨부(message_attachments): RPC가 반환하는 값이 이미 버킷 상대 경로({appId}/{uuid}.jpg)이므로
+//     그대로 db.storage.from('application-message-attachments').remove([...paths]) 로 삭제.
+//   - 영수증 이미지(receipt_images): receipt_url 컬럼에는 Supabase 공개 전체 URL이 저장됨
+//     (https://{project}.supabase.co/storage/v1/object/public/campaign-images/receipts/...).
+//     db.storage.remove()는 버킷 내 상대 경로를 요구하므로, URL에서
+//     '/storage/v1/object/public/campaign-images/' 접두사를 제거해 상대 경로를 추출한다.
+//     변환 실패 시(접두사 불일치 등) 그 파일만 건너뛰고 나머지는 계속 처리.
+
+// Supabase 공개 URL → campaign-images 버킷 상대 경로 변환 헬퍼
+// 예: 'https://xxx.supabase.co/storage/v1/object/public/campaign-images/receipts/abc.jpg'
+//     → 'receipts/abc.jpg'
+// 변환 불가(형식 불일치)면 null 반환.
+function _receiptUrlToStoragePath(url) {
+  if (!url || typeof url !== 'string') return null;
+  const MARKER = '/storage/v1/object/public/campaign-images/';
+  const idx = url.indexOf(MARKER);
+  if (idx === -1) return null;
+  const path = url.slice(idx + MARKER.length);
+  return path || null;
+}
+
+// Storage 파일 삭제 공통 헬퍼.
+// bucket: 버킷명, paths: 상대 경로 배열 (빈 배열이면 즉시 반환).
+// 삭제 실패 시 에러를 throw 하지 않고 {ok, failedPaths} 형태로 반환
+// (일부 경로 삭제 실패가 흔적 제거 전체를 막지 않도록).
+async function _deleteStorageFiles(bucket, paths) {
+  if (!db || !Array.isArray(paths) || paths.length === 0) return { ok: true, failedPaths: [] };
+  try {
+    const { error } = await db.storage.from(bucket).remove(paths);
+    if (error) {
+      console.warn(`[_deleteStorageFiles] ${bucket} 삭제 실패:`, error);
+      return { ok: false, failedPaths: paths };
+    }
+    return { ok: true, failedPaths: [] };
+  } catch (e) {
+    console.warn(`[_deleteStorageFiles] ${bucket} 예외:`, e);
+    return { ok: false, failedPaths: paths };
+  }
+}
+
+// 모든 감사용 계정 흔적 제거.
+// RPC 성공 후 Storage 파일(메시지 첨부 + 영수증 이미지)도 후속 삭제.
+// 반환: { rpc, storageResult } — 호출처가 삭제 결과를 사용자에게 표시할 수 있도록.
+async function purgeAuditDataAll() {
+  if (!db) throw new Error('DB 미연결');
+  return await retryWithRefresh(async () => {
+    const { data, error } = await db.rpc('purge_audit_data_all');
+    if (error) throw error;
+
+    // RPC 결과가 'no_audit_account' 이면 삭제할 Storage 파일도 없음
+    if (!data || data.status === 'no_audit_account') {
+      return { rpc: data, storageResult: null };
+    }
+
+    const storagePaths = data.storage_paths_to_delete || {};
+
+    // 메시지 첨부: 이미 버킷 상대 경로
+    const msgPaths = Array.isArray(storagePaths.message_attachments)
+      ? storagePaths.message_attachments.filter(Boolean)
+      : [];
+
+    // 영수증: 전체 URL → 버킷 상대 경로 변환 (변환 불가 항목 제외)
+    const receiptPaths = Array.isArray(storagePaths.receipt_images)
+      ? storagePaths.receipt_images.map(_receiptUrlToStoragePath).filter(Boolean)
+      : [];
+
+    const [msgResult, receiptResult] = await Promise.all([
+      _deleteStorageFiles(MSG_ATTACH_BUCKET, msgPaths),
+      _deleteStorageFiles('campaign-images', receiptPaths),
+    ]);
+
+    return {
+      rpc: data,
+      storageResult: { msgResult, receiptResult },
+    };
+  });
+}
+
+// 특정 캠페인의 감사용 계정 흔적 제거.
+// 반환: { rpc, storageResult }
+async function purgeAuditDataForCampaign(campaignId) {
+  if (!db) throw new Error('DB 미연결');
+  return await retryWithRefresh(async () => {
+    const { data, error } = await db.rpc('purge_audit_data_for_campaign', {
+      p_campaign_id: campaignId,
+    });
+    if (error) throw error;
+
+    // 응모건 0건 케이스: storage_paths_to_delete 키 자체가 없을 수 있음
+    if (!data || data.status === 'no_audit_account' || !data.storage_paths_to_delete) {
+      return { rpc: data, storageResult: null };
+    }
+
+    const storagePaths = data.storage_paths_to_delete;
+
+    const msgPaths = Array.isArray(storagePaths.message_attachments)
+      ? storagePaths.message_attachments.filter(Boolean)
+      : [];
+
+    const receiptPaths = Array.isArray(storagePaths.receipt_images)
+      ? storagePaths.receipt_images.map(_receiptUrlToStoragePath).filter(Boolean)
+      : [];
+
+    const [msgResult, receiptResult] = await Promise.all([
+      _deleteStorageFiles(MSG_ATTACH_BUCKET, msgPaths),
+      _deleteStorageFiles('campaign-images', receiptPaths),
+    ]);
+
+    return {
+      rpc: data,
+      storageResult: { msgResult, receiptResult },
+    };
+  });
 }
 
 

--- a/supabase/migrations/179_audit_influencer_account.sql
+++ b/supabase/migrations/179_audit_influencer_account.sql
@@ -1,0 +1,650 @@
+-- ============================================================
+-- 179_audit_influencer_account.sql
+-- 감사용 인플루언서 계정 메커니즘 — PR A: 데이터베이스 단계
+--
+-- 목적:
+--   운영서버에서 관리자가 인플루언서 동선을 시뮬레이션할 수 있는
+--   감사용 계정 메커니즘을 DB 레벨로 구현한다.
+--   실 운영 데이터(통계·슬롯·엑셀 산출물)에 흔적·영향 0.
+--
+-- 포함 내용:
+--   1. influencers.is_audit 컬럼 + partial index
+--   2. get_campaign_application_counts() RPC 재정의 (마이그레이션 151 재정의)
+--   3. check_monitor_slots() + recompute_campaign_applied_count() 재정의
+--      → 슬롯/applied_count 집계에서 감사용 응모 격리
+--   4. purge_audit_data_all()      — 전체 흔적 제거 RPC (super_admin 한정)
+--   5. purge_audit_data_for_campaign() — 캠페인별 흔적 제거 RPC (super_admin 한정)
+--   6. 공용 감사용 인플루언서 계정 시드 (auth.users + auth.identities + influencers)
+--
+-- 롤백:
+--   DROP FUNCTION IF EXISTS public.purge_audit_data_for_campaign(uuid);
+--   DROP FUNCTION IF EXISTS public.purge_audit_data_all();
+--   -- check_monitor_slots / recompute_campaign_applied_count / get_campaign_application_counts
+--   -- 는 각각 048, 058, 151 마이그레이션 내용으로 다시 CREATE OR REPLACE 하면 됨
+--   ALTER TABLE public.influencers DROP COLUMN IF EXISTS is_audit;
+--   DROP INDEX IF EXISTS idx_influencers_is_audit;
+--   -- 시드 계정 롤백 (순서 중요 — influencers → identities → users):
+--   DELETE FROM public.influencers WHERE email = 'audit.test@reverb.jp';
+--   DELETE FROM auth.identities
+--     WHERE user_id = (SELECT id FROM auth.users WHERE email = 'audit.test@reverb.jp');
+--   DELETE FROM auth.users WHERE email = 'audit.test@reverb.jp';
+-- ============================================================
+
+
+-- ============================================================
+-- 1. influencers.is_audit 컬럼 추가
+-- ============================================================
+
+ALTER TABLE public.influencers
+  ADD COLUMN IF NOT EXISTS is_audit boolean NOT NULL DEFAULT false;
+
+COMMENT ON COLUMN public.influencers.is_audit IS
+  '감사용 계정 여부. true이면 응모·결과물·통계·엑셀 산출물에서 격리됨. '
+  '운영팀 본인이 인플루언서 동선을 시뮬레이션할 때 사용하는 계정에만 설정. '
+  '감사용 응모는 모집 슬롯·응모수·진행 현황 집계에 포함되지 않는다.';
+
+-- partial index: 감사용 계정은 전체 인플루언서 중 극소수이므로 partial index로 비용 최소화
+CREATE INDEX IF NOT EXISTS idx_influencers_is_audit
+  ON public.influencers (id)
+  WHERE is_audit = true;
+
+
+-- ============================================================
+-- 2. get_campaign_application_counts() RPC 재정의
+--    원본: 마이그레이션 151_campaign_application_counts.sql
+--    변경: JOIN influencers + WHERE is_audit = false 추가
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.get_campaign_application_counts()
+RETURNS TABLE(
+  campaign_id uuid,
+  total       bigint,
+  approved    bigint,
+  pending     bigint
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+BEGIN
+  -- 관리자 전용 함수 — 비관리자 접근 차단
+  IF NOT public.is_admin() THEN
+    RAISE EXCEPTION '권한 없음' USING ERRCODE = '42501';
+  END IF;
+
+  RETURN QUERY
+  SELECT
+    a.campaign_id,
+    COUNT(*)                                FILTER (WHERE a.status <> 'cancelled') AS total,
+    COUNT(*) FILTER (WHERE a.status = 'approved') AS approved,
+    COUNT(*) FILTER (WHERE a.status = 'pending')  AS pending
+  FROM public.applications a
+  JOIN public.influencers i ON i.id = a.user_id  -- [179] 감사용 격리를 위해 JOIN 추가
+  WHERE i.is_audit = false                        -- [179] 감사용 응모 제외
+  GROUP BY a.campaign_id;
+END;
+$$;
+
+-- 기존 151 권한 정책 유지
+REVOKE ALL ON FUNCTION public.get_campaign_application_counts() FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.get_campaign_application_counts() FROM anon;
+GRANT EXECUTE ON FUNCTION public.get_campaign_application_counts() TO authenticated;
+
+
+-- ============================================================
+-- 3a. check_monitor_slots() 재정의
+--    원본: 마이그레이션 048_monitor_slots_guard.sql
+--    변경: 현재 신청수 카운트 시 감사용(is_audit=true) 응모 제외
+--
+--    조사 결과 (슬롯 격리 확인):
+--    - monitor(리뷰어) 캠페인의 슬롯 차단은 DB BEFORE INSERT 트리거
+--      (trg_monitor_slots_guard → check_monitor_slots)로 구현됨
+--    - 현재 로직은 status IN ('pending','approved') 카운트 기준
+--    - 감사용 계정이 응모하면 이 카운트에 포함되어 실 인플루언서 응모가
+--      차단될 수 있으므로, 감사용 응모를 카운트에서 제외하도록 재정의
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.check_monitor_slots()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_recruit_type text;
+  v_slots        int;
+  v_current      int;
+  v_is_audit     boolean;
+BEGIN
+  -- 감사용 계정의 응모이면 슬롯 검증 건너뜀 (슬롯 소진하지 않음)
+  SELECT i.is_audit INTO v_is_audit
+    FROM public.influencers i
+   WHERE i.id = NEW.user_id;
+
+  IF COALESCE(v_is_audit, false) = true THEN
+    RETURN NEW;  -- [179] 감사용 응모는 슬롯 차단 없이 통과
+  END IF;
+
+  -- FOR UPDATE: 동시 INSERT 시 campaigns 행에 row lock → 레이스 컨디션 방어
+  SELECT c.recruit_type, c.slots
+    INTO v_recruit_type, v_slots
+    FROM public.campaigns c
+   WHERE c.id = NEW.campaign_id
+     FOR UPDATE;
+
+  -- 리뷰어(monitor)가 아니거나 slots 미설정이면 통과
+  IF v_recruit_type IS DISTINCT FROM 'monitor' OR COALESCE(v_slots, 0) <= 0 THEN
+    RETURN NEW;
+  END IF;
+
+  -- 현재 신청수 카운트 (pending + approved — rejected·감사용 제외)
+  SELECT COUNT(*)
+    INTO v_current
+    FROM public.applications a
+    JOIN public.influencers i ON i.id = a.user_id  -- [179] 감사용 격리
+   WHERE a.campaign_id = NEW.campaign_id
+     AND a.status IN ('pending', 'approved')
+     AND i.is_audit = false;                       -- [179] 감사용 응모 제외
+
+  IF v_current >= v_slots THEN
+    RAISE EXCEPTION '모집 정원이 마감되었습니다 (slots: %, current: %)', v_slots, v_current
+      USING ERRCODE = 'P0001';
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+-- 트리거는 이미 048에서 등록됨 — 재등록으로 함수 교체만 반영
+DROP TRIGGER IF EXISTS trg_monitor_slots_guard ON public.applications;
+CREATE TRIGGER trg_monitor_slots_guard
+  BEFORE INSERT ON public.applications
+  FOR EACH ROW
+  EXECUTE FUNCTION public.check_monitor_slots();
+
+
+-- ============================================================
+-- 3b. recompute_campaign_applied_count() 재정의
+--    원본: 마이그레이션 058_applied_count_trigger.sql
+--    변경: 카운트에서 is_audit = true 응모 제외
+--    (campaigns.applied_count = 인플루언서 앱 카드에 표시되는 "N명 신청" 숫자)
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.recompute_campaign_applied_count(p_campaign_id uuid)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_count int;
+BEGIN
+  SELECT COUNT(*)
+    INTO v_count
+    FROM public.applications a
+    JOIN public.influencers i ON i.id = a.user_id  -- [179] 감사용 격리
+   WHERE a.campaign_id = p_campaign_id
+     AND a.status IN ('pending', 'approved')
+     AND i.is_audit = false;                       -- [179] 감사용 응모 제외
+
+  UPDATE public.campaigns
+     SET applied_count = v_count
+   WHERE id = p_campaign_id;
+END;
+$$;
+
+COMMENT ON FUNCTION public.recompute_campaign_applied_count(uuid) IS
+  '[058/179] campaign_id 하나의 applied_count를 applications 집계(pending+approved, '
+  '감사용 제외)로 재계산. SECURITY DEFINER — 트리거 함수에서만 호출.';
+
+
+-- ============================================================
+-- 4. purge_audit_data_all() — 전체 흔적 제거 RPC
+-- ============================================================
+--
+-- cascade 관계 정리 (마이그레이션 코드 직접 확인 결과):
+--
+-- [applications DELETE 시 cascade 대상 — FK ON DELETE CASCADE 확인]
+--   - deliverables            035: application_id FK ON DELETE CASCADE → OK
+--   - deliverable_events      035: deliverable_id FK ON DELETE CASCADE (deliverables 통해 cascade)
+--   - receipt_edit_history    128: deliverable_id FK ON DELETE CASCADE (deliverables 통해 cascade)
+--   - application_events      131: application_id FK ON DELETE CASCADE → OK
+--   - application_messages    144: application_id FK ON DELETE CASCADE → OK
+--   - application_message_admin_reads  144: message_id FK ON DELETE CASCADE (messages 통해 cascade)
+--   - application_message_resolutions  144: application_id FK ON DELETE CASCADE → OK
+--   - application_message_hide_history 144: message_id FK ON DELETE CASCADE (messages 통해 cascade)
+--     ⚠️ application_message_hide_history는 super_admin 내부 감사 테이블이지만
+--        message_id → application_messages → applications 의 cascade chain 위에 있으므로
+--        applications DELETE 시 함께 삭제됨. 감사용 계정 데이터이므로 허용.
+--   - faq_interactions        146: application_id FK ON DELETE SET NULL → 행 유지, application_id만 NULL
+--
+-- [influencers 기준 직접 cascade 대상 — user_id/influencer_id FK 확인]
+--   - campaign_promo_digest_sent     139: influencer_id FK ON DELETE CASCADE → OK
+--   - campaign_promo_exposure        139: influencer_id FK ON DELETE CASCADE → OK
+--   - campaign_promo_email_clicks    139: influencer_id FK ON DELETE CASCADE → OK
+--   - policy_notice_log (153)        153: influencer_id FK ON DELETE CASCADE → OK
+--   - client_error_logs (165)        165: user_id FK ON DELETE SET NULL → 행 유지
+--
+-- [별도 명시 DELETE 필요한 테이블]
+--   - notifications  037: user_id → auth.users(id) ON DELETE CASCADE
+--     → auth.users를 건드리지 않으므로 자동 삭제 안 됨. 명시적 DELETE 필요.
+--   - faq_interactions 146: influencer_id → auth.users(id) ON DELETE CASCADE
+--     → 감사용 계정은 auth.users를 삭제하지 않으므로 명시적 DELETE 필요.
+--     (application_id SET NULL으로 행은 남겨두므로 influencer_id로 직접 DELETE)
+--
+-- [Storage 첨부 파일 — cascade 불가, 클라이언트가 후속 삭제해야 함]
+--   - application-message-attachments 버킷: path = applications/{app_id}/{message_id}/...
+--   - deliverables 결과물 이미지: campaign-images/receipts/... (영수증 이미지)
+--   → 이 함수는 삭제 전 path를 수집해 반환값에 포함. 클라이언트가 후속 삭제.
+--
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.purge_audit_data_all()
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_audit_ids      uuid[];
+  v_app_ids        uuid[];
+  v_del_app_count  int;
+  v_del_notif_count int;
+  v_del_faq_count  int;
+  v_msg_attach_paths text[];
+  v_receipt_paths    text[];
+BEGIN
+  -- super_admin 전용
+  IF NOT public.is_super_admin() THEN
+    RAISE EXCEPTION '권한 없음 (super_admin 한정)' USING ERRCODE = '42501';
+  END IF;
+
+  -- 감사용 계정 ID 수집
+  SELECT array_agg(id) INTO v_audit_ids
+    FROM public.influencers
+   WHERE is_audit = true;
+
+  IF v_audit_ids IS NULL OR cardinality(v_audit_ids) = 0 THEN
+    RETURN jsonb_build_object('status', 'no_audit_account');
+  END IF;
+
+  -- 감사용 계정의 응모건 ID 수집 (Storage path 수집 + 삭제 범위 파악용)
+  SELECT array_agg(id) INTO v_app_ids
+    FROM public.applications
+   WHERE user_id = ANY(v_audit_ids);
+
+  -- ① Storage 파일 path 수집 (클라이언트가 후속 삭제할 수 있도록 반환)
+  --    응모건 메시지 첨부 파일
+  -- ⚠️ attachments는 [{path, name, size, mime}] 객체 배열(144 정의)이므로
+  --    jsonb_array_elements + ->>'path'로 path만 추출 (text 추출 함수 사용 금지)
+  SELECT array_agg(DISTINCT elem->>'path')
+    INTO v_msg_attach_paths
+  FROM public.application_messages am,
+       jsonb_array_elements(
+         COALESCE(am.attachments, '[]'::jsonb)
+       ) AS elem
+  WHERE am.application_id = ANY(v_app_ids)
+    AND elem->>'path' IS NOT NULL;
+
+  --    영수증 이미지 (receipt_url)
+  SELECT array_agg(DISTINCT d.receipt_url)
+    INTO v_receipt_paths
+    FROM public.deliverables d
+   WHERE d.application_id = ANY(v_app_ids)
+     AND d.receipt_url IS NOT NULL;
+
+  -- ② notifications 명시적 DELETE (auth.users cascade 미적용)
+  DELETE FROM public.notifications
+   WHERE user_id = ANY(v_audit_ids);
+  GET DIAGNOSTICS v_del_notif_count = ROW_COUNT;
+
+  -- ③ faq_interactions 명시적 DELETE (influencer_id 기준, auth.users cascade 미적용)
+  DELETE FROM public.faq_interactions
+   WHERE influencer_id = ANY(v_audit_ids);
+  GET DIAGNOSTICS v_del_faq_count = ROW_COUNT;
+
+  -- ④ applications DELETE
+  --    → deliverables, deliverable_events, receipt_edit_history,
+  --      application_events, application_messages,
+  --      application_message_admin_reads, application_message_resolutions,
+  --      application_message_hide_history 모두 cascade
+  DELETE FROM public.applications
+   WHERE user_id = ANY(v_audit_ids);
+  GET DIAGNOSTICS v_del_app_count = ROW_COUNT;
+
+  RETURN jsonb_build_object(
+    'status',            'ok',
+    'audit_account_count', cardinality(v_audit_ids),
+    'deleted', jsonb_build_object(
+      'applications',  v_del_app_count,
+      'notifications', v_del_notif_count,
+      'faq_interactions', v_del_faq_count
+    ),
+    'storage_paths_to_delete', jsonb_build_object(
+      'message_attachments', COALESCE(to_jsonb(v_msg_attach_paths), '[]'::jsonb),
+      'receipt_images',      COALESCE(to_jsonb(v_receipt_paths),    '[]'::jsonb)
+    )
+  );
+END;
+$$;
+
+COMMENT ON FUNCTION public.purge_audit_data_all() IS
+  '[179] 모든 감사용 계정(is_audit=true)의 응모·결과물·알림·메시지·FAQ 이력을 삭제. '
+  'super_admin 전용. 반환값의 storage_paths_to_delete를 참조해 클라이언트가 Storage 파일도 삭제할 것.';
+
+REVOKE ALL ON FUNCTION public.purge_audit_data_all() FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.purge_audit_data_all() TO authenticated;
+
+
+-- ============================================================
+-- 5. purge_audit_data_for_campaign() — 캠페인별 흔적 제거 RPC
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.purge_audit_data_for_campaign(p_campaign_id uuid)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_audit_ids       uuid[];
+  v_app_ids         uuid[];
+  v_del_app_count   int;
+  v_del_notif_count int;
+  v_msg_attach_paths text[];
+  v_receipt_paths    text[];
+BEGIN
+  -- super_admin 전용
+  IF NOT public.is_super_admin() THEN
+    RAISE EXCEPTION '권한 없음 (super_admin 한정)' USING ERRCODE = '42501';
+  END IF;
+
+  -- 감사용 계정 ID 수집
+  SELECT array_agg(id) INTO v_audit_ids
+    FROM public.influencers
+   WHERE is_audit = true;
+
+  IF v_audit_ids IS NULL OR cardinality(v_audit_ids) = 0 THEN
+    RETURN jsonb_build_object('status', 'no_audit_account');
+  END IF;
+
+  -- 해당 캠페인의 감사용 응모건 ID 수집
+  SELECT array_agg(id) INTO v_app_ids
+    FROM public.applications
+   WHERE campaign_id = p_campaign_id
+     AND user_id = ANY(v_audit_ids);
+
+  IF v_app_ids IS NULL OR cardinality(v_app_ids) = 0 THEN
+    RETURN jsonb_build_object(
+      'status',      'ok',
+      'campaign_id', p_campaign_id,
+      'deleted', jsonb_build_object('applications', 0, 'notifications', 0)
+    );
+  END IF;
+
+  -- ① Storage 파일 path 수집
+  -- ⚠️ attachments는 [{path, name, size, mime}] 객체 배열(144 정의)이므로
+  --    jsonb_array_elements + ->>'path'로 path만 추출 (text 추출 함수 사용 금지)
+  SELECT array_agg(DISTINCT elem->>'path')
+    INTO v_msg_attach_paths
+  FROM public.application_messages am,
+       jsonb_array_elements(
+         COALESCE(am.attachments, '[]'::jsonb)
+       ) AS elem
+  WHERE am.application_id = ANY(v_app_ids)
+    AND elem->>'path' IS NOT NULL;
+
+  SELECT array_agg(DISTINCT d.receipt_url)
+    INTO v_receipt_paths
+    FROM public.deliverables d
+   WHERE d.application_id = ANY(v_app_ids)
+     AND d.receipt_url IS NOT NULL;
+
+  -- ② 해당 캠페인 감사용 응모건의 notifications 삭제
+  --    (notifications.ref_table = 'applications' AND ref_id = ANY(v_app_ids) 건)
+  DELETE FROM public.notifications
+   WHERE user_id = ANY(v_audit_ids)
+     AND (
+       ref_id = ANY(v_app_ids)   -- 응모건 직접 참조 알림
+       OR (
+         ref_table = 'deliverables'
+         AND ref_id IN (
+           SELECT id FROM public.deliverables
+            WHERE application_id = ANY(v_app_ids)
+         )
+       )
+     );
+  GET DIAGNOSTICS v_del_notif_count = ROW_COUNT;
+
+  -- faq_interactions는 의도적으로 정리하지 않음:
+  --   campaign_id 컬럼이 없어 캠페인 단위 삭제 불가. 여기서 influencer_id로 지우면
+  --   다른 캠페인 열람 이력까지 삭제됨. 응모건 cascade로 application_id만 SET NULL 처리되고
+  --   FAQ 측정 통계는 전체 청소(purge_audit_data_all)에서만 제거된다.
+
+  -- ③ applications DELETE → cascade로 하위 테이블 모두 정리
+  DELETE FROM public.applications
+   WHERE id = ANY(v_app_ids);
+  GET DIAGNOSTICS v_del_app_count = ROW_COUNT;
+
+  RETURN jsonb_build_object(
+    'status',      'ok',
+    'campaign_id', p_campaign_id,
+    'deleted', jsonb_build_object(
+      'applications',  v_del_app_count,
+      'notifications', v_del_notif_count
+    ),
+    'storage_paths_to_delete', jsonb_build_object(
+      'message_attachments', COALESCE(to_jsonb(v_msg_attach_paths), '[]'::jsonb),
+      'receipt_images',      COALESCE(to_jsonb(v_receipt_paths),    '[]'::jsonb)
+    )
+  );
+END;
+$$;
+
+COMMENT ON FUNCTION public.purge_audit_data_for_campaign(uuid) IS
+  '[179] 특정 캠페인(p_campaign_id)에서 감사용 계정(is_audit=true)이 만든 '
+  '응모·결과물·메시지·알림을 삭제. super_admin 전용. '
+  '반환값의 storage_paths_to_delete를 참조해 클라이언트가 Storage 파일도 삭제할 것.';
+
+REVOKE ALL ON FUNCTION public.purge_audit_data_for_campaign(uuid) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.purge_audit_data_for_campaign(uuid) TO authenticated;
+
+
+-- ============================================================
+-- 6. 공용 감사용 인플루언서 계정 시드
+-- ============================================================
+--
+-- ⚠️ 환경별 이메일 설정:
+--   - 개발서버: audit.test@reverb.jp  (아래 SQL 그대로 사용)
+--   - 운영서버: 운영 적용 시 이메일을 실제 감사용 메일 주소로 변경할 것
+--     예: audit@globalreverb.com 또는 super_admin 본인 이메일 별칭
+--   - 이메일을 바꿀 때는 아래 4곳 모두 변경:
+--     ① DO 블록 상단 SELECT ... WHERE email = ... (존재 확인 조건절)
+--     ② auth.users INSERT email 값 + raw_user_meta_data 안 email
+--     ③ auth.identities INSERT identity_data jsonb 안 email
+--     ④ influencers UPSERT email 값
+--
+-- ⚠️ 비밀번호:
+--   - 아래 시드는 'AuditReverb2026!' 로 설정됨 (bcrypt round 10)
+--   - 운영 적용 시 반드시 강력한 비밀번호로 변경하거나,
+--     적용 후 관리자 페이지에서 초대 메일 발송(resetPasswordForEmail)로 재설정할 것
+--
+-- ⚠️ influencers 자동 생성 트리거 (마이그레이션 014):
+--   - auth.users INSERT 시 handle_new_user() 트리거가 실행되어
+--     influencers 행이 자동 생성됨 (id, email, created_at만 채움)
+--   - 따라서 auth.users INSERT 후 influencers를 INSERT하면 충돌(PK 중복) 발생
+--   - 아래 시드는 auth.users INSERT → 트리거 자동 생성된 influencers 행을
+--     UPDATE로 is_audit=true + 프로필 세팅하는 방식으로 작성
+--   - ON CONFLICT (id) DO UPDATE 패턴을 사용해 멱등성 확보
+--
+-- ⚠️ 멱등성:
+--   - 이미 같은 이메일이 존재하면 auth.users는 ON CONFLICT (email) DO NOTHING
+--   - auth.identities는 ON CONFLICT (provider, provider_id) DO NOTHING
+--   - influencers는 ON CONFLICT (id) DO UPDATE로 프로필 갱신
+-- ============================================================
+
+DO $$
+DECLARE
+  v_audit_uid uuid;
+  v_existing_uid uuid;
+BEGIN
+  -- 이미 동일 이메일의 auth.users 행이 있는지 확인
+  SELECT id INTO v_existing_uid
+    FROM auth.users
+   WHERE email = 'audit.test@reverb.jp';
+
+  IF v_existing_uid IS NOT NULL THEN
+    -- 이미 존재 → auth.users/identities는 건너뛰고 influencers만 갱신
+    v_audit_uid := v_existing_uid;
+
+  ELSE
+    -- 신규 생성
+    v_audit_uid := gen_random_uuid();
+
+    -- auth.users 행 삽입
+    -- supabase.md 「Auth 레코드 완전성」 준수:
+    --   email_confirmed_at = now()     (NULL이면 로그인 차단)
+    --   raw_app_meta_data              (provider 필수)
+    --   raw_user_meta_data             (sub, email, email_verified 필수)
+    --   token 필드들                   (NULL 금지, 빈 문자열 필수)
+    INSERT INTO auth.users (
+      instance_id,
+      id,
+      aud,
+      role,
+      email,
+      encrypted_password,
+      email_confirmed_at,
+      created_at,
+      updated_at,
+      raw_app_meta_data,
+      raw_user_meta_data,
+      confirmation_token,
+      recovery_token,
+      email_change_token_new,
+      email_change,
+      phone_change,
+      phone_change_token,
+      reauthentication_token
+    ) VALUES (
+      '00000000-0000-0000-0000-000000000000',
+      v_audit_uid,
+      'authenticated',
+      'authenticated',
+      'audit.test@reverb.jp',
+      extensions.crypt('AuditReverb2026!', extensions.gen_salt('bf', 10)),
+      now(),
+      now(),
+      now(),
+      jsonb_build_object('provider', 'email', 'providers', jsonb_build_array('email')),
+      jsonb_build_object(
+        'sub',            v_audit_uid::text,
+        'email',          'audit.test@reverb.jp',
+        'email_verified', true,
+        'phone_verified', false
+      ),
+      '',  -- confirmation_token
+      '',  -- recovery_token
+      '',  -- email_change_token_new
+      '',  -- email_change
+      '',  -- phone_change
+      '',  -- phone_change_token
+      ''   -- reauthentication_token
+    );
+
+    -- auth.identities 행 삽입 (없으면 로그인 불가)
+    INSERT INTO auth.identities (
+      id,                  -- [179 fix] 프로젝트 선례(029·031·012) 일치 — 일부 Supabase 버전은 NOT NULL/무DEFAULT
+      provider_id,
+      user_id,
+      identity_data,
+      provider,
+      last_sign_in_at,
+      created_at,
+      updated_at
+    ) VALUES (
+      gen_random_uuid(),   -- [179 fix] identities 행 자체 PK
+      v_audit_uid::text,
+      v_audit_uid,
+      jsonb_build_object(
+        'sub',   v_audit_uid::text,
+        'email', 'audit.test@reverb.jp',
+        'email_verified', true
+      ),
+      'email',
+      now(),
+      now(),
+      now()
+    ) ON CONFLICT (provider, provider_id) DO NOTHING;
+
+  END IF;
+
+  -- influencers 행 갱신 (트리거 자동 생성 행 + is_audit 설정)
+  -- 트리거가 생성한 행에 is_audit=true + 프로필 세팅
+  INSERT INTO public.influencers (
+    id,
+    email,
+    name,
+    name_kanji,
+    name_kana,
+    is_audit,
+    terms_agreed_at,
+    privacy_agreed_at,
+    created_at
+  ) VALUES (
+    v_audit_uid,
+    'audit.test@reverb.jp',
+    '監査用',
+    '監査用',
+    'かんさよう',
+    true,
+    now(),
+    now(),
+    now()
+  )
+  ON CONFLICT (id) DO UPDATE SET
+    name           = EXCLUDED.name,
+    name_kanji     = EXCLUDED.name_kanji,
+    name_kana      = EXCLUDED.name_kana,
+    is_audit       = true,
+    terms_agreed_at   = COALESCE(public.influencers.terms_agreed_at, now()),
+    privacy_agreed_at = COALESCE(public.influencers.privacy_agreed_at, now());
+
+END $$;
+
+
+-- ============================================================
+-- 검증 쿼리 (마이그레이션 후 SQL Editor에서 1단계씩 실행)
+-- ============================================================
+
+-- 1단계: is_audit 컬럼 추가 확인
+-- SELECT column_name, data_type, column_default, is_nullable
+--   FROM information_schema.columns
+--  WHERE table_schema = 'public'
+--    AND table_name = 'influencers'
+--    AND column_name = 'is_audit';
+-- 기대: boolean, false, NO
+
+-- 2단계: 시드 계정 생성 확인
+-- SELECT u.email, u.email_confirmed_at IS NOT NULL AS confirmed,
+--        i.is_audit, i.name_kanji
+--   FROM auth.users u
+--   JOIN public.influencers i ON i.id = u.id
+--  WHERE u.email = 'audit.test@reverb.jp';
+-- 기대: confirmed=true, is_audit=true, name_kanji='監査用'
+
+-- 3단계: auth.identities 행 확인
+-- SELECT provider, provider_id
+--   FROM auth.identities
+--  WHERE user_id = (SELECT id FROM auth.users WHERE email = 'audit.test@reverb.jp');
+-- 기대: provider='email', provider_id=<uuid>
+
+-- 4단계: get_campaign_application_counts RPC 확인 (감사용 응모 제외 여부)
+-- SELECT * FROM public.get_campaign_application_counts() LIMIT 5;
+-- 기대: 감사용 계정 응모건 미포함, 일반 집계와 동일
+
+-- 5단계: 슬롯 트리거 함수 존재 확인
+-- SELECT proname, prosecdef FROM pg_proc
+--  WHERE proname IN ('check_monitor_slots', 'recompute_campaign_applied_count')
+--    AND pronamespace = 'public'::regnamespace;
+-- 기대: 2건, prosecdef = true

--- a/supabase/migrations/181_brand_ops_exclude_audit.sql
+++ b/supabase/migrations/181_brand_ops_exclude_audit.sql
@@ -1,0 +1,531 @@
+-- ════════════════════════════════════════════════════════════════════
+-- migration 181: get_brand_ops_overview / get_brand_ops_detail
+--                감사용 계정(is_audit=true) 응모 격리
+-- ────────────────────────────────────────────────────────────────────
+-- 배경:
+--   마이그레이션 179에서 influencers.is_audit 컬럼을 추가하고
+--   get_campaign_application_counts / check_monitor_slots /
+--   recompute_campaign_applied_count 에 감사용 격리를 적용했으나,
+--   운영 현황 페인(#brand-ops)의 아래 두 함수는 누락됨.
+--
+--   - get_brand_ops_overview : app_agg CTE 가 applications 를 집계 →
+--     승인수(approved_total) / 모집률(recruit_rate) / alert_level 에
+--     감사용 응모가 포함되어 광고주 보고용 수치가 부정확.
+--   - get_brand_ops_detail   : 캠페인별 4개 상관 서브쿼리
+--     (신청 내부 × 2 + 외부 × 2) 가 applications / deliverables 를
+--     직접 집계 → approved_app_count / deliv_submitted_inf /
+--     deliv_total / deliv_approved 에 감사용 수치 혼입.
+--
+-- 변경 내용:
+--   [overview] app_agg CTE 에서
+--     JOIN public.influencers i ON i.id = a.user_id
+--     AND i.is_audit = false
+--   추가.
+--
+--   [detail] approved_app_count 서브쿼리 2지점에서
+--     AND NOT EXISTS (
+--       SELECT 1 FROM public.influencers i
+--        WHERE i.id = a.user_id AND i.is_audit = true
+--     )
+--   추가 (코릴레이티드 서브쿼리 내 추가 JOIN 보다 안전).
+--
+--   [detail] deliverables 집계 3지점(deliv_submitted_inf / deliv_total /
+--     deliv_approved) 에서 감사용 인플루언서의 결과물을 제외:
+--     AND NOT EXISTS (
+--       SELECT 1 FROM public.influencers i
+--        WHERE i.id = d.user_id AND i.is_audit = true
+--     )
+--   추가.
+--
+--   함수 시그니처·반환 타입·기존 로직(alert_level·alert_reasons·날짜·
+--   channel 등)·SECURITY DEFINER·SET search_path·GRANT 모두 불변.
+--
+-- 최신 정의 기준:
+--   get_brand_ops_overview : 148_brand_ops_alert_reasons.sql
+--   get_brand_ops_detail   : 150_brand_ops_detail_camp_periods.sql
+--
+-- ────────────────────────────────────────────────────────────────────
+-- ROLLBACK:
+--   get_brand_ops_overview 복원:
+--     148_brand_ops_alert_reasons.sql 의
+--     CREATE FUNCTION public.get_brand_ops_overview ... 블록 전체를
+--     SQL Editor 에서 재실행 (DROP 없이 CREATE OR REPLACE 가능하나
+--     반환 TABLE 컬럼 수가 같으므로 직접 대체 가능).
+--
+--   get_brand_ops_detail 복원:
+--     150_brand_ops_detail_camp_periods.sql 의
+--     CREATE OR REPLACE FUNCTION public.get_brand_ops_detail ... 블록 전체를
+--     SQL Editor 에서 재실행.
+-- ════════════════════════════════════════════════════════════════════
+
+BEGIN;
+
+-- ════════════════════════════════════════════════════════════════════
+-- 1. get_brand_ops_overview 재정의
+--    최신 정의: 148_brand_ops_alert_reasons.sql
+--    격리 추가: app_agg CTE 의 applications JOIN 에 감사용 제외 조건
+-- ════════════════════════════════════════════════════════════════════
+
+-- 반환 TABLE 구조가 148 과 동일하므로 CREATE OR REPLACE 사용 가능.
+-- (120 → 148 때는 컬럼 수 변경으로 DROP 필요했으나 181 은 구조 불변)
+CREATE OR REPLACE FUNCTION public.get_brand_ops_overview(p_company_id uuid DEFAULT NULL)
+RETURNS TABLE (
+  -- ── 기존 19컬럼 (148 기준 순서·이름 불변) ──
+  brand_id              uuid,
+  brand_seq             integer,
+  brand_no              text,
+  brand_name_ko         text,
+  brand_name_ja         text,
+  company_id            uuid,
+  company_name_ko       text,
+  open_applications     bigint,
+  active_campaigns      bigint,
+  slots_total           bigint,
+  approved_total        bigint,
+  recruit_rate          numeric,
+  deliverable_total     bigint,
+  deliverable_approved  bigint,
+  deliverable_rate      numeric,
+  d3_count              bigint,
+  cancel_7d             bigint,
+  last_activity_at      timestamptz,
+  alert_level           text,
+  -- ── 신규 3컬럼 (148 추가, 불변) ──
+  alert_reasons         text[],
+  soonest_deadline      date,
+  d1_count              bigint
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+BEGIN
+  IF NOT public.is_admin() THEN
+    RAISE EXCEPTION 'forbidden' USING ERRCODE = '42501';
+  END IF;
+
+  RETURN QUERY
+  WITH
+  -- ── 1. 캠페인 집계 (148 기준 그대로) ──
+  camp_agg AS (
+    SELECT
+      c.brand_id,
+      SUM(CASE WHEN c.status IN ('active','scheduled') THEN 1 ELSE 0 END)::bigint AS active_camps,
+      SUM(CASE WHEN c.status IN ('active','scheduled','closed') THEN COALESCE(c.slots,0) ELSE 0 END)::bigint AS slots_sum,
+      SUM(CASE
+            WHEN c.status = 'active'
+             AND c.deadline IS NOT NULL
+             AND c.deadline <= (current_date + INTERVAL '3 days')::date
+            THEN 1 ELSE 0
+          END)::bigint AS d3,
+      SUM(CASE
+            WHEN c.status = 'active'
+             AND c.deadline IS NOT NULL
+             AND c.deadline <= (current_date + INTERVAL '1 days')::date
+            THEN 1 ELSE 0
+          END)::bigint AS d1,
+      MIN(CASE WHEN c.status = 'active' THEN c.deadline END) AS soonest_dl,
+      MAX(c.updated_at) AS latest_camp_update
+    FROM public.campaigns c
+    WHERE c.brand_id IS NOT NULL
+    GROUP BY c.brand_id
+  ),
+
+  -- ── 2. 신청 집계 — [181] 감사용 응모 제외 ──
+  -- 변경: influencers JOIN + is_audit = false 조건 추가.
+  -- 취소(cancelled_at) 도 감사용 제외하여 cancel_7d 수치도 정확하게.
+  app_agg AS (
+    SELECT c.brand_id,
+           COUNT(*) FILTER (WHERE a.status = 'approved')::bigint AS approved_cnt,
+           COUNT(*) FILTER (
+             WHERE a.cancelled_at IS NOT NULL
+               AND a.cancelled_at >= (now() - INTERVAL '7 days')
+           )::bigint AS cancel7,
+           GREATEST(MAX(a.created_at), MAX(a.reviewed_at), MAX(a.cancelled_at)) AS latest_app_update
+    FROM public.applications a
+    JOIN public.campaigns    c ON c.id = a.campaign_id
+    JOIN public.influencers  i ON i.id = a.user_id   -- [181] 감사용 격리용 JOIN
+    WHERE c.brand_id IS NOT NULL
+      AND i.is_audit = false                          -- [181] 감사용 응모 제외
+    GROUP BY c.brand_id
+  ),
+
+  -- ── 3. 결과물 집계 — [181] 감사용 인플루언서 결과물 제외 ──
+  -- deliverables.user_id 가 influencers.id 와 동일 경로이므로 JOIN 추가.
+  deliv_agg AS (
+    SELECT c.brand_id,
+           COUNT(*)::bigint AS deliv_total,
+           COUNT(*) FILTER (WHERE d.status = 'approved')::bigint AS deliv_approved
+    FROM public.deliverables d
+    JOIN public.campaigns    c ON c.id = d.campaign_id
+    JOIN public.influencers  i ON i.id = d.user_id   -- [181] 감사용 격리용 JOIN
+    WHERE c.brand_id IS NOT NULL
+      AND i.is_audit = false                          -- [181] 감사용 결과물 제외
+    GROUP BY c.brand_id
+  ),
+
+  -- ── 4. 광고주 신청(brand_applications) 집계 (148 기준 그대로) ──
+  brand_app_agg AS (
+    SELECT ba.brand_id,
+           COUNT(*) FILTER (WHERE ba.status NOT IN ('done','rejected'))::bigint AS open_apps,
+           MAX(ba.updated_at) AS latest_brand_app_update
+    FROM public.brand_applications ba
+    WHERE ba.brand_id IS NOT NULL
+    GROUP BY ba.brand_id
+  ),
+
+  -- ── 5. alert 조건 플래그 사전 계산 (148 기준 그대로) ──
+  flag_agg AS (
+    SELECT
+      b_id,
+      (d1 >= 1)                                                            AS flag_d1,
+      (cancel7 >= 5)                                                       AS flag_cancel_high,
+      (slots_sum > 0
+         AND recruit_pct < 30
+         AND soonest_dl IS NOT NULL
+         AND soonest_dl < (current_date + INTERVAL '7 days')::date)        AS flag_low_near,
+      (d3 >= 1)                                                            AS flag_d3,
+      (slots_sum > 0
+         AND recruit_pct < 50
+         AND (soonest_dl IS NULL
+              OR soonest_dl >= (current_date + INTERVAL '7 days')::date))  AS flag_low,
+      d1          AS d1_val,
+      d3          AS d3_val,
+      cancel7     AS cancel7_val,
+      slots_sum   AS slots_val,
+      soonest_dl  AS soonest_dl_val,
+      recruit_pct AS recruit_pct_val
+    FROM (
+      SELECT
+        b.id AS b_id,
+        COALESCE(ca.d1, 0)                                     AS d1,
+        COALESCE(ca.d3, 0)                                     AS d3,
+        COALESCE(aa.cancel7, 0)                                AS cancel7,
+        COALESCE(ca.slots_sum, 0)                              AS slots_sum,
+        ca.soonest_dl,
+        CASE
+          WHEN COALESCE(ca.slots_sum, 0) = 0 THEN NULL
+          ELSE ROUND(100.0 * COALESCE(aa.approved_cnt, 0) / ca.slots_sum, 1)
+        END AS recruit_pct
+      FROM public.brands b
+      LEFT JOIN camp_agg  ca ON ca.brand_id = b.id
+      LEFT JOIN app_agg   aa ON aa.brand_id = b.id
+      WHERE (p_company_id IS NULL OR b.company_id = p_company_id)
+    ) sub
+  )
+
+  -- ── 6. 최종 SELECT (148 기준 그대로) ──
+  SELECT
+    b.id                                                         AS brand_id,
+    b.brand_seq                                                  AS brand_seq,
+    b.brand_no                                                   AS brand_no,
+    b.name                                                       AS brand_name_ko,
+    b.name_ja                                                    AS brand_name_ja,
+    b.company_id                                                 AS company_id,
+    co.name_ko                                                   AS company_name_ko,
+    COALESCE(ba.open_apps,    0)::bigint                         AS open_applications,
+    COALESCE(ca.active_camps, 0)::bigint                         AS active_campaigns,
+    COALESCE(ca.slots_sum,    0)::bigint                         AS slots_total,
+    COALESCE(aa.approved_cnt, 0)::bigint                         AS approved_total,
+    fg.recruit_pct_val                                           AS recruit_rate,
+    COALESCE(da.deliv_total,    0)::bigint                       AS deliverable_total,
+    COALESCE(da.deliv_approved, 0)::bigint                       AS deliverable_approved,
+    CASE
+      WHEN COALESCE(da.deliv_total, 0) = 0 THEN NULL
+      ELSE ROUND(100.0 * COALESCE(da.deliv_approved, 0) / da.deliv_total, 1)
+    END                                                          AS deliverable_rate,
+    COALESCE(ca.d3, 0)::bigint                                   AS d3_count,
+    COALESCE(aa.cancel7, 0)::bigint                              AS cancel_7d,
+    GREATEST(
+      COALESCE(ca.latest_camp_update,      'epoch'::timestamptz),
+      COALESCE(aa.latest_app_update,       'epoch'::timestamptz),
+      COALESCE(ba.latest_brand_app_update, 'epoch'::timestamptz),
+      b.updated_at
+    )                                                            AS last_activity_at,
+    CASE
+      WHEN fg.flag_d1          THEN 'danger'
+      WHEN fg.flag_cancel_high THEN 'danger'
+      WHEN fg.flag_low_near    THEN 'danger'
+      WHEN fg.flag_d3          THEN 'warning'
+      WHEN fg.flag_low         THEN 'caution'
+      ELSE                          'normal'
+    END                                                          AS alert_level,
+    ARRAY_REMOVE(
+      ARRAY[
+        CASE WHEN fg.flag_d1          THEN 'd1_imminent'            END,
+        CASE WHEN fg.flag_d3 AND fg.d3_val > fg.d1_val THEN 'd3_imminent' END,
+        CASE WHEN fg.flag_cancel_high THEN 'cancel_7d_high'          END,
+        CASE WHEN fg.flag_low_near   THEN 'recruit_low_deadline_near' END,
+        CASE WHEN fg.flag_low        THEN 'recruit_low'              END
+      ],
+      NULL
+    )                                                            AS alert_reasons,
+    fg.soonest_dl_val                                            AS soonest_deadline,
+    fg.d1_val::bigint                                            AS d1_count
+  FROM public.brands b
+  LEFT JOIN public.companies      co ON co.id = b.company_id
+  LEFT JOIN brand_app_agg          ba ON ba.brand_id = b.id
+  LEFT JOIN camp_agg               ca ON ca.brand_id = b.id
+  LEFT JOIN app_agg                aa ON aa.brand_id = b.id
+  LEFT JOIN deliv_agg              da ON da.brand_id = b.id
+  JOIN  flag_agg                   fg ON fg.b_id    = b.id
+  WHERE
+    (p_company_id IS NULL OR b.company_id = p_company_id);
+END;
+$$;
+
+COMMENT ON FUNCTION public.get_brand_ops_overview(uuid) IS
+  '[120 → 148 → 181] 운영 현황 페인용 브랜드 카드 그리드 집계. '
+  '모집률·결과물률·D-3 임박·7일 취소·alert_level. '
+  '148 추가: alert_reasons(조건 코드 배열)/soonest_deadline/d1_count. '
+  '181 추가: app_agg/deliv_agg 에서 감사용(is_audit=true) 응모·결과물 제외. '
+  'is_admin() 가드.';
+
+REVOKE ALL ON FUNCTION public.get_brand_ops_overview(uuid) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.get_brand_ops_overview(uuid) FROM authenticated;
+REVOKE ALL ON FUNCTION public.get_brand_ops_overview(uuid) FROM anon;
+GRANT EXECUTE ON FUNCTION public.get_brand_ops_overview(uuid) TO authenticated;
+
+
+-- ════════════════════════════════════════════════════════════════════
+-- 2. get_brand_ops_detail 재정의
+--    최신 정의: 150_brand_ops_detail_camp_periods.sql
+--    격리 추가:
+--      approved_app_count  2지점 (신청 내부 캠페인 / 외부 캠페인)
+--      deliv_submitted_inf 2지점
+--      deliv_total         2지점
+--      deliv_approved      2지점
+--    → 합계 8지점에 NOT EXISTS 감사용 제외 조건 추가.
+-- ════════════════════════════════════════════════════════════════════
+
+CREATE OR REPLACE FUNCTION public.get_brand_ops_detail(p_brand_id uuid)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_brand          public.brands%ROWTYPE;
+  v_company        jsonb;
+  v_applications   jsonb;
+  v_external_camps jsonb;
+BEGIN
+  IF NOT public.is_admin() THEN
+    RAISE EXCEPTION 'forbidden' USING ERRCODE = '42501';
+  END IF;
+
+  SELECT * INTO v_brand FROM public.brands WHERE id = p_brand_id;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'brand_not_found' USING ERRCODE = '22023';
+  END IF;
+
+  -- 소속 회사 (선택)
+  IF v_brand.company_id IS NOT NULL THEN
+    SELECT jsonb_build_object(
+             'id',       co.id,
+             'name_ko',  co.name_ko,
+             'name_ja',  co.name_ja
+           )
+      INTO v_company
+      FROM public.companies co
+     WHERE co.id = v_brand.company_id;
+  ELSE
+    v_company := NULL;
+  END IF;
+
+  -- ── 신청 목록 (신청 내부에 캠페인 배열) ──
+  SELECT COALESCE(jsonb_agg(app_row ORDER BY app_row->>'created_at' DESC), '[]'::jsonb)
+    INTO v_applications
+    FROM (
+      SELECT jsonb_build_object(
+               'id',               ba.id,
+               'application_no',   ba.application_no,
+               'form_type',        ba.form_type,
+               'status',           ba.status,
+               'final_quote_krw',  ba.final_quote_krw,
+               'estimated_krw',    ba.estimated_krw,
+               'created_at',       ba.created_at,
+               'updated_at',       ba.updated_at,
+               'campaigns',        (
+                 SELECT COALESCE(jsonb_agg(jsonb_build_object(
+                          -- 기존 키 (129 이후 유지)
+                          'id',           c.id,
+                          'campaign_no',  c.campaign_no,
+                          'title',        c.title,
+                          'brand_ko',     c.brand_ko,
+                          'product_ko',   c.product_ko,
+                          'status',       c.status,
+                          'recruit_type', c.recruit_type,
+                          'slots',        c.slots,
+                          'deadline',     c.deadline,
+                          'updated_at',   c.updated_at,
+                          -- 149 추가: 채널·썸네일
+                          'channel',        c.channel,
+                          'channel_match',  c.channel_match,
+                          'img1',           c.img1,
+                          -- 149 추가: 기간
+                          'recruit_start',  c.recruit_start,
+                          'submission_end', c.submission_end,
+                          -- 149 추가: 결과물 집계 (상관 서브쿼리) — [181] 감사용 제외 추가
+                          'approved_app_count', (
+                            SELECT count(*)
+                              FROM public.applications a
+                             WHERE a.campaign_id = c.id
+                               AND a.status = 'approved'
+                               AND NOT EXISTS (             -- [181] 감사용 응모 제외
+                                 SELECT 1
+                                   FROM public.influencers i
+                                  WHERE i.id = a.user_id
+                                    AND i.is_audit = true
+                               )
+                          ),
+                          'deliv_submitted_inf', (
+                            SELECT count(DISTINCT d.user_id)
+                              FROM public.deliverables d
+                             WHERE d.campaign_id = c.id
+                               AND NOT EXISTS (             -- [181] 감사용 결과물 제외
+                                 SELECT 1
+                                   FROM public.influencers i
+                                  WHERE i.id = d.user_id
+                                    AND i.is_audit = true
+                               )
+                          ),
+                          'deliv_total', (
+                            SELECT count(*)
+                              FROM public.deliverables d
+                             WHERE d.campaign_id = c.id
+                               AND NOT EXISTS (             -- [181] 감사용 결과물 제외
+                                 SELECT 1
+                                   FROM public.influencers i
+                                  WHERE i.id = d.user_id
+                                    AND i.is_audit = true
+                               )
+                          ),
+                          'deliv_approved', (
+                            SELECT count(*)
+                              FROM public.deliverables d
+                             WHERE d.campaign_id = c.id
+                               AND d.status = 'approved'
+                               AND NOT EXISTS (             -- [181] 감사용 결과물 제외
+                                 SELECT 1
+                                   FROM public.influencers i
+                                  WHERE i.id = d.user_id
+                                    AND i.is_audit = true
+                               )
+                          ),
+                          -- 150 신규 추가: 구매·방문 기간 (date, NULL 가능)
+                          'purchase_start', c.purchase_start,
+                          'purchase_end',   c.purchase_end,
+                          'visit_start',    c.visit_start,
+                          'visit_end',      c.visit_end
+                        ) ORDER BY c.created_at), '[]'::jsonb)
+                 FROM public.campaigns c
+                 WHERE c.source_application_id = ba.id
+               )
+             ) AS app_row
+        FROM public.brand_applications ba
+       WHERE ba.brand_id = p_brand_id
+    ) sub;
+
+  -- ── 외부 캠페인 (source_application_id IS NULL, brand 직접 등록) ──
+  SELECT COALESCE(jsonb_agg(jsonb_build_object(
+           -- 기존 키 (129 이후 유지)
+           'id',           c.id,
+           'campaign_no',  c.campaign_no,
+           'title',        c.title,
+           'brand_ko',     c.brand_ko,
+           'product_ko',   c.product_ko,
+           'status',       c.status,
+           'recruit_type', c.recruit_type,
+           'slots',        c.slots,
+           'deadline',     c.deadline,
+           'updated_at',   c.updated_at,
+           -- 149 추가: 채널·썸네일
+           'channel',        c.channel,
+           'channel_match',  c.channel_match,
+           'img1',           c.img1,
+           -- 149 추가: 기간
+           'recruit_start',  c.recruit_start,
+           'submission_end', c.submission_end,
+           -- 149 추가: 결과물 집계 (상관 서브쿼리) — [181] 감사용 제외 추가
+           'approved_app_count', (
+             SELECT count(*)
+               FROM public.applications a
+              WHERE a.campaign_id = c.id
+                AND a.status = 'approved'
+                AND NOT EXISTS (                            -- [181] 감사용 응모 제외
+                  SELECT 1
+                    FROM public.influencers i
+                   WHERE i.id = a.user_id
+                     AND i.is_audit = true
+                )
+           ),
+           'deliv_submitted_inf', (
+             SELECT count(DISTINCT d.user_id)
+               FROM public.deliverables d
+              WHERE d.campaign_id = c.id
+                AND NOT EXISTS (                            -- [181] 감사용 결과물 제외
+                  SELECT 1
+                    FROM public.influencers i
+                   WHERE i.id = d.user_id
+                     AND i.is_audit = true
+                )
+           ),
+           'deliv_total', (
+             SELECT count(*)
+               FROM public.deliverables d
+              WHERE d.campaign_id = c.id
+                AND NOT EXISTS (                            -- [181] 감사용 결과물 제외
+                  SELECT 1
+                    FROM public.influencers i
+                   WHERE i.id = d.user_id
+                     AND i.is_audit = true
+                )
+           ),
+           'deliv_approved', (
+             SELECT count(*)
+               FROM public.deliverables d
+              WHERE d.campaign_id = c.id
+                AND d.status = 'approved'
+                AND NOT EXISTS (                            -- [181] 감사용 결과물 제외
+                  SELECT 1
+                    FROM public.influencers i
+                   WHERE i.id = d.user_id
+                     AND i.is_audit = true
+                )
+           ),
+           -- 150 신규 추가: 구매·방문 기간 (date, NULL 가능)
+           'purchase_start', c.purchase_start,
+           'purchase_end',   c.purchase_end,
+           'visit_start',    c.visit_start,
+           'visit_end',      c.visit_end
+         ) ORDER BY c.created_at), '[]'::jsonb)
+    INTO v_external_camps
+    FROM public.campaigns c
+   WHERE c.brand_id = p_brand_id
+     AND c.source_application_id IS NULL;
+
+  RETURN jsonb_build_object(
+    'brand', jsonb_build_object(
+      'id',         v_brand.id,
+      'brand_seq',  v_brand.brand_seq,
+      'brand_no',   v_brand.brand_no,
+      'name',       v_brand.name,
+      'name_ja',    v_brand.name_ja,
+      'company_id', v_brand.company_id,
+      'updated_at', v_brand.updated_at
+    ),
+    'company',             v_company,
+    'applications',        v_applications,
+    'external_campaigns',  v_external_camps
+  );
+END;
+$$;
+
+COMMENT ON FUNCTION public.get_brand_ops_detail(uuid) IS
+  '[120 → 129 → 149 → 150 → 181] 브랜드 상세 페인용 — 신청 + 각 신청의 캠페인 + 외부 캠페인을 jsonb 통합 반환. is_admin() 가드. '
+  '149에서 channel/channel_match/img1/recruit_start/submission_end/결과물집계 추가. '
+  '150에서 purchase_start/purchase_end/visit_start/visit_end(구매·방문 기간) 추가. '
+  '181에서 approved_app_count 2지점·deliv_* 6지점(신청내부×3 + 외부×3)에 감사용(is_audit=true) 제외 추가.';
+
+COMMIT;

--- a/supabase/patches/179_audit_prod.sql
+++ b/supabase/patches/179_audit_prod.sql
@@ -1,0 +1,650 @@
+-- ============================================================
+-- 179_audit_influencer_account.sql
+-- 감사용 인플루언서 계정 메커니즘 — PR A: 데이터베이스 단계
+--
+-- 목적:
+--   운영서버에서 관리자가 인플루언서 동선을 시뮬레이션할 수 있는
+--   감사용 계정 메커니즘을 DB 레벨로 구현한다.
+--   실 운영 데이터(통계·슬롯·엑셀 산출물)에 흔적·영향 0.
+--
+-- 포함 내용:
+--   1. influencers.is_audit 컬럼 + partial index
+--   2. get_campaign_application_counts() RPC 재정의 (마이그레이션 151 재정의)
+--   3. check_monitor_slots() + recompute_campaign_applied_count() 재정의
+--      → 슬롯/applied_count 집계에서 감사용 응모 격리
+--   4. purge_audit_data_all()      — 전체 흔적 제거 RPC (super_admin 한정)
+--   5. purge_audit_data_for_campaign() — 캠페인별 흔적 제거 RPC (super_admin 한정)
+--   6. 공용 감사용 인플루언서 계정 시드 (auth.users + auth.identities + influencers)
+--
+-- 롤백:
+--   DROP FUNCTION IF EXISTS public.purge_audit_data_for_campaign(uuid);
+--   DROP FUNCTION IF EXISTS public.purge_audit_data_all();
+--   -- check_monitor_slots / recompute_campaign_applied_count / get_campaign_application_counts
+--   -- 는 각각 048, 058, 151 마이그레이션 내용으로 다시 CREATE OR REPLACE 하면 됨
+--   ALTER TABLE public.influencers DROP COLUMN IF EXISTS is_audit;
+--   DROP INDEX IF EXISTS idx_influencers_is_audit;
+--   -- 시드 계정 롤백 (순서 중요 — influencers → identities → users):
+--   DELETE FROM public.influencers WHERE email = 'mtact@jfun.co.kr';
+--   DELETE FROM auth.identities
+--     WHERE user_id = (SELECT id FROM auth.users WHERE email = 'mtact@jfun.co.kr');
+--   DELETE FROM auth.users WHERE email = 'mtact@jfun.co.kr';
+-- ============================================================
+
+
+-- ============================================================
+-- 1. influencers.is_audit 컬럼 추가
+-- ============================================================
+
+ALTER TABLE public.influencers
+  ADD COLUMN IF NOT EXISTS is_audit boolean NOT NULL DEFAULT false;
+
+COMMENT ON COLUMN public.influencers.is_audit IS
+  '감사용 계정 여부. true이면 응모·결과물·통계·엑셀 산출물에서 격리됨. '
+  '운영팀 본인이 인플루언서 동선을 시뮬레이션할 때 사용하는 계정에만 설정. '
+  '감사용 응모는 모집 슬롯·응모수·진행 현황 집계에 포함되지 않는다.';
+
+-- partial index: 감사용 계정은 전체 인플루언서 중 극소수이므로 partial index로 비용 최소화
+CREATE INDEX IF NOT EXISTS idx_influencers_is_audit
+  ON public.influencers (id)
+  WHERE is_audit = true;
+
+
+-- ============================================================
+-- 2. get_campaign_application_counts() RPC 재정의
+--    원본: 마이그레이션 151_campaign_application_counts.sql
+--    변경: JOIN influencers + WHERE is_audit = false 추가
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.get_campaign_application_counts()
+RETURNS TABLE(
+  campaign_id uuid,
+  total       bigint,
+  approved    bigint,
+  pending     bigint
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+BEGIN
+  -- 관리자 전용 함수 — 비관리자 접근 차단
+  IF NOT public.is_admin() THEN
+    RAISE EXCEPTION '권한 없음' USING ERRCODE = '42501';
+  END IF;
+
+  RETURN QUERY
+  SELECT
+    a.campaign_id,
+    COUNT(*)                                FILTER (WHERE a.status <> 'cancelled') AS total,
+    COUNT(*) FILTER (WHERE a.status = 'approved') AS approved,
+    COUNT(*) FILTER (WHERE a.status = 'pending')  AS pending
+  FROM public.applications a
+  JOIN public.influencers i ON i.id = a.user_id  -- [179] 감사용 격리를 위해 JOIN 추가
+  WHERE i.is_audit = false                        -- [179] 감사용 응모 제외
+  GROUP BY a.campaign_id;
+END;
+$$;
+
+-- 기존 151 권한 정책 유지
+REVOKE ALL ON FUNCTION public.get_campaign_application_counts() FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.get_campaign_application_counts() FROM anon;
+GRANT EXECUTE ON FUNCTION public.get_campaign_application_counts() TO authenticated;
+
+
+-- ============================================================
+-- 3a. check_monitor_slots() 재정의
+--    원본: 마이그레이션 048_monitor_slots_guard.sql
+--    변경: 현재 신청수 카운트 시 감사용(is_audit=true) 응모 제외
+--
+--    조사 결과 (슬롯 격리 확인):
+--    - monitor(리뷰어) 캠페인의 슬롯 차단은 DB BEFORE INSERT 트리거
+--      (trg_monitor_slots_guard → check_monitor_slots)로 구현됨
+--    - 현재 로직은 status IN ('pending','approved') 카운트 기준
+--    - 감사용 계정이 응모하면 이 카운트에 포함되어 실 인플루언서 응모가
+--      차단될 수 있으므로, 감사용 응모를 카운트에서 제외하도록 재정의
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.check_monitor_slots()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_recruit_type text;
+  v_slots        int;
+  v_current      int;
+  v_is_audit     boolean;
+BEGIN
+  -- 감사용 계정의 응모이면 슬롯 검증 건너뜀 (슬롯 소진하지 않음)
+  SELECT i.is_audit INTO v_is_audit
+    FROM public.influencers i
+   WHERE i.id = NEW.user_id;
+
+  IF COALESCE(v_is_audit, false) = true THEN
+    RETURN NEW;  -- [179] 감사용 응모는 슬롯 차단 없이 통과
+  END IF;
+
+  -- FOR UPDATE: 동시 INSERT 시 campaigns 행에 row lock → 레이스 컨디션 방어
+  SELECT c.recruit_type, c.slots
+    INTO v_recruit_type, v_slots
+    FROM public.campaigns c
+   WHERE c.id = NEW.campaign_id
+     FOR UPDATE;
+
+  -- 리뷰어(monitor)가 아니거나 slots 미설정이면 통과
+  IF v_recruit_type IS DISTINCT FROM 'monitor' OR COALESCE(v_slots, 0) <= 0 THEN
+    RETURN NEW;
+  END IF;
+
+  -- 현재 신청수 카운트 (pending + approved — rejected·감사용 제외)
+  SELECT COUNT(*)
+    INTO v_current
+    FROM public.applications a
+    JOIN public.influencers i ON i.id = a.user_id  -- [179] 감사용 격리
+   WHERE a.campaign_id = NEW.campaign_id
+     AND a.status IN ('pending', 'approved')
+     AND i.is_audit = false;                       -- [179] 감사용 응모 제외
+
+  IF v_current >= v_slots THEN
+    RAISE EXCEPTION '모집 정원이 마감되었습니다 (slots: %, current: %)', v_slots, v_current
+      USING ERRCODE = 'P0001';
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+-- 트리거는 이미 048에서 등록됨 — 재등록으로 함수 교체만 반영
+DROP TRIGGER IF EXISTS trg_monitor_slots_guard ON public.applications;
+CREATE TRIGGER trg_monitor_slots_guard
+  BEFORE INSERT ON public.applications
+  FOR EACH ROW
+  EXECUTE FUNCTION public.check_monitor_slots();
+
+
+-- ============================================================
+-- 3b. recompute_campaign_applied_count() 재정의
+--    원본: 마이그레이션 058_applied_count_trigger.sql
+--    변경: 카운트에서 is_audit = true 응모 제외
+--    (campaigns.applied_count = 인플루언서 앱 카드에 표시되는 "N명 신청" 숫자)
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.recompute_campaign_applied_count(p_campaign_id uuid)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_count int;
+BEGIN
+  SELECT COUNT(*)
+    INTO v_count
+    FROM public.applications a
+    JOIN public.influencers i ON i.id = a.user_id  -- [179] 감사용 격리
+   WHERE a.campaign_id = p_campaign_id
+     AND a.status IN ('pending', 'approved')
+     AND i.is_audit = false;                       -- [179] 감사용 응모 제외
+
+  UPDATE public.campaigns
+     SET applied_count = v_count
+   WHERE id = p_campaign_id;
+END;
+$$;
+
+COMMENT ON FUNCTION public.recompute_campaign_applied_count(uuid) IS
+  '[058/179] campaign_id 하나의 applied_count를 applications 집계(pending+approved, '
+  '감사용 제외)로 재계산. SECURITY DEFINER — 트리거 함수에서만 호출.';
+
+
+-- ============================================================
+-- 4. purge_audit_data_all() — 전체 흔적 제거 RPC
+-- ============================================================
+--
+-- cascade 관계 정리 (마이그레이션 코드 직접 확인 결과):
+--
+-- [applications DELETE 시 cascade 대상 — FK ON DELETE CASCADE 확인]
+--   - deliverables            035: application_id FK ON DELETE CASCADE → OK
+--   - deliverable_events      035: deliverable_id FK ON DELETE CASCADE (deliverables 통해 cascade)
+--   - receipt_edit_history    128: deliverable_id FK ON DELETE CASCADE (deliverables 통해 cascade)
+--   - application_events      131: application_id FK ON DELETE CASCADE → OK
+--   - application_messages    144: application_id FK ON DELETE CASCADE → OK
+--   - application_message_admin_reads  144: message_id FK ON DELETE CASCADE (messages 통해 cascade)
+--   - application_message_resolutions  144: application_id FK ON DELETE CASCADE → OK
+--   - application_message_hide_history 144: message_id FK ON DELETE CASCADE (messages 통해 cascade)
+--     ⚠️ application_message_hide_history는 super_admin 내부 감사 테이블이지만
+--        message_id → application_messages → applications 의 cascade chain 위에 있으므로
+--        applications DELETE 시 함께 삭제됨. 감사용 계정 데이터이므로 허용.
+--   - faq_interactions        146: application_id FK ON DELETE SET NULL → 행 유지, application_id만 NULL
+--
+-- [influencers 기준 직접 cascade 대상 — user_id/influencer_id FK 확인]
+--   - campaign_promo_digest_sent     139: influencer_id FK ON DELETE CASCADE → OK
+--   - campaign_promo_exposure        139: influencer_id FK ON DELETE CASCADE → OK
+--   - campaign_promo_email_clicks    139: influencer_id FK ON DELETE CASCADE → OK
+--   - policy_notice_log (153)        153: influencer_id FK ON DELETE CASCADE → OK
+--   - client_error_logs (165)        165: user_id FK ON DELETE SET NULL → 행 유지
+--
+-- [별도 명시 DELETE 필요한 테이블]
+--   - notifications  037: user_id → auth.users(id) ON DELETE CASCADE
+--     → auth.users를 건드리지 않으므로 자동 삭제 안 됨. 명시적 DELETE 필요.
+--   - faq_interactions 146: influencer_id → auth.users(id) ON DELETE CASCADE
+--     → 감사용 계정은 auth.users를 삭제하지 않으므로 명시적 DELETE 필요.
+--     (application_id SET NULL으로 행은 남겨두므로 influencer_id로 직접 DELETE)
+--
+-- [Storage 첨부 파일 — cascade 불가, 클라이언트가 후속 삭제해야 함]
+--   - application-message-attachments 버킷: path = applications/{app_id}/{message_id}/...
+--   - deliverables 결과물 이미지: campaign-images/receipts/... (영수증 이미지)
+--   → 이 함수는 삭제 전 path를 수집해 반환값에 포함. 클라이언트가 후속 삭제.
+--
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.purge_audit_data_all()
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_audit_ids      uuid[];
+  v_app_ids        uuid[];
+  v_del_app_count  int;
+  v_del_notif_count int;
+  v_del_faq_count  int;
+  v_msg_attach_paths text[];
+  v_receipt_paths    text[];
+BEGIN
+  -- super_admin 전용
+  IF NOT public.is_super_admin() THEN
+    RAISE EXCEPTION '권한 없음 (super_admin 한정)' USING ERRCODE = '42501';
+  END IF;
+
+  -- 감사용 계정 ID 수집
+  SELECT array_agg(id) INTO v_audit_ids
+    FROM public.influencers
+   WHERE is_audit = true;
+
+  IF v_audit_ids IS NULL OR cardinality(v_audit_ids) = 0 THEN
+    RETURN jsonb_build_object('status', 'no_audit_account');
+  END IF;
+
+  -- 감사용 계정의 응모건 ID 수집 (Storage path 수집 + 삭제 범위 파악용)
+  SELECT array_agg(id) INTO v_app_ids
+    FROM public.applications
+   WHERE user_id = ANY(v_audit_ids);
+
+  -- ① Storage 파일 path 수집 (클라이언트가 후속 삭제할 수 있도록 반환)
+  --    응모건 메시지 첨부 파일
+  -- ⚠️ attachments는 [{path, name, size, mime}] 객체 배열(144 정의)이므로
+  --    jsonb_array_elements + ->>'path'로 path만 추출 (text 추출 함수 사용 금지)
+  SELECT array_agg(DISTINCT elem->>'path')
+    INTO v_msg_attach_paths
+  FROM public.application_messages am,
+       jsonb_array_elements(
+         COALESCE(am.attachments, '[]'::jsonb)
+       ) AS elem
+  WHERE am.application_id = ANY(v_app_ids)
+    AND elem->>'path' IS NOT NULL;
+
+  --    영수증 이미지 (receipt_url)
+  SELECT array_agg(DISTINCT d.receipt_url)
+    INTO v_receipt_paths
+    FROM public.deliverables d
+   WHERE d.application_id = ANY(v_app_ids)
+     AND d.receipt_url IS NOT NULL;
+
+  -- ② notifications 명시적 DELETE (auth.users cascade 미적용)
+  DELETE FROM public.notifications
+   WHERE user_id = ANY(v_audit_ids);
+  GET DIAGNOSTICS v_del_notif_count = ROW_COUNT;
+
+  -- ③ faq_interactions 명시적 DELETE (influencer_id 기준, auth.users cascade 미적용)
+  DELETE FROM public.faq_interactions
+   WHERE influencer_id = ANY(v_audit_ids);
+  GET DIAGNOSTICS v_del_faq_count = ROW_COUNT;
+
+  -- ④ applications DELETE
+  --    → deliverables, deliverable_events, receipt_edit_history,
+  --      application_events, application_messages,
+  --      application_message_admin_reads, application_message_resolutions,
+  --      application_message_hide_history 모두 cascade
+  DELETE FROM public.applications
+   WHERE user_id = ANY(v_audit_ids);
+  GET DIAGNOSTICS v_del_app_count = ROW_COUNT;
+
+  RETURN jsonb_build_object(
+    'status',            'ok',
+    'audit_account_count', cardinality(v_audit_ids),
+    'deleted', jsonb_build_object(
+      'applications',  v_del_app_count,
+      'notifications', v_del_notif_count,
+      'faq_interactions', v_del_faq_count
+    ),
+    'storage_paths_to_delete', jsonb_build_object(
+      'message_attachments', COALESCE(to_jsonb(v_msg_attach_paths), '[]'::jsonb),
+      'receipt_images',      COALESCE(to_jsonb(v_receipt_paths),    '[]'::jsonb)
+    )
+  );
+END;
+$$;
+
+COMMENT ON FUNCTION public.purge_audit_data_all() IS
+  '[179] 모든 감사용 계정(is_audit=true)의 응모·결과물·알림·메시지·FAQ 이력을 삭제. '
+  'super_admin 전용. 반환값의 storage_paths_to_delete를 참조해 클라이언트가 Storage 파일도 삭제할 것.';
+
+REVOKE ALL ON FUNCTION public.purge_audit_data_all() FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.purge_audit_data_all() TO authenticated;
+
+
+-- ============================================================
+-- 5. purge_audit_data_for_campaign() — 캠페인별 흔적 제거 RPC
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.purge_audit_data_for_campaign(p_campaign_id uuid)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_audit_ids       uuid[];
+  v_app_ids         uuid[];
+  v_del_app_count   int;
+  v_del_notif_count int;
+  v_msg_attach_paths text[];
+  v_receipt_paths    text[];
+BEGIN
+  -- super_admin 전용
+  IF NOT public.is_super_admin() THEN
+    RAISE EXCEPTION '권한 없음 (super_admin 한정)' USING ERRCODE = '42501';
+  END IF;
+
+  -- 감사용 계정 ID 수집
+  SELECT array_agg(id) INTO v_audit_ids
+    FROM public.influencers
+   WHERE is_audit = true;
+
+  IF v_audit_ids IS NULL OR cardinality(v_audit_ids) = 0 THEN
+    RETURN jsonb_build_object('status', 'no_audit_account');
+  END IF;
+
+  -- 해당 캠페인의 감사용 응모건 ID 수집
+  SELECT array_agg(id) INTO v_app_ids
+    FROM public.applications
+   WHERE campaign_id = p_campaign_id
+     AND user_id = ANY(v_audit_ids);
+
+  IF v_app_ids IS NULL OR cardinality(v_app_ids) = 0 THEN
+    RETURN jsonb_build_object(
+      'status',      'ok',
+      'campaign_id', p_campaign_id,
+      'deleted', jsonb_build_object('applications', 0, 'notifications', 0)
+    );
+  END IF;
+
+  -- ① Storage 파일 path 수집
+  -- ⚠️ attachments는 [{path, name, size, mime}] 객체 배열(144 정의)이므로
+  --    jsonb_array_elements + ->>'path'로 path만 추출 (text 추출 함수 사용 금지)
+  SELECT array_agg(DISTINCT elem->>'path')
+    INTO v_msg_attach_paths
+  FROM public.application_messages am,
+       jsonb_array_elements(
+         COALESCE(am.attachments, '[]'::jsonb)
+       ) AS elem
+  WHERE am.application_id = ANY(v_app_ids)
+    AND elem->>'path' IS NOT NULL;
+
+  SELECT array_agg(DISTINCT d.receipt_url)
+    INTO v_receipt_paths
+    FROM public.deliverables d
+   WHERE d.application_id = ANY(v_app_ids)
+     AND d.receipt_url IS NOT NULL;
+
+  -- ② 해당 캠페인 감사용 응모건의 notifications 삭제
+  --    (notifications.ref_table = 'applications' AND ref_id = ANY(v_app_ids) 건)
+  DELETE FROM public.notifications
+   WHERE user_id = ANY(v_audit_ids)
+     AND (
+       ref_id = ANY(v_app_ids)   -- 응모건 직접 참조 알림
+       OR (
+         ref_table = 'deliverables'
+         AND ref_id IN (
+           SELECT id FROM public.deliverables
+            WHERE application_id = ANY(v_app_ids)
+         )
+       )
+     );
+  GET DIAGNOSTICS v_del_notif_count = ROW_COUNT;
+
+  -- faq_interactions는 의도적으로 정리하지 않음:
+  --   campaign_id 컬럼이 없어 캠페인 단위 삭제 불가. 여기서 influencer_id로 지우면
+  --   다른 캠페인 열람 이력까지 삭제됨. 응모건 cascade로 application_id만 SET NULL 처리되고
+  --   FAQ 측정 통계는 전체 청소(purge_audit_data_all)에서만 제거된다.
+
+  -- ③ applications DELETE → cascade로 하위 테이블 모두 정리
+  DELETE FROM public.applications
+   WHERE id = ANY(v_app_ids);
+  GET DIAGNOSTICS v_del_app_count = ROW_COUNT;
+
+  RETURN jsonb_build_object(
+    'status',      'ok',
+    'campaign_id', p_campaign_id,
+    'deleted', jsonb_build_object(
+      'applications',  v_del_app_count,
+      'notifications', v_del_notif_count
+    ),
+    'storage_paths_to_delete', jsonb_build_object(
+      'message_attachments', COALESCE(to_jsonb(v_msg_attach_paths), '[]'::jsonb),
+      'receipt_images',      COALESCE(to_jsonb(v_receipt_paths),    '[]'::jsonb)
+    )
+  );
+END;
+$$;
+
+COMMENT ON FUNCTION public.purge_audit_data_for_campaign(uuid) IS
+  '[179] 특정 캠페인(p_campaign_id)에서 감사용 계정(is_audit=true)이 만든 '
+  '응모·결과물·메시지·알림을 삭제. super_admin 전용. '
+  '반환값의 storage_paths_to_delete를 참조해 클라이언트가 Storage 파일도 삭제할 것.';
+
+REVOKE ALL ON FUNCTION public.purge_audit_data_for_campaign(uuid) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.purge_audit_data_for_campaign(uuid) TO authenticated;
+
+
+-- ============================================================
+-- 6. 공용 감사용 인플루언서 계정 시드
+-- ============================================================
+--
+-- ⚠️ 환경별 이메일 설정:
+--   - 개발서버: mtact@jfun.co.kr  (아래 SQL 그대로 사용)
+--   - 운영서버: 운영 적용 시 이메일을 실제 감사용 메일 주소로 변경할 것
+--     예: audit@globalreverb.com 또는 super_admin 본인 이메일 별칭
+--   - 이메일을 바꿀 때는 아래 4곳 모두 변경:
+--     ① DO 블록 상단 SELECT ... WHERE email = ... (존재 확인 조건절)
+--     ② auth.users INSERT email 값 + raw_user_meta_data 안 email
+--     ③ auth.identities INSERT identity_data jsonb 안 email
+--     ④ influencers UPSERT email 값
+--
+-- ⚠️ 비밀번호:
+--   - 아래 시드는 'AuditReverb2026!' 로 설정됨 (bcrypt round 10)
+--   - 운영 적용 시 반드시 강력한 비밀번호로 변경하거나,
+--     적용 후 관리자 페이지에서 초대 메일 발송(resetPasswordForEmail)로 재설정할 것
+--
+-- ⚠️ influencers 자동 생성 트리거 (마이그레이션 014):
+--   - auth.users INSERT 시 handle_new_user() 트리거가 실행되어
+--     influencers 행이 자동 생성됨 (id, email, created_at만 채움)
+--   - 따라서 auth.users INSERT 후 influencers를 INSERT하면 충돌(PK 중복) 발생
+--   - 아래 시드는 auth.users INSERT → 트리거 자동 생성된 influencers 행을
+--     UPDATE로 is_audit=true + 프로필 세팅하는 방식으로 작성
+--   - ON CONFLICT (id) DO UPDATE 패턴을 사용해 멱등성 확보
+--
+-- ⚠️ 멱등성:
+--   - 이미 같은 이메일이 존재하면 auth.users는 ON CONFLICT (email) DO NOTHING
+--   - auth.identities는 ON CONFLICT (provider, provider_id) DO NOTHING
+--   - influencers는 ON CONFLICT (id) DO UPDATE로 프로필 갱신
+-- ============================================================
+
+DO $$
+DECLARE
+  v_audit_uid uuid;
+  v_existing_uid uuid;
+BEGIN
+  -- 이미 동일 이메일의 auth.users 행이 있는지 확인
+  SELECT id INTO v_existing_uid
+    FROM auth.users
+   WHERE email = 'mtact@jfun.co.kr';
+
+  IF v_existing_uid IS NOT NULL THEN
+    -- 이미 존재 → auth.users/identities는 건너뛰고 influencers만 갱신
+    v_audit_uid := v_existing_uid;
+
+  ELSE
+    -- 신규 생성
+    v_audit_uid := gen_random_uuid();
+
+    -- auth.users 행 삽입
+    -- supabase.md 「Auth 레코드 완전성」 준수:
+    --   email_confirmed_at = now()     (NULL이면 로그인 차단)
+    --   raw_app_meta_data              (provider 필수)
+    --   raw_user_meta_data             (sub, email, email_verified 필수)
+    --   token 필드들                   (NULL 금지, 빈 문자열 필수)
+    INSERT INTO auth.users (
+      instance_id,
+      id,
+      aud,
+      role,
+      email,
+      encrypted_password,
+      email_confirmed_at,
+      created_at,
+      updated_at,
+      raw_app_meta_data,
+      raw_user_meta_data,
+      confirmation_token,
+      recovery_token,
+      email_change_token_new,
+      email_change,
+      phone_change,
+      phone_change_token,
+      reauthentication_token
+    ) VALUES (
+      '00000000-0000-0000-0000-000000000000',
+      v_audit_uid,
+      'authenticated',
+      'authenticated',
+      'mtact@jfun.co.kr',
+      extensions.crypt(extensions.gen_random_uuid()::text, extensions.gen_salt('bf', 10)),
+      now(),
+      now(),
+      now(),
+      jsonb_build_object('provider', 'email', 'providers', jsonb_build_array('email')),
+      jsonb_build_object(
+        'sub',            v_audit_uid::text,
+        'email',          'mtact@jfun.co.kr',
+        'email_verified', true,
+        'phone_verified', false
+      ),
+      '',  -- confirmation_token
+      '',  -- recovery_token
+      '',  -- email_change_token_new
+      '',  -- email_change
+      '',  -- phone_change
+      '',  -- phone_change_token
+      ''   -- reauthentication_token
+    );
+
+    -- auth.identities 행 삽입 (없으면 로그인 불가)
+    INSERT INTO auth.identities (
+      id,                  -- [179 fix] 프로젝트 선례(029·031·012) 일치 — 일부 Supabase 버전은 NOT NULL/무DEFAULT
+      provider_id,
+      user_id,
+      identity_data,
+      provider,
+      last_sign_in_at,
+      created_at,
+      updated_at
+    ) VALUES (
+      gen_random_uuid(),   -- [179 fix] identities 행 자체 PK
+      v_audit_uid::text,
+      v_audit_uid,
+      jsonb_build_object(
+        'sub',   v_audit_uid::text,
+        'email', 'mtact@jfun.co.kr',
+        'email_verified', true
+      ),
+      'email',
+      now(),
+      now(),
+      now()
+    ) ON CONFLICT (provider, provider_id) DO NOTHING;
+
+  END IF;
+
+  -- influencers 행 갱신 (트리거 자동 생성 행 + is_audit 설정)
+  -- 트리거가 생성한 행에 is_audit=true + 프로필 세팅
+  INSERT INTO public.influencers (
+    id,
+    email,
+    name,
+    name_kanji,
+    name_kana,
+    is_audit,
+    terms_agreed_at,
+    privacy_agreed_at,
+    created_at
+  ) VALUES (
+    v_audit_uid,
+    'mtact@jfun.co.kr',
+    '監査用',
+    '監査用',
+    'かんさよう',
+    true,
+    now(),
+    now(),
+    now()
+  )
+  ON CONFLICT (id) DO UPDATE SET
+    name           = EXCLUDED.name,
+    name_kanji     = EXCLUDED.name_kanji,
+    name_kana      = EXCLUDED.name_kana,
+    is_audit       = true,
+    terms_agreed_at   = COALESCE(public.influencers.terms_agreed_at, now()),
+    privacy_agreed_at = COALESCE(public.influencers.privacy_agreed_at, now());
+
+END $$;
+
+
+-- ============================================================
+-- 검증 쿼리 (마이그레이션 후 SQL Editor에서 1단계씩 실행)
+-- ============================================================
+
+-- 1단계: is_audit 컬럼 추가 확인
+-- SELECT column_name, data_type, column_default, is_nullable
+--   FROM information_schema.columns
+--  WHERE table_schema = 'public'
+--    AND table_name = 'influencers'
+--    AND column_name = 'is_audit';
+-- 기대: boolean, false, NO
+
+-- 2단계: 시드 계정 생성 확인
+-- SELECT u.email, u.email_confirmed_at IS NOT NULL AS confirmed,
+--        i.is_audit, i.name_kanji
+--   FROM auth.users u
+--   JOIN public.influencers i ON i.id = u.id
+--  WHERE u.email = 'mtact@jfun.co.kr';
+-- 기대: confirmed=true, is_audit=true, name_kanji='監査用'
+
+-- 3단계: auth.identities 행 확인
+-- SELECT provider, provider_id
+--   FROM auth.identities
+--  WHERE user_id = (SELECT id FROM auth.users WHERE email = 'mtact@jfun.co.kr');
+-- 기대: provider='email', provider_id=<uuid>
+
+-- 4단계: get_campaign_application_counts RPC 확인 (감사용 응모 제외 여부)
+-- SELECT * FROM public.get_campaign_application_counts() LIMIT 5;
+-- 기대: 감사용 계정 응모건 미포함, 일반 집계와 동일
+
+-- 5단계: 슬롯 트리거 함수 존재 확인
+-- SELECT proname, prosecdef FROM pg_proc
+--  WHERE proname IN ('check_monitor_slots', 'recompute_campaign_applied_count')
+--    AND pronamespace = 'public'::regnamespace;
+-- 기대: 2건, prosecdef = true

--- a/supabase/patches/audit_prod_dummy_profile.sql
+++ b/supabase/patches/audit_prod_dummy_profile.sql
@@ -1,0 +1,56 @@
+-- ============================================================
+-- 감사용 인플루언서 계정 더미 프로필 시드 (개발서버 전용)
+-- ============================================================
+-- 목적:
+--   운영팀이 인플루언서 동선을 시뮬레이션할 때 쓰는 감사용 계정
+--   (influencers.is_audit = true, 마이그레이션 179 에서 시드)에
+--   프로필이 비어 있어 응모 테스트마다 필수 정보를 손으로 채워야 했다.
+--   이 시드는 그 빈 프로필을 응모 시뮬레이션에 필요한 더미 값으로 한 번에 채운다.
+--
+-- 대상 계정: mtact@jfun.co.kr (개발서버 전용 — 마이그레이션 179 시드 계정)
+--
+-- 멱등성: UPDATE 라 여러 번 실행해도 안전. 계정이 없으면 0행 갱신(에러 아님).
+--
+-- 생년월일·성별은 건드리지 않는다:
+--   감사용 계정은 이미 birthdate(만 18세 이상)·gender 가 채워져 있다(응모 게이트 테스트 시 입력됨).
+--   생년월일 잠금 트리거(180-G)는 값→다른값 변경을 P0003 으로 차단하고,
+--   SQL Editor 실행은 auth.uid() 가 비어 관리자로 인식되지 않으므로 birthdate 를 바꿀 수 없다.
+--   이미 응모에 적합한 값이라 교체할 이유도 없어, 이 시드는 birthdate/gender 를 제외한다.
+--
+-- 주의: 운영서버에는 감사용 계정 이메일이 다르므로 이 파일을 그대로 쓰지 말 것
+--       (운영 적용은 별도 결정 — 이메일·값 확인 후 진행).
+-- ============================================================
+
+UPDATE public.influencers SET
+  -- 이름: 감사용 식별을 위해 「監査用」 유지
+  name        = '監査用',
+  name_kanji  = '監査用',
+  name_kana   = 'かんさよう',
+  -- 4채널 SNS 계정 + 팔로워 (모든 채널 캠페인에 응모 가능하도록 전부 채움)
+  ig          = 'reverb_audit',     ig_followers      = 8000,
+  x           = 'reverb_audit_x',   x_followers       = 3000,
+  tiktok      = 'reverb_audit_tt',  tiktok_followers  = 5000,
+  youtube     = 'reverb_audit_yt',  youtube_followers = 2000,
+  line_id     = 'reverb_audit_line',
+  -- 대표 SNS·카테고리·소개
+  primary_sns = 'instagram',
+  category    = 'beauty',
+  bio         = '監査用アカウント（運営シミュレーション）',
+  -- 배송지 (우편번호·도도부현·시·건물·전화 — 응모 필수정보)
+  zip         = '150-0001',
+  prefecture  = '東京都',
+  city        = '渋谷区神宮前1-1-1',
+  building    = '監査ビル 101',
+  phone       = '090-0000-0000',
+  -- PayPal (응모 필수정보)
+  paypal_email = 'audit.paypal@example.com',
+  -- 생년월일·성별은 이미 채워져 있어 제외 (잠금 트리거 180-G 로 변경 불가 + 교체 불필요)
+  -- 약관·개인정보 동의 시각 (응모 진행에 필요)
+  terms_agreed_at   = COALESCE(terms_agreed_at, now()),
+  privacy_agreed_at = COALESCE(privacy_agreed_at, now())
+WHERE email = 'mtact@jfun.co.kr';
+
+-- 검증: 1행 갱신되었는지 + 채워진 값 확인
+-- SELECT email, name_kanji, ig, ig_followers, prefecture, paypal_email,
+--        birthdate, gender, is_audit
+--   FROM public.influencers WHERE email = 'mtact@jfun.co.kr';

--- a/supabase/seed/dev_audit_influencer_profile.sql
+++ b/supabase/seed/dev_audit_influencer_profile.sql
@@ -1,0 +1,56 @@
+-- ============================================================
+-- 감사용 인플루언서 계정 더미 프로필 시드 (개발서버 전용)
+-- ============================================================
+-- 목적:
+--   운영팀이 인플루언서 동선을 시뮬레이션할 때 쓰는 감사용 계정
+--   (influencers.is_audit = true, 마이그레이션 179 에서 시드)에
+--   프로필이 비어 있어 응모 테스트마다 필수 정보를 손으로 채워야 했다.
+--   이 시드는 그 빈 프로필을 응모 시뮬레이션에 필요한 더미 값으로 한 번에 채운다.
+--
+-- 대상 계정: audit.test@reverb.jp (개발서버 전용 — 마이그레이션 179 시드 계정)
+--
+-- 멱등성: UPDATE 라 여러 번 실행해도 안전. 계정이 없으면 0행 갱신(에러 아님).
+--
+-- 생년월일·성별은 건드리지 않는다:
+--   감사용 계정은 이미 birthdate(만 18세 이상)·gender 가 채워져 있다(응모 게이트 테스트 시 입력됨).
+--   생년월일 잠금 트리거(180-G)는 값→다른값 변경을 P0003 으로 차단하고,
+--   SQL Editor 실행은 auth.uid() 가 비어 관리자로 인식되지 않으므로 birthdate 를 바꿀 수 없다.
+--   이미 응모에 적합한 값이라 교체할 이유도 없어, 이 시드는 birthdate/gender 를 제외한다.
+--
+-- 주의: 운영서버에는 감사용 계정 이메일이 다르므로 이 파일을 그대로 쓰지 말 것
+--       (운영 적용은 별도 결정 — 이메일·값 확인 후 진행).
+-- ============================================================
+
+UPDATE public.influencers SET
+  -- 이름: 감사용 식별을 위해 「監査用」 유지
+  name        = '監査用',
+  name_kanji  = '監査用',
+  name_kana   = 'かんさよう',
+  -- 4채널 SNS 계정 + 팔로워 (모든 채널 캠페인에 응모 가능하도록 전부 채움)
+  ig          = 'reverb_audit',     ig_followers      = 8000,
+  x           = 'reverb_audit_x',   x_followers       = 3000,
+  tiktok      = 'reverb_audit_tt',  tiktok_followers  = 5000,
+  youtube     = 'reverb_audit_yt',  youtube_followers = 2000,
+  line_id     = 'reverb_audit_line',
+  -- 대표 SNS·카테고리·소개
+  primary_sns = 'instagram',
+  category    = 'beauty',
+  bio         = '監査用アカウント（運営シミュレーション）',
+  -- 배송지 (우편번호·도도부현·시·건물·전화 — 응모 필수정보)
+  zip         = '150-0001',
+  prefecture  = '東京都',
+  city        = '渋谷区神宮前1-1-1',
+  building    = '監査ビル 101',
+  phone       = '090-0000-0000',
+  -- PayPal (응모 필수정보)
+  paypal_email = 'audit.paypal@example.com',
+  -- 생년월일·성별은 이미 채워져 있어 제외 (잠금 트리거 180-G 로 변경 불가 + 교체 불필요)
+  -- 약관·개인정보 동의 시각 (응모 진행에 필요)
+  terms_agreed_at   = COALESCE(terms_agreed_at, now()),
+  privacy_agreed_at = COALESCE(privacy_agreed_at, now())
+WHERE email = 'audit.test@reverb.jp';
+
+-- 검증: 1행 갱신되었는지 + 채워진 값 확인
+-- SELECT email, name_kanji, ig, ig_followers, prefecture, paypal_email,
+--        birthdate, gender, is_audit
+--   FROM public.influencers WHERE email = 'audit.test@reverb.jp';


### PR DESCRIPTION
## 변경 요약
감사용 인플루언서 계정 기능을 운영서버에 출시. dev의 보류 기능(연령 정책·오픈 예정 기능 보드)이 섞이지 않도록 main 기준에서 감사용 변경만 분리 적용 후 재빌드(핫픽스 패턴).

- 감사용(is_audit) 격리: 배지·빈자리/승인 카운트·대시보드 KPI·운영현황·엑셀 + super_admin 흔적 청소
- 마이그레이션 179(스키마·함수·purge·시드) + 181(운영현황 격리)
- 누출 검증 완료: 연령정책 0 · 오픈예정보드 0 · post-channel 회귀 없음

## 배포 순서 (중요)
1. 운영 DB에 마이그레이션 179 → 181 적용 (SQL Editor, 감사용 계정 이메일 mtact@jfun.co.kr)
2. 운영 더미 프로필 시드 적용
3. **이 PR 머지** (DB 적용 후 — 코드가 없는 컬럼 조회 방지)
4. 감사용 계정 비밀번호 초대메일 재설정

## 요청 외 추가 변경
없음

## 관련 사양서
docs/specs/2026-05-28-audit-influencer-account.md

[via planner][via supabase-expert][via reviewer] GO