### PR TITLE
fix(i18n): connect signup email/password labels to i18n

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -12,7 +12,7 @@
 // 회귀(2026-05-12 PR #182 머지 직후 발생)를 방지하기 위한 자동 reload 가드.
 // sessionStorage 차단 환경(시크릿 모드 일부, 쿠키 차단)에서는 자연스럽게 skip.
 (function(){
-  var CURRENT_BUILD = 'v1781738633';
+  var CURRENT_BUILD = 'v1781740340';
   if (CURRENT_BUILD.indexOf('__') === 0) return; // 빌드 미적용 (dev/ 직접 열기) 시 skip
   try {
     var prev = sessionStorage.getItem('reverb.adminBuild');
@@ -2090,7 +2090,7 @@ tr.audit-row, .audit-row { background: #fff3e0 !important; }
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-06-18 08:23 · 3ba4976</span>
+          <span class="admin-build-text">2026-06-18 08:52 · 81138d1</span>
         </div>
       </div>
     </aside>

--- a/dev/index.html
+++ b/dev/index.html
@@ -914,21 +914,21 @@ window._supabaseLoaded = false;
           </div>
         </div>
         <div class="form-group">
-          <label class="form-label">メールアドレス <span style="color:var(--red)">*</span></label>
+          <label class="form-label"><span data-i18n="auth.signup.emailLabel">メールアドレス</span> <span style="color:var(--red)">*</span></label>
           <input type="email" id="signupEmail" class="form-input" placeholder="your@email.com" required>
         </div>
         <div class="form-row">
           <div class="form-group">
-            <label class="form-label">パスワード <span style="color:var(--red)">*</span> <span style="font-size:10px;color:var(--muted);font-weight:400">（8文字以上）</span></label>
+            <label class="form-label"><span data-i18n="auth.signup.pwLabel">パスワード</span> <span style="color:var(--red)">*</span> <span style="font-size:10px;color:var(--muted);font-weight:400" data-i18n="auth.signup.pwHint">（8文字以上）</span></label>
             <div class="pw-wrap">
-              <input type="password" id="signupPw" class="form-input" placeholder="8文字以上" required minlength="8">
+              <input type="password" id="signupPw" class="form-input" placeholder="8文字以上" data-i18n-attr="placeholder:auth.signup.pwPlaceholder" required minlength="8">
               <button type="button" class="pw-toggle" onclick="togglePw('signupPw',this)"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg></button>
             </div>
           </div>
           <div class="form-group">
-            <label class="form-label">パスワード（確認） <span style="color:var(--red)">*</span></label>
+            <label class="form-label"><span data-i18n="auth.signup.pwConfirmLabel">パスワード（確認）</span> <span style="color:var(--red)">*</span></label>
             <div class="pw-wrap">
-              <input type="password" id="signupPw2" class="form-input" placeholder="パスワード再入力" required>
+              <input type="password" id="signupPw2" class="form-input" placeholder="パスワード再入力" data-i18n-attr="placeholder:auth.signup.pwConfirmPlaceholder" required>
               <button type="button" class="pw-toggle" onclick="togglePw('signupPw2',this)"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg></button>
             </div>
           </div>

--- a/dev/lib/i18n/ja.js
+++ b/dev/lib/i18n/ja.js
@@ -144,6 +144,8 @@ window.I18N_JA = {
       pwLabel: 'パスワード',
       pwHint: '（8文字以上）',
       pwConfirmLabel: 'パスワード（確認）',
+      pwPlaceholder: '8文字以上',
+      pwConfirmPlaceholder: 'パスワード再入力',
       agreeAll: 'すべてに同意する',
       required: '必須',
       optional: '任意',

--- a/dev/lib/i18n/ko.js
+++ b/dev/lib/i18n/ko.js
@@ -139,6 +139,8 @@ window.I18N_KO = {
       pwLabel: '비밀번호',
       pwHint: '(8자 이상)',
       pwConfirmLabel: '비밀번호 확인',
+      pwPlaceholder: '8자 이상',
+      pwConfirmPlaceholder: '비밀번호 재입력',
       agreeAll: '전체 동의',
       required: '필수',
       optional: '선택',

--- a/index.html
+++ b/index.html
@@ -1587,21 +1587,21 @@ input[type="date"].form-input::-webkit-calendar-picker-indicator{margin-left:aut
           </div>
         </div>
         <div class="form-group">
-          <label class="form-label">メールアドレス <span style="color:var(--red)">*</span></label>
+          <label class="form-label"><span data-i18n="auth.signup.emailLabel">メールアドレス</span> <span style="color:var(--red)">*</span></label>
           <input type="email" id="signupEmail" class="form-input" placeholder="your@email.com" required>
         </div>
         <div class="form-row">
           <div class="form-group">
-            <label class="form-label">パスワード <span style="color:var(--red)">*</span> <span style="font-size:10px;color:var(--muted);font-weight:400">（8文字以上）</span></label>
+            <label class="form-label"><span data-i18n="auth.signup.pwLabel">パスワード</span> <span style="color:var(--red)">*</span> <span style="font-size:10px;color:var(--muted);font-weight:400" data-i18n="auth.signup.pwHint">（8文字以上）</span></label>
             <div class="pw-wrap">
-              <input type="password" id="signupPw" class="form-input" placeholder="8文字以上" required minlength="8">
+              <input type="password" id="signupPw" class="form-input" placeholder="8文字以上" data-i18n-attr="placeholder:auth.signup.pwPlaceholder" required minlength="8">
               <button type="button" class="pw-toggle" onclick="togglePw('signupPw',this)"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg></button>
             </div>
           </div>
           <div class="form-group">
-            <label class="form-label">パスワード（確認） <span style="color:var(--red)">*</span></label>
+            <label class="form-label"><span data-i18n="auth.signup.pwConfirmLabel">パスワード（確認）</span> <span style="color:var(--red)">*</span></label>
             <div class="pw-wrap">
-              <input type="password" id="signupPw2" class="form-input" placeholder="パスワード再入力" required>
+              <input type="password" id="signupPw2" class="form-input" placeholder="パスワード再入力" data-i18n-attr="placeholder:auth.signup.pwConfirmPlaceholder" required>
               <button type="button" class="pw-toggle" onclick="togglePw('signupPw2',this)"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg></button>
             </div>
           </div>
@@ -2944,6 +2944,8 @@ window.I18N_JA = {
       pwLabel: 'パスワード',
       pwHint: '（8文字以上）',
       pwConfirmLabel: 'パスワード（確認）',
+      pwPlaceholder: '8文字以上',
+      pwConfirmPlaceholder: 'パスワード再入力',
       agreeAll: 'すべてに同意する',
       required: '必須',
       optional: '任意',
@@ -3649,6 +3651,8 @@ window.I18N_KO = {
       pwLabel: '비밀번호',
       pwHint: '(8자 이상)',
       pwConfirmLabel: '비밀번호 확인',
+      pwPlaceholder: '8자 이상',
+      pwConfirmPlaceholder: '비밀번호 재입력',
       agreeAll: '전체 동의',
       required: '필수',
       optional: '선택',


### PR DESCRIPTION
## 변경 요약
한국어 토글 시 회원가입 폼의 이메일·비밀번호 필드만 일본어로 남던 버그 수정(사용자 제보). 라벨에 `data-i18n` 연결이 빠져 있었음(로그인 폼은 정상이었음).
- 라벨 3개(이메일·비번·비번확인) 텍스트를 span으로 감싸 `data-i18n`(별표 `*` 보존)
- 비번·비번확인 placeholder `data-i18n-attr`
- i18n ja/ko에 `pwPlaceholder`·`pwConfirmPlaceholder` 키 추가

## 요청 외 추가 변경
- 없음

## 비고
- i18n 토글은 개발서버 한정 기능이라 운영서버 영향 없음. 연령 정책 PR과 별개 버그픽스.

[via reviewer] GO / qa skip

🤖 Generated with [Claude Code](https://claude.com/claude-code)