### PR TITLE
feat(admin): 관리자 목록 UX 묶음 — 캠페인 상태 필터·보기 초기화·미리보기 버튼·열 정리 (운영 핫픽스)

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -12,7 +12,7 @@
 // 회귀(2026-05-12 PR #182 머지 직후 발생)를 방지하기 위한 자동 reload 가드.
 // sessionStorage 차단 환경(시크릿 모드 일부, 쿠키 차단)에서는 자연스럽게 skip.
 (function(){
-  var CURRENT_BUILD = 'v1781661983';
+  var CURRENT_BUILD = 'v1781669882';
   if (CURRENT_BUILD.indexOf('__') === 0) return; // 빌드 미적용 (dev/ 직접 열기) 시 skip
   try {
     var prev = sessionStorage.getItem('reverb.adminBuild');
@@ -2065,7 +2065,7 @@ tr.audit-row, .audit-row { background: #fff3e0 !important; }
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-06-17 11:06 · 632a98f</span>
+          <span class="admin-build-text">2026-06-17 13:18 · ab1376b</span>
         </div>
       </div>
     </aside>
@@ -2166,15 +2166,14 @@ tr.audit-row, .audit-row { background: #fff3e0 !important; }
                 <label>캠페인 상태</label>
                 <div id="campStatusMulti" class="mf-wrap"><button type="button" class="mf-btn">전체 상태</button><div class="mf-drop"></div></div>
               </div>
-              <div class="admin-filter-group" style="justify-content:flex-end">
-                <label>&nbsp;</label>
-                <button class="btn btn-ghost btn-xs" id="btnCampFilterReset" onclick="resetCampFilters()" style="display:none">초기화</button>
-              </div>
               <div class="admin-filter-group" style="flex:1;min-width:200px;margin-left:auto">
                 <label>검색</label>
-                <div style="position:relative">
-                  <span class="material-icons-round" style="position:absolute;left:8px;top:50%;transform:translateY(-50%);font-size:16px;color:var(--muted)">search</span>
-                  <input type="search" id="adminCampSearch" class="admin-filter-search" autocomplete="off" data-lpignore="true" data-1p-ignore="true" readonly onfocus="this.removeAttribute('readonly')" placeholder="캠페인명 · 브랜드 · 캠페인번호 검색" oninput="debouncedFilterAdminCampaigns()">
+                <div style="display:flex;gap:6px;align-items:center">
+                  <div style="position:relative;flex:1">
+                    <span class="material-icons-round" style="position:absolute;left:8px;top:50%;transform:translateY(-50%);font-size:16px;color:var(--muted)">search</span>
+                    <input type="search" id="adminCampSearch" class="admin-filter-search" autocomplete="off" data-lpignore="true" data-1p-ignore="true" readonly onfocus="this.removeAttribute('readonly')" placeholder="캠페인명 · 브랜드 · 캠페인번호 검색" oninput="debouncedFilterAdminCampaigns()">
+                  </div>
+                  <button class="btn btn-ghost btn-xs" id="btnCampViewReset" onclick="resetCampView()" style="display:none;white-space:nowrap">보기 초기화</button>
                 </div>
               </div>
             </div>
@@ -2186,7 +2185,6 @@ tr.audit-row, .audit-row { background: #fff3e0 !important; }
                 <button class="btn btn-ghost btn-xs" id="btnCampSelectClear" onclick="clearCampSelection()" style="display:none">선택 초기화</button>
                 <button class="btn btn-ghost btn-xs" id="btnCampSelectApplicants" onclick="exportSelectedCampaignsApplicants()" disabled title="캠페인을 1개 이상 선택하세요"><span class="material-icons-round notranslate" translate="no" style="font-size:14px;vertical-align:middle">download</span> 신청자 엑셀</button>
                 <button class="btn btn-ghost btn-xs" id="btnCampSelectDeliverables" onclick="exportSelectedCampaignsDeliverables()" disabled title="캠페인을 1개 이상 선택하세요"><span class="material-icons-round notranslate" translate="no" style="font-size:14px;vertical-align:middle">download</span> 결과물 엑셀</button>
-                <button class="btn btn-ghost btn-xs" id="btnCampSortReset" onclick="resetCampSort()" style="display:none">정렬 초기화</button>
                 <button class="btn btn-ghost btn-xs" id="btnReorderMode" onclick="enterReorderMode()">순서 변경</button>
               </div>
             </div>
@@ -2808,15 +2806,14 @@ tr.audit-row, .audit-row { background: #fff3e0 !important; }
                   <input type="number" id="infFollowersMax" class="admin-filter no-spinner" inputmode="numeric" min="0" step="1" placeholder="최대" style="width:84px" oninput="rerenderInfluencersFromCache()">
                 </div>
               </div>
-              <div class="admin-filter-group" style="justify-content:flex-end">
-                <label>&nbsp;</label>
-                <button class="btn btn-ghost btn-xs" id="btnInfFilterReset" onclick="resetInfluencerFilters()" style="display:none">초기화</button>
-              </div>
               <div class="admin-filter-group" style="flex:1;min-width:200px;margin-left:auto">
                 <label>검색</label>
-                <div style="position:relative">
-                  <span class="material-icons-round" style="position:absolute;left:8px;top:50%;transform:translateY(-50%);font-size:16px;color:var(--muted)">search</span>
-                  <input type="search" id="infSearch" class="admin-filter-search" autocomplete="off" data-lpignore="true" data-1p-ignore="true" readonly onfocus="this.removeAttribute('readonly')" placeholder="이름 · SNS · 메일주소" oninput="rerenderInfluencersFromCache()">
+                <div style="display:flex;gap:6px;align-items:center">
+                  <div style="position:relative;flex:1">
+                    <span class="material-icons-round" style="position:absolute;left:8px;top:50%;transform:translateY(-50%);font-size:16px;color:var(--muted)">search</span>
+                    <input type="search" id="infSearch" class="admin-filter-search" autocomplete="off" data-lpignore="true" data-1p-ignore="true" readonly onfocus="this.removeAttribute('readonly')" placeholder="이름 · SNS · 메일주소" oninput="rerenderInfluencersFromCache()">
+                  </div>
+                  <button class="btn btn-ghost btn-xs" id="btnInfViewReset" onclick="resetInfView()" style="display:none;white-space:nowrap">보기 초기화</button>
                 </div>
               </div>
             </div>
@@ -2827,7 +2824,6 @@ tr.audit-row, .audit-row { background: #fff3e0 !important; }
               <div style="display:flex;align-items:center;gap:8px">
                 <label id="infExcelSensitiveWrap" style="display:none;align-items:center;gap:3px;font-size:11px;color:var(--muted);cursor:pointer" title="전화·LINE·PayPal·상세주소 열을 추가합니다 (캠페인 관리자 이상)"><input type="checkbox" id="infExcelSensitive">민감정보 포함</label>
                 <button class="btn btn-ghost btn-xs" id="btnInfExcel" onclick="exportInfluencersExcel()" style="display:inline-flex;align-items:center;gap:4px" title="현재 필터 결과를 엑셀로 다운로드"><span class="material-icons-round notranslate" translate="no" style="font-size:14px">download</span> 엑셀 다운로드</button>
-                <button class="btn btn-ghost btn-xs" id="btnInfSortReset" onclick="resetInfSort()" style="display:none">정렬 초기화</button>
               </div>
             </div>
             <div class="admin-table-wrap">
@@ -2948,18 +2944,21 @@ tr.audit-row, .audit-row { background: #fff3e0 !important; }
                 <div id="appTypeMulti" class="mf-wrap"><button type="button" class="mf-btn">전체 타입</button><div class="mf-drop"></div></div>
               </div>
               <div class="admin-filter-group">
+                <label>캠페인 상태</label>
+                <div id="appCampStatusMulti" class="mf-wrap"><button type="button" class="mf-btn">전체 상태</button><div class="mf-drop"></div></div>
+              </div>
+              <div class="admin-filter-group">
                 <label>신청 상태</label>
                 <div id="appStatusMulti" class="mf-wrap"><button type="button" class="mf-btn">전체 상태</button><div class="mf-drop"></div></div>
               </div>
-              <div class="admin-filter-group" style="justify-content:flex-end">
-                <label>&nbsp;</label>
-                <button class="btn btn-ghost btn-xs" id="btnAppFilterReset" onclick="resetAppFilters()" style="display:none">초기화</button>
-              </div>
               <div class="admin-filter-group" style="flex:1;min-width:200px;margin-left:auto">
                 <label>검색</label>
-                <div style="position:relative">
-                  <span class="material-icons-round" style="position:absolute;left:8px;top:50%;transform:translateY(-50%);font-size:16px;color:var(--muted)">search</span>
-                  <input type="search" id="appSearch" class="admin-filter-search" autocomplete="off" data-lpignore="true" data-1p-ignore="true" readonly onfocus="this.removeAttribute('readonly')" placeholder="인플루언서명 · 이메일 검색" oninput="renderAppCampList()">
+                <div style="display:flex;gap:6px;align-items:center">
+                  <div style="position:relative;flex:1">
+                    <span class="material-icons-round" style="position:absolute;left:8px;top:50%;transform:translateY(-50%);font-size:16px;color:var(--muted)">search</span>
+                    <input type="search" id="appSearch" class="admin-filter-search" autocomplete="off" data-lpignore="true" data-1p-ignore="true" readonly onfocus="this.removeAttribute('readonly')" placeholder="인플루언서명 · 이메일 검색" oninput="renderAppCampList()">
+                  </div>
+                  <button class="btn btn-ghost btn-xs" id="btnAppViewReset" onclick="resetAppView()" style="display:none;white-space:nowrap">보기 초기화</button>
                 </div>
               </div>
             </div>
@@ -2968,13 +2967,10 @@ tr.audit-row, .audit-row { background: #fff3e0 !important; }
             <div class="admin-card" id="appCampList">
               <div class="admin-card-header">
                 <div style="display:flex;align-items:center;gap:8px"><span class="admin-card-title">신청 목록</span><span id="appTotalCount" style="font-size:12px;color:var(--muted)"></span></div>
-                <div style="display:flex;align-items:center;gap:6px">
-                  <button class="btn btn-ghost btn-xs" id="btnAppSortReset" onclick="resetAppSort()" style="display:none">정렬 초기화</button>
-                </div>
               </div>
               <div class="admin-table-wrap">
               <table class="data-table">
-                <thead id="appTableHead"><tr><th>캠페인</th><th>채널</th><th>브랜드</th><th>제품</th><th>모집기간 <span class="sort-arrows app-sort-arrows" data-sort="deadline" onclick="toggleAppSort('deadline')">▲▼</span></th><th>인플루언서 <span class="sort-arrows app-sort-arrows" data-sort="name" onclick="toggleAppSort('name')">▲▼</span></th><th>신청 사유</th><th>신청일 <span class="sort-arrows app-sort-arrows" data-sort="created" onclick="toggleAppSort('created')">▲▼</span></th><th>상태 <span class="sort-arrows app-sort-arrows" data-sort="status" onclick="toggleAppSort('status')">▲▼</span></th><th>처리</th></tr></thead>
+                <thead id="appTableHead"><tr><th>캠페인</th><th>채널</th><th>브랜드</th><th>제품</th><th style="min-width:170px;white-space:nowrap">모집기간 <span class="sort-arrows app-sort-arrows" data-sort="deadline" onclick="toggleAppSort('deadline')">▲▼</span></th><th>인플루언서 <span class="sort-arrows app-sort-arrows" data-sort="name" onclick="toggleAppSort('name')">▲▼</span></th><th>신청 사유</th><th>신청일 <span class="sort-arrows app-sort-arrows" data-sort="created" onclick="toggleAppSort('created')">▲▼</span></th><th style="min-width:88px;white-space:nowrap">상태 <span class="sort-arrows app-sort-arrows" data-sort="status" onclick="toggleAppSort('status')">▲▼</span></th><th>처리</th></tr></thead>
                 <tbody id="appTableBody"><tr><td colspan="10" style="text-align:center;color:var(--muted);padding:24px"><span class="spinner" style="width:20px;height:20px;border-width:2px;border-color:rgba(200,120,163,.2);border-top-color:var(--pink)"></span></td></tr></tbody>
               </table>
               </div>
@@ -3039,7 +3035,7 @@ tr.audit-row, .audit-row { background: #fff3e0 !important; }
               </div>
               <div class="admin-filter-group" style="justify-content:flex-end">
                 <label>&nbsp;</label>
-                <button class="btn btn-ghost btn-xs" id="btnDelivFilterReset" onclick="resetDelivFiltersAndSort()" style="display:none">초기화</button>
+                <button class="btn btn-ghost btn-xs" id="btnDelivFilterReset" onclick="resetDelivFiltersAndSort()" style="display:none;white-space:nowrap">보기 초기화</button>
               </div>
               <!-- 텍스트 검색 입력 (기본 숨김 — 돋보기 버튼으로 토글) -->
               <div class="admin-filter-group" id="delivSearchBox" style="display:none;flex:1;min-width:220px">
@@ -3064,9 +3060,9 @@ tr.audit-row, .audit-row { background: #fff3e0 !important; }
                 <th style="width:180px">구매기간 <span class="sort-arrows" data-sort="purchase" onclick="toggleDelivSort('purchase')">▲▼</span></th>
                 <th style="width:130px">결과물 제출 마감 <span class="sort-arrows" data-sort="submission_end" onclick="toggleDelivSort('submission_end')">▲▼</span></th>
                 <th>인플루언서</th>
-                <th style="width:110px">인증 상태</th>
-                <th style="width:170px">영수증</th>
-                <th style="width:170px">결과물</th>
+                <th style="width:132px;white-space:nowrap">인증 상태</th>
+                <th style="width:195px">영수증</th>
+                <th style="width:195px">결과물</th>
                 <th style="width:130px">최근 제출 <span class="sort-arrows" data-sort="submitted" onclick="toggleDelivSort('submitted')">▲▼</span></th>
                 <th style="width:90px">처리</th>
               </tr></thead>
@@ -3624,18 +3620,14 @@ tr.audit-row, .audit-row { background: #fff3e0 !important; }
                 <input type="hidden" id="brandAppFromDate">
                 <input type="hidden" id="brandAppToDate">
               </div>
-              <div class="admin-filter-group" style="justify-content:flex-end">
-                <label>&nbsp;</label>
-                <div style="display:flex;gap:4px">
-                  <button class="btn btn-ghost btn-xs" id="btnBrandAppSortReset" onclick="resetBrandAppSort()" style="display:none">정렬 초기화</button>
-                  <button class="btn btn-ghost btn-xs" id="btnBrandAppFilterReset" onclick="resetBrandAppFilters()" style="display:none">초기화</button>
-                </div>
-              </div>
               <div class="admin-filter-group" style="flex:1;min-width:200px;margin-left:auto">
                 <label>검색</label>
-                <div style="position:relative">
-                  <span class="material-icons-round" style="position:absolute;left:8px;top:50%;transform:translateY(-50%);font-size:16px;color:var(--muted)">search</span>
-                  <input type="search" id="brandAppSearch" name="brandapp-q" class="admin-filter-search" autocomplete="off" data-lpignore="true" data-1p-ignore="true" readonly onfocus="this.removeAttribute('readonly')" placeholder="브랜드 · 담당자 · 주소 검색" oninput="renderBrandApplicationsList()">
+                <div style="display:flex;gap:6px;align-items:center">
+                  <div style="position:relative;flex:1">
+                    <span class="material-icons-round" style="position:absolute;left:8px;top:50%;transform:translateY(-50%);font-size:16px;color:var(--muted)">search</span>
+                    <input type="search" id="brandAppSearch" name="brandapp-q" class="admin-filter-search" autocomplete="off" data-lpignore="true" data-1p-ignore="true" readonly onfocus="this.removeAttribute('readonly')" placeholder="브랜드 · 담당자 · 주소 검색" oninput="renderBrandApplicationsList()">
+                  </div>
+                  <button class="btn btn-ghost btn-xs" id="btnBrandAppViewReset" onclick="resetBrandAppView()" style="display:none;white-space:nowrap">보기 초기화</button>
                 </div>
               </div>
             </div>
@@ -5951,6 +5943,12 @@ const CAMPAIGN_STATUS_BADGE_CLASS = {
 function brandLabelAdmin(c) {
   if (!c) return '';
   return (c.brand || c.brand_en || c.brand_ja || '').trim();
+}
+// 캠페인 미리보기 돋보기 버튼 — 관리자 목록 캠페인 열 공통. 이름 옆에 배치, 클릭 시 미리보기 모달.
+//   (기존엔 캠페인명 자체 클릭으로 열렸으나, 명시적 버튼으로 통일 — 2026-06-17)
+function campPreviewBtn(campId) {
+  if (!campId) return '';
+  return `<button type="button" onclick="event.stopPropagation();openCampPreviewModal('${esc(String(campId))}')" title="미리보기" style="flex-shrink:0;background:none;border:none;cursor:pointer;padding:0;margin:0;color:var(--muted);display:inline-flex;align-items:center;line-height:1"><span class="material-icons-round notranslate" translate="no" style="font-size:16px">search</span></button>`;
 }
 function brandLabelInflu(c) {
   if (!c) return '';
@@ -12964,10 +12962,9 @@ function renderBrandApplicationsList() {
   var res = getFilteredBrandApps();
   var list = res.list;
   var filterActive = res.filterActive;
-  var resetBtn = $('btnBrandAppFilterReset');
-  if (resetBtn) resetBtn.style.display = filterActive ? 'inline-block' : 'none';
-  var sortResetBtn = $('btnBrandAppSortReset');
-  if (sortResetBtn) sortResetBtn.style.display = _brandAppSortIsDefault() ? 'none' : 'inline-block';
+  // 보기 초기화 — 필터·검색·정렬 중 하나라도 비기본이면 표시
+  var viewResetBtn = $('btnBrandAppViewReset');
+  if (viewResetBtn) viewResetBtn.style.display = (filterActive || !_brandAppSortIsDefault()) ? 'inline-block' : 'none';
 
   var count = $('brandAppTotalCount');
   if (count) {
@@ -13025,7 +13022,8 @@ function renderBrandApplicationsList() {
   });
 }
 
-function resetBrandAppFilters() {
+// 보기 초기화 — 필터·검색·정렬을 한 번에 기본값으로
+function resetBrandAppView() {
   resetMultiFilter('brandAppFormMulti', '전체 폼');
   // 상태 탭 초기화 (전체 탭으로)
   _brandAppActiveStatusTab = null;
@@ -13041,6 +13039,8 @@ function resetBrandAppFilters() {
   ['brandAppFromDate','brandAppToDate','brandAppDateRange'].forEach(function(id){
     var el = $(id); if (el) el.classList.remove('filter-active');
   });
+  _brandAppSort = {field: 'created', dir: 'desc'};
+  updateBrandAppSortIndicators();
   renderBrandApplicationsList();
 }
 
@@ -13085,12 +13085,6 @@ function toggleBrandAppSort(field) {
 
 function _brandAppSortIsDefault() {
   return _brandAppSort.field === 'created' && _brandAppSort.dir === 'desc';
-}
-
-function resetBrandAppSort() {
-  _brandAppSort = {field: 'created', dir: 'desc'};
-  updateBrandAppSortIndicators();
-  renderBrandApplicationsList();
 }
 
 // 정렬 화살표 활성 상태 시각화 (▲ asc / ▼ desc / ▲▼ inactive)
@@ -18297,20 +18291,22 @@ function renderInfluencersPane() {
   const total = (infUsersCache || []).length;
   const totalEl = $('infTotalCount');
   if (totalEl) totalEl.textContent = `${filtered.length}명 표시 (전체 ${total}명)`;
-  const resetBtn = $('btnInfFilterReset');
+  const resetBtn = $('btnInfViewReset');
   if (resetBtn) {
     const verifiedSel = $('infFilterVerifiedSelect')?.value || 'all';
     const violationSel = $('infFilterViolationSelect')?.value || 'all';
     const searchQ = ($('infSearch')?.value || '').trim();
     const prefSel = (typeof getMultiFilterValues === 'function') ? getMultiFilterValues('infPrefectureMulti') : [];
     const hasFollower = !!($('infFollowersMin')?.value || $('infFollowersMax')?.value);
-    const anyActive = (verifiedSel !== 'all' || violationSel !== 'all' || currentInfTab !== 'all' || !!searchQ || prefSel.length > 0 || hasFollower);
+    const hasSort = !(infSortKey === 'created' && infSortDir === 'desc');
+    const anyActive = (verifiedSel !== 'all' || violationSel !== 'all' || currentInfTab !== 'all' || !!searchQ || prefSel.length > 0 || hasFollower || hasSort);
     resetBtn.style.display = anyActive ? '' : 'none';
   }
   renderInfTable(filtered);
 }
 
-function resetInfluencerFilters() {
+// 보기 초기화 — 필터·검색·정렬을 한 번에 기본값으로
+function resetInfView() {
   const v = $('infFilterVerifiedSelect'); if (v) v.value = 'all';
   const w = $('infFilterViolationSelect'); if (w) w.value = 'all';
   const c = $('infChannelFilter'); if (c) c.value = 'all';
@@ -18319,6 +18315,8 @@ function resetInfluencerFilters() {
   const mn = $('infFollowersMin'); if (mn) mn.value = '';
   const mx = $('infFollowersMax'); if (mx) mx.value = '';
   currentInfTab = 'all';
+  infSortKey = 'created'; infSortDir = 'desc';
+  updateInfSortUI();
   rerenderInfluencersFromCache();
 }
 
@@ -18341,13 +18339,6 @@ function toggleInfSort(key) {
   rerenderInfluencersFromCache();
 }
 
-function resetInfSort() {
-  infSortKey = 'created';
-  infSortDir = 'desc';
-  updateInfSortUI();
-  rerenderInfluencersFromCache();
-}
-
 function updateInfSortUI() {
   document.querySelectorAll('.inf-sort-arrows').forEach(el => {
     el.classList.remove('asc','desc');
@@ -18357,8 +18348,6 @@ function updateInfSortUI() {
       el.textContent = infSortDir === 'asc' ? '▲' : '▼';
     }
   });
-  const resetBtn = $('btnInfSortReset');
-  if (resetBtn) resetBtn.style.display = (infSortKey === 'created' && infSortDir === 'desc') ? 'none' : '';
 }
 
 function sortInfUsers(users) {
@@ -19714,13 +19703,13 @@ function renderDelivAppRow(g) {
   const brandLabel = brandLabelAdmin(camp);
 
   return `<tr data-app-id="${esc(g.application_id)}" class="${inf.is_audit ? 'audit-row' : ''}" style="${rowStyle}">
-    <td><div style="display:flex;align-items:center;gap:6px;flex-wrap:wrap;margin-bottom:2px">${rtBadge}${campNoBadge}</div><div>${esc(camp.title || '—')}</div></td>
+    <td><div style="display:flex;align-items:center;gap:6px;flex-wrap:wrap;margin-bottom:2px">${rtBadge}${campNoBadge}</div><div style="display:flex;align-items:flex-start;gap:4px"><span style="flex:1">${esc(camp.title || '—')}</span>${campPreviewBtn(camp.id)}</div></td>
     <td>${channelChipsHtml(camp.channel, camp.channel_match)}</td>
     <td style="font-size:12px;color:var(--ink);min-width:100px;max-width:160px;word-break:break-word">${brandLabel ? esc(brandLabel) : '—'}</td>
     <td style="font-size:11px;color:var(--ink);white-space:nowrap">${periodRangeCell(ps, pe)}</td>
     <td style="font-size:11px;color:var(--ink);white-space:nowrap">${periodSingleCell(camp.submission_end)}</td>
     <td><div style="font-weight:600;color:var(--pink);cursor:pointer" onclick="openInfluencerModal('${esc(inf.id||'')}')">${infName}${auditBadgeHtml(inf)}${(typeof influencerStatusBadges === 'function') ? influencerStatusBadges(inf) : ''}</div>${infSub ? `<div style="font-size:10px;color:var(--muted)">${infSub}</div>` : ''}<div style="margin-top:4px">${renderApplicantMsgBtn({id: g.application_id, campaign_id: (camp && camp.id) || ''})}</div></td>
-    <td>${certStatusBadge(g)}</td>
+    <td style="white-space:nowrap">${certStatusBadge(g)}</td>
     <td>${receiptCell}</td>
     <td>${resultCell}</td>
     <td>${submittedCell}</td>
@@ -19776,12 +19765,16 @@ function renderDelivResultCellMonitor(g) {
 // 영수증·결과물 셀 — slot: 'receipt' | 'result', rt: campaign.recruit_type
 //   opts.hasValidApprovedPost: 같은 신청에 캠페인 채널 일치 승인 게시물이 있으면 채널 불일치 배지 숨김
 function renderDelivStatusCell(d, slot, rt, opts) {
+  // 결과물 셀(result)은 monitor 채널별 미니행(10px)과 라벨 크기를 통일. 영수증 셀은 기존 11px 유지.
+  const small = slot === 'result';
+  const badgeFs = small ? '10px' : '11px';
+  const badgePad = small ? '1px 6px' : '2px 8px';
   // 영수증은 monitor에서만 사용. gifting/visit은 영수증 단계 없음 → 「-」 표시
   if (slot === 'receipt' && rt !== 'monitor') {
     return '<span style="font-size:11px;color:var(--muted)">—</span>';
   }
   if (!d) {
-    return '<span style="display:inline-block;background:#f5f5f5;color:var(--muted);font-size:11px;font-weight:600;padding:2px 8px;border-radius:3px">미제출</span>';
+    return `<span style="display:inline-block;background:#f5f5f5;color:var(--muted);font-size:${badgeFs};font-weight:600;padding:${badgePad};border-radius:3px">미제출</span>`;
   }
   let preview = '';
   if (d.kind === 'receipt' || d.kind === 'review_image') {
@@ -19805,8 +19798,8 @@ function renderDelivStatusCell(d, slot, rt, opts) {
   // 마이그레이션 160: 대리 등록 행은 status 배지를 「대리 등록」으로 교체 (자동 승인이라 "승인" 표기 무의미)
   // 사용자 결정 2026-05-28: 「승인 + 작은 대리 마커」 중복 → 단일 「대리 등록」 배지로 통합
   const statusBadgeHtml = d.submitted_by_admin
-    ? `<span style="background:#FEF3C7;color:#92400E;font-size:11px;font-weight:600;padding:2px 8px;border-radius:3px" title="관리자 대리 등록·자동 승인">대리 등록</span>`
-    : delivStatusBadge(d.status);
+    ? `<span style="background:#FEF3C7;color:#92400E;font-size:${badgeFs};font-weight:600;padding:${badgePad};border-radius:3px" title="관리자 대리 등록·자동 승인">대리 등록</span>`
+    : delivStatusBadge(d.status, small);
   return `<div style="display:flex;align-items:center;gap:6px">${preview}${statusBadgeHtml}</div>`;
 }
 
@@ -19814,11 +19807,14 @@ function statusLabelKo(status) {
   return {pending: '검수대기', approved: '승인', rejected: '반려'}[status] || status;
 }
 
-function delivStatusBadge(status) {
+// small=true: 결과물 목록 셀에서 monitor 채널별 미니행(10px)과 라벨 크기 통일용. 미지정 시 기존 11px.
+function delivStatusBadge(status, small) {
+  const fs = small ? '10px' : '11px';
+  const pad = small ? '1px 6px' : '2px 8px';
   const map = {
-    pending: '<span style="background:#FFF4E4;color:#B8741A;font-size:11px;font-weight:600;padding:2px 8px;border-radius:3px">검수대기</span>',
-    approved: '<span style="background:#E4F5E8;color:#2D7A3E;font-size:11px;font-weight:600;padding:2px 8px;border-radius:3px">승인</span>',
-    rejected: '<span style="background:#FFE4E4;color:#C33;font-size:11px;font-weight:600;padding:2px 8px;border-radius:3px">반려</span>'
+    pending: `<span style="background:#FFF4E4;color:#B8741A;font-size:${fs};font-weight:600;padding:${pad};border-radius:3px">검수대기</span>`,
+    approved: `<span style="background:#E4F5E8;color:#2D7A3E;font-size:${fs};font-weight:600;padding:${pad};border-radius:3px">승인</span>`,
+    rejected: `<span style="background:#FFE4E4;color:#C33;font-size:${fs};font-weight:600;padding:${pad};border-radius:3px">반려</span>`
   };
   return map[status] || status;
 }
@@ -23443,7 +23439,7 @@ function renderRecentAppsTable(apps, camps, users) {
           </div>
           <div style="min-width:0">
             <div>${typeLabel}</div>
-            <strong style="font-size:13px;cursor:pointer" onclick="openCampPreviewModal('${camp.id}')">${esc(camp.title)||'—'}</strong>
+            <div style="display:flex;align-items:flex-start;gap:4px"><strong style="font-size:13px;flex:1">${esc(camp.title)||'—'}</strong>${campPreviewBtn(camp.id)}</div>
             <div style="font-size:11px;color:var(--muted)">${esc(brandLabelAdmin(camp))}</div>
             ${camp.slots?`<div style="font-size:10px;color:var(--muted);margin-top:2px">모집 ${camp.slots}명 · 빈자리 <span style="color:${_dRem>0?'var(--green)':'var(--red)'};font-weight:600">${_dRem>0?_dRem+'건':'없음'}</span></div>`:''}
           </div>
@@ -24124,20 +24120,6 @@ function toggleAppSort(key) {
       el.textContent = appSortDir === 'asc' ? '▲' : '▼';
     }
   });
-  const btn = $('btnAppSortReset');
-  if (btn) btn.style.display = (appSortKey === 'created' && appSortDir === 'desc') ? 'none' : '';
-  renderAppCampList();
-}
-
-function resetAppSort() {
-  appSortKey = 'created';
-  appSortDir = 'desc';
-  document.querySelectorAll('.app-sort-arrows').forEach(el => {
-    el.classList.remove('asc','desc');
-    el.textContent = '▲▼';
-    if (el.dataset.sort === 'created') { el.classList.add('desc'); el.textContent = '▼'; }
-  });
-  const btn = $('btnAppSortReset'); if (btn) btn.style.display = 'none';
   renderAppCampList();
 }
 
@@ -24186,16 +24168,35 @@ async function renderAppCampList() {
   if (campStale.length > 0 && typeof toast === 'function') toast(`선택한 캠페인 ${campStale.length}건이 타입 필터에 맞지 않아 해제되었습니다`, 'info');
   if (typeStale.length > 0 && typeof toast === 'function') toast(`선택한 타입 ${typeStale.length}건이 캠페인 필터에 맞지 않아 해제되었습니다`, 'info');
 
-  // 옵션별 카운트 계산 (전체 신청 기준 — 다른 필터 무관)
+  // 필터 값 추출 (카운트·필터 적용 공용) — 동적 카운트를 위해 미리 확보
+  const campRtLookup = new Map(camps.map(c => [c.id, c.recruit_type]));
+  const campStatusLookup = new Map(camps.map(c => [c.id, c.status]));  // 신청의 캠페인 상태 조회용
+  const appTypeVals = getMultiFilterValues('appTypeMulti');
+  const appCampStatusVals = getMultiFilterValues('appCampStatusMulti');
+  const appStatusVals = getMultiFilterValues('appStatusMulti');
+  const campFilterVals = getMultiFilterValues('appCampMulti');
+  const searchVal = ($('appSearch')?.value || '').trim().toLowerCase();
+  // 단일 신청이 필터를 통과하는지 — skip 지정 시 그 필터만 무시(옵션별 동적 카운트용)
+  const passesAppFilters = (a, skip) => {
+    if (skip !== 'type'       && appTypeVals.length       && !appTypeVals.includes(campRtLookup.get(a.campaign_id))) return false;
+    if (skip !== 'campStatus' && appCampStatusVals.length && !appCampStatusVals.includes(campStatusLookup.get(a.campaign_id))) return false;
+    if (skip !== 'status'     && appStatusVals.length     && !appStatusVals.includes(a.status)) return false;
+    if (skip !== 'camp'       && campFilterVals.length    && !campFilterVals.includes(a.campaign_id)) return false;
+    if (searchVal && !matchSearchTokens(searchVal, [a.user_name, a.user_email, a.cancel_reason, a.cancel_reason_code])) return false;
+    return true;
+  };
+  // 옵션별 카운트 — 「자기 자신 필터 제외 + 다른 모든 필터 적용」 후 집계 (동적, 결과물 관리 페인과 동일 방식)
   const appCampCounts = {};
   const appTypeCounts = {};
   const appStatusCountsMap = {};
-  const campRtLookup = new Map(camps.map(c => [c.id, c.recruit_type]));
+  const appCampStatusCounts = {};
   for (const a of allAppsRaw) {
-    if (a.campaign_id) appCampCounts[a.campaign_id] = (appCampCounts[a.campaign_id] || 0) + 1;
+    if (a.campaign_id && passesAppFilters(a, 'camp')) appCampCounts[a.campaign_id] = (appCampCounts[a.campaign_id] || 0) + 1;
     const rt = campRtLookup.get(a.campaign_id);
-    if (rt) appTypeCounts[rt] = (appTypeCounts[rt] || 0) + 1;
-    if (a.status) appStatusCountsMap[a.status] = (appStatusCountsMap[a.status] || 0) + 1;
+    if (rt && passesAppFilters(a, 'type')) appTypeCounts[rt] = (appTypeCounts[rt] || 0) + 1;
+    const cst = campStatusLookup.get(a.campaign_id);
+    if (cst && passesAppFilters(a, 'campStatus')) appCampStatusCounts[cst] = (appCampStatusCounts[cst] || 0) + 1;
+    if (a.status && passesAppFilters(a, 'status')) appStatusCountsMap[a.status] = (appStatusCountsMap[a.status] || 0) + 1;
   }
 
   // 드롭다운 동기화 — count 포함
@@ -24203,6 +24204,15 @@ async function renderAppCampList() {
   syncMultiFilter('appTypeMulti', '전체 타입',
     availableTypes.map(t => ({value:t, label:RECRUIT_TYPE_LABEL_KO[t] || t, count: appTypeCounts[t] || 0})),
     () => renderAppCampList());
+  // 캠페인 상태 필터 — 캠페인 관리 페인과 동일 6단계 (admin.js campStatusMulti 와 라벨·순서 통일)
+  syncMultiFilter('appCampStatusMulti', '전체 상태', [
+    {value:'draft',     label:'준비',     count: appCampStatusCounts.draft     || 0},
+    {value:'scheduled', label:'모집예정', count: appCampStatusCounts.scheduled || 0},
+    {value:'active',    label:'모집중',   count: appCampStatusCounts.active    || 0},
+    {value:'closed',    label:'모집마감', count: appCampStatusCounts.closed    || 0},
+    {value:'ended',     label:'종료',     count: appCampStatusCounts.ended     || 0},
+    {value:'expired',   label:'노출종료', count: appCampStatusCounts.expired   || 0},
+  ], () => renderAppCampList());
   syncMultiFilter('appStatusMulti', '전체 상태', [
     {value:'pending',   label:'심사중', count: appStatusCountsMap.pending   || 0},
     {value:'approved',  label:'승인',   count: appStatusCountsMap.approved  || 0},
@@ -24210,33 +24220,15 @@ async function renderAppCampList() {
     {value:'cancelled', label:'취소',   count: appStatusCountsMap.cancelled || 0},
   ], () => renderAppCampList());
 
-  // 타입 필터 (다중 선택) — stale 제거 후 최종값
-  const appTypeVals = getMultiFilterValues('appTypeMulti');
-  if (appTypeVals.length) {
-    const filteredCampIds = camps.filter(c => appTypeVals.includes(c.recruit_type)).map(c => c.id);
-    apps = apps.filter(a => filteredCampIds.includes(a.campaign_id));
-  }
+  // 필터 적용 — 위에서 정의한 passesAppFilters 로 일괄 (타입·캠페인상태·신청상태·캠페인·검색 모두 포함)
+  //   검색은 인플루언서 전용 (캠페인은 검색형 캠페인 드롭다운으로 분리)
+  apps = apps.filter(a => passesAppFilters(a));
 
-  // 상태 필터 (다중 선택)
-  const appStatusVals = getMultiFilterValues('appStatusMulti');
-  if (appStatusVals.length) apps = apps.filter(a => appStatusVals.includes(a.status));
-
-  // 캠페인 다중 선택 필터 — stale 제거 후 최종값
-  const campFilterVals = getMultiFilterValues('appCampMulti');
-  if (campFilterVals.length) apps = apps.filter(a => campFilterVals.includes(a.campaign_id));
-
-  // 검색 필터 — 단어 단위 AND 매칭 (matchSearchTokens, 전각/반각 공백 무관)
-  const searchVal = ($('appSearch')?.value || '').trim().toLowerCase();
-  if (searchVal) {
-    apps = apps.filter(a => {
-      // 검색은 인플루언서 전용 (캠페인은 검색형 캠페인 드롭다운으로 분리)
-      return matchSearchTokens(searchVal, [
-        a.user_name, a.user_email, a.cancel_reason, a.cancel_reason_code,
-      ]);
-    });
-  }
-
-  updateFilterResetBtn('btnAppFilterReset', ['appTypeMulti','appStatusMulti','appCampMulti'], 'appSearch');
+  // 보기 초기화 버튼 — 필터·검색·정렬 중 하나라도 비기본이면 노출 (필터+정렬+검색 통합)
+  const _appViewActive = ['appTypeMulti','appCampStatusMulti','appStatusMulti','appCampMulti'].some(id => getMultiFilterValues(id).length > 0)
+    || !!(($('appSearch')?.value || '').trim())
+    || !(appSortKey === 'created' && appSortDir === 'desc');
+  const _appViewBtn = $('btnAppViewReset'); if (_appViewBtn) _appViewBtn.style.display = _appViewActive ? '' : 'none';
 
   const appDir = appSortDir === 'asc' ? 1 : -1;
   if (appSortKey === 'status') {
@@ -24282,7 +24274,7 @@ async function renderAppCampList() {
           </div>
           <div style="min-width:0;flex:1">
             <div>${typeLabel}</div>
-            <strong style="font-size:13px;cursor:pointer;display:block;word-break:break-word;line-height:1.4" onclick="openCampPreviewModal('${camp.id}')">${esc(camp.title)||'—'}</strong>
+            <div style="display:flex;align-items:flex-start;gap:4px"><strong style="font-size:13px;display:block;word-break:break-word;line-height:1.4;flex:1">${esc(camp.title)||'—'}</strong>${campPreviewBtn(camp.id)}</div>
             ${camp.slots?(()=>{const _r=Math.max(camp.slots-countNonAuditApproved(allAppsRaw, camp.id, _auditIds),0);return `<div style="font-size:10px;color:var(--muted);margin-top:2px">모집 ${camp.slots}명 · 빈자리 <span style="color:${_r>0?'var(--green)':'var(--red)'};font-weight:600">${_r>0?_r+'건':'없음'}</span></div>`;})():''}
           </div>
         </div>
@@ -24296,9 +24288,8 @@ async function renderAppCampList() {
         ${productPrimary?esc(productPrimary):'—'}
         ${productSub?`<div style="font-size:10px;color:var(--muted);margin-top:2px">${esc(productSub)}</div>`:''}
       </td>
-      <td style="font-size:11px;color:var(--muted);white-space:nowrap">
-        ${recruitStart?`<div>${recruitStart}</div>`:''}
-        <div style="color:var(--ink)">~ ${recruitEnd||'—'}</div>
+      <td style="font-size:11px;color:var(--ink);white-space:nowrap">
+        ${(recruitStart||recruitEnd) ? `${recruitStart||'—'} ~ ${recruitEnd||'—'}` : '<span style="color:var(--muted)">—</span>'}
       </td>
       <td>
         <div style="font-weight:600;color:var(--pink);cursor:pointer" onclick="openInfluencerModal('${u.id||''}')">${esc(a.user_name)||'—'}${auditBadgeHtml(u)}${influencerStatusBadges(u)}</div>
@@ -24307,7 +24298,7 @@ async function renderAppCampList() {
       </td>
       <td>${msgCell(a.message, a)}</td>
       <td style="font-size:12px;color:var(--muted);white-space:nowrap">${formatDate(a.created_at)}</td>
-      <td>${getStatusBadgeKo(a.status, a.auto_reject_reason)}${a.status==='cancelled' && a.cancel_phase ? `<div style="font-size:10px;color:var(--muted);margin-top:2px">${esc(cancelPhaseLabelKo(a.cancel_phase))}</div>` : ''}</td>
+      <td style="white-space:nowrap">${getStatusBadgeKo(a.status, a.auto_reject_reason)}${a.status==='cancelled' && a.cancel_phase ? `<div style="font-size:10px;color:var(--muted);margin-top:2px">${esc(cancelPhaseLabelKo(a.cancel_phase))}</div>` : ''}</td>
       <td style="white-space:nowrap">
         ${a.status==='pending'?`<div style="display:flex;gap:4px"><button class="btn btn-green btn-xs" ${(_campRemaining<=0 && !u.is_audit)?'disabled style="background:var(--muted);opacity:.5;cursor:not-allowed"':''}onclick="updateAppStatus('${a.id}','approved')">승인</button><button class="btn btn-ghost btn-xs" style="color:var(--red);border-color:var(--red)" onclick="updateAppStatus('${a.id}','rejected')">미승인</button></div>`
         :a.status==='cancelled'?`<div style="font-size:10px;color:var(--muted)">${a.cancelled_at?formatDateTime(a.cancelled_at):'—'}</div>`
@@ -26200,18 +26191,13 @@ function filterAdminCampaigns() { loadAdminCampaigns(true); }
 // 검색창 전용 — 글자 연타 시 마지막 입력만 반영(0.3초). 드롭다운 필터는 즉시 호출 유지.
 const debouncedFilterAdminCampaigns = debounce(filterAdminCampaigns, 300);
 
-function resetCampSort() {
-  adminCampSortKey = '';
-  adminCampSortDir = '';
-  updateSortArrows();
-  updateCampTableHead();
-  const btn = $('btnCampSortReset'); if (btn) btn.style.display = 'none';
-  filterAdminCampaigns();
-}
-
-function updateCampSortResetBtn() {
-  const btn = $('btnCampSortReset');
-  if (btn) btn.style.display = adminCampSortKey ? '' : 'none';
+// 보기 초기화 버튼 노출 — 필터·검색·정렬 중 하나라도 비기본이면 표시
+function updateCampViewResetBtn() {
+  const hasFilter = ['campTypeMulti','campStatusMulti'].some(id => getMultiFilterValues(id).length > 0);
+  const hasSearch = !!(($('adminCampSearch')?.value || '').trim());
+  const hasSort = !!adminCampSortKey;
+  const btn = $('btnCampViewReset');
+  if (btn) btn.style.display = (hasFilter || hasSearch || hasSort) ? '' : 'none';
 }
 
 function resetCampFilters() {
@@ -26220,11 +26206,27 @@ function resetCampFilters() {
   const s = $('adminCampSearch'); if (s) s.value = '';
   filterAdminCampaigns();
 }
-function resetAppFilters() {
+// 보기 초기화 — 필터·검색·정렬을 한 번에 기본값으로
+function resetCampView() {
+  resetMultiFilter('campTypeMulti', '전체 타입');
+  resetMultiFilter('campStatusMulti', '전체 상태');
+  const s = $('adminCampSearch'); if (s) s.value = '';
+  adminCampSortKey = ''; adminCampSortDir = '';
+  updateSortArrows(); updateCampTableHead();
+  filterAdminCampaigns();
+}
+// 보기 초기화 — 필터·검색·정렬을 한 번에 기본값으로 (목록 페인 공통 패턴)
+function resetAppView() {
   resetMultiFilter('appTypeMulti', '전체 타입');
+  resetMultiFilter('appCampStatusMulti', '전체 상태');
   resetMultiFilter('appStatusMulti', '전체 상태');
   resetMultiFilter('appCampMulti', '전체 캠페인');
   const s = $('appSearch'); if (s) s.value = '';
+  appSortKey = 'created'; appSortDir = 'desc';
+  document.querySelectorAll('.app-sort-arrows').forEach(el => {
+    el.classList.remove('asc','desc'); el.textContent = '▲▼';
+    if (el.dataset.sort === 'created') { el.classList.add('desc'); el.textContent = '▼'; }
+  });
   renderAppCampList();
 }
 
@@ -26258,7 +26260,7 @@ function toggleCampSort(key) {
     adminCampSortDir = 'desc';
   }
   updateSortArrows();
-  updateCampSortResetBtn();
+  updateCampViewResetBtn();
   filterAdminCampaigns();
 }
 
@@ -26410,7 +26412,7 @@ async function loadAdminCampaigns(useCache) {
       [c.title, c.brand, c.brand_ko, c.brand_ja, c.brand_en, c.product, c.product_ko, c.campaign_no]));
   }
 
-  updateFilterResetBtn('btnCampFilterReset', ['campTypeMulti','campStatusMulti'], 'adminCampSearch');
+  updateCampViewResetBtn();
 
   // useCache(검색/필터/정렬)면 캐시 재사용 → 서버 재조회 0회. 캐시가 비어있으면 1회만 조회.
   // PR 4 서버 집계: 신청 전건 전송 대신 서버 집계 함수 1회 호출로 전환.
@@ -26497,7 +26499,7 @@ async function loadAdminCampaigns(useCache) {
               ${typeLabel(c.recruit_type)}
               ${c.campaign_no ? `<span style="font-family:monospace;font-size:10px;font-weight:600;color:var(--muted);letter-spacing:0.02em">${esc(c.campaign_no)}</span>` : ''}
             </div>
-            <strong style="cursor:pointer;color:var(--ink);display:block;word-break:break-word;line-height:1.4" onclick="openCampPreviewModal('${c.id}')">${esc(c.title)}</strong>
+            <div style="display:flex;align-items:flex-start;gap:4px"><strong style="color:var(--ink);display:block;word-break:break-word;line-height:1.4;flex:1">${esc(c.title)}</strong>${campPreviewBtn(c.id)}</div>
           </div>
         </div>
       </td>

--- a/dev/admin/index.html
+++ b/dev/admin/index.html
@@ -233,15 +233,14 @@
                 <label>캠페인 상태</label>
                 <div id="campStatusMulti" class="mf-wrap"><button type="button" class="mf-btn">전체 상태</button><div class="mf-drop"></div></div>
               </div>
-              <div class="admin-filter-group" style="justify-content:flex-end">
-                <label>&nbsp;</label>
-                <button class="btn btn-ghost btn-xs" id="btnCampFilterReset" onclick="resetCampFilters()" style="display:none">초기화</button>
-              </div>
               <div class="admin-filter-group" style="flex:1;min-width:200px;margin-left:auto">
                 <label>검색</label>
-                <div style="position:relative">
-                  <span class="material-icons-round" style="position:absolute;left:8px;top:50%;transform:translateY(-50%);font-size:16px;color:var(--muted)">search</span>
-                  <input type="search" id="adminCampSearch" class="admin-filter-search" autocomplete="off" data-lpignore="true" data-1p-ignore="true" readonly onfocus="this.removeAttribute('readonly')" placeholder="캠페인명 · 브랜드 · 캠페인번호 검색" oninput="debouncedFilterAdminCampaigns()">
+                <div style="display:flex;gap:6px;align-items:center">
+                  <div style="position:relative;flex:1">
+                    <span class="material-icons-round" style="position:absolute;left:8px;top:50%;transform:translateY(-50%);font-size:16px;color:var(--muted)">search</span>
+                    <input type="search" id="adminCampSearch" class="admin-filter-search" autocomplete="off" data-lpignore="true" data-1p-ignore="true" readonly onfocus="this.removeAttribute('readonly')" placeholder="캠페인명 · 브랜드 · 캠페인번호 검색" oninput="debouncedFilterAdminCampaigns()">
+                  </div>
+                  <button class="btn btn-ghost btn-xs" id="btnCampViewReset" onclick="resetCampView()" style="display:none;white-space:nowrap">보기 초기화</button>
                 </div>
               </div>
             </div>
@@ -253,7 +252,6 @@
                 <button class="btn btn-ghost btn-xs" id="btnCampSelectClear" onclick="clearCampSelection()" style="display:none">선택 초기화</button>
                 <button class="btn btn-ghost btn-xs" id="btnCampSelectApplicants" onclick="exportSelectedCampaignsApplicants()" disabled title="캠페인을 1개 이상 선택하세요"><span class="material-icons-round notranslate" translate="no" style="font-size:14px;vertical-align:middle">download</span> 신청자 엑셀</button>
                 <button class="btn btn-ghost btn-xs" id="btnCampSelectDeliverables" onclick="exportSelectedCampaignsDeliverables()" disabled title="캠페인을 1개 이상 선택하세요"><span class="material-icons-round notranslate" translate="no" style="font-size:14px;vertical-align:middle">download</span> 결과물 엑셀</button>
-                <button class="btn btn-ghost btn-xs" id="btnCampSortReset" onclick="resetCampSort()" style="display:none">정렬 초기화</button>
                 <button class="btn btn-ghost btn-xs" id="btnReorderMode" onclick="enterReorderMode()">순서 변경</button>
               </div>
             </div>
@@ -875,15 +873,14 @@
                   <input type="number" id="infFollowersMax" class="admin-filter no-spinner" inputmode="numeric" min="0" step="1" placeholder="최대" style="width:84px" oninput="rerenderInfluencersFromCache()">
                 </div>
               </div>
-              <div class="admin-filter-group" style="justify-content:flex-end">
-                <label>&nbsp;</label>
-                <button class="btn btn-ghost btn-xs" id="btnInfFilterReset" onclick="resetInfluencerFilters()" style="display:none">초기화</button>
-              </div>
               <div class="admin-filter-group" style="flex:1;min-width:200px;margin-left:auto">
                 <label>검색</label>
-                <div style="position:relative">
-                  <span class="material-icons-round" style="position:absolute;left:8px;top:50%;transform:translateY(-50%);font-size:16px;color:var(--muted)">search</span>
-                  <input type="search" id="infSearch" class="admin-filter-search" autocomplete="off" data-lpignore="true" data-1p-ignore="true" readonly onfocus="this.removeAttribute('readonly')" placeholder="이름 · SNS · 메일주소" oninput="rerenderInfluencersFromCache()">
+                <div style="display:flex;gap:6px;align-items:center">
+                  <div style="position:relative;flex:1">
+                    <span class="material-icons-round" style="position:absolute;left:8px;top:50%;transform:translateY(-50%);font-size:16px;color:var(--muted)">search</span>
+                    <input type="search" id="infSearch" class="admin-filter-search" autocomplete="off" data-lpignore="true" data-1p-ignore="true" readonly onfocus="this.removeAttribute('readonly')" placeholder="이름 · SNS · 메일주소" oninput="rerenderInfluencersFromCache()">
+                  </div>
+                  <button class="btn btn-ghost btn-xs" id="btnInfViewReset" onclick="resetInfView()" style="display:none;white-space:nowrap">보기 초기화</button>
                 </div>
               </div>
             </div>
@@ -894,7 +891,6 @@
               <div style="display:flex;align-items:center;gap:8px">
                 <label id="infExcelSensitiveWrap" style="display:none;align-items:center;gap:3px;font-size:11px;color:var(--muted);cursor:pointer" title="전화·LINE·PayPal·상세주소 열을 추가합니다 (캠페인 관리자 이상)"><input type="checkbox" id="infExcelSensitive">민감정보 포함</label>
                 <button class="btn btn-ghost btn-xs" id="btnInfExcel" onclick="exportInfluencersExcel()" style="display:inline-flex;align-items:center;gap:4px" title="현재 필터 결과를 엑셀로 다운로드"><span class="material-icons-round notranslate" translate="no" style="font-size:14px">download</span> 엑셀 다운로드</button>
-                <button class="btn btn-ghost btn-xs" id="btnInfSortReset" onclick="resetInfSort()" style="display:none">정렬 초기화</button>
               </div>
             </div>
             <div class="admin-table-wrap">
@@ -1015,18 +1011,21 @@
                 <div id="appTypeMulti" class="mf-wrap"><button type="button" class="mf-btn">전체 타입</button><div class="mf-drop"></div></div>
               </div>
               <div class="admin-filter-group">
+                <label>캠페인 상태</label>
+                <div id="appCampStatusMulti" class="mf-wrap"><button type="button" class="mf-btn">전체 상태</button><div class="mf-drop"></div></div>
+              </div>
+              <div class="admin-filter-group">
                 <label>신청 상태</label>
                 <div id="appStatusMulti" class="mf-wrap"><button type="button" class="mf-btn">전체 상태</button><div class="mf-drop"></div></div>
               </div>
-              <div class="admin-filter-group" style="justify-content:flex-end">
-                <label>&nbsp;</label>
-                <button class="btn btn-ghost btn-xs" id="btnAppFilterReset" onclick="resetAppFilters()" style="display:none">초기화</button>
-              </div>
               <div class="admin-filter-group" style="flex:1;min-width:200px;margin-left:auto">
                 <label>검색</label>
-                <div style="position:relative">
-                  <span class="material-icons-round" style="position:absolute;left:8px;top:50%;transform:translateY(-50%);font-size:16px;color:var(--muted)">search</span>
-                  <input type="search" id="appSearch" class="admin-filter-search" autocomplete="off" data-lpignore="true" data-1p-ignore="true" readonly onfocus="this.removeAttribute('readonly')" placeholder="인플루언서명 · 이메일 검색" oninput="renderAppCampList()">
+                <div style="display:flex;gap:6px;align-items:center">
+                  <div style="position:relative;flex:1">
+                    <span class="material-icons-round" style="position:absolute;left:8px;top:50%;transform:translateY(-50%);font-size:16px;color:var(--muted)">search</span>
+                    <input type="search" id="appSearch" class="admin-filter-search" autocomplete="off" data-lpignore="true" data-1p-ignore="true" readonly onfocus="this.removeAttribute('readonly')" placeholder="인플루언서명 · 이메일 검색" oninput="renderAppCampList()">
+                  </div>
+                  <button class="btn btn-ghost btn-xs" id="btnAppViewReset" onclick="resetAppView()" style="display:none;white-space:nowrap">보기 초기화</button>
                 </div>
               </div>
             </div>
@@ -1035,13 +1034,10 @@
             <div class="admin-card" id="appCampList">
               <div class="admin-card-header">
                 <div style="display:flex;align-items:center;gap:8px"><span class="admin-card-title">신청 목록</span><span id="appTotalCount" style="font-size:12px;color:var(--muted)"></span></div>
-                <div style="display:flex;align-items:center;gap:6px">
-                  <button class="btn btn-ghost btn-xs" id="btnAppSortReset" onclick="resetAppSort()" style="display:none">정렬 초기화</button>
-                </div>
               </div>
               <div class="admin-table-wrap">
               <table class="data-table">
-                <thead id="appTableHead"><tr><th>캠페인</th><th>채널</th><th>브랜드</th><th>제품</th><th>모집기간 <span class="sort-arrows app-sort-arrows" data-sort="deadline" onclick="toggleAppSort('deadline')">▲▼</span></th><th>인플루언서 <span class="sort-arrows app-sort-arrows" data-sort="name" onclick="toggleAppSort('name')">▲▼</span></th><th>신청 사유</th><th>신청일 <span class="sort-arrows app-sort-arrows" data-sort="created" onclick="toggleAppSort('created')">▲▼</span></th><th>상태 <span class="sort-arrows app-sort-arrows" data-sort="status" onclick="toggleAppSort('status')">▲▼</span></th><th>처리</th></tr></thead>
+                <thead id="appTableHead"><tr><th>캠페인</th><th>채널</th><th>브랜드</th><th>제품</th><th style="min-width:170px;white-space:nowrap">모집기간 <span class="sort-arrows app-sort-arrows" data-sort="deadline" onclick="toggleAppSort('deadline')">▲▼</span></th><th>인플루언서 <span class="sort-arrows app-sort-arrows" data-sort="name" onclick="toggleAppSort('name')">▲▼</span></th><th>신청 사유</th><th>신청일 <span class="sort-arrows app-sort-arrows" data-sort="created" onclick="toggleAppSort('created')">▲▼</span></th><th style="min-width:88px;white-space:nowrap">상태 <span class="sort-arrows app-sort-arrows" data-sort="status" onclick="toggleAppSort('status')">▲▼</span></th><th>처리</th></tr></thead>
                 <tbody id="appTableBody"><tr><td colspan="10" style="text-align:center;color:var(--muted);padding:24px"><span class="spinner" style="width:20px;height:20px;border-width:2px;border-color:rgba(200,120,163,.2);border-top-color:var(--pink)"></span></td></tr></tbody>
               </table>
               </div>
@@ -1106,7 +1102,7 @@
               </div>
               <div class="admin-filter-group" style="justify-content:flex-end">
                 <label>&nbsp;</label>
-                <button class="btn btn-ghost btn-xs" id="btnDelivFilterReset" onclick="resetDelivFiltersAndSort()" style="display:none">초기화</button>
+                <button class="btn btn-ghost btn-xs" id="btnDelivFilterReset" onclick="resetDelivFiltersAndSort()" style="display:none;white-space:nowrap">보기 초기화</button>
               </div>
               <!-- 텍스트 검색 입력 (기본 숨김 — 돋보기 버튼으로 토글) -->
               <div class="admin-filter-group" id="delivSearchBox" style="display:none;flex:1;min-width:220px">
@@ -1131,9 +1127,9 @@
                 <th style="width:180px">구매기간 <span class="sort-arrows" data-sort="purchase" onclick="toggleDelivSort('purchase')">▲▼</span></th>
                 <th style="width:130px">결과물 제출 마감 <span class="sort-arrows" data-sort="submission_end" onclick="toggleDelivSort('submission_end')">▲▼</span></th>
                 <th>인플루언서</th>
-                <th style="width:110px">인증 상태</th>
-                <th style="width:170px">영수증</th>
-                <th style="width:170px">결과물</th>
+                <th style="width:132px;white-space:nowrap">인증 상태</th>
+                <th style="width:195px">영수증</th>
+                <th style="width:195px">결과물</th>
                 <th style="width:130px">최근 제출 <span class="sort-arrows" data-sort="submitted" onclick="toggleDelivSort('submitted')">▲▼</span></th>
                 <th style="width:90px">처리</th>
               </tr></thead>
@@ -1691,18 +1687,14 @@
                 <input type="hidden" id="brandAppFromDate">
                 <input type="hidden" id="brandAppToDate">
               </div>
-              <div class="admin-filter-group" style="justify-content:flex-end">
-                <label>&nbsp;</label>
-                <div style="display:flex;gap:4px">
-                  <button class="btn btn-ghost btn-xs" id="btnBrandAppSortReset" onclick="resetBrandAppSort()" style="display:none">정렬 초기화</button>
-                  <button class="btn btn-ghost btn-xs" id="btnBrandAppFilterReset" onclick="resetBrandAppFilters()" style="display:none">초기화</button>
-                </div>
-              </div>
               <div class="admin-filter-group" style="flex:1;min-width:200px;margin-left:auto">
                 <label>검색</label>
-                <div style="position:relative">
-                  <span class="material-icons-round" style="position:absolute;left:8px;top:50%;transform:translateY(-50%);font-size:16px;color:var(--muted)">search</span>
-                  <input type="search" id="brandAppSearch" name="brandapp-q" class="admin-filter-search" autocomplete="off" data-lpignore="true" data-1p-ignore="true" readonly onfocus="this.removeAttribute('readonly')" placeholder="브랜드 · 담당자 · 주소 검색" oninput="renderBrandApplicationsList()">
+                <div style="display:flex;gap:6px;align-items:center">
+                  <div style="position:relative;flex:1">
+                    <span class="material-icons-round" style="position:absolute;left:8px;top:50%;transform:translateY(-50%);font-size:16px;color:var(--muted)">search</span>
+                    <input type="search" id="brandAppSearch" name="brandapp-q" class="admin-filter-search" autocomplete="off" data-lpignore="true" data-1p-ignore="true" readonly onfocus="this.removeAttribute('readonly')" placeholder="브랜드 · 담당자 · 주소 검색" oninput="renderBrandApplicationsList()">
+                  </div>
+                  <button class="btn btn-ghost btn-xs" id="btnBrandAppViewReset" onclick="resetBrandAppView()" style="display:none;white-space:nowrap">보기 초기화</button>
                 </div>
               </div>
             </div>

--- a/dev/js/admin-applications.js
+++ b/dev/js/admin-applications.js
@@ -370,20 +370,6 @@ function toggleAppSort(key) {
       el.textContent = appSortDir === 'asc' ? '▲' : '▼';
     }
   });
-  const btn = $('btnAppSortReset');
-  if (btn) btn.style.display = (appSortKey === 'created' && appSortDir === 'desc') ? 'none' : '';
-  renderAppCampList();
-}
-
-function resetAppSort() {
-  appSortKey = 'created';
-  appSortDir = 'desc';
-  document.querySelectorAll('.app-sort-arrows').forEach(el => {
-    el.classList.remove('asc','desc');
-    el.textContent = '▲▼';
-    if (el.dataset.sort === 'created') { el.classList.add('desc'); el.textContent = '▼'; }
-  });
-  const btn = $('btnAppSortReset'); if (btn) btn.style.display = 'none';
   renderAppCampList();
 }
 
@@ -432,16 +418,35 @@ async function renderAppCampList() {
   if (campStale.length > 0 && typeof toast === 'function') toast(`선택한 캠페인 ${campStale.length}건이 타입 필터에 맞지 않아 해제되었습니다`, 'info');
   if (typeStale.length > 0 && typeof toast === 'function') toast(`선택한 타입 ${typeStale.length}건이 캠페인 필터에 맞지 않아 해제되었습니다`, 'info');
 
-  // 옵션별 카운트 계산 (전체 신청 기준 — 다른 필터 무관)
+  // 필터 값 추출 (카운트·필터 적용 공용) — 동적 카운트를 위해 미리 확보
+  const campRtLookup = new Map(camps.map(c => [c.id, c.recruit_type]));
+  const campStatusLookup = new Map(camps.map(c => [c.id, c.status]));  // 신청의 캠페인 상태 조회용
+  const appTypeVals = getMultiFilterValues('appTypeMulti');
+  const appCampStatusVals = getMultiFilterValues('appCampStatusMulti');
+  const appStatusVals = getMultiFilterValues('appStatusMulti');
+  const campFilterVals = getMultiFilterValues('appCampMulti');
+  const searchVal = ($('appSearch')?.value || '').trim().toLowerCase();
+  // 단일 신청이 필터를 통과하는지 — skip 지정 시 그 필터만 무시(옵션별 동적 카운트용)
+  const passesAppFilters = (a, skip) => {
+    if (skip !== 'type'       && appTypeVals.length       && !appTypeVals.includes(campRtLookup.get(a.campaign_id))) return false;
+    if (skip !== 'campStatus' && appCampStatusVals.length && !appCampStatusVals.includes(campStatusLookup.get(a.campaign_id))) return false;
+    if (skip !== 'status'     && appStatusVals.length     && !appStatusVals.includes(a.status)) return false;
+    if (skip !== 'camp'       && campFilterVals.length    && !campFilterVals.includes(a.campaign_id)) return false;
+    if (searchVal && !matchSearchTokens(searchVal, [a.user_name, a.user_email, a.cancel_reason, a.cancel_reason_code])) return false;
+    return true;
+  };
+  // 옵션별 카운트 — 「자기 자신 필터 제외 + 다른 모든 필터 적용」 후 집계 (동적, 결과물 관리 페인과 동일 방식)
   const appCampCounts = {};
   const appTypeCounts = {};
   const appStatusCountsMap = {};
-  const campRtLookup = new Map(camps.map(c => [c.id, c.recruit_type]));
+  const appCampStatusCounts = {};
   for (const a of allAppsRaw) {
-    if (a.campaign_id) appCampCounts[a.campaign_id] = (appCampCounts[a.campaign_id] || 0) + 1;
+    if (a.campaign_id && passesAppFilters(a, 'camp')) appCampCounts[a.campaign_id] = (appCampCounts[a.campaign_id] || 0) + 1;
     const rt = campRtLookup.get(a.campaign_id);
-    if (rt) appTypeCounts[rt] = (appTypeCounts[rt] || 0) + 1;
-    if (a.status) appStatusCountsMap[a.status] = (appStatusCountsMap[a.status] || 0) + 1;
+    if (rt && passesAppFilters(a, 'type')) appTypeCounts[rt] = (appTypeCounts[rt] || 0) + 1;
+    const cst = campStatusLookup.get(a.campaign_id);
+    if (cst && passesAppFilters(a, 'campStatus')) appCampStatusCounts[cst] = (appCampStatusCounts[cst] || 0) + 1;
+    if (a.status && passesAppFilters(a, 'status')) appStatusCountsMap[a.status] = (appStatusCountsMap[a.status] || 0) + 1;
   }
 
   // 드롭다운 동기화 — count 포함
@@ -449,6 +454,15 @@ async function renderAppCampList() {
   syncMultiFilter('appTypeMulti', '전체 타입',
     availableTypes.map(t => ({value:t, label:RECRUIT_TYPE_LABEL_KO[t] || t, count: appTypeCounts[t] || 0})),
     () => renderAppCampList());
+  // 캠페인 상태 필터 — 캠페인 관리 페인과 동일 6단계 (admin.js campStatusMulti 와 라벨·순서 통일)
+  syncMultiFilter('appCampStatusMulti', '전체 상태', [
+    {value:'draft',     label:'준비',     count: appCampStatusCounts.draft     || 0},
+    {value:'scheduled', label:'모집예정', count: appCampStatusCounts.scheduled || 0},
+    {value:'active',    label:'모집중',   count: appCampStatusCounts.active    || 0},
+    {value:'closed',    label:'모집마감', count: appCampStatusCounts.closed    || 0},
+    {value:'ended',     label:'종료',     count: appCampStatusCounts.ended     || 0},
+    {value:'expired',   label:'노출종료', count: appCampStatusCounts.expired   || 0},
+  ], () => renderAppCampList());
   syncMultiFilter('appStatusMulti', '전체 상태', [
     {value:'pending',   label:'심사중', count: appStatusCountsMap.pending   || 0},
     {value:'approved',  label:'승인',   count: appStatusCountsMap.approved  || 0},
@@ -456,33 +470,15 @@ async function renderAppCampList() {
     {value:'cancelled', label:'취소',   count: appStatusCountsMap.cancelled || 0},
   ], () => renderAppCampList());
 
-  // 타입 필터 (다중 선택) — stale 제거 후 최종값
-  const appTypeVals = getMultiFilterValues('appTypeMulti');
-  if (appTypeVals.length) {
-    const filteredCampIds = camps.filter(c => appTypeVals.includes(c.recruit_type)).map(c => c.id);
-    apps = apps.filter(a => filteredCampIds.includes(a.campaign_id));
-  }
+  // 필터 적용 — 위에서 정의한 passesAppFilters 로 일괄 (타입·캠페인상태·신청상태·캠페인·검색 모두 포함)
+  //   검색은 인플루언서 전용 (캠페인은 검색형 캠페인 드롭다운으로 분리)
+  apps = apps.filter(a => passesAppFilters(a));
 
-  // 상태 필터 (다중 선택)
-  const appStatusVals = getMultiFilterValues('appStatusMulti');
-  if (appStatusVals.length) apps = apps.filter(a => appStatusVals.includes(a.status));
-
-  // 캠페인 다중 선택 필터 — stale 제거 후 최종값
-  const campFilterVals = getMultiFilterValues('appCampMulti');
-  if (campFilterVals.length) apps = apps.filter(a => campFilterVals.includes(a.campaign_id));
-
-  // 검색 필터 — 단어 단위 AND 매칭 (matchSearchTokens, 전각/반각 공백 무관)
-  const searchVal = ($('appSearch')?.value || '').trim().toLowerCase();
-  if (searchVal) {
-    apps = apps.filter(a => {
-      // 검색은 인플루언서 전용 (캠페인은 검색형 캠페인 드롭다운으로 분리)
-      return matchSearchTokens(searchVal, [
-        a.user_name, a.user_email, a.cancel_reason, a.cancel_reason_code,
-      ]);
-    });
-  }
-
-  updateFilterResetBtn('btnAppFilterReset', ['appTypeMulti','appStatusMulti','appCampMulti'], 'appSearch');
+  // 보기 초기화 버튼 — 필터·검색·정렬 중 하나라도 비기본이면 노출 (필터+정렬+검색 통합)
+  const _appViewActive = ['appTypeMulti','appCampStatusMulti','appStatusMulti','appCampMulti'].some(id => getMultiFilterValues(id).length > 0)
+    || !!(($('appSearch')?.value || '').trim())
+    || !(appSortKey === 'created' && appSortDir === 'desc');
+  const _appViewBtn = $('btnAppViewReset'); if (_appViewBtn) _appViewBtn.style.display = _appViewActive ? '' : 'none';
 
   const appDir = appSortDir === 'asc' ? 1 : -1;
   if (appSortKey === 'status') {
@@ -528,7 +524,7 @@ async function renderAppCampList() {
           </div>
           <div style="min-width:0;flex:1">
             <div>${typeLabel}</div>
-            <strong style="font-size:13px;cursor:pointer;display:block;word-break:break-word;line-height:1.4" onclick="openCampPreviewModal('${camp.id}')">${esc(camp.title)||'—'}</strong>
+            <div style="display:flex;align-items:flex-start;gap:4px"><strong style="font-size:13px;display:block;word-break:break-word;line-height:1.4;flex:1">${esc(camp.title)||'—'}</strong>${campPreviewBtn(camp.id)}</div>
             ${camp.slots?(()=>{const _r=Math.max(camp.slots-countNonAuditApproved(allAppsRaw, camp.id, _auditIds),0);return `<div style="font-size:10px;color:var(--muted);margin-top:2px">모집 ${camp.slots}명 · 빈자리 <span style="color:${_r>0?'var(--green)':'var(--red)'};font-weight:600">${_r>0?_r+'건':'없음'}</span></div>`;})():''}
           </div>
         </div>
@@ -542,9 +538,8 @@ async function renderAppCampList() {
         ${productPrimary?esc(productPrimary):'—'}
         ${productSub?`<div style="font-size:10px;color:var(--muted);margin-top:2px">${esc(productSub)}</div>`:''}
       </td>
-      <td style="font-size:11px;color:var(--muted);white-space:nowrap">
-        ${recruitStart?`<div>${recruitStart}</div>`:''}
-        <div style="color:var(--ink)">~ ${recruitEnd||'—'}</div>
+      <td style="font-size:11px;color:var(--ink);white-space:nowrap">
+        ${(recruitStart||recruitEnd) ? `${recruitStart||'—'} ~ ${recruitEnd||'—'}` : '<span style="color:var(--muted)">—</span>'}
       </td>
       <td>
         <div style="font-weight:600;color:var(--pink);cursor:pointer" onclick="openInfluencerModal('${u.id||''}')">${esc(a.user_name)||'—'}${auditBadgeHtml(u)}${influencerStatusBadges(u)}</div>
@@ -553,7 +548,7 @@ async function renderAppCampList() {
       </td>
       <td>${msgCell(a.message, a)}</td>
       <td style="font-size:12px;color:var(--muted);white-space:nowrap">${formatDate(a.created_at)}</td>
-      <td>${getStatusBadgeKo(a.status, a.auto_reject_reason)}${a.status==='cancelled' && a.cancel_phase ? `<div style="font-size:10px;color:var(--muted);margin-top:2px">${esc(cancelPhaseLabelKo(a.cancel_phase))}</div>` : ''}</td>
+      <td style="white-space:nowrap">${getStatusBadgeKo(a.status, a.auto_reject_reason)}${a.status==='cancelled' && a.cancel_phase ? `<div style="font-size:10px;color:var(--muted);margin-top:2px">${esc(cancelPhaseLabelKo(a.cancel_phase))}</div>` : ''}</td>
       <td style="white-space:nowrap">
         ${a.status==='pending'?`<div style="display:flex;gap:4px"><button class="btn btn-green btn-xs" ${(_campRemaining<=0 && !u.is_audit)?'disabled style="background:var(--muted);opacity:.5;cursor:not-allowed"':''}onclick="updateAppStatus('${a.id}','approved')">승인</button><button class="btn btn-ghost btn-xs" style="color:var(--red);border-color:var(--red)" onclick="updateAppStatus('${a.id}','rejected')">미승인</button></div>`
         :a.status==='cancelled'?`<div style="font-size:10px;color:var(--muted)">${a.cancelled_at?formatDateTime(a.cancelled_at):'—'}</div>`

--- a/dev/js/admin-brand.js
+++ b/dev/js/admin-brand.js
@@ -1795,10 +1795,9 @@ function renderBrandApplicationsList() {
   var res = getFilteredBrandApps();
   var list = res.list;
   var filterActive = res.filterActive;
-  var resetBtn = $('btnBrandAppFilterReset');
-  if (resetBtn) resetBtn.style.display = filterActive ? 'inline-block' : 'none';
-  var sortResetBtn = $('btnBrandAppSortReset');
-  if (sortResetBtn) sortResetBtn.style.display = _brandAppSortIsDefault() ? 'none' : 'inline-block';
+  // 보기 초기화 — 필터·검색·정렬 중 하나라도 비기본이면 표시
+  var viewResetBtn = $('btnBrandAppViewReset');
+  if (viewResetBtn) viewResetBtn.style.display = (filterActive || !_brandAppSortIsDefault()) ? 'inline-block' : 'none';
 
   var count = $('brandAppTotalCount');
   if (count) {
@@ -1856,7 +1855,8 @@ function renderBrandApplicationsList() {
   });
 }
 
-function resetBrandAppFilters() {
+// 보기 초기화 — 필터·검색·정렬을 한 번에 기본값으로
+function resetBrandAppView() {
   resetMultiFilter('brandAppFormMulti', '전체 폼');
   // 상태 탭 초기화 (전체 탭으로)
   _brandAppActiveStatusTab = null;
@@ -1872,6 +1872,8 @@ function resetBrandAppFilters() {
   ['brandAppFromDate','brandAppToDate','brandAppDateRange'].forEach(function(id){
     var el = $(id); if (el) el.classList.remove('filter-active');
   });
+  _brandAppSort = {field: 'created', dir: 'desc'};
+  updateBrandAppSortIndicators();
   renderBrandApplicationsList();
 }
 
@@ -1916,12 +1918,6 @@ function toggleBrandAppSort(field) {
 
 function _brandAppSortIsDefault() {
   return _brandAppSort.field === 'created' && _brandAppSort.dir === 'desc';
-}
-
-function resetBrandAppSort() {
-  _brandAppSort = {field: 'created', dir: 'desc'};
-  updateBrandAppSortIndicators();
-  renderBrandApplicationsList();
 }
 
 // 정렬 화살표 활성 상태 시각화 (▲ asc / ▼ desc / ▲▼ inactive)

--- a/dev/js/admin-dashboard.js
+++ b/dev/js/admin-dashboard.js
@@ -98,7 +98,7 @@ function renderRecentAppsTable(apps, camps, users) {
           </div>
           <div style="min-width:0">
             <div>${typeLabel}</div>
-            <strong style="font-size:13px;cursor:pointer" onclick="openCampPreviewModal('${camp.id}')">${esc(camp.title)||'—'}</strong>
+            <div style="display:flex;align-items:flex-start;gap:4px"><strong style="font-size:13px;flex:1">${esc(camp.title)||'—'}</strong>${campPreviewBtn(camp.id)}</div>
             <div style="font-size:11px;color:var(--muted)">${esc(brandLabelAdmin(camp))}</div>
             ${camp.slots?`<div style="font-size:10px;color:var(--muted);margin-top:2px">모집 ${camp.slots}명 · 빈자리 <span style="color:${_dRem>0?'var(--green)':'var(--red)'};font-weight:600">${_dRem>0?_dRem+'건':'없음'}</span></div>`:''}
           </div>

--- a/dev/js/admin-deliverables.js
+++ b/dev/js/admin-deliverables.js
@@ -606,13 +606,13 @@ function renderDelivAppRow(g) {
   const brandLabel = brandLabelAdmin(camp);
 
   return `<tr data-app-id="${esc(g.application_id)}" class="${inf.is_audit ? 'audit-row' : ''}" style="${rowStyle}">
-    <td><div style="display:flex;align-items:center;gap:6px;flex-wrap:wrap;margin-bottom:2px">${rtBadge}${campNoBadge}</div><div>${esc(camp.title || '—')}</div></td>
+    <td><div style="display:flex;align-items:center;gap:6px;flex-wrap:wrap;margin-bottom:2px">${rtBadge}${campNoBadge}</div><div style="display:flex;align-items:flex-start;gap:4px"><span style="flex:1">${esc(camp.title || '—')}</span>${campPreviewBtn(camp.id)}</div></td>
     <td>${channelChipsHtml(camp.channel, camp.channel_match)}</td>
     <td style="font-size:12px;color:var(--ink);min-width:100px;max-width:160px;word-break:break-word">${brandLabel ? esc(brandLabel) : '—'}</td>
     <td style="font-size:11px;color:var(--ink);white-space:nowrap">${periodRangeCell(ps, pe)}</td>
     <td style="font-size:11px;color:var(--ink);white-space:nowrap">${periodSingleCell(camp.submission_end)}</td>
     <td><div style="font-weight:600;color:var(--pink);cursor:pointer" onclick="openInfluencerModal('${esc(inf.id||'')}')">${infName}${auditBadgeHtml(inf)}${(typeof influencerStatusBadges === 'function') ? influencerStatusBadges(inf) : ''}</div>${infSub ? `<div style="font-size:10px;color:var(--muted)">${infSub}</div>` : ''}<div style="margin-top:4px">${renderApplicantMsgBtn({id: g.application_id, campaign_id: (camp && camp.id) || ''})}</div></td>
-    <td>${certStatusBadge(g)}</td>
+    <td style="white-space:nowrap">${certStatusBadge(g)}</td>
     <td>${receiptCell}</td>
     <td>${resultCell}</td>
     <td>${submittedCell}</td>
@@ -668,12 +668,16 @@ function renderDelivResultCellMonitor(g) {
 // 영수증·결과물 셀 — slot: 'receipt' | 'result', rt: campaign.recruit_type
 //   opts.hasValidApprovedPost: 같은 신청에 캠페인 채널 일치 승인 게시물이 있으면 채널 불일치 배지 숨김
 function renderDelivStatusCell(d, slot, rt, opts) {
+  // 결과물 셀(result)은 monitor 채널별 미니행(10px)과 라벨 크기를 통일. 영수증 셀은 기존 11px 유지.
+  const small = slot === 'result';
+  const badgeFs = small ? '10px' : '11px';
+  const badgePad = small ? '1px 6px' : '2px 8px';
   // 영수증은 monitor에서만 사용. gifting/visit은 영수증 단계 없음 → 「-」 표시
   if (slot === 'receipt' && rt !== 'monitor') {
     return '<span style="font-size:11px;color:var(--muted)">—</span>';
   }
   if (!d) {
-    return '<span style="display:inline-block;background:#f5f5f5;color:var(--muted);font-size:11px;font-weight:600;padding:2px 8px;border-radius:3px">미제출</span>';
+    return `<span style="display:inline-block;background:#f5f5f5;color:var(--muted);font-size:${badgeFs};font-weight:600;padding:${badgePad};border-radius:3px">미제출</span>`;
   }
   let preview = '';
   if (d.kind === 'receipt' || d.kind === 'review_image') {
@@ -697,8 +701,8 @@ function renderDelivStatusCell(d, slot, rt, opts) {
   // 마이그레이션 160: 대리 등록 행은 status 배지를 「대리 등록」으로 교체 (자동 승인이라 "승인" 표기 무의미)
   // 사용자 결정 2026-05-28: 「승인 + 작은 대리 마커」 중복 → 단일 「대리 등록」 배지로 통합
   const statusBadgeHtml = d.submitted_by_admin
-    ? `<span style="background:#FEF3C7;color:#92400E;font-size:11px;font-weight:600;padding:2px 8px;border-radius:3px" title="관리자 대리 등록·자동 승인">대리 등록</span>`
-    : delivStatusBadge(d.status);
+    ? `<span style="background:#FEF3C7;color:#92400E;font-size:${badgeFs};font-weight:600;padding:${badgePad};border-radius:3px" title="관리자 대리 등록·자동 승인">대리 등록</span>`
+    : delivStatusBadge(d.status, small);
   return `<div style="display:flex;align-items:center;gap:6px">${preview}${statusBadgeHtml}</div>`;
 }
 
@@ -706,11 +710,14 @@ function statusLabelKo(status) {
   return {pending: '검수대기', approved: '승인', rejected: '반려'}[status] || status;
 }
 
-function delivStatusBadge(status) {
+// small=true: 결과물 목록 셀에서 monitor 채널별 미니행(10px)과 라벨 크기 통일용. 미지정 시 기존 11px.
+function delivStatusBadge(status, small) {
+  const fs = small ? '10px' : '11px';
+  const pad = small ? '1px 6px' : '2px 8px';
   const map = {
-    pending: '<span style="background:#FFF4E4;color:#B8741A;font-size:11px;font-weight:600;padding:2px 8px;border-radius:3px">검수대기</span>',
-    approved: '<span style="background:#E4F5E8;color:#2D7A3E;font-size:11px;font-weight:600;padding:2px 8px;border-radius:3px">승인</span>',
-    rejected: '<span style="background:#FFE4E4;color:#C33;font-size:11px;font-weight:600;padding:2px 8px;border-radius:3px">반려</span>'
+    pending: `<span style="background:#FFF4E4;color:#B8741A;font-size:${fs};font-weight:600;padding:${pad};border-radius:3px">검수대기</span>`,
+    approved: `<span style="background:#E4F5E8;color:#2D7A3E;font-size:${fs};font-weight:600;padding:${pad};border-radius:3px">승인</span>`,
+    rejected: `<span style="background:#FFE4E4;color:#C33;font-size:${fs};font-weight:600;padding:${pad};border-radius:3px">반려</span>`
   };
   return map[status] || status;
 }

--- a/dev/js/admin-influencers.js
+++ b/dev/js/admin-influencers.js
@@ -109,20 +109,22 @@ function renderInfluencersPane() {
   const total = (infUsersCache || []).length;
   const totalEl = $('infTotalCount');
   if (totalEl) totalEl.textContent = `${filtered.length}명 표시 (전체 ${total}명)`;
-  const resetBtn = $('btnInfFilterReset');
+  const resetBtn = $('btnInfViewReset');
   if (resetBtn) {
     const verifiedSel = $('infFilterVerifiedSelect')?.value || 'all';
     const violationSel = $('infFilterViolationSelect')?.value || 'all';
     const searchQ = ($('infSearch')?.value || '').trim();
     const prefSel = (typeof getMultiFilterValues === 'function') ? getMultiFilterValues('infPrefectureMulti') : [];
     const hasFollower = !!($('infFollowersMin')?.value || $('infFollowersMax')?.value);
-    const anyActive = (verifiedSel !== 'all' || violationSel !== 'all' || currentInfTab !== 'all' || !!searchQ || prefSel.length > 0 || hasFollower);
+    const hasSort = !(infSortKey === 'created' && infSortDir === 'desc');
+    const anyActive = (verifiedSel !== 'all' || violationSel !== 'all' || currentInfTab !== 'all' || !!searchQ || prefSel.length > 0 || hasFollower || hasSort);
     resetBtn.style.display = anyActive ? '' : 'none';
   }
   renderInfTable(filtered);
 }
 
-function resetInfluencerFilters() {
+// 보기 초기화 — 필터·검색·정렬을 한 번에 기본값으로
+function resetInfView() {
   const v = $('infFilterVerifiedSelect'); if (v) v.value = 'all';
   const w = $('infFilterViolationSelect'); if (w) w.value = 'all';
   const c = $('infChannelFilter'); if (c) c.value = 'all';
@@ -131,6 +133,8 @@ function resetInfluencerFilters() {
   const mn = $('infFollowersMin'); if (mn) mn.value = '';
   const mx = $('infFollowersMax'); if (mx) mx.value = '';
   currentInfTab = 'all';
+  infSortKey = 'created'; infSortDir = 'desc';
+  updateInfSortUI();
   rerenderInfluencersFromCache();
 }
 
@@ -153,13 +157,6 @@ function toggleInfSort(key) {
   rerenderInfluencersFromCache();
 }
 
-function resetInfSort() {
-  infSortKey = 'created';
-  infSortDir = 'desc';
-  updateInfSortUI();
-  rerenderInfluencersFromCache();
-}
-
 function updateInfSortUI() {
   document.querySelectorAll('.inf-sort-arrows').forEach(el => {
     el.classList.remove('asc','desc');
@@ -169,8 +166,6 @@ function updateInfSortUI() {
       el.textContent = infSortDir === 'asc' ? '▲' : '▼';
     }
   });
-  const resetBtn = $('btnInfSortReset');
-  if (resetBtn) resetBtn.style.display = (infSortKey === 'created' && infSortDir === 'desc') ? 'none' : '';
 }
 
 function sortInfUsers(users) {

--- a/dev/js/admin.js
+++ b/dev/js/admin.js
@@ -60,18 +60,13 @@ function filterAdminCampaigns() { loadAdminCampaigns(true); }
 // 검색창 전용 — 글자 연타 시 마지막 입력만 반영(0.3초). 드롭다운 필터는 즉시 호출 유지.
 const debouncedFilterAdminCampaigns = debounce(filterAdminCampaigns, 300);
 
-function resetCampSort() {
-  adminCampSortKey = '';
-  adminCampSortDir = '';
-  updateSortArrows();
-  updateCampTableHead();
-  const btn = $('btnCampSortReset'); if (btn) btn.style.display = 'none';
-  filterAdminCampaigns();
-}
-
-function updateCampSortResetBtn() {
-  const btn = $('btnCampSortReset');
-  if (btn) btn.style.display = adminCampSortKey ? '' : 'none';
+// 보기 초기화 버튼 노출 — 필터·검색·정렬 중 하나라도 비기본이면 표시
+function updateCampViewResetBtn() {
+  const hasFilter = ['campTypeMulti','campStatusMulti'].some(id => getMultiFilterValues(id).length > 0);
+  const hasSearch = !!(($('adminCampSearch')?.value || '').trim());
+  const hasSort = !!adminCampSortKey;
+  const btn = $('btnCampViewReset');
+  if (btn) btn.style.display = (hasFilter || hasSearch || hasSort) ? '' : 'none';
 }
 
 function resetCampFilters() {
@@ -80,11 +75,27 @@ function resetCampFilters() {
   const s = $('adminCampSearch'); if (s) s.value = '';
   filterAdminCampaigns();
 }
-function resetAppFilters() {
+// 보기 초기화 — 필터·검색·정렬을 한 번에 기본값으로
+function resetCampView() {
+  resetMultiFilter('campTypeMulti', '전체 타입');
+  resetMultiFilter('campStatusMulti', '전체 상태');
+  const s = $('adminCampSearch'); if (s) s.value = '';
+  adminCampSortKey = ''; adminCampSortDir = '';
+  updateSortArrows(); updateCampTableHead();
+  filterAdminCampaigns();
+}
+// 보기 초기화 — 필터·검색·정렬을 한 번에 기본값으로 (목록 페인 공통 패턴)
+function resetAppView() {
   resetMultiFilter('appTypeMulti', '전체 타입');
+  resetMultiFilter('appCampStatusMulti', '전체 상태');
   resetMultiFilter('appStatusMulti', '전체 상태');
   resetMultiFilter('appCampMulti', '전체 캠페인');
   const s = $('appSearch'); if (s) s.value = '';
+  appSortKey = 'created'; appSortDir = 'desc';
+  document.querySelectorAll('.app-sort-arrows').forEach(el => {
+    el.classList.remove('asc','desc'); el.textContent = '▲▼';
+    if (el.dataset.sort === 'created') { el.classList.add('desc'); el.textContent = '▼'; }
+  });
   renderAppCampList();
 }
 
@@ -118,7 +129,7 @@ function toggleCampSort(key) {
     adminCampSortDir = 'desc';
   }
   updateSortArrows();
-  updateCampSortResetBtn();
+  updateCampViewResetBtn();
   filterAdminCampaigns();
 }
 
@@ -270,7 +281,7 @@ async function loadAdminCampaigns(useCache) {
       [c.title, c.brand, c.brand_ko, c.brand_ja, c.brand_en, c.product, c.product_ko, c.campaign_no]));
   }
 
-  updateFilterResetBtn('btnCampFilterReset', ['campTypeMulti','campStatusMulti'], 'adminCampSearch');
+  updateCampViewResetBtn();
 
   // useCache(검색/필터/정렬)면 캐시 재사용 → 서버 재조회 0회. 캐시가 비어있으면 1회만 조회.
   // PR 4 서버 집계: 신청 전건 전송 대신 서버 집계 함수 1회 호출로 전환.
@@ -357,7 +368,7 @@ async function loadAdminCampaigns(useCache) {
               ${typeLabel(c.recruit_type)}
               ${c.campaign_no ? `<span style="font-family:monospace;font-size:10px;font-weight:600;color:var(--muted);letter-spacing:0.02em">${esc(c.campaign_no)}</span>` : ''}
             </div>
-            <strong style="cursor:pointer;color:var(--ink);display:block;word-break:break-word;line-height:1.4" onclick="openCampPreviewModal('${c.id}')">${esc(c.title)}</strong>
+            <div style="display:flex;align-items:flex-start;gap:4px"><strong style="color:var(--ink);display:block;word-break:break-word;line-height:1.4;flex:1">${esc(c.title)}</strong>${campPreviewBtn(c.id)}</div>
           </div>
         </div>
       </td>

--- a/dev/lib/shared.js
+++ b/dev/lib/shared.js
@@ -727,6 +727,12 @@ function brandLabelAdmin(c) {
   if (!c) return '';
   return (c.brand || c.brand_en || c.brand_ja || '').trim();
 }
+// 캠페인 미리보기 돋보기 버튼 — 관리자 목록 캠페인 열 공통. 이름 옆에 배치, 클릭 시 미리보기 모달.
+//   (기존엔 캠페인명 자체 클릭으로 열렸으나, 명시적 버튼으로 통일 — 2026-06-17)
+function campPreviewBtn(campId) {
+  if (!campId) return '';
+  return `<button type="button" onclick="event.stopPropagation();openCampPreviewModal('${esc(String(campId))}')" title="미리보기" style="flex-shrink:0;background:none;border:none;cursor:pointer;padding:0;margin:0;color:var(--muted);display:inline-flex;align-items:center;line-height:1"><span class="material-icons-round notranslate" translate="no" style="font-size:16px">search</span></button>`;
+}
 function brandLabelInflu(c) {
   if (!c) return '';
   return (c.brand_ja || c.brand_en || c.brand || '').trim();

--- a/index.html
+++ b/index.html
@@ -2598,6 +2598,12 @@ function brandLabelAdmin(c) {
   if (!c) return '';
   return (c.brand || c.brand_en || c.brand_ja || '').trim();
 }
+// 캠페인 미리보기 돋보기 버튼 — 관리자 목록 캠페인 열 공통. 이름 옆에 배치, 클릭 시 미리보기 모달.
+//   (기존엔 캠페인명 자체 클릭으로 열렸으나, 명시적 버튼으로 통일 — 2026-06-17)
+function campPreviewBtn(campId) {
+  if (!campId) return '';
+  return `<button type="button" onclick="event.stopPropagation();openCampPreviewModal('${esc(String(campId))}')" title="미리보기" style="flex-shrink:0;background:none;border:none;cursor:pointer;padding:0;margin:0;color:var(--muted);display:inline-flex;align-items:center;line-height:1"><span class="material-icons-round notranslate" translate="no" style="font-size:16px">search</span></button>`;
+}
 function brandLabelInflu(c) {
   if (!c) return '';
   return (c.brand_ja || c.brand_en || c.brand || '').trim();


### PR DESCRIPTION
## 변경 요약
- **신청 관리**: 캠페인 상태 필터 추가, 모집기간 열 확대(한 줄), 필터 옵션 카운트 동적화
- **모든 목록 화면**: 「초기화」+「정렬 초기화」 2버튼 → 단일 「보기 초기화」(필터+정렬+검색, 검색창 옆)
- **캠페인 미리보기**: 이름 클릭 → 이름 옆 돋보기 버튼으로 통일 (캠페인 관리·신청 관리·대시보드·결과물 관리)
- **열/라벨**: 상태·인증 상태·영수증·결과물 열 너비 확대, 결과물 라벨 크기 통일

## 운영 반영 방식
dev에는 운영 보류 기능(연령정책·오픈예정 보드 등)이 섞여 있어 dev→main 통머지 대신, 검수모달 핫픽스 이후의 이번 세션 변경 diff만 main 기준 worktree에 적용·재빌드. 연령정책 미혼입 검증 완료.

## DB 적용
- 없음 (UI 변경, DB 무관)

## 요청 외 추가 변경
- 없음

## 관련 사양서
- 없음