### PR TITLE
feat(admin): 채널 열을 라벨 칩 형식으로 표시

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -12,7 +12,7 @@
 // 회귀(2026-05-12 PR #182 머지 직후 발생)를 방지하기 위한 자동 reload 가드.
 // sessionStorage 차단 환경(시크릿 모드 일부, 쿠키 차단)에서는 자연스럽게 skip.
 (function(){
-  var CURRENT_BUILD = 'v1781606354';
+  var CURRENT_BUILD = 'v1781606996';
   if (CURRENT_BUILD.indexOf('__') === 0) return; // 빌드 미적용 (dev/ 직접 열기) 시 skip
   try {
     var prev = sessionStorage.getItem('reverb.adminBuild');
@@ -2079,7 +2079,7 @@ tr.audit-row, .audit-row { background: #fff3e0 !important; }
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-06-16 19:39 · c1ece77</span>
+          <span class="admin-build-text">2026-06-16 19:49 · 580bd85</span>
         </div>
       </div>
     </aside>
@@ -9748,6 +9748,17 @@ function getChannelLabel(ch, lang) {
     }
     return CHANNEL_LABEL_FALLBACK[code] || code;
   }).join(' or ');
+}
+
+// 채널 문자열(콤마구분) → 채널별 회색 라벨 칩. 관리자 목록 채널 열 공용.
+// 빈 채널은 '—'. 채널마다 한글 라벨 칩 1개씩 줄바꿈 허용.
+function channelChipsHtml(channel) {
+  const codes = (channel || '').split(',').map(s => s.trim()).filter(Boolean);
+  if (!codes.length) return '<span style="color:var(--muted)">—</span>';
+  return '<div style="display:flex;flex-wrap:wrap;gap:3px">' + codes.map(function(code) {
+    const label = (typeof getChannelLabel === 'function') ? (getChannelLabel(code) || code) : code;
+    return '<span style="background:#F0F0F0;color:#666;font-size:10px;font-weight:600;padding:2px 7px;border-radius:3px;white-space:nowrap">' + esc(label) + '</span>';
+  }).join('') + '</div>';
 }
 
 // lookup_values 공통: code 또는 name_ja를 현재 locale의 표시값으로
@@ -19813,7 +19824,7 @@ function renderDelivAppRow(g) {
 
   return `<tr data-app-id="${esc(g.application_id)}" class="${inf.is_audit ? 'audit-row' : ''}" style="${rowStyle}">
     <td><div style="display:flex;align-items:center;gap:6px;flex-wrap:wrap;margin-bottom:2px">${rtBadge}${campNoBadge}</div><div>${esc(camp.title || '—')}</div></td>
-    <td style="font-size:12px;color:var(--ink)">${(typeof brandOpsChannelText==='function'?brandOpsChannelText(camp.channel, camp.channel_match):'') || '—'}</td>
+    <td>${channelChipsHtml(camp.channel)}</td>
     <td style="font-size:12px;color:var(--ink);min-width:100px;max-width:160px;word-break:break-word">${brandLabel ? esc(brandLabel) : '—'}</td>
     <td style="font-size:11px;color:var(--ink);white-space:nowrap">${periodRangeCell(ps, pe)}</td>
     <td style="font-size:11px;color:var(--ink);white-space:nowrap">${periodSingleCell(camp.submission_end)}</td>
@@ -24446,7 +24457,7 @@ async function renderAppCampList() {
           </div>
         </div>
       </td>
-      <td style="font-size:12px;color:var(--ink)">${(typeof brandOpsChannelText==='function'?brandOpsChannelText(camp.channel, camp.channel_match):'') || '—'}</td>
+      <td>${channelChipsHtml(camp.channel)}</td>
       <td style="font-size:12px;color:var(--ink);min-width:100px;max-width:160px;word-break:break-word">
         ${brandPrimary?esc(brandPrimary):'—'}
         ${brandSub?`<div style="font-size:10px;color:var(--muted);margin-top:2px">${esc(brandSub)}</div>`:''}
@@ -26655,7 +26666,7 @@ async function loadAdminCampaigns(useCache) {
           </div>
         </div>
       </td>
-      <td style="font-size:12px;color:var(--ink)">${(typeof brandOpsChannelText==='function'?brandOpsChannelText(c.channel, c.channel_match):'') || '—'}</td>
+      <td>${channelChipsHtml(c.channel)}</td>
       ${(()=>{
         const bp = brandLabelAdmin(c);
         const bs = '';

--- a/dev/js/admin-applications.js
+++ b/dev/js/admin-applications.js
@@ -533,7 +533,7 @@ async function renderAppCampList() {
           </div>
         </div>
       </td>
-      <td style="font-size:12px;color:var(--ink)">${(typeof brandOpsChannelText==='function'?brandOpsChannelText(camp.channel, camp.channel_match):'') || '—'}</td>
+      <td>${channelChipsHtml(camp.channel)}</td>
       <td style="font-size:12px;color:var(--ink);min-width:100px;max-width:160px;word-break:break-word">
         ${brandPrimary?esc(brandPrimary):'—'}
         ${brandSub?`<div style="font-size:10px;color:var(--muted);margin-top:2px">${esc(brandSub)}</div>`:''}

--- a/dev/js/admin-deliverables.js
+++ b/dev/js/admin-deliverables.js
@@ -607,7 +607,7 @@ function renderDelivAppRow(g) {
 
   return `<tr data-app-id="${esc(g.application_id)}" class="${inf.is_audit ? 'audit-row' : ''}" style="${rowStyle}">
     <td><div style="display:flex;align-items:center;gap:6px;flex-wrap:wrap;margin-bottom:2px">${rtBadge}${campNoBadge}</div><div>${esc(camp.title || '—')}</div></td>
-    <td style="font-size:12px;color:var(--ink)">${(typeof brandOpsChannelText==='function'?brandOpsChannelText(camp.channel, camp.channel_match):'') || '—'}</td>
+    <td>${channelChipsHtml(camp.channel)}</td>
     <td style="font-size:12px;color:var(--ink);min-width:100px;max-width:160px;word-break:break-word">${brandLabel ? esc(brandLabel) : '—'}</td>
     <td style="font-size:11px;color:var(--ink);white-space:nowrap">${periodRangeCell(ps, pe)}</td>
     <td style="font-size:11px;color:var(--ink);white-space:nowrap">${periodSingleCell(camp.submission_end)}</td>

--- a/dev/js/admin.js
+++ b/dev/js/admin.js
@@ -356,7 +356,7 @@ async function loadAdminCampaigns(useCache) {
           </div>
         </div>
       </td>
-      <td style="font-size:12px;color:var(--ink)">${(typeof brandOpsChannelText==='function'?brandOpsChannelText(c.channel, c.channel_match):'') || '—'}</td>
+      <td>${channelChipsHtml(c.channel)}</td>
       ${(()=>{
         const bp = brandLabelAdmin(c);
         const bs = '';

--- a/dev/js/ui.js
+++ b/dev/js/ui.js
@@ -208,6 +208,17 @@ function getChannelLabel(ch, lang) {
   }).join(' or ');
 }
 
+// 채널 문자열(콤마구분) → 채널별 회색 라벨 칩. 관리자 목록 채널 열 공용.
+// 빈 채널은 '—'. 채널마다 한글 라벨 칩 1개씩 줄바꿈 허용.
+function channelChipsHtml(channel) {
+  const codes = (channel || '').split(',').map(s => s.trim()).filter(Boolean);
+  if (!codes.length) return '<span style="color:var(--muted)">—</span>';
+  return '<div style="display:flex;flex-wrap:wrap;gap:3px">' + codes.map(function(code) {
+    const label = (typeof getChannelLabel === 'function') ? (getChannelLabel(code) || code) : code;
+    return '<span style="background:#F0F0F0;color:#666;font-size:10px;font-weight:600;padding:2px 7px;border-radius:3px;white-space:nowrap">' + esc(label) + '</span>';
+  }).join('') + '</div>';
+}
+
 // lookup_values 공통: code 또는 name_ja를 현재 locale의 표시값으로
 function getLookupLabel(kind, valueOrCode, lang) {
   if (!valueOrCode) return '';

--- a/index.html
+++ b/index.html
@@ -8284,6 +8284,17 @@ function getChannelLabel(ch, lang) {
   }).join(' or ');
 }
 
+// 채널 문자열(콤마구분) → 채널별 회색 라벨 칩. 관리자 목록 채널 열 공용.
+// 빈 채널은 '—'. 채널마다 한글 라벨 칩 1개씩 줄바꿈 허용.
+function channelChipsHtml(channel) {
+  const codes = (channel || '').split(',').map(s => s.trim()).filter(Boolean);
+  if (!codes.length) return '<span style="color:var(--muted)">—</span>';
+  return '<div style="display:flex;flex-wrap:wrap;gap:3px">' + codes.map(function(code) {
+    const label = (typeof getChannelLabel === 'function') ? (getChannelLabel(code) || code) : code;
+    return '<span style="background:#F0F0F0;color:#666;font-size:10px;font-weight:600;padding:2px 7px;border-radius:3px;white-space:nowrap">' + esc(label) + '</span>';
+  }).join('') + '</div>';
+}
+
 // lookup_values 공통: code 또는 name_ja를 현재 locale의 표시값으로
 function getLookupLabel(kind, valueOrCode, lang) {
   if (!valueOrCode) return '';


### PR DESCRIPTION
## 변경 요약
- 3개 목록(캠페인·신청·결과물 관리)의 채널 열을 한 줄 텍스트에서 채널별 회색 라벨 칩으로 변경
- 공통 헬퍼 channelChipsHtml(channel) ui.js 추가 (esc 적용, flex-wrap)

## 요청 외 추가 변경
- 없음

[via reviewer] GO · qa skip