### PR TITLE
운영 배포: 관리자 목록 화면 열 개선 (캠페인 너비·브랜드/채널 열)

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -12,7 +12,7 @@
 // 회귀(2026-05-12 PR #182 머지 직후 발생)를 방지하기 위한 자동 reload 가드.
 // sessionStorage 차단 환경(시크릿 모드 일부, 쿠키 차단)에서는 자연스럽게 skip.
 (function(){
-  var CURRENT_BUILD = 'v1781600429';
+  var CURRENT_BUILD = 'v1781608906';
   if (CURRENT_BUILD.indexOf('__') === 0) return; // 빌드 미적용 (dev/ 직접 열기) 시 skip
   try {
     var prev = sessionStorage.getItem('reverb.adminBuild');
@@ -624,7 +624,7 @@ input[type="date"].form-input::-webkit-calendar-picker-indicator{margin-left:aut
    2026-05-15 확장: 모집기간·구매기간·제출마감·조회 컬럼 추가로 표 폭 증가.
    브랜드 서베이 패턴(75~96) 동일 구조 적용. */
 #adminPane-campaigns .admin-table-wrap{overflow-x:auto}
-#adminPane-campaigns .data-table{min-width:2000px}
+#adminPane-campaigns .data-table{min-width:2150px}
 
 /* 1열 체크박스 (44px) — sticky
    thead th 는 78줄 전역에서 이미 position:sticky;top:0;z-index:5 적용됨.
@@ -640,17 +640,15 @@ input[type="date"].form-input::-webkit-calendar-picker-indicator{margin-left:aut
 #adminPane-campaigns .data-table tbody td:nth-child(2){position:sticky;left:44px;z-index:3;background:var(--surface)}
 #adminPane-campaigns .data-table thead th:nth-child(2){left:44px;z-index:7;background:var(--surface-dim)}
 
-/* 3열 브랜드 (170px) — sticky + 우측 그림자 (sticky 영역 경계 시각화) */
+/* 3열 채널 (150px) — sticky + 우측 그림자 (sticky 영역 경계 시각화, 2026-06-16 채널 열 신설 → 고정 영역 끝) */
 #adminPane-campaigns .data-table th:nth-child(3),
-#adminPane-campaigns .data-table td:nth-child(3){width:170px;min-width:170px;max-width:170px;box-sizing:border-box;word-break:break-word}
+#adminPane-campaigns .data-table td:nth-child(3){width:150px;min-width:150px;max-width:150px;box-sizing:border-box;word-break:break-word}
 #adminPane-campaigns .data-table tbody td:nth-child(3){position:sticky;left:424px;z-index:3;background:var(--surface)}
 #adminPane-campaigns .data-table thead th:nth-child(3){left:424px;z-index:7;background:var(--surface-dim)}
 #adminPane-campaigns .data-table tbody td:nth-child(3),
 #adminPane-campaigns .data-table thead th:nth-child(3){box-shadow:2px 0 4px -2px rgba(0,0,0,.08)}
 
-/* 4열 제품 — 최소 폭 보장 (sticky 아님) */
-#adminPane-campaigns .data-table th:nth-child(4),
-#adminPane-campaigns .data-table td:nth-child(4){width:220px;min-width:220px;max-width:240px;box-sizing:border-box;word-break:break-word}
+/* 4열 브랜드 · 5열 제품 — sticky 아님, 폭은 행 인라인 style로 관리 */
 
 /* sticky 컬럼 hover 색상 */
 #adminPane-campaigns .data-table tbody tr:hover td:nth-child(1),
@@ -661,33 +659,39 @@ input[type="date"].form-input::-webkit-calendar-picker-indicator{margin-left:aut
 
 /* (세로 보더는 .data-table 공통 규칙에서 처리 — 위쪽 「관리자 목록 표 세로 구분선 공통」 참조) */
 
-/* 신청 관리 — 첫 컬럼(캠페인) 좌측 고정 */
+/* 신청 관리 — 캠페인(1) + 채널(2) 좌측 고정 (2026-06-16 채널 열 신설) */
 #adminPane-applications .admin-table-wrap{overflow-x:auto}
-#adminPane-applications .data-table{min-width:1400px}
+#adminPane-applications .data-table{min-width:1690px}
 #adminPane-applications .data-table th:nth-child(1),
-#adminPane-applications .data-table td:nth-child(1){width:240px;min-width:240px;max-width:240px;box-sizing:border-box}
+#adminPane-applications .data-table td:nth-child(1){width:380px;min-width:380px;max-width:380px;box-sizing:border-box}
 #adminPane-applications .data-table tbody td:nth-child(1){position:sticky;left:0;z-index:3;background:var(--surface)}
-#adminPane-applications .data-table tbody tr:hover td:nth-child(1){background:var(--surface-dim)}
-#adminPane-applications .data-table thead th:nth-child(1){left:0;z-index:7}
-#adminPane-applications .data-table tbody td:nth-child(1),
-#adminPane-applications .data-table thead th:nth-child(1){box-shadow:2px 0 4px -2px rgba(0,0,0,.08)}
+#adminPane-applications .data-table thead th:nth-child(1){left:0;z-index:7;background:var(--surface-dim)}
+#adminPane-applications .data-table th:nth-child(2),
+#adminPane-applications .data-table td:nth-child(2){width:150px;min-width:150px;max-width:150px;box-sizing:border-box;word-break:break-word}
+#adminPane-applications .data-table tbody td:nth-child(2){position:sticky;left:380px;z-index:3;background:var(--surface)}
+#adminPane-applications .data-table thead th:nth-child(2){left:380px;z-index:7;background:var(--surface-dim)}
+#adminPane-applications .data-table tbody td:nth-child(2),
+#adminPane-applications .data-table thead th:nth-child(2){box-shadow:2px 0 4px -2px rgba(0,0,0,.08)}
+#adminPane-applications .data-table tbody tr:hover td:nth-child(1),
+#adminPane-applications .data-table tbody tr:hover td:nth-child(2){background:var(--surface-dim)}
 #adminPane-applications .data-table thead th{white-space:nowrap}
 
-/* 결과물 관리 — 모집타입(1) + 캠페인(2) 양쪽 좌측 고정. 가로 스크롤 시 두 컬럼 어긋남 방지. */
+/* 결과물 관리 — 캠페인(1) + 채널(2) 좌측 고정 (2026-06-16 채널 열 신설).
+   캠페인 셀은 모집타입 칩을 흡수, 브랜드·채널은 별도 열. */
 #adminPane-deliverables .admin-table-wrap{overflow-x:auto}
-#adminPane-deliverables .data-table{min-width:1200px}
+#adminPane-deliverables .data-table{min-width:1650px}
 #adminPane-deliverables .data-table th:nth-child(1),
-#adminPane-deliverables .data-table td:nth-child(1){width:90px;min-width:90px;max-width:90px;box-sizing:border-box}
+#adminPane-deliverables .data-table td:nth-child(1){width:380px;min-width:380px;max-width:380px;box-sizing:border-box}
 #adminPane-deliverables .data-table tbody td:nth-child(1){position:sticky;left:0;z-index:3;background:var(--surface)}
 #adminPane-deliverables .data-table thead th:nth-child(1){left:0;z-index:7;background:var(--surface-dim)}
 #adminPane-deliverables .data-table th:nth-child(2),
-#adminPane-deliverables .data-table td:nth-child(2){width:240px;min-width:240px;max-width:240px;box-sizing:border-box}
-#adminPane-deliverables .data-table tbody td:nth-child(2){position:sticky;left:90px;z-index:3;background:var(--surface)}
-#adminPane-deliverables .data-table thead th:nth-child(2){left:90px;z-index:7;background:var(--surface-dim)}
-#adminPane-deliverables .data-table tbody tr:hover td:nth-child(1),
-#adminPane-deliverables .data-table tbody tr:hover td:nth-child(2){background:var(--surface-dim)}
+#adminPane-deliverables .data-table td:nth-child(2){width:150px;min-width:150px;max-width:150px;box-sizing:border-box;word-break:break-word}
+#adminPane-deliverables .data-table tbody td:nth-child(2){position:sticky;left:380px;z-index:3;background:var(--surface)}
+#adminPane-deliverables .data-table thead th:nth-child(2){left:380px;z-index:7;background:var(--surface-dim)}
 #adminPane-deliverables .data-table tbody td:nth-child(2),
 #adminPane-deliverables .data-table thead th:nth-child(2){box-shadow:2px 0 4px -2px rgba(0,0,0,.08)}
+#adminPane-deliverables .data-table tbody tr:hover td:nth-child(1),
+#adminPane-deliverables .data-table tbody tr:hover td:nth-child(2){background:var(--surface-dim)}
 #adminPane-deliverables .data-table thead th{white-space:nowrap}
 
 /* 브랜드 관리 — 첫 컬럼(brand_no) 좌측 고정. 컬럼 폭은 inline style로 이미 명시됨 */
@@ -2061,7 +2065,7 @@ tr.audit-row, .audit-row { background: #fff3e0 !important; }
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-06-16 18:00 · f9aa0e2</span>
+          <span class="admin-build-text">2026-06-16 20:21 · eddf0b2</span>
         </div>
       </div>
     </aside>
@@ -2191,6 +2195,7 @@ tr.audit-row, .audit-row { background: #fff3e0 !important; }
               <thead id="adminCampTableHead"><tr>
   <th style="width:44px;min-width:44px;max-width:44px;text-align:center;padding:8px 4px"><input type="checkbox" id="campSelectAll" onchange="toggleCampSelectAll(this.checked)" title="필터 결과 전체 선택"></th>
   <th>캠페인</th>
+  <th>채널</th>
   <th>브랜드</th>
   <th>제품</th>
   <th>상태 <span class="sort-arrows" data-sort="status" onclick="toggleCampSort('status')">▲▼</span></th>
@@ -2203,7 +2208,7 @@ tr.audit-row, .audit-row { background: #fff3e0 !important; }
   <th>수정일 <span class="sort-arrows" data-sort="updated" onclick="toggleCampSort('updated')">▲▼</span></th>
   <th></th>
 </tr></thead>
-              <tbody id="adminCampsBody"><tr><td colspan="14" style="text-align:center;color:var(--muted);padding:24px"><span class="spinner" style="width:20px;height:20px;border-width:2px;border-color:rgba(200,120,163,.2);border-top-color:var(--pink)"></span></td></tr></tbody>
+              <tbody id="adminCampsBody"><tr><td colspan="15" style="text-align:center;color:var(--muted);padding:24px"><span class="spinner" style="width:20px;height:20px;border-width:2px;border-color:rgba(200,120,163,.2);border-top-color:var(--pink)"></span></td></tr></tbody>
             </table>
             </div>
           </div>
@@ -2969,8 +2974,8 @@ tr.audit-row, .audit-row { background: #fff3e0 !important; }
               </div>
               <div class="admin-table-wrap">
               <table class="data-table">
-                <thead id="appTableHead"><tr><th>캠페인</th><th>브랜드</th><th>제품</th><th>모집기간 <span class="sort-arrows app-sort-arrows" data-sort="deadline" onclick="toggleAppSort('deadline')">▲▼</span></th><th>인플루언서 <span class="sort-arrows app-sort-arrows" data-sort="name" onclick="toggleAppSort('name')">▲▼</span></th><th>신청 사유</th><th>신청일 <span class="sort-arrows app-sort-arrows" data-sort="created" onclick="toggleAppSort('created')">▲▼</span></th><th>상태 <span class="sort-arrows app-sort-arrows" data-sort="status" onclick="toggleAppSort('status')">▲▼</span></th><th>처리</th></tr></thead>
-                <tbody id="appTableBody"><tr><td colspan="9" style="text-align:center;color:var(--muted);padding:24px"><span class="spinner" style="width:20px;height:20px;border-width:2px;border-color:rgba(200,120,163,.2);border-top-color:var(--pink)"></span></td></tr></tbody>
+                <thead id="appTableHead"><tr><th>캠페인</th><th>채널</th><th>브랜드</th><th>제품</th><th>모집기간 <span class="sort-arrows app-sort-arrows" data-sort="deadline" onclick="toggleAppSort('deadline')">▲▼</span></th><th>인플루언서 <span class="sort-arrows app-sort-arrows" data-sort="name" onclick="toggleAppSort('name')">▲▼</span></th><th>신청 사유</th><th>신청일 <span class="sort-arrows app-sort-arrows" data-sort="created" onclick="toggleAppSort('created')">▲▼</span></th><th>상태 <span class="sort-arrows app-sort-arrows" data-sort="status" onclick="toggleAppSort('status')">▲▼</span></th><th>처리</th></tr></thead>
+                <tbody id="appTableBody"><tr><td colspan="10" style="text-align:center;color:var(--muted);padding:24px"><span class="spinner" style="width:20px;height:20px;border-width:2px;border-color:rgba(200,120,163,.2);border-top-color:var(--pink)"></span></td></tr></tbody>
               </table>
               </div>
             </div>
@@ -3053,8 +3058,9 @@ tr.audit-row, .audit-row { background: #fff3e0 !important; }
             <div class="admin-table-wrap">
             <table class="data-table deliv-app-table">
               <thead><tr>
-                <th style="width:90px">모집 타입</th>
                 <th>캠페인</th>
+                <th>채널</th>
+                <th>브랜드</th>
                 <th style="width:180px">구매기간 <span class="sort-arrows" data-sort="purchase" onclick="toggleDelivSort('purchase')">▲▼</span></th>
                 <th style="width:130px">결과물 제출 마감 <span class="sort-arrows" data-sort="submission_end" onclick="toggleDelivSort('submission_end')">▲▼</span></th>
                 <th>인플루언서</th>
@@ -3064,7 +3070,7 @@ tr.audit-row, .audit-row { background: #fff3e0 !important; }
                 <th style="width:130px">최근 제출 <span class="sort-arrows" data-sort="submitted" onclick="toggleDelivSort('submitted')">▲▼</span></th>
                 <th style="width:90px">처리</th>
               </tr></thead>
-              <tbody id="delivTableBody"><tr><td colspan="10" style="text-align:center;color:var(--muted);padding:24px"><span class="spinner" style="width:20px;height:20px;border-width:2px;border-color:rgba(200,120,163,.2);border-top-color:var(--pink)"></span></td></tr></tbody>
+              <tbody id="delivTableBody"><tr><td colspan="11" style="text-align:center;color:var(--muted);padding:24px"><span class="spinner" style="width:20px;height:20px;border-width:2px;border-color:rgba(200,120,163,.2);border-top-color:var(--pink)"></span></td></tr></tbody>
             </table>
             </div>
           </div>
@@ -6024,7 +6030,7 @@ async function fetchCampaigns() {
 const ADMIN_LIST_COLUMNS = [
   'id', 'title', 'brand', 'brand_ko', 'brand_ja', 'brand_en', 'product', 'product_ko',
   'campaign_no', 'legacy_no',
-  'recruit_type', 'channel', 'status',
+  'recruit_type', 'channel', 'channel_match', 'status',
   'slots', 'view_count',
   'img1', 'img2', 'img3', 'img4', 'img5', 'img6', 'img7', 'img8',
   'image_url', 'image_crops', 'emoji',
@@ -6581,7 +6587,7 @@ async function fetchDeliverables(filters) {
         application_id, user_id, campaign_id,
         submitted_by_admin, submitted_by_admin_reason_code, submitted_by_admin_reason, submitted_by_admin_at,
         submitted_by_admin_evidence,
-        campaigns:campaign_id (id, campaign_no, title, brand, recruit_type, channel, purchase_start, purchase_end, visit_start, visit_end, submission_end)
+        campaigns:campaign_id (id, campaign_no, title, brand, recruit_type, channel, channel_match, purchase_start, purchase_end, visit_start, visit_end, submission_end)
       `).neq('status', 'draft');
       if (filters?.status && filters.status !== 'all') q = q.eq('status', filters.status);
       if (filters?.kind && filters.kind !== 'all') q = q.eq('kind', filters.kind);
@@ -9631,6 +9637,20 @@ function getChannelLabel(ch, lang) {
     }
     return CHANNEL_LABEL_FALLBACK[code] || code;
   }).join(' or ');
+}
+
+// 채널 문자열(콤마구분) → 채널별 회색 라벨 칩. 관리자 목록 채널 열 공용.
+// 빈 채널은 '—'. 채널마다 한글 라벨 칩 1개씩 줄바꿈 허용.
+// 채널 2개 이상이면 칩 사이에 match 구분자 표시 ('and'=&, 그 외=or).
+function channelChipsHtml(channel, match) {
+  const codes = (channel || '').split(',').map(s => s.trim()).filter(Boolean);
+  if (!codes.length) return '<span style="color:var(--muted)">—</span>';
+  const chips = codes.map(function(code) {
+    const label = (typeof getChannelLabel === 'function') ? (getChannelLabel(code) || code) : code;
+    return '<span style="background:#F0F0F0;color:#666;font-size:10px;font-weight:600;padding:2px 7px;border-radius:3px;white-space:nowrap">' + esc(label) + '</span>';
+  });
+  const sep = '<span style="font-size:9px;color:var(--muted);font-weight:600;padding:0 1px">' + (match === 'and' ? '&' : 'or') + '</span>';
+  return '<div style="display:flex;flex-wrap:wrap;align-items:center;gap:3px">' + chips.join(sep) + '</div>';
 }
 
 // lookup_values 공통: code 또는 name_ja를 현재 locale의 표시값으로
@@ -19247,7 +19267,7 @@ function toggleDelivSearch() {
 async function renderDeliverablesList() {
   const tbody = $('delivTableBody');
   if (!tbody) return;
-  tbody.innerHTML = '<tr><td colspan="10" style="text-align:center;color:var(--muted);padding:24px"><span class="spinner" style="width:20px;height:20px;border-width:2px;border-color:rgba(200,120,163,.2);border-top-color:var(--pink)"></span></td></tr>';
+  tbody.innerHTML = '<tr><td colspan="11" style="text-align:center;color:var(--muted);padding:24px"><span class="spinner" style="width:20px;height:20px;border-width:2px;border-color:rgba(200,120,163,.2);border-top-color:var(--pink)"></span></td></tr>';
   await loadApplicantMsgUnread();  // 응모건 메시지 본인 미열람 배지 맵
   setupDelivSubmittedRange();  // 최근 제출일 range picker (1회 mount)
   // 채널 라벨 캐시 보장 — monitor 채널별 미니 행·검수 모달 패널 제목에서 getLookupLabel 사용. 캐시 없으면 코드 그대로 노출됨(예: 'qoo10' → 'Qoo10' 변환 실패).
@@ -19520,7 +19540,7 @@ async function renderDeliverablesList() {
     rows: filtered,
     renderRow: renderDelivAppRow,
     pageSize: DELIV_PAGE_SIZE,
-    emptyHtml: '<tr><td colspan="10" style="text-align:center;color:var(--muted);padding:30px">해당 조건의 결과물이 없습니다.</td></tr>',
+    emptyHtml: '<tr><td colspan="11" style="text-align:center;color:var(--muted);padding:30px">해당 조건의 결과물이 없습니다.</td></tr>',
   });
   refreshDelivSidebarBadge();
 }
@@ -19681,7 +19701,7 @@ function renderDelivAppRow(g) {
     : '<span style="font-size:11px;color:var(--muted)">미제출</span>';
 
   const campNoBadge = camp.campaign_no
-    ? `<span style="font-family:monospace;font-size:10px;font-weight:600;color:var(--muted);margin-right:6px">${esc(camp.campaign_no)}</span>`
+    ? `<span style="font-family:monospace;font-size:10px;font-weight:600;color:var(--muted)">${esc(camp.campaign_no)}</span>`
     : '';
 
   // 구매기간(리뷰어 monitor) / 방문기간(visit) 분기. gifting 은 빈칸(—).
@@ -19691,9 +19711,12 @@ function renderDelivAppRow(g) {
   const pe = (rt === 'monitor') ? camp.purchase_end
            : (rt === 'visit')   ? camp.visit_end    : '';
 
+  const brandLabel = brandLabelAdmin(camp);
+
   return `<tr data-app-id="${esc(g.application_id)}" class="${inf.is_audit ? 'audit-row' : ''}" style="${rowStyle}">
-    <td>${rtBadge}</td>
-    <td>${campNoBadge}<div>${esc(camp.title || '—')}</div><div style="font-size:10px;color:var(--muted)">${esc(brandLabelAdmin(camp))}</div></td>
+    <td><div style="display:flex;align-items:center;gap:6px;flex-wrap:wrap;margin-bottom:2px">${rtBadge}${campNoBadge}</div><div>${esc(camp.title || '—')}</div></td>
+    <td>${channelChipsHtml(camp.channel, camp.channel_match)}</td>
+    <td style="font-size:12px;color:var(--ink);min-width:100px;max-width:160px;word-break:break-word">${brandLabel ? esc(brandLabel) : '—'}</td>
     <td style="font-size:11px;color:var(--ink);white-space:nowrap">${periodRangeCell(ps, pe)}</td>
     <td style="font-size:11px;color:var(--ink);white-space:nowrap">${periodSingleCell(camp.submission_end)}</td>
     <td><div style="font-weight:600;color:var(--pink);cursor:pointer" onclick="openInfluencerModal('${esc(inf.id||'')}')">${infName}${auditBadgeHtml(inf)}${(typeof influencerStatusBadges === 'function') ? influencerStatusBadges(inf) : ''}</div>${infSub ? `<div style="font-size:10px;color:var(--muted)">${infSub}</div>` : ''}<div style="margin-top:4px">${renderApplicantMsgBtn({id: g.application_id, campaign_id: (camp && camp.id) || ''})}</div></td>
@@ -24245,7 +24268,7 @@ async function renderAppCampList() {
     const recruitStart   = camp.recruit_start ? formatDate(camp.recruit_start) : '';
     const recruitEnd     = camp.deadline ? formatDate(camp.deadline) : '';
     return `<tr data-id="${esc(a.id)}" class="${u.is_audit?'audit-row':''}">
-      <td style="max-width:260px">
+      <td>
         <div style="display:flex;align-items:center;gap:10px">
           <div style="position:relative;width:40px;height:40px;flex-shrink:0;border-radius:6px;overflow:hidden;background:var(--surface-dim)">
             ${thumbUrl ? `<img src="${imgThumb(thumbUrl,96,70)}" data-orig="${thumbUrl}" loading="lazy" decoding="async" onerror="if(this.src!==this.dataset.orig){this.src=this.dataset.orig}" style="width:100%;height:100%;object-fit:cover">` : `<span style="display:flex;align-items:center;justify-content:center;width:100%;height:100%;font-size:18px">${esc(camp.emoji)||'<span class="material-icons-round notranslate" translate="no" style="font-size:18px;color:var(--muted)">inventory_2</span>'}</span>`}
@@ -24257,6 +24280,7 @@ async function renderAppCampList() {
           </div>
         </div>
       </td>
+      <td>${channelChipsHtml(camp.channel, camp.channel_match)}</td>
       <td style="font-size:12px;color:var(--ink);min-width:100px;max-width:160px;word-break:break-word">
         ${brandPrimary?esc(brandPrimary):'—'}
         ${brandSub?`<div style="font-size:10px;color:var(--muted);margin-top:2px">${esc(brandSub)}</div>`:''}
@@ -26252,11 +26276,12 @@ function updateCampTableHead() {
   if (!head) return;
   const statusHelpIcon = `<span class="material-icons-round notranslate" translate="no" title="상태별 클라이언트 노출 안내" style="font-size:14px;cursor:pointer;color:var(--muted);vertical-align:middle;margin-left:2px" onclick="event.stopPropagation();openCampStatusHelp()">info_outline</span>`;
   if (adminReorderMode) {
-    head.innerHTML = `<tr><th>순서</th><th>캠페인</th><th>브랜드</th><th>제품</th><th>상태 ${statusHelpIcon}</th><th>노출</th><th>신청</th><th>조회</th><th>등록일</th><th>수정일</th></tr>`;
+    head.innerHTML = `<tr><th>순서</th><th>캠페인</th><th>채널</th><th>브랜드</th><th>제품</th><th>상태 ${statusHelpIcon}</th><th>노출</th><th>신청</th><th>조회</th><th>등록일</th><th>수정일</th></tr>`;
   } else {
     head.innerHTML = `<tr>
       <th style="width:44px;min-width:44px;max-width:44px;text-align:center;padding:8px 4px"><input type="checkbox" id="campSelectAll" onchange="toggleCampSelectAll(this.checked)" title="필터 결과 전체 선택"></th>
       <th>캠페인</th>
+      <th>채널</th>
       <th>브랜드</th>
       <th>제품</th>
       <th>상태 ${statusHelpIcon} <span class="sort-arrows" data-sort="status" onclick="toggleCampSort('status')">${adminCampSortKey==='status'?(adminCampSortDir==='asc'?'▲':'▼'):'▲▼'}</span></th>
@@ -26465,6 +26490,7 @@ async function loadAdminCampaigns(useCache) {
           </div>
         </div>
       </td>
+      <td>${channelChipsHtml(c.channel, c.channel_match)}</td>
       ${(()=>{
         const bp = brandLabelAdmin(c);
         const bs = '';
@@ -26514,9 +26540,9 @@ async function loadAdminCampaigns(useCache) {
       </td>`}
     </tr>`;
   };
-  // 일반 모드 13컬럼(체크/캠페인/브랜드/제품/상태/신청/모집기간/구매기간/제출마감/조회/등록일/수정일/액션)
-  // 순서변경 모드 9컬럼(순서/캠페인/브랜드/제품/상태/신청/조회/등록일/수정일)
-  const emptyHtml = `<tr><td colspan="${adminReorderMode ? 10 : 14}" style="text-align:center;color:var(--muted);padding:24px">캠페인 없음</td></tr>`;
+  // 일반 모드 15컬럼(체크/캠페인/채널/브랜드/제품/상태/노출/신청/모집기간/구매기간/제출마감/조회/등록일/수정일/액션)
+  // 순서변경 모드(순서/캠페인/채널/브랜드/제품/상태/노출/신청/조회/등록일/수정일) / 일반 모드 컬럼 수
+  const emptyHtml = `<tr><td colspan="${adminReorderMode ? 11 : 15}" style="text-align:center;color:var(--muted);padding:24px">캠페인 없음</td></tr>`;
   if (adminReorderMode) {
     // 순서변경 모드: 전체 DOM 필요 (↑↓ 위치 인덱스 기반). lazy 비활성.
     if (campsLazy) { campsLazy.destroy(); campsLazy = null; }

--- a/dev/admin/index.html
+++ b/dev/admin/index.html
@@ -262,6 +262,7 @@
               <thead id="adminCampTableHead"><tr>
   <th style="width:44px;min-width:44px;max-width:44px;text-align:center;padding:8px 4px"><input type="checkbox" id="campSelectAll" onchange="toggleCampSelectAll(this.checked)" title="필터 결과 전체 선택"></th>
   <th>캠페인</th>
+  <th>채널</th>
   <th>브랜드</th>
   <th>제품</th>
   <th>상태 <span class="sort-arrows" data-sort="status" onclick="toggleCampSort('status')">▲▼</span></th>
@@ -274,7 +275,7 @@
   <th>수정일 <span class="sort-arrows" data-sort="updated" onclick="toggleCampSort('updated')">▲▼</span></th>
   <th></th>
 </tr></thead>
-              <tbody id="adminCampsBody"><tr><td colspan="14" style="text-align:center;color:var(--muted);padding:24px"><span class="spinner" style="width:20px;height:20px;border-width:2px;border-color:rgba(200,120,163,.2);border-top-color:var(--pink)"></span></td></tr></tbody>
+              <tbody id="adminCampsBody"><tr><td colspan="15" style="text-align:center;color:var(--muted);padding:24px"><span class="spinner" style="width:20px;height:20px;border-width:2px;border-color:rgba(200,120,163,.2);border-top-color:var(--pink)"></span></td></tr></tbody>
             </table>
             </div>
           </div>
@@ -1040,8 +1041,8 @@
               </div>
               <div class="admin-table-wrap">
               <table class="data-table">
-                <thead id="appTableHead"><tr><th>캠페인</th><th>브랜드</th><th>제품</th><th>모집기간 <span class="sort-arrows app-sort-arrows" data-sort="deadline" onclick="toggleAppSort('deadline')">▲▼</span></th><th>인플루언서 <span class="sort-arrows app-sort-arrows" data-sort="name" onclick="toggleAppSort('name')">▲▼</span></th><th>신청 사유</th><th>신청일 <span class="sort-arrows app-sort-arrows" data-sort="created" onclick="toggleAppSort('created')">▲▼</span></th><th>상태 <span class="sort-arrows app-sort-arrows" data-sort="status" onclick="toggleAppSort('status')">▲▼</span></th><th>처리</th></tr></thead>
-                <tbody id="appTableBody"><tr><td colspan="9" style="text-align:center;color:var(--muted);padding:24px"><span class="spinner" style="width:20px;height:20px;border-width:2px;border-color:rgba(200,120,163,.2);border-top-color:var(--pink)"></span></td></tr></tbody>
+                <thead id="appTableHead"><tr><th>캠페인</th><th>채널</th><th>브랜드</th><th>제품</th><th>모집기간 <span class="sort-arrows app-sort-arrows" data-sort="deadline" onclick="toggleAppSort('deadline')">▲▼</span></th><th>인플루언서 <span class="sort-arrows app-sort-arrows" data-sort="name" onclick="toggleAppSort('name')">▲▼</span></th><th>신청 사유</th><th>신청일 <span class="sort-arrows app-sort-arrows" data-sort="created" onclick="toggleAppSort('created')">▲▼</span></th><th>상태 <span class="sort-arrows app-sort-arrows" data-sort="status" onclick="toggleAppSort('status')">▲▼</span></th><th>처리</th></tr></thead>
+                <tbody id="appTableBody"><tr><td colspan="10" style="text-align:center;color:var(--muted);padding:24px"><span class="spinner" style="width:20px;height:20px;border-width:2px;border-color:rgba(200,120,163,.2);border-top-color:var(--pink)"></span></td></tr></tbody>
               </table>
               </div>
             </div>
@@ -1124,8 +1125,9 @@
             <div class="admin-table-wrap">
             <table class="data-table deliv-app-table">
               <thead><tr>
-                <th style="width:90px">모집 타입</th>
                 <th>캠페인</th>
+                <th>채널</th>
+                <th>브랜드</th>
                 <th style="width:180px">구매기간 <span class="sort-arrows" data-sort="purchase" onclick="toggleDelivSort('purchase')">▲▼</span></th>
                 <th style="width:130px">결과물 제출 마감 <span class="sort-arrows" data-sort="submission_end" onclick="toggleDelivSort('submission_end')">▲▼</span></th>
                 <th>인플루언서</th>
@@ -1135,7 +1137,7 @@
                 <th style="width:130px">최근 제출 <span class="sort-arrows" data-sort="submitted" onclick="toggleDelivSort('submitted')">▲▼</span></th>
                 <th style="width:90px">처리</th>
               </tr></thead>
-              <tbody id="delivTableBody"><tr><td colspan="10" style="text-align:center;color:var(--muted);padding:24px"><span class="spinner" style="width:20px;height:20px;border-width:2px;border-color:rgba(200,120,163,.2);border-top-color:var(--pink)"></span></td></tr></tbody>
+              <tbody id="delivTableBody"><tr><td colspan="11" style="text-align:center;color:var(--muted);padding:24px"><span class="spinner" style="width:20px;height:20px;border-width:2px;border-color:rgba(200,120,163,.2);border-top-color:var(--pink)"></span></td></tr></tbody>
             </table>
             </div>
           </div>

--- a/dev/css/admin.css
+++ b/dev/css/admin.css
@@ -166,7 +166,7 @@
    2026-05-15 확장: 모집기간·구매기간·제출마감·조회 컬럼 추가로 표 폭 증가.
    브랜드 서베이 패턴(75~96) 동일 구조 적용. */
 #adminPane-campaigns .admin-table-wrap{overflow-x:auto}
-#adminPane-campaigns .data-table{min-width:2000px}
+#adminPane-campaigns .data-table{min-width:2150px}
 
 /* 1열 체크박스 (44px) — sticky
    thead th 는 78줄 전역에서 이미 position:sticky;top:0;z-index:5 적용됨.
@@ -182,17 +182,15 @@
 #adminPane-campaigns .data-table tbody td:nth-child(2){position:sticky;left:44px;z-index:3;background:var(--surface)}
 #adminPane-campaigns .data-table thead th:nth-child(2){left:44px;z-index:7;background:var(--surface-dim)}
 
-/* 3열 브랜드 (170px) — sticky + 우측 그림자 (sticky 영역 경계 시각화) */
+/* 3열 채널 (150px) — sticky + 우측 그림자 (sticky 영역 경계 시각화, 2026-06-16 채널 열 신설 → 고정 영역 끝) */
 #adminPane-campaigns .data-table th:nth-child(3),
-#adminPane-campaigns .data-table td:nth-child(3){width:170px;min-width:170px;max-width:170px;box-sizing:border-box;word-break:break-word}
+#adminPane-campaigns .data-table td:nth-child(3){width:150px;min-width:150px;max-width:150px;box-sizing:border-box;word-break:break-word}
 #adminPane-campaigns .data-table tbody td:nth-child(3){position:sticky;left:424px;z-index:3;background:var(--surface)}
 #adminPane-campaigns .data-table thead th:nth-child(3){left:424px;z-index:7;background:var(--surface-dim)}
 #adminPane-campaigns .data-table tbody td:nth-child(3),
 #adminPane-campaigns .data-table thead th:nth-child(3){box-shadow:2px 0 4px -2px rgba(0,0,0,.08)}
 
-/* 4열 제품 — 최소 폭 보장 (sticky 아님) */
-#adminPane-campaigns .data-table th:nth-child(4),
-#adminPane-campaigns .data-table td:nth-child(4){width:220px;min-width:220px;max-width:240px;box-sizing:border-box;word-break:break-word}
+/* 4열 브랜드 · 5열 제품 — sticky 아님, 폭은 행 인라인 style로 관리 */
 
 /* sticky 컬럼 hover 색상 */
 #adminPane-campaigns .data-table tbody tr:hover td:nth-child(1),
@@ -203,33 +201,39 @@
 
 /* (세로 보더는 .data-table 공통 규칙에서 처리 — 위쪽 「관리자 목록 표 세로 구분선 공통」 참조) */
 
-/* 신청 관리 — 첫 컬럼(캠페인) 좌측 고정 */
+/* 신청 관리 — 캠페인(1) + 채널(2) 좌측 고정 (2026-06-16 채널 열 신설) */
 #adminPane-applications .admin-table-wrap{overflow-x:auto}
-#adminPane-applications .data-table{min-width:1400px}
+#adminPane-applications .data-table{min-width:1690px}
 #adminPane-applications .data-table th:nth-child(1),
-#adminPane-applications .data-table td:nth-child(1){width:240px;min-width:240px;max-width:240px;box-sizing:border-box}
+#adminPane-applications .data-table td:nth-child(1){width:380px;min-width:380px;max-width:380px;box-sizing:border-box}
 #adminPane-applications .data-table tbody td:nth-child(1){position:sticky;left:0;z-index:3;background:var(--surface)}
-#adminPane-applications .data-table tbody tr:hover td:nth-child(1){background:var(--surface-dim)}
-#adminPane-applications .data-table thead th:nth-child(1){left:0;z-index:7}
-#adminPane-applications .data-table tbody td:nth-child(1),
-#adminPane-applications .data-table thead th:nth-child(1){box-shadow:2px 0 4px -2px rgba(0,0,0,.08)}
+#adminPane-applications .data-table thead th:nth-child(1){left:0;z-index:7;background:var(--surface-dim)}
+#adminPane-applications .data-table th:nth-child(2),
+#adminPane-applications .data-table td:nth-child(2){width:150px;min-width:150px;max-width:150px;box-sizing:border-box;word-break:break-word}
+#adminPane-applications .data-table tbody td:nth-child(2){position:sticky;left:380px;z-index:3;background:var(--surface)}
+#adminPane-applications .data-table thead th:nth-child(2){left:380px;z-index:7;background:var(--surface-dim)}
+#adminPane-applications .data-table tbody td:nth-child(2),
+#adminPane-applications .data-table thead th:nth-child(2){box-shadow:2px 0 4px -2px rgba(0,0,0,.08)}
+#adminPane-applications .data-table tbody tr:hover td:nth-child(1),
+#adminPane-applications .data-table tbody tr:hover td:nth-child(2){background:var(--surface-dim)}
 #adminPane-applications .data-table thead th{white-space:nowrap}
 
-/* 결과물 관리 — 모집타입(1) + 캠페인(2) 양쪽 좌측 고정. 가로 스크롤 시 두 컬럼 어긋남 방지. */
+/* 결과물 관리 — 캠페인(1) + 채널(2) 좌측 고정 (2026-06-16 채널 열 신설).
+   캠페인 셀은 모집타입 칩을 흡수, 브랜드·채널은 별도 열. */
 #adminPane-deliverables .admin-table-wrap{overflow-x:auto}
-#adminPane-deliverables .data-table{min-width:1200px}
+#adminPane-deliverables .data-table{min-width:1650px}
 #adminPane-deliverables .data-table th:nth-child(1),
-#adminPane-deliverables .data-table td:nth-child(1){width:90px;min-width:90px;max-width:90px;box-sizing:border-box}
+#adminPane-deliverables .data-table td:nth-child(1){width:380px;min-width:380px;max-width:380px;box-sizing:border-box}
 #adminPane-deliverables .data-table tbody td:nth-child(1){position:sticky;left:0;z-index:3;background:var(--surface)}
 #adminPane-deliverables .data-table thead th:nth-child(1){left:0;z-index:7;background:var(--surface-dim)}
 #adminPane-deliverables .data-table th:nth-child(2),
-#adminPane-deliverables .data-table td:nth-child(2){width:240px;min-width:240px;max-width:240px;box-sizing:border-box}
-#adminPane-deliverables .data-table tbody td:nth-child(2){position:sticky;left:90px;z-index:3;background:var(--surface)}
-#adminPane-deliverables .data-table thead th:nth-child(2){left:90px;z-index:7;background:var(--surface-dim)}
-#adminPane-deliverables .data-table tbody tr:hover td:nth-child(1),
-#adminPane-deliverables .data-table tbody tr:hover td:nth-child(2){background:var(--surface-dim)}
+#adminPane-deliverables .data-table td:nth-child(2){width:150px;min-width:150px;max-width:150px;box-sizing:border-box;word-break:break-word}
+#adminPane-deliverables .data-table tbody td:nth-child(2){position:sticky;left:380px;z-index:3;background:var(--surface)}
+#adminPane-deliverables .data-table thead th:nth-child(2){left:380px;z-index:7;background:var(--surface-dim)}
 #adminPane-deliverables .data-table tbody td:nth-child(2),
 #adminPane-deliverables .data-table thead th:nth-child(2){box-shadow:2px 0 4px -2px rgba(0,0,0,.08)}
+#adminPane-deliverables .data-table tbody tr:hover td:nth-child(1),
+#adminPane-deliverables .data-table tbody tr:hover td:nth-child(2){background:var(--surface-dim)}
 #adminPane-deliverables .data-table thead th{white-space:nowrap}
 
 /* 브랜드 관리 — 첫 컬럼(brand_no) 좌측 고정. 컬럼 폭은 inline style로 이미 명시됨 */

--- a/dev/js/admin-applications.js
+++ b/dev/js/admin-applications.js
@@ -521,7 +521,7 @@ async function renderAppCampList() {
     const recruitStart   = camp.recruit_start ? formatDate(camp.recruit_start) : '';
     const recruitEnd     = camp.deadline ? formatDate(camp.deadline) : '';
     return `<tr data-id="${esc(a.id)}" class="${u.is_audit?'audit-row':''}">
-      <td style="max-width:260px">
+      <td>
         <div style="display:flex;align-items:center;gap:10px">
           <div style="position:relative;width:40px;height:40px;flex-shrink:0;border-radius:6px;overflow:hidden;background:var(--surface-dim)">
             ${thumbUrl ? `<img src="${imgThumb(thumbUrl,96,70)}" data-orig="${thumbUrl}" loading="lazy" decoding="async" onerror="if(this.src!==this.dataset.orig){this.src=this.dataset.orig}" style="width:100%;height:100%;object-fit:cover">` : `<span style="display:flex;align-items:center;justify-content:center;width:100%;height:100%;font-size:18px">${esc(camp.emoji)||'<span class="material-icons-round notranslate" translate="no" style="font-size:18px;color:var(--muted)">inventory_2</span>'}</span>`}
@@ -533,6 +533,7 @@ async function renderAppCampList() {
           </div>
         </div>
       </td>
+      <td>${channelChipsHtml(camp.channel, camp.channel_match)}</td>
       <td style="font-size:12px;color:var(--ink);min-width:100px;max-width:160px;word-break:break-word">
         ${brandPrimary?esc(brandPrimary):'—'}
         ${brandSub?`<div style="font-size:10px;color:var(--muted);margin-top:2px">${esc(brandSub)}</div>`:''}

--- a/dev/js/admin-deliverables.js
+++ b/dev/js/admin-deliverables.js
@@ -159,7 +159,7 @@ function toggleDelivSearch() {
 async function renderDeliverablesList() {
   const tbody = $('delivTableBody');
   if (!tbody) return;
-  tbody.innerHTML = '<tr><td colspan="10" style="text-align:center;color:var(--muted);padding:24px"><span class="spinner" style="width:20px;height:20px;border-width:2px;border-color:rgba(200,120,163,.2);border-top-color:var(--pink)"></span></td></tr>';
+  tbody.innerHTML = '<tr><td colspan="11" style="text-align:center;color:var(--muted);padding:24px"><span class="spinner" style="width:20px;height:20px;border-width:2px;border-color:rgba(200,120,163,.2);border-top-color:var(--pink)"></span></td></tr>';
   await loadApplicantMsgUnread();  // 응모건 메시지 본인 미열람 배지 맵
   setupDelivSubmittedRange();  // 최근 제출일 range picker (1회 mount)
   // 채널 라벨 캐시 보장 — monitor 채널별 미니 행·검수 모달 패널 제목에서 getLookupLabel 사용. 캐시 없으면 코드 그대로 노출됨(예: 'qoo10' → 'Qoo10' 변환 실패).
@@ -432,7 +432,7 @@ async function renderDeliverablesList() {
     rows: filtered,
     renderRow: renderDelivAppRow,
     pageSize: DELIV_PAGE_SIZE,
-    emptyHtml: '<tr><td colspan="10" style="text-align:center;color:var(--muted);padding:30px">해당 조건의 결과물이 없습니다.</td></tr>',
+    emptyHtml: '<tr><td colspan="11" style="text-align:center;color:var(--muted);padding:30px">해당 조건의 결과물이 없습니다.</td></tr>',
   });
   refreshDelivSidebarBadge();
 }
@@ -593,7 +593,7 @@ function renderDelivAppRow(g) {
     : '<span style="font-size:11px;color:var(--muted)">미제출</span>';
 
   const campNoBadge = camp.campaign_no
-    ? `<span style="font-family:monospace;font-size:10px;font-weight:600;color:var(--muted);margin-right:6px">${esc(camp.campaign_no)}</span>`
+    ? `<span style="font-family:monospace;font-size:10px;font-weight:600;color:var(--muted)">${esc(camp.campaign_no)}</span>`
     : '';
 
   // 구매기간(리뷰어 monitor) / 방문기간(visit) 분기. gifting 은 빈칸(—).
@@ -603,9 +603,12 @@ function renderDelivAppRow(g) {
   const pe = (rt === 'monitor') ? camp.purchase_end
            : (rt === 'visit')   ? camp.visit_end    : '';
 
+  const brandLabel = brandLabelAdmin(camp);
+
   return `<tr data-app-id="${esc(g.application_id)}" class="${inf.is_audit ? 'audit-row' : ''}" style="${rowStyle}">
-    <td>${rtBadge}</td>
-    <td>${campNoBadge}<div>${esc(camp.title || '—')}</div><div style="font-size:10px;color:var(--muted)">${esc(brandLabelAdmin(camp))}</div></td>
+    <td><div style="display:flex;align-items:center;gap:6px;flex-wrap:wrap;margin-bottom:2px">${rtBadge}${campNoBadge}</div><div>${esc(camp.title || '—')}</div></td>
+    <td>${channelChipsHtml(camp.channel, camp.channel_match)}</td>
+    <td style="font-size:12px;color:var(--ink);min-width:100px;max-width:160px;word-break:break-word">${brandLabel ? esc(brandLabel) : '—'}</td>
     <td style="font-size:11px;color:var(--ink);white-space:nowrap">${periodRangeCell(ps, pe)}</td>
     <td style="font-size:11px;color:var(--ink);white-space:nowrap">${periodSingleCell(camp.submission_end)}</td>
     <td><div style="font-weight:600;color:var(--pink);cursor:pointer" onclick="openInfluencerModal('${esc(inf.id||'')}')">${infName}${auditBadgeHtml(inf)}${(typeof influencerStatusBadges === 'function') ? influencerStatusBadges(inf) : ''}</div>${infSub ? `<div style="font-size:10px;color:var(--muted)">${infSub}</div>` : ''}<div style="margin-top:4px">${renderApplicantMsgBtn({id: g.application_id, campaign_id: (camp && camp.id) || ''})}</div></td>

--- a/dev/js/admin.js
+++ b/dev/js/admin.js
@@ -143,11 +143,12 @@ function updateCampTableHead() {
   if (!head) return;
   const statusHelpIcon = `<span class="material-icons-round notranslate" translate="no" title="상태별 클라이언트 노출 안내" style="font-size:14px;cursor:pointer;color:var(--muted);vertical-align:middle;margin-left:2px" onclick="event.stopPropagation();openCampStatusHelp()">info_outline</span>`;
   if (adminReorderMode) {
-    head.innerHTML = `<tr><th>순서</th><th>캠페인</th><th>브랜드</th><th>제품</th><th>상태 ${statusHelpIcon}</th><th>노출</th><th>신청</th><th>조회</th><th>등록일</th><th>수정일</th></tr>`;
+    head.innerHTML = `<tr><th>순서</th><th>캠페인</th><th>채널</th><th>브랜드</th><th>제품</th><th>상태 ${statusHelpIcon}</th><th>노출</th><th>신청</th><th>조회</th><th>등록일</th><th>수정일</th></tr>`;
   } else {
     head.innerHTML = `<tr>
       <th style="width:44px;min-width:44px;max-width:44px;text-align:center;padding:8px 4px"><input type="checkbox" id="campSelectAll" onchange="toggleCampSelectAll(this.checked)" title="필터 결과 전체 선택"></th>
       <th>캠페인</th>
+      <th>채널</th>
       <th>브랜드</th>
       <th>제품</th>
       <th>상태 ${statusHelpIcon} <span class="sort-arrows" data-sort="status" onclick="toggleCampSort('status')">${adminCampSortKey==='status'?(adminCampSortDir==='asc'?'▲':'▼'):'▲▼'}</span></th>
@@ -356,6 +357,7 @@ async function loadAdminCampaigns(useCache) {
           </div>
         </div>
       </td>
+      <td>${channelChipsHtml(c.channel, c.channel_match)}</td>
       ${(()=>{
         const bp = brandLabelAdmin(c);
         const bs = '';
@@ -405,9 +407,9 @@ async function loadAdminCampaigns(useCache) {
       </td>`}
     </tr>`;
   };
-  // 일반 모드 13컬럼(체크/캠페인/브랜드/제품/상태/신청/모집기간/구매기간/제출마감/조회/등록일/수정일/액션)
-  // 순서변경 모드 9컬럼(순서/캠페인/브랜드/제품/상태/신청/조회/등록일/수정일)
-  const emptyHtml = `<tr><td colspan="${adminReorderMode ? 10 : 14}" style="text-align:center;color:var(--muted);padding:24px">캠페인 없음</td></tr>`;
+  // 일반 모드 15컬럼(체크/캠페인/채널/브랜드/제품/상태/노출/신청/모집기간/구매기간/제출마감/조회/등록일/수정일/액션)
+  // 순서변경 모드(순서/캠페인/채널/브랜드/제품/상태/노출/신청/조회/등록일/수정일) / 일반 모드 컬럼 수
+  const emptyHtml = `<tr><td colspan="${adminReorderMode ? 11 : 15}" style="text-align:center;color:var(--muted);padding:24px">캠페인 없음</td></tr>`;
   if (adminReorderMode) {
     // 순서변경 모드: 전체 DOM 필요 (↑↓ 위치 인덱스 기반). lazy 비활성.
     if (campsLazy) { campsLazy.destroy(); campsLazy = null; }

--- a/dev/js/ui.js
+++ b/dev/js/ui.js
@@ -208,6 +208,20 @@ function getChannelLabel(ch, lang) {
   }).join(' or ');
 }
 
+// 채널 문자열(콤마구분) → 채널별 회색 라벨 칩. 관리자 목록 채널 열 공용.
+// 빈 채널은 '—'. 채널마다 한글 라벨 칩 1개씩 줄바꿈 허용.
+// 채널 2개 이상이면 칩 사이에 match 구분자 표시 ('and'=&, 그 외=or).
+function channelChipsHtml(channel, match) {
+  const codes = (channel || '').split(',').map(s => s.trim()).filter(Boolean);
+  if (!codes.length) return '<span style="color:var(--muted)">—</span>';
+  const chips = codes.map(function(code) {
+    const label = (typeof getChannelLabel === 'function') ? (getChannelLabel(code) || code) : code;
+    return '<span style="background:#F0F0F0;color:#666;font-size:10px;font-weight:600;padding:2px 7px;border-radius:3px;white-space:nowrap">' + esc(label) + '</span>';
+  });
+  const sep = '<span style="font-size:9px;color:var(--muted);font-weight:600;padding:0 1px">' + (match === 'and' ? '&' : 'or') + '</span>';
+  return '<div style="display:flex;flex-wrap:wrap;align-items:center;gap:3px">' + chips.join(sep) + '</div>';
+}
+
 // lookup_values 공통: code 또는 name_ja를 현재 locale의 표시값으로
 function getLookupLabel(kind, valueOrCode, lang) {
   if (!valueOrCode) return '';

--- a/dev/lib/storage.js
+++ b/dev/lib/storage.js
@@ -62,7 +62,7 @@ async function fetchCampaigns() {
 const ADMIN_LIST_COLUMNS = [
   'id', 'title', 'brand', 'brand_ko', 'brand_ja', 'brand_en', 'product', 'product_ko',
   'campaign_no', 'legacy_no',
-  'recruit_type', 'channel', 'status',
+  'recruit_type', 'channel', 'channel_match', 'status',
   'slots', 'view_count',
   'img1', 'img2', 'img3', 'img4', 'img5', 'img6', 'img7', 'img8',
   'image_url', 'image_crops', 'emoji',
@@ -619,7 +619,7 @@ async function fetchDeliverables(filters) {
         application_id, user_id, campaign_id,
         submitted_by_admin, submitted_by_admin_reason_code, submitted_by_admin_reason, submitted_by_admin_at,
         submitted_by_admin_evidence,
-        campaigns:campaign_id (id, campaign_no, title, brand, recruit_type, channel, purchase_start, purchase_end, visit_start, visit_end, submission_end)
+        campaigns:campaign_id (id, campaign_no, title, brand, recruit_type, channel, channel_match, purchase_start, purchase_end, visit_start, visit_end, submission_end)
       `).neq('status', 'draft');
       if (filters?.status && filters.status !== 'all') q = q.eq('status', filters.status);
       if (filters?.kind && filters.kind !== 'all') q = q.eq('kind', filters.kind);

--- a/index.html
+++ b/index.html
@@ -4342,7 +4342,7 @@ async function fetchCampaigns() {
 const ADMIN_LIST_COLUMNS = [
   'id', 'title', 'brand', 'brand_ko', 'brand_ja', 'brand_en', 'product', 'product_ko',
   'campaign_no', 'legacy_no',
-  'recruit_type', 'channel', 'status',
+  'recruit_type', 'channel', 'channel_match', 'status',
   'slots', 'view_count',
   'img1', 'img2', 'img3', 'img4', 'img5', 'img6', 'img7', 'img8',
   'image_url', 'image_crops', 'emoji',
@@ -4899,7 +4899,7 @@ async function fetchDeliverables(filters) {
         application_id, user_id, campaign_id,
         submitted_by_admin, submitted_by_admin_reason_code, submitted_by_admin_reason, submitted_by_admin_at,
         submitted_by_admin_evidence,
-        campaigns:campaign_id (id, campaign_no, title, brand, recruit_type, channel, purchase_start, purchase_end, visit_start, visit_end, submission_end)
+        campaigns:campaign_id (id, campaign_no, title, brand, recruit_type, channel, channel_match, purchase_start, purchase_end, visit_start, visit_end, submission_end)
       `).neq('status', 'draft');
       if (filters?.status && filters.status !== 'all') q = q.eq('status', filters.status);
       if (filters?.kind && filters.kind !== 'all') q = q.eq('kind', filters.kind);
@@ -8094,6 +8094,20 @@ function getChannelLabel(ch, lang) {
     }
     return CHANNEL_LABEL_FALLBACK[code] || code;
   }).join(' or ');
+}
+
+// 채널 문자열(콤마구분) → 채널별 회색 라벨 칩. 관리자 목록 채널 열 공용.
+// 빈 채널은 '—'. 채널마다 한글 라벨 칩 1개씩 줄바꿈 허용.
+// 채널 2개 이상이면 칩 사이에 match 구분자 표시 ('and'=&, 그 외=or).
+function channelChipsHtml(channel, match) {
+  const codes = (channel || '').split(',').map(s => s.trim()).filter(Boolean);
+  if (!codes.length) return '<span style="color:var(--muted)">—</span>';
+  const chips = codes.map(function(code) {
+    const label = (typeof getChannelLabel === 'function') ? (getChannelLabel(code) || code) : code;
+    return '<span style="background:#F0F0F0;color:#666;font-size:10px;font-weight:600;padding:2px 7px;border-radius:3px;white-space:nowrap">' + esc(label) + '</span>';
+  });
+  const sep = '<span style="font-size:9px;color:var(--muted);font-weight:600;padding:0 1px">' + (match === 'and' ? '&' : 'or') + '</span>';
+  return '<div style="display:flex;flex-wrap:wrap;align-items:center;gap:3px">' + chips.join(sep) + '</div>';
 }
 
 // lookup_values 공통: code 또는 name_ja를 현재 locale의 표시값으로


### PR DESCRIPTION
## 변경 요약
이번 세션의 관리자 목록 변경만 운영(main) 배포 (dev에 연령 정책·감사용 계정 등 보류 기능이 섞여 dev→main 전체 머지 불가 → 소스 패치 후 재빌드한 핫픽스).

- 결과물 관리: 모집타입을 캠페인 셀로 이동 + 캠페인 열 좌측 고정 복구
- 신청·결과물 관리: 캠페인 열 너비 380px 통일 + 결과물 브랜드 별도 열
- 캠페인·신청·결과물 관리: 채널 열 추가(캠페인+채널 좌측 고정), 라벨 칩 + and/or 구분자
- storage.js: channel_match 조회 컬럼 추가 (DB 변경 없음)
- 캠페인 관리 동적 헤더(updateCampTableHead)에 채널 th 반영(버그픽스)

## 요청 외 추가 변경
- 없음

## 보류 기능 미혼입 확인
- 빌드 산출물에 연령 정책(ageGate·migration 180) 0건, 감사용 신규분 없음 — main 소스 기반 빌드

[via reviewer] GO · [via supabase-expert] GO · qa skip