### PR TITLE
feat: brand self orient-sheet PR1 (orient_sheets table + anon token functions)

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -12,7 +12,7 @@
 // 회귀(2026-05-12 PR #182 머지 직후 발생)를 방지하기 위한 자동 reload 가드.
 // sessionStorage 차단 환경(시크릿 모드 일부, 쿠키 차단)에서는 자연스럽게 skip.
 (function(){
-  var CURRENT_BUILD = 'v1781753029';
+  var CURRENT_BUILD = 'v1781761197';
   if (CURRENT_BUILD.indexOf('__') === 0) return; // 빌드 미적용 (dev/ 직접 열기) 시 skip
   try {
     var prev = sessionStorage.getItem('reverb.adminBuild');
@@ -2090,7 +2090,7 @@ tr.audit-row, .audit-row { background: #fff3e0 !important; }
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-06-18 12:23 · cdb6304</span>
+          <span class="admin-build-text">2026-06-18 14:39 · 1e670f3</span>
         </div>
       </div>
     </aside>
@@ -9426,6 +9426,109 @@ async function purgeAuditDataForCampaign(campaignId) {
       storageResult: { msgResult, receiptResult },
     };
   });
+}
+
+
+// ════════════════════════════════════════════════════════════════════
+// 브랜드 셀프 오리엔시트 — PR 1 (DB + 익명 토큰 함수)
+//   사양서: docs/specs/2026-06-18-brand-self-orient-sheet.md §6, §7
+//   마이그레이션: 186(테이블) → 187(함수 3종)
+//
+//   이 함수 3종은 비로그인 브랜드 담당자(sales 폼)에서 호출되는 익명 경로.
+//   따라서 세션 갱신(retryWithRefresh) 없이 db.rpc 직접 호출한다 — 140 패턴과 동일.
+//   (익명 호출에서 JWT 세션이 없으므로 갱신 시도 자체가 무의미)
+// ════════════════════════════════════════════════════════════════════
+
+// 오리엔시트 조회 — 토큰으로 현재 내용·상태를 가져온다.
+// 연결된 신청이 있으면 initial_values(모집 희망값)도 함께 반환.
+// 반환: {ok:true, id, form_type, data, status, version, submitted_at, initial_values}
+//        | {ok:false, error, reason}
+async function getOrientSheet(token) {
+  if (!db) return { ok: false, error: 'no_db' };
+  if (!token) return { ok: false, error: 'invalid_token' };
+  try {
+    const { data, error } = await db.rpc('get_orient_sheet', { p_token: token });
+    if (error) throw error;
+    // data: {success:bool, reason?, id?, form_type?, data?, status?, version?, submitted_at?, initial_values?}
+    if (data && data.success) {
+      return {
+        ok:             true,
+        id:             data.id,
+        form_type:      data.form_type,
+        data:           data.data,
+        status:         data.status,
+        version:        data.version,
+        submitted_at:   data.submitted_at,
+        initial_values: data.initial_values || null,
+      };
+    }
+    return { ok: false, error: data?.reason || 'invalid_token', reason: data?.reason };
+  } catch (e) {
+    // 잘못된 UUID 형식 등은 무효 토큰으로 처리
+    console.error('[getOrientSheet]', e);
+    return { ok: false, error: 'invalid_token' };
+  }
+}
+
+// 오리엔시트 임시저장 — 작성 중 중간 저장. status는 변경하지 않음(submitted→draft 역전환 없음).
+// 반환: {ok:true, version} | {ok:false, error, reason, current_version?}
+async function saveOrientDraft(token, data, version) {
+  if (!db) return { ok: false, error: 'no_db' };
+  if (!token) return { ok: false, error: 'invalid_token' };
+  try {
+    const { data: result, error } = await db.rpc('save_orient_draft', {
+      p_token:   token,
+      p_data:    data,
+      p_version: version,
+    });
+    if (error) throw error;
+    // result: {success:bool, reason?, version?, current_version?, ...}
+    if (result && result.success) {
+      return { ok: true, version: result.version };
+    }
+    return {
+      ok:              false,
+      error:           result?.reason || 'unknown',
+      reason:          result?.reason,
+      current_version: result?.current_version,
+    };
+  } catch (e) {
+    console.error('[saveOrientDraft]', e);
+    return { ok: false, error: e?.message || 'unknown' };
+  }
+}
+
+// 오리엔시트 제출 — 브랜드 담당자의 최종 제출. draft/submitted → submitted.
+// 발행 전까지 재제출 가능(사양서 결정⑨).
+// 반환: {ok:true, version, submitted_at} | {ok:false, error, reason, current_version?}
+async function submitOrientSheet(token, data, version) {
+  if (!db) return { ok: false, error: 'no_db' };
+  if (!token) return { ok: false, error: 'invalid_token' };
+  try {
+    const { data: result, error } = await db.rpc('submit_orient_sheet', {
+      p_token:   token,
+      p_data:    data,
+      p_version: version,
+    });
+    if (error) throw error;
+    // result: {success:bool, reason?, version?, submitted_at?, current_version?}
+    if (result && result.success) {
+      return {
+        ok:           true,
+        version:      result.version,
+        submitted_at: result.submitted_at,
+      };
+    }
+    return {
+      ok:              false,
+      error:           result?.reason || 'unknown',
+      reason:          result?.reason,
+      current_version: result?.current_version,
+    };
+  } catch (e) {
+    console.error('[submitOrientSheet]', e);
+    return { ok: false, error: e?.message || 'unknown' };
+  }
 }
 
 

--- a/dev/lib/storage.js
+++ b/dev/lib/storage.js
@@ -3324,3 +3324,106 @@ async function purgeAuditDataForCampaign(campaignId) {
   });
 }
 
