### PR TITLE
fix: even spacing for orient row2 fields on mobile

### DIFF
--- a/dev/sales/orient.html
+++ b/dev/sales/orient.html
@@ -200,7 +200,11 @@ input[type="date"] { min-height: 44px; }
 .row2 > .field { min-width: 0; }
 
 .row2 { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
-@media (max-width: 520px) { .row2 { grid-template-columns: 1fr; } }
+/* 모바일 1열 전환 시 칸 간격을 일반 .field 간격(14px)과 통일 — 묶음 내부·묶음 사이 균일 */
+@media (max-width: 520px) {
+  .row2 { grid-template-columns: 1fr; gap: 14px; margin-bottom: 14px; }
+  .row2 > .field { margin-bottom: 0; }
+}
 
 /* 반복 블록(가격·URL·채널·이미지) */
 .rep-item {

--- a/sales/orient.html
+++ b/sales/orient.html
@@ -200,7 +200,11 @@ input[type="date"] { min-height: 44px; }
 .row2 > .field { min-width: 0; }
 
 .row2 { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
-@media (max-width: 520px) { .row2 { grid-template-columns: 1fr; } }
+/* 모바일 1열 전환 시 칸 간격을 일반 .field 간격(14px)과 통일 — 묶음 내부·묶음 사이 균일 */
+@media (max-width: 520px) {
+  .row2 { grid-template-columns: 1fr; gap: 14px; margin-bottom: 14px; }
+  .row2 > .field { margin-bottom: 0; }
+}
 
 /* 반복 블록(가격·URL·채널·이미지) */
 .rep-item {


### PR DESCRIPTION
## 변경 요약
- 모바일에서 2열(.row2)이 1열로 줄 때 칸 간격 불균일(묶음 내부 넓고 묶음 사이 좁음) 수정 → 모두 14px 통일.

## 요청 외 추가 변경
- 없음 (모바일 @media CSS만).

## 배포
- 개발서버 전용. 운영 보류.