### PR TITLE
refactor(admin): 모달 인라인 CSS를 admin.css로 분리 (운영 핫픽스, 동작 동일)

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -12,7 +12,7 @@
 // 회귀(2026-05-12 PR #182 머지 직후 발생)를 방지하기 위한 자동 reload 가드.
 // sessionStorage 차단 환경(시크릿 모드 일부, 쿠키 차단)에서는 자연스럽게 skip.
 (function(){
-  var CURRENT_BUILD = 'v1781670848';
+  var CURRENT_BUILD = 'v1781671694';
   if (CURRENT_BUILD.indexOf('__') === 0) return; // 빌드 미적용 (dev/ 직접 열기) 시 skip
   try {
     var prev = sessionStorage.getItem('reverb.adminBuild');
@@ -1990,6 +1990,17 @@ input[type="date"].form-input::-webkit-calendar-picker-indicator{margin-left:aut
 /* 감사용 행 — 행 배경도 옅게 강조해 목록에서 즉시 식별 */
 tr.audit-row, .audit-row { background: #fff3e0 !important; }
 
+/* 브랜드 상세·신규 브랜드 등록 모달 입력칸 글자 크기 (HTML 인라인 <style>에서 이전, 2026-06-17) */
+#brandDetailModal input.admin-filter,
+#brandDetailModal textarea.admin-filter,
+#brandDetailModal select.admin-filter,
+#brandDetailModal input.form-input,
+#brandDetailModal textarea.form-input,
+#brandDetailModal select.form-input { font-size: 14px; }
+#newBrandAppModal .form-input,
+#newBrandAppModal select.form-input,
+#newBrandAppModal textarea.form-input { font-size: 14px; }
+
 </style>
 </head>
 <body style="background:#F8F5F8">
@@ -2065,7 +2076,7 @@ tr.audit-row, .audit-row { background: #fff3e0 !important; }
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-06-17 13:34 · 5ead677</span>
+          <span class="admin-build-text">2026-06-17 13:48 · 58bd513</span>
         </div>
       </div>
     </aside>
@@ -3571,7 +3582,6 @@ tr.audit-row, .audit-row { background: #fff3e0 !important; }
 
         <!-- BRAND DETAIL/EDIT MODAL -->
         <div class="modal-overlay" id="brandDetailModal" style="z-index:612">
-          <style>#brandDetailModal input.admin-filter,#brandDetailModal textarea.admin-filter,#brandDetailModal select.admin-filter,#brandDetailModal input.form-input,#brandDetailModal textarea.form-input,#brandDetailModal select.form-input{font-size:14px}</style>
           <div class="modal" style="max-width:1280px;width:96vw;border-radius:16px;margin:auto;max-height:88vh;display:flex;flex-direction:column">
             <div class="modal-header" style="padding:16px 20px 12px;border-bottom:1px solid var(--line);display:flex;align-items:center;justify-content:space-between">
               <div id="brandDetailTitle">
@@ -4771,7 +4781,6 @@ tr.audit-row, .audit-row { background: #fff3e0 !important; }
 
 <!-- 관리자 직접 신청 등록 모달 (091 admin_create_brand_application) -->
 <div class="modal-overlay" id="newBrandAppModal" style="z-index:612">
-  <style>#newBrandAppModal .form-input,#newBrandAppModal select.form-input,#newBrandAppModal textarea.form-input{font-size:14px}</style>
   <div class="modal" style="width:80vw;max-width:1600px;border-radius:16px;margin:auto;max-height:90vh;display:flex;flex-direction:column">
     <div class="modal-header" style="padding:16px 20px 12px;border-bottom:1px solid var(--line);display:flex;align-items:center;justify-content:space-between">
       <div>

--- a/dev/admin/index.html
+++ b/dev/admin/index.html
@@ -1638,7 +1638,6 @@
 
         <!-- BRAND DETAIL/EDIT MODAL -->
         <div class="modal-overlay" id="brandDetailModal" style="z-index:612">
-          <style>#brandDetailModal input.admin-filter,#brandDetailModal textarea.admin-filter,#brandDetailModal select.admin-filter,#brandDetailModal input.form-input,#brandDetailModal textarea.form-input,#brandDetailModal select.form-input{font-size:14px}</style>
           <div class="modal" style="max-width:1280px;width:96vw;border-radius:16px;margin:auto;max-height:88vh;display:flex;flex-direction:column">
             <div class="modal-header" style="padding:16px 20px 12px;border-bottom:1px solid var(--line);display:flex;align-items:center;justify-content:space-between">
               <div id="brandDetailTitle">
@@ -2840,7 +2839,6 @@
 
 <!-- 관리자 직접 신청 등록 모달 (091 admin_create_brand_application) -->
 <div class="modal-overlay" id="newBrandAppModal" style="z-index:612">
-  <style>#newBrandAppModal .form-input,#newBrandAppModal select.form-input,#newBrandAppModal textarea.form-input{font-size:14px}</style>
   <div class="modal" style="width:80vw;max-width:1600px;border-radius:16px;margin:auto;max-height:90vh;display:flex;flex-direction:column">
     <div class="modal-header" style="padding:16px 20px 12px;border-bottom:1px solid var(--line);display:flex;align-items:center;justify-content:space-between">
       <div>

--- a/dev/css/admin.css
+++ b/dev/css/admin.css
@@ -1531,3 +1531,14 @@
 }
 /* 감사용 행 — 행 배경도 옅게 강조해 목록에서 즉시 식별 */
 tr.audit-row, .audit-row { background: #fff3e0 !important; }
+
+/* 브랜드 상세·신규 브랜드 등록 모달 입력칸 글자 크기 (HTML 인라인 <style>에서 이전, 2026-06-17) */
+#brandDetailModal input.admin-filter,
+#brandDetailModal textarea.admin-filter,
+#brandDetailModal select.admin-filter,
+#brandDetailModal input.form-input,
+#brandDetailModal textarea.form-input,
+#brandDetailModal select.form-input { font-size: 14px; }
+#newBrandAppModal .form-input,
+#newBrandAppModal select.form-input,
+#newBrandAppModal textarea.form-input { font-size: 14px; }


### PR DESCRIPTION
## 변경 요약
- 브랜드 상세·신규 브랜드 등록 모달의 인라인 `<style>`(input font-size 14px) 2개를 dev/css/admin.css로 이전. 동작·화면 동일.

## DB 적용
- 없음

## 요청 외 추가 변경
- 없음