+
+// ════════════════════════════════════════════════════════════════════
+// 브랜드 셀프 오리엔시트 — PR 1 (DB + 익명 토큰 함수)
+//   사양서: docs/specs/2026-06-18-brand-self-orient-sheet.md §6, §7
+//   마이그레이션: 186(테이블) → 187(함수 3종)
+//
+//   이 함수 3종은 비로그인 브랜드 담당자(sales 폼)에서 호출되는 익명 경로.
+//   따라서 세션 갱신(retryWithRefresh) 없이 db.rpc 직접 호출한다 — 140 패턴과 동일.
+//   (익명 호출에서 JWT 세션이 없으므로 갱신 시도 자체가 무의미)
+// ════════════════════════════════════════════════════════════════════
+
+// 오리엔시트 조회 — 토큰으로 현재 내용·상태를 가져온다.
+// 연결된 신청이 있으면 initial_values(모집 희망값)도 함께 반환.
+// 반환: {ok:true, id, form_type, data, status, version, submitted_at, initial_values}
+//        | {ok:false, error, reason}
+async function getOrientSheet(token) {
+  if (!db) return { ok: false, error: 'no_db' };
+  if (!token) return { ok: false, error: 'invalid_token' };
+  try {
+    const { data, error } = await db.rpc('get_orient_sheet', { p_token: token });
+    if (error) throw error;
+    // data: {success:bool, reason?, id?, form_type?, data?, status?, version?, submitted_at?, initial_values?}
+    if (data && data.success) {
+      return {
+        ok:             true,
+        id:             data.id,
+        form_type:      data.form_type,
+        data:           data.data,
+        status:         data.status,
+        version:        data.version,
+        submitted_at:   data.submitted_at,
+        initial_values: data.initial_values || null,
+      };
+    }
+    return { ok: false, error: data?.reason || 'invalid_token', reason: data?.reason };
+  } catch (e) {
+    // 잘못된 UUID 형식 등은 무효 토큰으로 처리
+    console.error('[getOrientSheet]', e);
+    return { ok: false, error: 'invalid_token' };
+  }
+}
+
+// 오리엔시트 임시저장 — 작성 중 중간 저장. status는 변경하지 않음(submitted→draft 역전환 없음).
+// 반환: {ok:true, version} | {ok:false, error, reason, current_version?}
+async function saveOrientDraft(token, data, version) {
+  if (!db) return { ok: false, error: 'no_db' };
+  if (!token) return { ok: false, error: 'invalid_token' };
+  try {
+    const { data: result, error } = await db.rpc('save_orient_draft', {
+      p_token:   token,
+      p_data:    data,
+      p_version: version,
+    });
+    if (error) throw error;
+    // result: {success:bool, reason?, version?, current_version?, ...}
+    if (result && result.success) {
+      return { ok: true, version: result.version };
+    }
+    return {
+      ok:              false,
+      error:           result?.reason || 'unknown',
+      reason:          result?.reason,
+      current_version: result?.current_version,
+    };
+  } catch (e) {
+    console.error('[saveOrientDraft]', e);
+    return { ok: false, error: e?.message || 'unknown' };
+  }
+}
+
+// 오리엔시트 제출 — 브랜드 담당자의 최종 제출. draft/submitted → submitted.
+// 발행 전까지 재제출 가능(사양서 결정⑨).
+// 반환: {ok:true, version, submitted_at} | {ok:false, error, reason, current_version?}
+async function submitOrientSheet(token, data, version) {
+  if (!db) return { ok: false, error: 'no_db' };
+  if (!token) return { ok: false, error: 'invalid_token' };
+  try {
+    const { data: result, error } = await db.rpc('submit_orient_sheet', {
+      p_token:   token,
+      p_data:    data,
+      p_version: version,
+    });
+    if (error) throw error;
+    // result: {success:bool, reason?, version?, submitted_at?, current_version?}
+    if (result && result.success) {
+      return {
+        ok:           true,
+        version:      result.version,
+        submitted_at: result.submitted_at,
+      };
+    }
+    return {
+      ok:              false,
+      error:           result?.reason || 'unknown',
+      reason:          result?.reason,
+      current_version: result?.current_version,
+    };
+  } catch (e) {
+    console.error('[submitOrientSheet]', e);
+    return { ok: false, error: e?.message || 'unknown' };
+  }
+}
+

