### PR TITLE
style(admin): 결과물 관리 인증·영수증 라벨 10px 통일 + 영수증·검수 열 확대 (운영 핫픽스)

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -12,7 +12,7 @@
 // 회귀(2026-05-12 PR #182 머지 직후 발생)를 방지하기 위한 자동 reload 가드.
 // sessionStorage 차단 환경(시크릿 모드 일부, 쿠키 차단)에서는 자연스럽게 skip.
 (function(){
-  var CURRENT_BUILD = 'v1781669882';
+  var CURRENT_BUILD = 'v1781670848';
   if (CURRENT_BUILD.indexOf('__') === 0) return; // 빌드 미적용 (dev/ 직접 열기) 시 skip
   try {
     var prev = sessionStorage.getItem('reverb.adminBuild');
@@ -2065,7 +2065,7 @@ tr.audit-row, .audit-row { background: #fff3e0 !important; }
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-06-17 13:18 · ab1376b</span>
+          <span class="admin-build-text">2026-06-17 13:34 · 5ead677</span>
         </div>
       </div>
     </aside>
@@ -3061,10 +3061,10 @@ tr.audit-row, .audit-row { background: #fff3e0 !important; }
                 <th style="width:130px">결과물 제출 마감 <span class="sort-arrows" data-sort="submission_end" onclick="toggleDelivSort('submission_end')">▲▼</span></th>
                 <th>인플루언서</th>
                 <th style="width:132px;white-space:nowrap">인증 상태</th>
-                <th style="width:195px">영수증</th>
+                <th style="width:230px">영수증</th>
                 <th style="width:195px">결과물</th>
                 <th style="width:130px">최근 제출 <span class="sort-arrows" data-sort="submitted" onclick="toggleDelivSort('submitted')">▲▼</span></th>
-                <th style="width:90px">처리</th>
+                <th style="width:120px">처리</th>
               </tr></thead>
               <tbody id="delivTableBody"><tr><td colspan="11" style="text-align:center;color:var(--muted);padding:24px"><span class="spinner" style="width:20px;height:20px;border-width:2px;border-color:rgba(200,120,163,.2);border-top-color:var(--pink)"></span></td></tr></tbody>
             </table>
@@ -19649,9 +19649,11 @@ function certStatusLabelKo(g) {
 }
 function certStatusBadge(g) {
   const s = computeCertStatus(g);
-  if (s === 'success')    return '<span class="badge badge-green">인증성공</span>';
-  if (s === 'submitting') return '<span class="badge badge-gold">인증샷 제출중</span>';
-  return '<span class="badge badge-gray">미제출</span>';
+  // 결과물 셀 라벨(10px)과 크기 통일 + 줄바꿈 방지
+  const st = 'font-size:10px;padding:1px 6px;white-space:nowrap';
+  if (s === 'success')    return `<span class="badge badge-green" style="${st}">인증성공</span>`;
+  if (s === 'submitting') return `<span class="badge badge-gold" style="${st}">인증샷 제출중</span>`;
+  return `<span class="badge badge-gray" style="${st}">미제출</span>`;
 }
 
 // 신청 1건 = 1행. 영수증 셀 / 결과물 셀 각각 상태 배지·미리보기 노출.
@@ -19765,8 +19767,8 @@ function renderDelivResultCellMonitor(g) {
 // 영수증·결과물 셀 — slot: 'receipt' | 'result', rt: campaign.recruit_type
 //   opts.hasValidApprovedPost: 같은 신청에 캠페인 채널 일치 승인 게시물이 있으면 채널 불일치 배지 숨김
 function renderDelivStatusCell(d, slot, rt, opts) {
-  // 결과물 셀(result)은 monitor 채널별 미니행(10px)과 라벨 크기를 통일. 영수증 셀은 기존 11px 유지.
-  const small = slot === 'result';
+  // 결과물·영수증 셀 라벨을 monitor 채널별 미니행(10px)과 크기 통일.
+  const small = (slot === 'result' || slot === 'receipt');
   const badgeFs = small ? '10px' : '11px';
   const badgePad = small ? '1px 6px' : '2px 8px';
   // 영수증은 monitor에서만 사용. gifting/visit은 영수증 단계 없음 → 「-」 표시

--- a/dev/admin/index.html
+++ b/dev/admin/index.html
@@ -1128,10 +1128,10 @@
                 <th style="width:130px">결과물 제출 마감 <span class="sort-arrows" data-sort="submission_end" onclick="toggleDelivSort('submission_end')">▲▼</span></th>
                 <th>인플루언서</th>
                 <th style="width:132px;white-space:nowrap">인증 상태</th>
-                <th style="width:195px">영수증</th>
+                <th style="width:230px">영수증</th>
                 <th style="width:195px">결과물</th>
                 <th style="width:130px">최근 제출 <span class="sort-arrows" data-sort="submitted" onclick="toggleDelivSort('submitted')">▲▼</span></th>
-                <th style="width:90px">처리</th>
+                <th style="width:120px">처리</th>
               </tr></thead>
               <tbody id="delivTableBody"><tr><td colspan="11" style="text-align:center;color:var(--muted);padding:24px"><span class="spinner" style="width:20px;height:20px;border-width:2px;border-color:rgba(200,120,163,.2);border-top-color:var(--pink)"></span></td></tr></tbody>
             </table>

--- a/dev/js/admin-deliverables.js
+++ b/dev/js/admin-deliverables.js
@@ -552,9 +552,11 @@ function certStatusLabelKo(g) {
 }
 function certStatusBadge(g) {
   const s = computeCertStatus(g);
-  if (s === 'success')    return '<span class="badge badge-green">인증성공</span>';
-  if (s === 'submitting') return '<span class="badge badge-gold">인증샷 제출중</span>';
-  return '<span class="badge badge-gray">미제출</span>';
+  // 결과물 셀 라벨(10px)과 크기 통일 + 줄바꿈 방지
+  const st = 'font-size:10px;padding:1px 6px;white-space:nowrap';
+  if (s === 'success')    return `<span class="badge badge-green" style="${st}">인증성공</span>`;
+  if (s === 'submitting') return `<span class="badge badge-gold" style="${st}">인증샷 제출중</span>`;
+  return `<span class="badge badge-gray" style="${st}">미제출</span>`;
 }
 
 // 신청 1건 = 1행. 영수증 셀 / 결과물 셀 각각 상태 배지·미리보기 노출.
@@ -668,8 +670,8 @@ function renderDelivResultCellMonitor(g) {
 // 영수증·결과물 셀 — slot: 'receipt' | 'result', rt: campaign.recruit_type
 //   opts.hasValidApprovedPost: 같은 신청에 캠페인 채널 일치 승인 게시물이 있으면 채널 불일치 배지 숨김
 function renderDelivStatusCell(d, slot, rt, opts) {
-  // 결과물 셀(result)은 monitor 채널별 미니행(10px)과 라벨 크기를 통일. 영수증 셀은 기존 11px 유지.
-  const small = slot === 'result';
+  // 결과물·영수증 셀 라벨을 monitor 채널별 미니행(10px)과 크기 통일.
+  const small = (slot === 'result' || slot === 'receipt');
   const badgeFs = small ? '10px' : '11px';
   const badgePad = small ? '1px 6px' : '2px 8px';
   // 영수증은 monitor에서만 사용. gifting/visit은 영수증 단계 없음 → 「-」 표시


### PR DESCRIPTION
## 변경 요약
- 인증 상태·영수증 라벨을 결과물 라벨(10px)과 크기 통일, 줄바꿈 방지
- 영수증 열 195→230px, 검수(처리) 열 90→120px

## 운영 반영 방식
이번 변경 diff만 main 기준 worktree에 적용·재빌드. 연령정책 미혼입 확인.

## DB 적용
- 없음 (UI 스타일)

## 요청 외 추가 변경
- 없음