--- a/docs/specs/2026-06-18-brand-self-orient-sheet.md
+++ b/docs/specs/2026-06-18-brand-self-orient-sheet.md
@@ -193,15 +193,37 @@ orient_sheets(
 
 ---
 
-## 구현 결과 (개발 세션이 채울 것)
+## 구현 결과
 
-**구현일:**
-**관련 커밋·PR:**
+### PR 1 — 데이터 모델 + 익명 작성/제출 함수 (2026-06-18)
+
+**구현일:** 2026-06-18
+**관련 브랜치:** `feature/orient-sheet` (PR·커밋 해시는 세션종료 시 기록)
+**마이그레이션 (실제 번호 확정):**
+- **186** `186_orient_sheets_table.sql` — `orient_sheets` 테이블 + 인덱스 5종 + 행 단위 보안 정책(RLS) + `updated_at` 자동 갱신 트리거(`trg_orient_sheets_updated_at`)
+- **187** `187_orient_sheets_functions.sql` — 익명 토큰 함수 3종
+
+**함수 시그니처 (확정):**
+- `get_orient_sheet(p_token uuid) → jsonb` (GRANT anon, authenticated)
+- `save_orient_draft(p_token uuid, p_data jsonb, p_version int) → jsonb` (GRANT anon)
+- `submit_orient_sheet(p_token uuid, p_data jsonb, p_version int) → jsonb` (GRANT anon)
+- `storage.js`: `getOrientSheet(token)` / `saveOrientDraft(token, data, version)` / `submitOrientSheet(token, data, version)`
 
 ### 초안 대비 변경 사항
-- 추가된 것:
-- 빠진 것(+이유):
-- 달라진 것:
+- **추가된 것**:
+  - `updated_at` 자동 갱신 트리거(`touch_orient_sheets_updated_at` + `trg_orient_sheets_updated_at`) — 기존 테이블(admin_notices·deliverables 등) 패턴과 일관성 확보(초안 §4엔 명시 없었음).
+  - 외래 키 `ON DELETE` 옵션 명시: `brand_id` RESTRICT(발행된 오리엔시트 이력 보호), `application_id`·`campaign_id`·`created_by` SET NULL.
+  - 186 마이그레이션에도 `NOTIFY pgrst` 추가(186 단독 적용 시 PostgREST 인식 보장).
+- **빠진 것**: 없음(PR1 범위 그대로).
+- **달라진 것**:
+  - `save_orient_draft`가 **status를 변경하지 않음**으로 확정(초안 §6.3은 "status='draft' 유지"였으나, submitted 상태에서 임시저장 시 draft로 역전환하면 §4 상태전이도와 모순 → data·version만 갱신). reverb-reviewer P0 지적 반영.
+  - `get_orient_sheet`(조회)는 **읽기 전용**으로 확정 — 만료 시 status 전환 부작용을 제거하고 반환값으로만 만료를 알림(상태 전환은 save/submit 쓰기 함수의 FOR UPDATE 잠금 하에서만). reverb-reviewer P1 지적 반영.
 
 ### 구현 중 기술 결정 사항
-- (마이그레이션 실제 번호·함수 시그니처·긴급 발행 기록 방식 등)
+- 익명 함수 검증: SECURITY DEFINER + `SET search_path=''` + `REVOKE ... FROM PUBLIC` 후 명시 GRANT(140 선례). 미매칭은 `{success:false, reason:'invalid_token'}` HTTP 200(자원 열거 방지).
+- 낙관적 락 3단: `FOR UPDATE` 행 잠금 + `WHERE version = p_version` + `GET DIAGNOSTICS ROW_COUNT` 0행이면 충돌 반환.
+- jsonb 크기 상한 100KB(`octet_length`). 이미지는 PR2에서 링크 URL + 파일 업로드(전용 버킷)로 받으므로 `data`에는 URL 텍스트만.
+- **PR3·4 인계 메모**: ① `delete_brand` RPC(마이그레이션 174)에 `orient_sheets` 카운트 체크 추가 필요(brand_id RESTRICT와 정합). ② 관리자 대리 저장이 필요하면 `save/submit_orient_sheet`에 `authenticated` GRANT 추가. ③ `create_orient_sheet`/`mark_orient_consumed`는 PR3·4에서 구현(PR1 의도적 제외).
+
+### PR 2·3·4
+- 미착수. PR2(브랜드 작성 폼 `dev/sales/orient.html` + 익명 업로드 보안) → PR3(관리자 발급·조회 페인) → PR4(자동 채움 매핑 + 일본어 발행 게이트). §8 분할대로 **시퀀셜**(PR3·4는 `dev/js/admin.js` 핫스팟이라 병렬 금지).

--- a/index.html
+++ b/index.html
@@ -7854,6 +7854,109 @@ async function purgeAuditDataForCampaign(campaignId) {
 }
 
 
+// ════════════════════════════════════════════════════════════════════
+// 브랜드 셀프 오리엔시트 — PR 1 (DB + 익명 토큰 함수)
+//   사양서: docs/specs/2026-06-18-brand-self-orient-sheet.md §6, §7
+//   마이그레이션: 186(테이블) → 187(함수 3종)
+//
+//   이 함수 3종은 비로그인 브랜드 담당자(sales 폼)에서 호출되는 익명 경로.
+//   따라서 세션 갱신(retryWithRefresh) 없이 db.rpc 직접 호출한다 — 140 패턴과 동일.
+//   (익명 호출에서 JWT 세션이 없으므로 갱신 시도 자체가 무의미)
+// ════════════════════════════════════════════════════════════════════
+
+// 오리엔시트 조회 — 토큰으로 현재 내용·상태를 가져온다.
+// 연결된 신청이 있으면 initial_values(모집 희망값)도 함께 반환.
+// 반환: {ok:true, id, form_type, data, status, version, submitted_at, initial_values}
+//        | {ok:false, error, reason}
+async function getOrientSheet(token) {
+  if (!db) return { ok: false, error: 'no_db' };
+  if (!token) return { ok: false, error: 'invalid_token' };
+  try {
+    const { data, error } = await db.rpc('get_orient_sheet', { p_token: token });
+    if (error) throw error;
+    // data: {success:bool, reason?, id?, form_type?, data?, status?, version?, submitted_at?, initial_values?}
+    if (data && data.success) {
+      return {
+        ok:             true,
+        id:             data.id,
+        form_type:      data.form_type,
+        data:           data.data,
+        status:         data.status,
+        version:        data.version,
+        submitted_at:   data.submitted_at,
+        initial_values: data.initial_values || null,
+      };
+    }
+    return { ok: false, error: data?.reason || 'invalid_token', reason: data?.reason };
+  } catch (e) {
+    // 잘못된 UUID 형식 등은 무효 토큰으로 처리
+    console.error('[getOrientSheet]', e);
+    return { ok: false, error: 'invalid_token' };
+  }
+}
+
+// 오리엔시트 임시저장 — 작성 중 중간 저장. status는 변경하지 않음(submitted→draft 역전환 없음).
+// 반환: {ok:true, version} | {ok:false, error, reason, current_version?}
+async function saveOrientDraft(token, data, version) {
+  if (!db) return { ok: false, error: 'no_db' };
+  if (!token) return { ok: false, error: 'invalid_token' };
+  try {
+    const { data: result, error } = await db.rpc('save_orient_draft', {
+      p_token:   token,
+      p_data:    data,
+      p_version: version,
+    });
+    if (error) throw error;
+    // result: {success:bool, reason?, version?, current_version?, ...}
+    if (result && result.success) {
+      return { ok: true, version: result.version };
+    }
+    return {
+      ok:              false,
+      error:           result?.reason || 'unknown',
+      reason:          result?.reason,
+      current_version: result?.current_version,
+    };
+  } catch (e) {
+    console.error('[saveOrientDraft]', e);
+    return { ok: false, error: e?.message || 'unknown' };
+  }
+}
+
+// 오리엔시트 제출 — 브랜드 담당자의 최종 제출. draft/submitted → submitted.
+// 발행 전까지 재제출 가능(사양서 결정⑨).
+// 반환: {ok:true, version, submitted_at} | {ok:false, error, reason, current_version?}
+async function submitOrientSheet(token, data, version) {
+  if (!db) return { ok: false, error: 'no_db' };
+  if (!token) return { ok: false, error: 'invalid_token' };
+  try {
+    const { data: result, error } = await db.rpc('submit_orient_sheet', {
+      p_token:   token,
+      p_data:    data,
+      p_version: version,
+    });
+    if (error) throw error;
+    // result: {success:bool, reason?, version?, submitted_at?, current_version?}
+    if (result && result.success) {
+      return {
+        ok:           true,
+        version:      result.version,
+        submitted_at: result.submitted_at,
+      };
+    }
+    return {
+      ok:              false,
+      error:           result?.reason || 'unknown',
+      reason:          result?.reason,
+      current_version: result?.current_version,
+    };
+  } catch (e) {
+    console.error('[submitOrientSheet]', e);
+    return { ok: false, error: e?.message || 'unknown' };
+  }
+}
+
+
 // ══════════════════════════════════════
 // LEGAL — 약관/개인정보 페이지 마크다운 렌더링
 // ══════════════════════════════════════

--- a/supabase/migrations/186_orient_sheets_table.sql
+++ b/supabase/migrations/186_orient_sheets_table.sql
@@ -1,0 +1,196 @@
+-- ============================================================
+-- 186_orient_sheets_table.sql
+-- 2026-06-18
+--
+-- 목적:
+--   브랜드 셀프 오리엔시트 전용 테이블 신규 생성.
+--   브랜드사(광고주)에게 토큰 링크를 보내 로그인 없이 캠페인 콘텐츠
+--   정보(오리엔시트)를 작성·제출하게 하는 기능의 데이터 모델 기반.
+--
+-- 사양서:
+--   docs/specs/2026-06-18-brand-self-orient-sheet.md §4, §8(PR 1)
+--
+-- 변경 내용:
+--   [A] orient_sheets 테이블 신규 생성
+--       - brands.id 기준(brand_id 필수 NOT NULL)
+--       - brand_applications.id 선택 연결(application_id NULL 허용)
+--       - 토큰(token): UUID UNIQUE — 로그인 없는 작성 링크 식별자
+--       - data jsonb: 오리엔시트 전체 내용(작성 폼 필드 전체)
+--       - status: draft(작성중) → submitted(브랜드 제출) → consumed(캠페인 발행됨) | expired(만료)
+--       - version: 낙관적 락(동시 편집 충돌 감지)
+--       - token_expires_at: 발급 +30일 (NULL이면 만료 없음)
+--       - campaign_id: 발행 후 1:1 역참조(소비 완료 후 관리자가 채움)
+--
+--   [B] 인덱스
+--       - token UNIQUE 인덱스
+--       - brand_id, application_id, status, campaign_id 보조 인덱스
+--
+--   [C] 행 단위 보안 정책(RLS)
+--       - SELECT: is_admin() 이상 (관리자 전체 조회)
+--       - INSERT: is_campaign_admin() 이상 (발급 권한)
+--       - UPDATE: is_campaign_admin() 이상 (상태 변경·소비 처리)
+--       - DELETE: is_super_admin() 이상 (운영 긴급 시만)
+--       - 익명(anon)은 테이블 직접 접근 0 — 187의 토큰 함수로만 접근
+--
+-- 행 단위 보안 정책 관련:
+--   is_admin() / is_campaign_admin() / is_super_admin() 함수는 기존 정의 사용.
+--   anon은 이 테이블에 어떤 정책도 없어 완전 차단.
+--
+-- 운영 데이터 영향:
+--   신규 테이블이므로 기존 데이터 영향 없음.
+--
+-- 적용 순서:
+--   1. 이 파일(186) 먼저 적용
+--   2. 187_orient_sheets_functions.sql 적용
+--
+-- 롤백:
+--   DROP TABLE IF EXISTS public.orient_sheets CASCADE;
+-- ============================================================
+
+BEGIN;
+
+
+-- ============================================================
+-- A. orient_sheets 테이블 신규 생성
+-- ============================================================
+CREATE TABLE IF NOT EXISTS public.orient_sheets (
+  id               uuid        NOT NULL DEFAULT gen_random_uuid(),
+  -- ON DELETE RESTRICT 명시: 오리엔시트가 남아 있으면 브랜드 삭제 차단(발행된 오리엔시트 이력 보호).
+  --   ⚠️ PR 3에서 delete_brand RPC(마이그레이션 174)에 orient_sheets 카운트 체크를 추가해야
+  --      "연결 0건만 삭제" 가드가 이 외래 키와 정합. (현재 delete_brand는 orient_sheets를 세지 않음)
+  brand_id         uuid        NOT NULL REFERENCES public.brands(id) ON DELETE RESTRICT,
+  application_id   uuid        NULL     REFERENCES public.brand_applications(id) ON DELETE SET NULL,
+  token            uuid        NOT NULL UNIQUE DEFAULT gen_random_uuid(),
+  form_type        text        NULL
+                   CHECK (form_type IS NULL OR form_type IN ('reviewer', 'seeding')),
+  data             jsonb       NOT NULL DEFAULT '{}',
+  status           text        NOT NULL DEFAULT 'draft'
+                   CHECK (status IN ('draft', 'submitted', 'consumed', 'expired')),
+  campaign_id      uuid        NULL     REFERENCES public.campaigns(id) ON DELETE SET NULL,
+  token_expires_at timestamptz NULL,
+  submitted_at     timestamptz NULL,
+  consumed_at      timestamptz NULL,
+  version          integer     NOT NULL DEFAULT 0,
+  created_by       uuid        NULL     REFERENCES auth.users(id) ON DELETE SET NULL,
+  created_at       timestamptz NOT NULL DEFAULT now(),
+  updated_at       timestamptz NOT NULL DEFAULT now(),
+
+  CONSTRAINT orient_sheets_pkey PRIMARY KEY (id)
+);
+
+COMMENT ON TABLE public.orient_sheets IS
+  '[186] 브랜드 셀프 오리엔시트 전용 테이블. '
+  '브랜드사가 토큰 링크로 캠페인 콘텐츠 정보를 작성·제출하는 기능의 데이터 저장소. '
+  '1장 = 제품 1개 = 모집 건 1개(1:1). 익명(anon)은 토큰 함수로만 접근.';
+
+COMMENT ON COLUMN public.orient_sheets.id              IS '[186] 행 기본 키 (UUID v4).';
+COMMENT ON COLUMN public.orient_sheets.brand_id        IS '[186] 브랜드 마스터(brands.id) 참조. 오리엔시트는 브랜드 기준으로 발급.';
+COMMENT ON COLUMN public.orient_sheets.application_id  IS '[186] 광고주 신청(brand_applications.id) 선택 연결. NULL이면 신청 없이 생성.';
+COMMENT ON COLUMN public.orient_sheets.token           IS '[186] 로그인 없는 작성 링크 식별자(UUID v4). 브랜드 담당자에게 전달하는 토큰. UNIQUE 보장.';
+COMMENT ON COLUMN public.orient_sheets.form_type       IS '[186] reviewer | seeding. 신청 연결 건은 신청서에서 승계, 미연결 건은 관리자가 지정.';
+COMMENT ON COLUMN public.orient_sheets.data            IS '[186] 오리엔시트 전체 입력 내용 (모집정보·브랜드정보·제품정보·채널가이드 등). 브라우저 폼 구조 그대로 저장.';
+COMMENT ON COLUMN public.orient_sheets.status          IS '[186] 상태 전이: draft(작성중) → submitted(브랜드 제출) → consumed(캠페인 발행됨) | expired(만료).';
+COMMENT ON COLUMN public.orient_sheets.campaign_id     IS '[186] 발행 완료 후 연결된 캠페인(campaigns.id). mark_orient_consumed RPC가 채움.';
+COMMENT ON COLUMN public.orient_sheets.token_expires_at IS '[186] 토큰 만료 시각. 발급 시 +30일로 설정 권장. NULL이면 만료 없음.';
+COMMENT ON COLUMN public.orient_sheets.submitted_at    IS '[186] 브랜드가 제출(submit_orient_sheet)한 시각. status=submitted 전이 시 기록.';
+COMMENT ON COLUMN public.orient_sheets.consumed_at     IS '[186] 관리자가 캠페인 발행(mark_orient_consumed)한 시각. status=consumed 전이 시 기록.';
+COMMENT ON COLUMN public.orient_sheets.version         IS '[186] 낙관적 락 버전. 저장·제출 시 일치해야 함. 불일치 시 충돌 반환.';
+COMMENT ON COLUMN public.orient_sheets.created_by      IS '[186] 이 오리엔시트 링크를 발급한 관리자(auth.users.id).';
+COMMENT ON COLUMN public.orient_sheets.created_at      IS '[186] 레코드 생성 시각.';
+COMMENT ON COLUMN public.orient_sheets.updated_at      IS '[186] 마지막 수정 시각. 저장·제출·소비 시 갱신.';
+
+
+-- ============================================================
+-- B. 인덱스
+--   - token은 CREATE TABLE의 UNIQUE 제약으로 이미 인덱스 생성됨
+--   - 나머지는 조회 성능용 보조 인덱스
+-- ============================================================
+
+-- brand_id: 브랜드별 오리엔시트 목록 조회
+CREATE INDEX IF NOT EXISTS idx_orient_sheets_brand_id
+  ON public.orient_sheets (brand_id);
+
+-- application_id: 신청 연결 건 조회 (NULL 포함)
+CREATE INDEX IF NOT EXISTS idx_orient_sheets_application_id
+  ON public.orient_sheets (application_id)
+  WHERE application_id IS NOT NULL;
+
+-- status: 상태별 필터링 (draft/submitted 등 관리 목록)
+CREATE INDEX IF NOT EXISTS idx_orient_sheets_status
+  ON public.orient_sheets (status);
+
+-- campaign_id: 발행된 캠페인에서 역참조
+CREATE INDEX IF NOT EXISTS idx_orient_sheets_campaign_id
+  ON public.orient_sheets (campaign_id)
+  WHERE campaign_id IS NOT NULL;
+
+
+-- ============================================================
+-- C. 행 단위 보안 정책(RLS) 활성화 및 정책 등록
+--   익명(anon)에게는 어떠한 정책도 부여하지 않음 → 완전 차단.
+--   익명 접근은 오직 187의 토큰 함수(SECURITY DEFINER)로만.
+-- ============================================================
+ALTER TABLE public.orient_sheets ENABLE ROW LEVEL SECURITY;
+
+-- SELECT: 관리자 전체 조회 (campaign_manager 이상)
+CREATE POLICY "orient_sheets_select_admin"
+  ON public.orient_sheets
+  FOR SELECT
+  TO authenticated
+  USING (public.is_admin());
+
+-- INSERT: campaign_admin 이상만 오리엔시트 발급 가능
+CREATE POLICY "orient_sheets_insert_campaign_admin"
+  ON public.orient_sheets
+  FOR INSERT
+  TO authenticated
+  WITH CHECK (public.is_campaign_admin());
+
+-- UPDATE: campaign_admin 이상만 상태 변경·소비 처리 가능
+CREATE POLICY "orient_sheets_update_campaign_admin"
+  ON public.orient_sheets
+  FOR UPDATE
+  TO authenticated
+  USING (public.is_campaign_admin())
+  WITH CHECK (public.is_campaign_admin());
+
+-- DELETE: super_admin 한정 (운영 긴급 삭제만)
+CREATE POLICY "orient_sheets_delete_super_admin"
+  ON public.orient_sheets
+  FOR DELETE
+  TO authenticated
+  USING (public.is_super_admin());
+
+
+-- ============================================================
+-- D. updated_at 자동 갱신 트리거
+--   기존 테이블(admin_notices·deliverables·brand_applications 등)과 동일하게
+--   BEFORE UPDATE 트리거로 updated_at을 자동 갱신한다(테이블별 touch 함수 패턴).
+--   이로써 187 익명 함수에서 updated_at을 수동 SET 하지 않아도 일관 갱신.
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.touch_orient_sheets_updated_at()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$;
+
+-- 트리거 함수는 트리거로만 발동(직접 EXECUTE 불필요) → PUBLIC EXECUTE 회수
+REVOKE ALL ON FUNCTION public.touch_orient_sheets_updated_at() FROM PUBLIC;
+
+DROP TRIGGER IF EXISTS trg_orient_sheets_updated_at ON public.orient_sheets;
+CREATE TRIGGER trg_orient_sheets_updated_at
+  BEFORE UPDATE ON public.orient_sheets
+  FOR EACH ROW EXECUTE FUNCTION public.touch_orient_sheets_updated_at();
+
+
+-- PostgREST 스키마 캐시 재로드 (186 단독 적용 시에도 새 테이블 즉시 인식)
+NOTIFY pgrst, 'reload schema';
+
+
+COMMIT;

--- a/supabase/migrations/187_orient_sheets_functions.sql
+++ b/supabase/migrations/187_orient_sheets_functions.sql
@@ -1,0 +1,390 @@
+-- ============================================================
+-- 187_orient_sheets_functions.sql
+-- 2026-06-18
+--
+-- 목적:
+--   브랜드 셀프 오리엔시트 익명(anon) 토큰 함수 3종 생성.
+--   로그인 없는 브랜드 담당자가 토큰 링크로 오리엔시트를
+--   조회·임시저장·제출할 수 있도록 한다.
+--
+-- 사양서:
+--   docs/specs/2026-06-18-brand-self-orient-sheet.md §6, §7, §8(PR 1)
+--
+-- 전제:
+--   186_orient_sheets_table.sql 이 먼저 적용되어 있어야 함.
+--
+-- 변경 내용:
+--   [A] get_orient_sheet(p_token uuid) → jsonb
+--       - anon, authenticated GRANT
+--       - 미매칭 → {success:false, reason:'invalid_token'} (자원 열거 방지)
+--       - 만료(token_expires_at 경과) → {success:false, reason:'expired', status:'expired'}
+--       - consumed → {success:false, reason:'consumed', status:'consumed'}
+--       - expired 상태(명시) → {success:false, reason:'expired', status:'expired'}
+--       - 성공 → {success:true, data, status, version, initial_values?}
+--         initial_values: application_id 연결 시 brand_applications의 모집 희망값 포함(잔여②)
+--
+--   [B] save_orient_draft(p_token uuid, p_data jsonb, p_version int) → jsonb
+--       - anon GRANT
+--       - 만료·consumed·expired 상태 차단
+--       - 낙관적 락: version 불일치 시 {success:false, reason:'conflict', current_version}
+--       - jsonb 크기 상한 가드 (100KB)
+--       - status='draft' 유지, version+1, updated_at 갱신
+--
+--   [C] submit_orient_sheet(p_token uuid, p_data jsonb, p_version int) → jsonb
+--       - anon GRANT
+--       - 만료·consumed·expired 상태 차단(draft·submitted 모두 허용 — 재제출 가능)
+--       - 낙관적 락
+--       - 기본 입력 검증(data 비어있지 않아야 함)
+--       - draft/submitted → submitted 전이, submitted_at 기록(첫 제출만), version+1
+--
+-- 보안:
+--   - 모두 SECURITY DEFINER + SET search_path='' (security.md 필수 규칙)
+--   - PostgreSQL 기본 PUBLIC EXECUTE 권한 REVOKE 후 명시 GRANT
+--   - 자원 열거 방지: 토큰 미매칭은 HTTP 200 + {success:false} (에러 코드 없음)
+--   - 선례: 140_influencer_unsubscribe_token.sql 패턴 그대로 따름
+--
+-- PR 1 범위에서 제외:
+--   - create_orient_sheet(p_brand_id, p_application_id) — 관리자 발급 함수 (PR 3)
+--   - mark_orient_consumed(p_orient_id, p_campaign_id)  — 발행 소비 함수 (PR 4)
+--
+-- 운영 데이터 영향:
+--   신규 함수이므로 기존 데이터 영향 없음.
+--
+-- 적용 순서:
+--   186_orient_sheets_table.sql → 이 파일(187)
+--
+-- 롤백:
+--   DROP FUNCTION IF EXISTS public.submit_orient_sheet(uuid, jsonb, int);
+--   DROP FUNCTION IF EXISTS public.save_orient_draft(uuid, jsonb, int);
+--   DROP FUNCTION IF EXISTS public.get_orient_sheet(uuid);
+-- ============================================================
+
+BEGIN;
+
+
+-- ============================================================
+-- A. get_orient_sheet(p_token uuid) — 토큰으로 오리엔시트 조회
+--   anon + authenticated 양쪽 GRANT (sales 폼: 비로그인 브랜드 담당자 호출)
+--   미매칭 시 success=false 반환 (HTTP 에러 없이 정상 200 — 자원 열거 방지)
+--   연결된 신청(application_id)이 있으면 모집 희망값을 initial_values로 함께 반환 (잔여②)
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.get_orient_sheet(p_token uuid)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_sheet          record;
+  v_initial_values jsonb := NULL;
+BEGIN
+  -- 토큰으로 오리엔시트 행 조회
+  SELECT id, brand_id, application_id, form_type, data, status, version,
+         token_expires_at, submitted_at, consumed_at, campaign_id
+    INTO v_sheet
+    FROM public.orient_sheets
+   WHERE token = p_token;
+
+  -- 미매칭: UUID v4 엔트로피(122 bit)로 무차별 대입 사실상 불가.
+  -- 잘못된 토큰은 success=false 반환 (자원 열거 공격 방지 — 140 패턴 동일)
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('success', false, 'reason', 'invalid_token');
+  END IF;
+
+  -- consumed 상태: 캠페인 발행 완료, 더 이상 수정 불가
+  IF v_sheet.status = 'consumed' THEN
+    RETURN jsonb_build_object(
+      'success', false,
+      'reason',  'consumed',
+      'status',  'consumed'
+    );
+  END IF;
+
+  -- 만료 판정(P1-1): 조회 함수는 읽기 전용. 실제 status='expired' 전환은
+  --   쓰기 함수(save_orient_draft·submit_orient_sheet)가 FOR UPDATE 잠금 하에 수행한다.
+  --   여기서는 만료를 반환값으로만 알린다(조회 함수의 쓰기 부작용·동시 조회 race 제거).
+  IF v_sheet.status = 'expired'
+     OR (v_sheet.token_expires_at IS NOT NULL AND v_sheet.token_expires_at < now())
+  THEN
+    RETURN jsonb_build_object(
+      'success', false,
+      'reason',  'expired',
+      'status',  'expired'
+    );
+  END IF;
+
+  -- 연결된 신청이 있으면 모집 희망값을 initial_values로 반환 (잔여②)
+  -- brand_applications의 관련 필드: products(모집 수량/종류), total_qty, total_jpy
+  -- 추가로 form_type도 승계 참고로 포함
+  IF v_sheet.application_id IS NOT NULL THEN
+    SELECT jsonb_build_object(
+             'form_type',   ba.form_type,
+             'total_qty',   ba.total_qty,
+             'total_jpy',   ba.total_jpy,
+             'products',    ba.products
+           )
+      INTO v_initial_values
+      FROM public.brand_applications ba
+     WHERE ba.id = v_sheet.application_id;
+    -- 신청 행이 삭제됐거나 못 찾으면 NULL 유지 (오류 없이 진행)
+  END IF;
+
+  -- 정상 반환: data, status, version + 초기값(있는 경우)
+  RETURN jsonb_build_object(
+    'success',        true,
+    'id',             v_sheet.id,
+    'form_type',      v_sheet.form_type,
+    'data',           v_sheet.data,
+    'status',         v_sheet.status,
+    'version',        v_sheet.version,
+    'submitted_at',   v_sheet.submitted_at,
+    'initial_values', v_initial_values   -- NULL이면 JSON null로 직렬화됨
+  );
+END;
+$$;
+
+-- PostgreSQL 기본은 PUBLIC EXECUTE 권한 부여 → REVOKE 후 명시 GRANT 로 표면적 최소화
+REVOKE EXECUTE ON FUNCTION public.get_orient_sheet(uuid) FROM PUBLIC;
+-- 익명(anon) GRANT 필수: sales 폼은 비로그인 브랜드 담당자가 호출
+GRANT EXECUTE ON FUNCTION public.get_orient_sheet(uuid) TO anon, authenticated;
+
+COMMENT ON FUNCTION public.get_orient_sheet(uuid) IS
+  '[187] 오리엔시트 토큰 조회. anon GRANT — 로그인 없이 토큰만으로 현재 내용·상태 반환. '
+  '미매칭·만료·소비 상태는 success=false. '
+  '연결 신청이 있으면 initial_values에 모집 희망값 포함. '
+  'SECURITY DEFINER + search_path 고정.';
+
+
+-- ============================================================
+-- B. save_orient_draft(p_token uuid, p_data jsonb, p_version int) — 임시저장
+--   anon GRANT (비로그인 브랜드 담당자가 폼 중간에 저장)
+--   만료·consumed·expired 상태는 저장 차단.
+--   낙관적 락: version 불일치 시 충돌 반환.
+--   jsonb 크기 상한 100KB.
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.save_orient_draft(
+  p_token   uuid,
+  p_data    jsonb,
+  p_version int
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_sheet       record;
+  v_data_size   int;
+  v_rows_updated int;
+BEGIN
+  -- 토큰으로 오리엔시트 행 조회 (FOR UPDATE 행 잠금 — 동시 저장 충돌 대비)
+  SELECT id, status, version, token_expires_at
+    INTO v_sheet
+    FROM public.orient_sheets
+   WHERE token = p_token
+     FOR UPDATE;
+
+  -- 미매칭
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('success', false, 'reason', 'invalid_token');
+  END IF;
+
+  -- 만료 시각 경과 확인 (쓰기 함수이므로 FOR UPDATE 잠금 하에 status='expired' 전환)
+  IF v_sheet.token_expires_at IS NOT NULL AND v_sheet.token_expires_at < now() THEN
+    IF v_sheet.status NOT IN ('expired', 'consumed') THEN
+      UPDATE public.orient_sheets
+         SET status = 'expired'   -- updated_at은 트리거가 자동 갱신
+       WHERE id = v_sheet.id;
+    END IF;
+    RETURN jsonb_build_object('success', false, 'reason', 'expired');
+  END IF;
+
+  -- 저장 불가 상태 차단
+  IF v_sheet.status = 'consumed' THEN
+    RETURN jsonb_build_object('success', false, 'reason', 'consumed');
+  END IF;
+  IF v_sheet.status = 'expired' THEN
+    RETURN jsonb_build_object('success', false, 'reason', 'expired');
+  END IF;
+
+  -- jsonb 크기 상한 가드 (100KB = 102400 바이트)
+  v_data_size := octet_length(p_data::text);
+  IF v_data_size > 102400 THEN
+    RETURN jsonb_build_object(
+      'success', false,
+      'reason',  'data_too_large',
+      'limit_bytes', 102400,
+      'actual_bytes', v_data_size
+    );
+  END IF;
+
+  -- 낙관적 락: 클라이언트가 보낸 version이 현재 DB version과 다르면 충돌
+  IF p_version <> v_sheet.version THEN
+    RETURN jsonb_build_object(
+      'success',         false,
+      'reason',          'conflict',
+      'current_version', v_sheet.version
+    );
+  END IF;
+
+  -- 임시저장: data·version만 갱신. status는 변경하지 않음(submitted→draft 역전환 없음, P0-1).
+  --   updated_at은 BEFORE UPDATE 트리거(trg_orient_sheets_updated_at)가 자동 갱신.
+  UPDATE public.orient_sheets
+     SET data    = p_data,
+         version = v_sheet.version + 1
+   WHERE id      = v_sheet.id
+     AND version = p_version;           -- 이중 낙관적 락 (FOR UPDATE + WHERE version)
+
+  GET DIAGNOSTICS v_rows_updated = ROW_COUNT;
+
+  -- UPDATE가 0행이면 version 충돌(FOR UPDATE 이후 다른 트랜잭션이 먼저 커밋)
+  IF v_rows_updated = 0 THEN
+    RETURN jsonb_build_object(
+      'success', false,
+      'reason',  'conflict'
+    );
+  END IF;
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'version', v_sheet.version + 1
+  );
+END;
+$$;
+
+-- PostgreSQL 기본 PUBLIC EXECUTE 권한 → REVOKE 후 익명(anon)만 명시 GRANT
+--   ※ 관리자 대리 저장(authenticated GRANT)은 PR 3 관리자 흐름에서 필요 시 추가 예정.
+REVOKE EXECUTE ON FUNCTION public.save_orient_draft(uuid, jsonb, int) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.save_orient_draft(uuid, jsonb, int) TO anon;
+
+COMMENT ON FUNCTION public.save_orient_draft(uuid, jsonb, int) IS
+  '[187] 오리엔시트 임시저장. anon GRANT — 로그인 없이 토큰·data·version으로 저장. '
+  '만료·consumed 상태 차단. 낙관적 락(version 불일치=충돌 반환). jsonb 100KB 상한. '
+  'status 미변경(submitted→draft 역전환 없음 — data·version만 갱신). '
+  'SECURITY DEFINER + search_path 고정.';
+
+
+-- ============================================================
+-- C. submit_orient_sheet(p_token uuid, p_data jsonb, p_version int) — 제출
+--   anon GRANT (비로그인 브랜드 담당자가 최종 제출)
+--   draft, submitted 양쪽에서 전이 허용 (사양서 결정⑨: 발행 전 재편집·재제출 가능)
+--   만료·consumed 차단.
+--   낙관적 락.
+--   기본 입력 검증: data가 비어있지 않아야 함.
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.submit_orient_sheet(
+  p_token   uuid,
+  p_data    jsonb,
+  p_version int
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_sheet        record;
+  v_data_size    int;
+  v_rows_updated int;
+  v_now          timestamptz := now();
+BEGIN
+  -- 토큰으로 오리엔시트 행 조회 (FOR UPDATE 행 잠금)
+  SELECT id, status, version, token_expires_at, submitted_at
+    INTO v_sheet
+    FROM public.orient_sheets
+   WHERE token = p_token
+     FOR UPDATE;
+
+  -- 미매칭
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('success', false, 'reason', 'invalid_token');
+  END IF;
+
+  -- 만료 시각 경과 확인
+  IF v_sheet.token_expires_at IS NOT NULL AND v_sheet.token_expires_at < v_now THEN
+    IF v_sheet.status NOT IN ('expired', 'consumed') THEN
+      UPDATE public.orient_sheets
+         SET status = 'expired'   -- updated_at은 트리거가 자동 갱신
+       WHERE id = v_sheet.id;
+    END IF;
+    RETURN jsonb_build_object('success', false, 'reason', 'expired');
+  END IF;
+
+  -- 제출 불가 상태 차단
+  IF v_sheet.status = 'consumed' THEN
+    RETURN jsonb_build_object('success', false, 'reason', 'consumed');
+  END IF;
+  IF v_sheet.status = 'expired' THEN
+    RETURN jsonb_build_object('success', false, 'reason', 'expired');
+  END IF;
+
+  -- 기본 입력 검증: data가 NULL이거나 빈 객체이면 제출 거부
+  IF p_data IS NULL OR p_data = '{}'::jsonb THEN
+    RETURN jsonb_build_object(
+      'success', false,
+      'reason',  'data_required'
+    );
+  END IF;
+
+  -- jsonb 크기 상한 가드 (100KB = 102400 바이트)
+  v_data_size := octet_length(p_data::text);
+  IF v_data_size > 102400 THEN
+    RETURN jsonb_build_object(
+      'success',      false,
+      'reason',       'data_too_large',
+      'limit_bytes',  102400,
+      'actual_bytes', v_data_size
+    );
+  END IF;
+
+  -- 낙관적 락: version 불일치 시 충돌 반환
+  IF p_version <> v_sheet.version THEN
+    RETURN jsonb_build_object(
+      'success',         false,
+      'reason',          'conflict',
+      'current_version', v_sheet.version
+    );
+  END IF;
+
+  -- 제출 전이: draft | submitted → submitted
+  -- submitted_at: 첫 제출 시각만 기록 (재제출 시 덮어쓰지 않음 — COALESCE)
+  UPDATE public.orient_sheets
+     SET data         = p_data,
+         status       = 'submitted',
+         submitted_at = COALESCE(v_sheet.submitted_at, v_now),
+         version      = v_sheet.version + 1
+         -- updated_at은 트리거가 자동 갱신
+   WHERE id      = v_sheet.id
+     AND version = p_version;
+
+  GET DIAGNOSTICS v_rows_updated = ROW_COUNT;
+
+  IF v_rows_updated = 0 THEN
+    RETURN jsonb_build_object('success', false, 'reason', 'conflict');
+  END IF;
+
+  RETURN jsonb_build_object(
+    'success',      true,
+    'version',      v_sheet.version + 1,
+    'submitted_at', COALESCE(v_sheet.submitted_at, v_now)
+  );
+END;
+$$;
+
+-- PostgreSQL 기본 PUBLIC EXECUTE 권한 → REVOKE 후 익명(anon)만 명시 GRANT
+--   ※ 관리자 대리 제출(authenticated GRANT)은 PR 3 관리자 흐름에서 필요 시 추가 예정.
+REVOKE EXECUTE ON FUNCTION public.submit_orient_sheet(uuid, jsonb, int) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.submit_orient_sheet(uuid, jsonb, int) TO anon;
+
+COMMENT ON FUNCTION public.submit_orient_sheet(uuid, jsonb, int) IS
+  '[187] 오리엔시트 제출. anon GRANT — 로그인 없이 토큰·data·version으로 최종 제출. '
+  'draft·submitted 양쪽 허용(발행 전 재제출 가능). 만료·consumed 차단. '
+  '낙관적 락. submitted_at은 첫 제출 시각만 기록. '
+  'SECURITY DEFINER + search_path 고정.';
+
+
+-- PostgREST 스키마 캐시 재로드 (신규 함수 즉시 인식)
+NOTIFY pgrst, 'reload schema';
+
+
+COMMIT;


### PR DESCRIPTION
## 변경 요약
브랜드 셀프 오리엔시트 **PR1 — 데이터 모델 + 익명 토큰 함수** (화면 없음).
- 마이그레이션 186: `orient_sheets` 테이블 + 인덱스 5종 + 행 단위 보안 정책(RLS, 익명 직접접근 0) + `updated_at` 자동 트리거
- 마이그레이션 187: 익명 토큰 함수 3종 (`get_orient_sheet`/`save_orient_draft`/`submit_orient_sheet`) — `SECURITY DEFINER` + `search_path=''` + `REVOKE PUBLIC` 후 `anon` GRANT, 낙관적 락, jsonb 100KB 상한
- `storage.js`: `getOrientSheet`/`saveOrientDraft`/`submitOrientSheet`

## 요청 외 추가 변경
없음 (PR1 범위 그대로).

## 검증
- 개발서버 DB(qysmxtipobomefudyixw)에 186→187 적용
- 스모크 8단계 통과(조회·임시저장·낙관적 락·제출·**제출상태 역전환 방지**·빈제출 차단·만료·무효토큰)

## 리뷰
reverb-reviewer: P0 2건(상태 역전환 모순·외래 키 옵션 누락)·P1 4건(조회 함수 쓰기 부작용·updated_at 트리거·권한·캐시) 전부 반영. qa 권장: skip(화면 없음).

## 관련 사양서
docs/specs/2026-06-18-brand-self-orient-sheet.md (§4·§6·§7·§8, 구현 결과 섹션 기록 완료)

## PR3·4 인계 메모
- `delete_brand` RPC(마이그레이션 174)에 `orient_sheets` 카운트 체크 추가 필요(brand_id RESTRICT 정합)
- 관리자 대리 저장 필요 시 save/submit에 `authenticated` GRANT 추가
- `create_orient_sheet`/`mark_orient_consumed`는 PR3·4에서 구현(의도적 제외)

🤖 Generated with [Claude Code](https://claude.com/claude-code)