### PR TITLE
feat(admin): 회원 연령·성별 분포 대시보드 카드

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -12,7 +12,7 @@
 // 회귀(2026-05-12 PR #182 머지 직후 발생)를 방지하기 위한 자동 reload 가드.
 // sessionStorage 차단 환경(시크릿 모드 일부, 쿠키 차단)에서는 자연스럽게 skip.
 (function(){
-  var CURRENT_BUILD = 'v1782087324';
+  var CURRENT_BUILD = 'v1782096755';
   if (CURRENT_BUILD.indexOf('__') === 0) return; // 빌드 미적용 (dev/ 직접 열기) 시 skip
   try {
     var prev = sessionStorage.getItem('reverb.adminBuild');
@@ -2091,7 +2091,7 @@ tr.audit-row, .audit-row { background: #fff3e0 !important; }
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-06-22 09:15 · 737822e</span>
+          <span class="admin-build-text">2026-06-22 11:52 · ed34036</span>
         </div>
       </div>
     </aside>
@@ -2180,6 +2180,33 @@ tr.audit-row, .audit-row { background: #fff3e0 !important; }
               <canvas id="addressDistChart"></canvas>
               <div id="addressDistEmpty" style="display:none;text-align:center;color:var(--muted);padding:60px 0;font-size:13px">집계할 배송지 데이터가 없습니다</div>
               <div id="addressDistLoading" style="position:absolute;inset:0;display:flex;align-items:center;justify-content:center"><span class="spinner" style="width:20px;height:20px;border-width:2px;border-color:rgba(200,120,163,.2);border-top-color:var(--pink)"></span></div>
+            </div>
+          </div>
+
+          <!-- 회원 연령·성별 분포 (마케팅 구간 + 성별 도넛 + 교차표) -->
+          <div class="admin-card" style="margin-bottom:16px">
+            <div class="admin-card-header">
+              <span class="admin-card-title">회원 연령·성별 분포</span>
+              <span id="ageGenderTotal" style="font-size:11px;color:var(--muted)"></span>
+            </div>
+            <div style="padding:16px">
+              <div id="ageGenderCollectBars" style="margin-bottom:14px"></div>
+              <div id="ageGenderEmpty" style="display:none;text-align:center;color:var(--muted);padding:32px 0;font-size:13px">아직 생년월일·성별 데이터가 수집되지 않았습니다. 신규 가입과 응모 시 점진적으로 채워집니다.</div>
+              <div id="ageGenderBody">
+                <div style="display:grid;grid-template-columns:1fr 1fr;gap:16px">
+                  <div>
+                    <div style="font-size:11px;color:var(--muted);margin-bottom:6px">연령대 분포</div>
+                    <div style="position:relative;height:200px"><canvas id="ageDistChart"></canvas></div>
+                  </div>
+                  <div>
+                    <div style="font-size:11px;color:var(--muted);margin-bottom:6px">성별 분포</div>
+                    <div style="position:relative;height:200px"><canvas id="genderDistChart"></canvas></div>
+                  </div>
+                </div>
+                <div id="ageGenderCaption" style="display:none;font-size:11px;color:var(--muted);margin-top:8px"></div>
+                <div style="font-size:11px;color:var(--muted);margin:14px 0 6px">연령대 × 성별 (단위: 명, 만 18세 미만은 정책상 0)</div>
+                <div id="ageGenderCrossTable"></div>
+              </div>
             </div>
           </div>
 
@@ -6454,6 +6481,53 @@ function computePrefectureStats(users, limit) {
     .slice(0, maxTop)
     .map(([name, count]) => ({ name, count }));
   return { top, unregistered, overseas, total: rows.length };
+}
+
+// 연령·성별 분포 집계 — 대시보드 카드용 (computePrefectureStats 패턴: 추가 쿼리 없이 배열만 집계).
+// 연령대=마케팅 구간(18-24/25-29/30-34/35-39/40-49/50+) + 미등록 + 이상치(생년월일 있으나 18세 미만/비현실).
+// 성별=male/female/other/undisclosed + unregistered(미등록). 연령×성별 교차표 cross 포함.
+// 만 나이는 shared.js calcAgeFromBirthdate(KST) 재사용. 감사용 격리는 호출부(statsUsers)에서 선처리.
+const AGE_GENDER_BUCKETS = ['18-24', '25-29', '30-34', '35-39', '40-49', '50+'];
+function computeAgeGenderStats(users) {
+  const rows = Array.isArray(users) ? users : [];
+  const genders = ['male', 'female', 'other', 'undisclosed'];
+  const bucketOf = (age) => {
+    if (age == null || age < 18 || age > 120) return null; // 미등록/이상치
+    if (age <= 24) return '18-24';
+    if (age <= 29) return '25-29';
+    if (age <= 34) return '30-34';
+    if (age <= 39) return '35-39';
+    if (age <= 49) return '40-49';
+    return '50+';
+  };
+
+  const ageCounts = {}; AGE_GENDER_BUCKETS.forEach(l => { ageCounts[l] = 0; });
+  let ageUnregistered = 0, ageInvalid = 0;
+  const gender = { male: 0, female: 0, other: 0, undisclosed: 0, unregistered: 0 };
+  const cross = {}; [...AGE_GENDER_BUCKETS, '미등록'].forEach(l => { cross[l] = { male: 0, female: 0, other: 0, undisclosed: 0, unregistered: 0 }; });
+
+  let ageRegistered = 0, genderRegistered = 0;
+  for (const row of rows) {
+    const bd = row && row.birthdate ? String(row.birthdate) : '';
+    const age = (typeof calcAgeFromBirthdate === 'function') ? calcAgeFromBirthdate(bd) : null;
+    const bucket = bucketOf(age);
+    const g = genders.includes(row && row.gender) ? row.gender : 'unregistered';
+
+    if (bucket) { ageCounts[bucket]++; ageRegistered++; }
+    else if (bd && age != null) { ageInvalid++; }   // 생년월일 있으나 18세 미만/비현실값 = 이상치
+    else { ageUnregistered++; }                       // 생년월일 미입력/파싱 실패 = 미등록
+
+    gender[g]++;
+    if (g !== 'unregistered') genderRegistered++;
+
+    cross[bucket || '미등록'][g]++;
+  }
+
+  const ageBuckets = AGE_GENDER_BUCKETS.map(l => ({ label: l, count: ageCounts[l] }));
+  ageBuckets.push({ label: '미등록', count: ageUnregistered });
+  if (ageInvalid > 0) ageBuckets.push({ label: '이상치', count: ageInvalid });
+
+  return { total: rows.length, ageRegistered, genderRegistered, ageBuckets, gender, cross, ageInvalid };
 }
 
 // ── 인플루언서 인증/블랙리스트 (관리자 전용, migration 059) ──
@@ -24070,6 +24144,8 @@ async function loadAdminData(preloaded) {
   renderProfileCompletion(statsUsers);
   // 배송지 분포(도도부현 Top N) — 통계용 statsUsers 재사용 (중복 쿼리 방지)
   renderAddressDistribution(statsUsers);
+  // 회원 연령·성별 분포(연령대 막대 + 성별 도넛 + 교차표) — statsUsers 재사용(감사용 제외)
+  renderAgeGenderDistribution(statsUsers);
   // 대시보드는 apps 전건을 KPI용으로 이미 보유 → 추가 count 쿼리 없이 인라인 계산.
   // 그 외 경로(부트의 대시보드 외 페인)는 refreshApplySidebarBadge() 가 가벼운 count 로 갱신.
   if ($('adminApplySi')) $('adminApplySi').innerHTML = `<span class="si-icon material-icons-round notranslate" translate="no">assignment</span><span class="si-text">신청 관리</span>${pending.length>0?`<span class="admin-si-badge">${pending.length>999?'999+':pending.length}</span>`:''}`;
@@ -24166,6 +24242,8 @@ function renderCampaignBreakdown(camps) {
 var _allUsers = [];
 var _signupChart = null;
 var _addressDistChart = null;
+var _ageDistChart = null;
+var _genderDistChart = null;
 
 // 일본 도도부현 한국어 표기 매핑 (47개 전체)
 var PREFECTURE_KO = {
@@ -24281,6 +24359,118 @@ function renderAddressDistribution(users) {
   } catch (e) {
     if (loading) loading.style.display = 'none';
     console.error('[addressDist] render failed:', e);
+  }
+}
+
+// 회원 연령·성별 분포 — 수집률 막대 + 연령대 막대 + 성별 도넛 + 연령×성별 교차표.
+// loadAdminData가 넘긴 statsUsers(감사용 제외) 재사용(추가 쿼리 0). 집계는 storage.js computeAgeGenderStats.
+// 데이터 0건이면 빈 상태 안내, 소표본(생년월일 등록 30명 미만)이면 참고용 캡션.
+function renderAgeGenderDistribution(users) {
+  const totalLabel = $('ageGenderTotal');
+  const collectBars = $('ageGenderCollectBars');
+  const body = $('ageGenderBody');
+  const empty = $('ageGenderEmpty');
+  const caption = $('ageGenderCaption');
+  const ageCanvas = $('ageDistChart');
+  const genderCanvas = $('genderDistChart');
+  const crossEl = $('ageGenderCrossTable');
+  if (!ageCanvas || !genderCanvas) return;
+
+  try {
+    const stats = computeAgeGenderStats(users || []);
+    const total = stats.total;
+    if (totalLabel) totalLabel.textContent = `생년월일 ${stats.ageRegistered}·성별 ${stats.genderRegistered} / 전체 ${total}명`;
+
+    // 수집률 막대 (renderProfileCompletion 패턴)
+    const pct = v => total ? Math.round(v / total * 100) : 0;
+    const bar = (label, val, color) => `
+      <div style="margin-bottom:8px">
+        <div style="display:flex;justify-content:space-between;font-size:11px;margin-bottom:3px">
+          <span style="color:var(--ink)">${label}</span><span style="color:var(--muted);font-weight:600">${val}%</span>
+        </div>
+        <div style="height:6px;background:var(--bg);border-radius:3px;overflow:hidden">
+          <div style="height:100%;width:${val}%;background:${color};border-radius:3px;transition:width .4s"></div>
+        </div>
+      </div>`;
+    if (collectBars) collectBars.innerHTML =
+      bar('생년월일 등록', pct(stats.ageRegistered), '#5B7CFF') +
+      bar('성별 등록', pct(stats.genderRegistered), '#28C76F');
+
+    if (_ageDistChart) { _ageDistChart.destroy(); _ageDistChart = null; }
+    if (_genderDistChart) { _genderDistChart.destroy(); _genderDistChart = null; }
+
+    // 수집 0건 → 차트·표 숨기고 안내 (현재 운영 상태)
+    const hasData = (stats.ageRegistered + stats.genderRegistered) > 0;
+    if (!hasData) {
+      if (body) body.style.display = 'none';
+      if (empty) empty.style.display = 'block';
+      if (caption) caption.style.display = 'none';
+      return;
+    }
+    if (body) body.style.display = '';
+    if (empty) empty.style.display = 'none';
+
+    // 소표본 참고용 캡션
+    if (caption) {
+      if (stats.ageRegistered > 0 && stats.ageRegistered < 30) {
+        caption.style.display = 'block';
+        caption.textContent = `표본이 적어 참고용입니다 (생년월일 등록 ${stats.ageRegistered}명). 비율보다 실제 인원수로 보세요.`;
+      } else { caption.style.display = 'none'; }
+    }
+
+    // 연령대 막대 (이상치는 0이면 제외, 미등록·이상치는 회색)
+    const ageRows = stats.ageBuckets.filter(b => b.label !== '이상치' || b.count > 0);
+    _ageDistChart = new Chart(ageCanvas.getContext('2d'), {
+      type: 'bar',
+      data: {
+        labels: ageRows.map(b => b.label),
+        datasets: [{
+          data: ageRows.map(b => b.count),
+          backgroundColor: ageRows.map(b => (b.label === '미등록' || b.label === '이상치') ? '#BDBDC4' : '#5B7CFF'),
+          borderRadius: 4
+        }]
+      },
+      options: {
+        responsive: true, maintainAspectRatio: false,
+        plugins: { legend: { display: false }, tooltip: { callbacks: { label: ctx => `${ctx.parsed.y}명` } } },
+        scales: { y: { beginAtZero: true, ticks: { precision: 0 } } }
+      }
+    });
+
+    // 성별 도넛 (남/여/그 외/응답 안 함/미등록) — 분모=전체 회원
+    _genderDistChart = new Chart(genderCanvas.getContext('2d'), {
+      type: 'doughnut',
+      data: {
+        labels: ['남성', '여성', '그 외', '응답 안 함', '미등록'],
+        datasets: [{
+          data: [stats.gender.male, stats.gender.female, stats.gender.other, stats.gender.undisclosed, stats.gender.unregistered],
+          backgroundColor: ['#5B7CFF', '#E87A96', '#F4A43A', '#9B59B6', '#BDBDC4'],
+          borderColor: '#fff', borderWidth: 2
+        }]
+      },
+      options: buildAddressChartOptions({ total })
+    });
+
+    // 연령×성별 교차표 (실수 명 중심, 0은 '-')
+    if (crossEl) {
+      const gKeys = ['male', 'female', 'other', 'undisclosed', 'unregistered'];
+      const gHead = ['남성', '여성', '그 외', '응답 안 함', '미등록'];
+      const crossRows = [...AGE_GENDER_BUCKETS, '미등록'];
+      const cell = v => v > 0 ? v : '<span style="color:var(--muted)">-</span>';
+      crossEl.innerHTML =
+        '<table style="width:100%;border-collapse:collapse;font-size:11px">' +
+        '<thead><tr><th style="text-align:left;padding:4px 6px;color:var(--muted);font-weight:600">연령대</th>' +
+        gHead.map(h => `<th style="text-align:right;padding:4px 6px;color:var(--muted);font-weight:600">${h}</th>`).join('') +
+        '</tr></thead><tbody>' +
+        crossRows.map(rk => {
+          const r = stats.cross[rk] || {};
+          return `<tr style="border-top:1px solid var(--line)"><td style="padding:4px 6px;color:var(--ink)">${rk}</td>` +
+            gKeys.map(gk => `<td style="text-align:right;padding:4px 6px">${cell(r[gk] || 0)}</td>`).join('') + '</tr>';
+        }).join('') +
+        '</tbody></table>';
+    }
+  } catch (e) {
+    console.error('[ageGenderDist] render failed:', e);
   }
 }
 

--- a/dev/admin/index.html
+++ b/dev/admin/index.html
@@ -226,6 +226,33 @@
             </div>
           </div>
 
+          <!-- 회원 연령·성별 분포 (마케팅 구간 + 성별 도넛 + 교차표) -->
+          <div class="admin-card" style="margin-bottom:16px">
+            <div class="admin-card-header">
+              <span class="admin-card-title">회원 연령·성별 분포</span>
+              <span id="ageGenderTotal" style="font-size:11px;color:var(--muted)"></span>
+            </div>
+            <div style="padding:16px">
+              <div id="ageGenderCollectBars" style="margin-bottom:14px"></div>
+              <div id="ageGenderEmpty" style="display:none;text-align:center;color:var(--muted);padding:32px 0;font-size:13px">아직 생년월일·성별 데이터가 수집되지 않았습니다. 신규 가입과 응모 시 점진적으로 채워집니다.</div>
+              <div id="ageGenderBody">
+                <div style="display:grid;grid-template-columns:1fr 1fr;gap:16px">
+                  <div>
+                    <div style="font-size:11px;color:var(--muted);margin-bottom:6px">연령대 분포</div>
+                    <div style="position:relative;height:200px"><canvas id="ageDistChart"></canvas></div>
+                  </div>
+                  <div>
+                    <div style="font-size:11px;color:var(--muted);margin-bottom:6px">성별 분포</div>
+                    <div style="position:relative;height:200px"><canvas id="genderDistChart"></canvas></div>
+                  </div>
+                </div>
+                <div id="ageGenderCaption" style="display:none;font-size:11px;color:var(--muted);margin-top:8px"></div>
+                <div style="font-size:11px;color:var(--muted);margin:14px 0 6px">연령대 × 성별 (단위: 명, 만 18세 미만은 정책상 0)</div>
+                <div id="ageGenderCrossTable"></div>
+              </div>
+            </div>
+          </div>
+
         </div>
 
         <!-- CAMPAIGNS PANE -->

--- a/dev/js/admin-dashboard.js
+++ b/dev/js/admin-dashboard.js
@@ -71,6 +71,8 @@ async function loadAdminData(preloaded) {
   renderProfileCompletion(statsUsers);
   // 배송지 분포(도도부현 Top N) — 통계용 statsUsers 재사용 (중복 쿼리 방지)
   renderAddressDistribution(statsUsers);
+  // 회원 연령·성별 분포(연령대 막대 + 성별 도넛 + 교차표) — statsUsers 재사용(감사용 제외)
+  renderAgeGenderDistribution(statsUsers);
   // 대시보드는 apps 전건을 KPI용으로 이미 보유 → 추가 count 쿼리 없이 인라인 계산.
   // 그 외 경로(부트의 대시보드 외 페인)는 refreshApplySidebarBadge() 가 가벼운 count 로 갱신.
   if ($('adminApplySi')) $('adminApplySi').innerHTML = `<span class="si-icon material-icons-round notranslate" translate="no">assignment</span><span class="si-text">신청 관리</span>${pending.length>0?`<span class="admin-si-badge">${pending.length>999?'999+':pending.length}</span>`:''}`;
@@ -167,6 +169,8 @@ function renderCampaignBreakdown(camps) {
 var _allUsers = [];
 var _signupChart = null;
 var _addressDistChart = null;
+var _ageDistChart = null;
+var _genderDistChart = null;
 
 // 일본 도도부현 한국어 표기 매핑 (47개 전체)
 var PREFECTURE_KO = {
@@ -282,6 +286,118 @@ function renderAddressDistribution(users) {
   } catch (e) {
     if (loading) loading.style.display = 'none';
     console.error('[addressDist] render failed:', e);
+  }
+}
+
+// 회원 연령·성별 분포 — 수집률 막대 + 연령대 막대 + 성별 도넛 + 연령×성별 교차표.
+// loadAdminData가 넘긴 statsUsers(감사용 제외) 재사용(추가 쿼리 0). 집계는 storage.js computeAgeGenderStats.
+// 데이터 0건이면 빈 상태 안내, 소표본(생년월일 등록 30명 미만)이면 참고용 캡션.
+function renderAgeGenderDistribution(users) {
+  const totalLabel = $('ageGenderTotal');
+  const collectBars = $('ageGenderCollectBars');
+  const body = $('ageGenderBody');
+  const empty = $('ageGenderEmpty');
+  const caption = $('ageGenderCaption');
+  const ageCanvas = $('ageDistChart');
+  const genderCanvas = $('genderDistChart');
+  const crossEl = $('ageGenderCrossTable');
+  if (!ageCanvas || !genderCanvas) return;
+
+  try {
+    const stats = computeAgeGenderStats(users || []);
+    const total = stats.total;
+    if (totalLabel) totalLabel.textContent = `생년월일 ${stats.ageRegistered}·성별 ${stats.genderRegistered} / 전체 ${total}명`;
+
+    // 수집률 막대 (renderProfileCompletion 패턴)
+    const pct = v => total ? Math.round(v / total * 100) : 0;
+    const bar = (label, val, color) => `
+      <div style="margin-bottom:8px">
+        <div style="display:flex;justify-content:space-between;font-size:11px;margin-bottom:3px">
+          <span style="color:var(--ink)">${label}</span><span style="color:var(--muted);font-weight:600">${val}%</span>
+        </div>
+        <div style="height:6px;background:var(--bg);border-radius:3px;overflow:hidden">
+          <div style="height:100%;width:${val}%;background:${color};border-radius:3px;transition:width .4s"></div>
+        </div>
+      </div>`;
+    if (collectBars) collectBars.innerHTML =
+      bar('생년월일 등록', pct(stats.ageRegistered), '#5B7CFF') +
+      bar('성별 등록', pct(stats.genderRegistered), '#28C76F');
+
+    if (_ageDistChart) { _ageDistChart.destroy(); _ageDistChart = null; }
+    if (_genderDistChart) { _genderDistChart.destroy(); _genderDistChart = null; }
+
+    // 수집 0건 → 차트·표 숨기고 안내 (현재 운영 상태)
+    const hasData = (stats.ageRegistered + stats.genderRegistered) > 0;
+    if (!hasData) {
+      if (body) body.style.display = 'none';
+      if (empty) empty.style.display = 'block';
+      if (caption) caption.style.display = 'none';
+      return;
+    }
+    if (body) body.style.display = '';
+    if (empty) empty.style.display = 'none';
+
+    // 소표본 참고용 캡션
+    if (caption) {
+      if (stats.ageRegistered > 0 && stats.ageRegistered < 30) {
+        caption.style.display = 'block';
+        caption.textContent = `표본이 적어 참고용입니다 (생년월일 등록 ${stats.ageRegistered}명). 비율보다 실제 인원수로 보세요.`;
+      } else { caption.style.display = 'none'; }
+    }
+
+    // 연령대 막대 (이상치는 0이면 제외, 미등록·이상치는 회색)
+    const ageRows = stats.ageBuckets.filter(b => b.label !== '이상치' || b.count > 0);
+    _ageDistChart = new Chart(ageCanvas.getContext('2d'), {
+      type: 'bar',
+      data: {
+        labels: ageRows.map(b => b.label),
+        datasets: [{
+          data: ageRows.map(b => b.count),
+          backgroundColor: ageRows.map(b => (b.label === '미등록' || b.label === '이상치') ? '#BDBDC4' : '#5B7CFF'),
+          borderRadius: 4
+        }]
+      },
+      options: {
+        responsive: true, maintainAspectRatio: false,
+        plugins: { legend: { display: false }, tooltip: { callbacks: { label: ctx => `${ctx.parsed.y}명` } } },
+        scales: { y: { beginAtZero: true, ticks: { precision: 0 } } }
+      }
+    });
+
+    // 성별 도넛 (남/여/그 외/응답 안 함/미등록) — 분모=전체 회원
+    _genderDistChart = new Chart(genderCanvas.getContext('2d'), {
+      type: 'doughnut',
+      data: {
+        labels: ['남성', '여성', '그 외', '응답 안 함', '미등록'],
+        datasets: [{
+          data: [stats.gender.male, stats.gender.female, stats.gender.other, stats.gender.undisclosed, stats.gender.unregistered],
+          backgroundColor: ['#5B7CFF', '#E87A96', '#F4A43A', '#9B59B6', '#BDBDC4'],
+          borderColor: '#fff', borderWidth: 2
+        }]
+      },
+      options: buildAddressChartOptions({ total })
+    });
+
+    // 연령×성별 교차표 (실수 명 중심, 0은 '-')
+    if (crossEl) {
+      const gKeys = ['male', 'female', 'other', 'undisclosed', 'unregistered'];
+      const gHead = ['남성', '여성', '그 외', '응답 안 함', '미등록'];
+      const crossRows = [...AGE_GENDER_BUCKETS, '미등록'];
+      const cell = v => v > 0 ? v : '<span style="color:var(--muted)">-</span>';
+      crossEl.innerHTML =
+        '<table style="width:100%;border-collapse:collapse;font-size:11px">' +
+        '<thead><tr><th style="text-align:left;padding:4px 6px;color:var(--muted);font-weight:600">연령대</th>' +
+        gHead.map(h => `<th style="text-align:right;padding:4px 6px;color:var(--muted);font-weight:600">${h}</th>`).join('') +
+        '</tr></thead><tbody>' +
+        crossRows.map(rk => {
+          const r = stats.cross[rk] || {};
+          return `<tr style="border-top:1px solid var(--line)"><td style="padding:4px 6px;color:var(--ink)">${rk}</td>` +
+            gKeys.map(gk => `<td style="text-align:right;padding:4px 6px">${cell(r[gk] || 0)}</td>`).join('') + '</tr>';
+        }).join('') +
+        '</tbody></table>';
+    }
+  } catch (e) {
+    console.error('[ageGenderDist] render failed:', e);
   }
 }
 

--- a/dev/lib/storage.js
+++ b/dev/lib/storage.js
@@ -308,6 +308,53 @@ function computePrefectureStats(users, limit) {
   return { top, unregistered, overseas, total: rows.length };
 }
 
+// 연령·성별 분포 집계 — 대시보드 카드용 (computePrefectureStats 패턴: 추가 쿼리 없이 배열만 집계).
+// 연령대=마케팅 구간(18-24/25-29/30-34/35-39/40-49/50+) + 미등록 + 이상치(생년월일 있으나 18세 미만/비현실).
+// 성별=male/female/other/undisclosed + unregistered(미등록). 연령×성별 교차표 cross 포함.
+// 만 나이는 shared.js calcAgeFromBirthdate(KST) 재사용. 감사용 격리는 호출부(statsUsers)에서 선처리.
+const AGE_GENDER_BUCKETS = ['18-24', '25-29', '30-34', '35-39', '40-49', '50+'];
+function computeAgeGenderStats(users) {
+  const rows = Array.isArray(users) ? users : [];
+  const genders = ['male', 'female', 'other', 'undisclosed'];
+  const bucketOf = (age) => {
+    if (age == null || age < 18 || age > 120) return null; // 미등록/이상치
+    if (age <= 24) return '18-24';
+    if (age <= 29) return '25-29';
+    if (age <= 34) return '30-34';
+    if (age <= 39) return '35-39';
+    if (age <= 49) return '40-49';
+    return '50+';
+  };
+
+  const ageCounts = {}; AGE_GENDER_BUCKETS.forEach(l => { ageCounts[l] = 0; });
+  let ageUnregistered = 0, ageInvalid = 0;
+  const gender = { male: 0, female: 0, other: 0, undisclosed: 0, unregistered: 0 };
+  const cross = {}; [...AGE_GENDER_BUCKETS, '미등록'].forEach(l => { cross[l] = { male: 0, female: 0, other: 0, undisclosed: 0, unregistered: 0 }; });
+
+  let ageRegistered = 0, genderRegistered = 0;
+  for (const row of rows) {
+    const bd = row && row.birthdate ? String(row.birthdate) : '';
+    const age = (typeof calcAgeFromBirthdate === 'function') ? calcAgeFromBirthdate(bd) : null;
+    const bucket = bucketOf(age);
+    const g = genders.includes(row && row.gender) ? row.gender : 'unregistered';
+
+    if (bucket) { ageCounts[bucket]++; ageRegistered++; }
+    else if (bd && age != null) { ageInvalid++; }   // 생년월일 있으나 18세 미만/비현실값 = 이상치
+    else { ageUnregistered++; }                       // 생년월일 미입력/파싱 실패 = 미등록
+
+    gender[g]++;
+    if (g !== 'unregistered') genderRegistered++;
+
+    cross[bucket || '미등록'][g]++;
+  }
+
+  const ageBuckets = AGE_GENDER_BUCKETS.map(l => ({ label: l, count: ageCounts[l] }));
+  ageBuckets.push({ label: '미등록', count: ageUnregistered });
+  if (ageInvalid > 0) ageBuckets.push({ label: '이상치', count: ageInvalid });
+
+  return { total: rows.length, ageRegistered, genderRegistered, ageBuckets, gender, cross, ageInvalid };
+}
+
 // ── 인플루언서 인증/블랙리스트 (관리자 전용, migration 059) ──
 async function setInfluencerVerified(targetId, verify, note = null) {
   if (!db) throw new Error('DB 미연결');

--- a/docs/specs/2026-06-22-age-gender-dashboard.md
+++ b/docs/specs/2026-06-22-age-gender-dashboard.md
@@ -111,9 +111,21 @@
 - (해소됨) 위치=관리자 대시보드 / 연령 구간=마케팅 구간 / 범위=연령×성별 교차 포함.
 - 남은 확인: 착수 시점(지금 vs 데이터 쌓인 뒤).
 
-## 구현 결과 (개발 세션이 채울 것)
-**구현일:** / **관련 커밋:**
+## 구현 결과
+**구현일:** 2026-06-22 / **관련 커밋:** feature/age-gender-dashboard (dev PR)
+
 ### 초안 대비 변경 사항
-- 추가된 것: / 빠진 것(+이유): / 달라진 것:
+- 추가된 것: 설계대로 전부 구현(수집률 막대·연령대 막대·성별 도넛·연령×성별 교차표·빈 상태·소표본 캡션).
+- 빠진 것: 없음.
+- 달라진 것: 없음(설계 그대로). 데이터 0건이라 현재 운영에선 「아직 수집 전」 안내만 노출.
+
 ### 구현 중 기술 결정 사항
-- (집계 함수 시그니처·연령대 경계·교차표 형식·빈 상태 문구 확정 등)
+- `dev/lib/storage.js` `computeAgeGenderStats(users)` — 순수 집계(`computePrefectureStats` 패턴). 연령 버킷: `null/age<18/age>120`은 분류 제외(미등록 또는 이상치), 18-24/25-29/30-34/35-39/40-49/50+. **미등록(생년월일 NULL)** vs **이상치(생년월일 있으나 18세 미만/비현실)** 분리. 성별 `unregistered` = male/female/other/undisclosed 외. 교차 `cross[버킷|미등록][성별]`. 만나이는 `calcAgeFromBirthdate`(KST, shared.js).
+- `dev/js/admin-dashboard.js` `renderAgeGenderDistribution(statsUsers)` — 연령 막대=Chart.js bar(미등록/이상치 회색), 성별 도넛=`buildAddressChartOptions({total})` 재사용(분모=전체), 교차표=HTML 테이블(0은 `-`, DB 문자열 미삽입이라 esc 불필요). 전역 `_ageDistChart`/`_genderDistChart`(재생성 전 destroy). `loadAdminData`에서 `statsUsers`(감사용 격리) 전달.
+- `dev/admin/index.html` — 「회원 연령·성별 분포」 카드(배송지 분포 카드 다음). DOM 8종.
+- **DB 변경 없음**(기존 birthdate/gender 컬럼·클라 in-memory 집계).
+- [via planner] 설계 / [via reviewer] GO(감사용 격리·버킷 경계·교차 합 정합·DOM 일치·빈상태 destroy 확인). qa 권장 light.
+
+### 후속 백로그
+- 🟡 **번들 오염(무해)**: `computeAgeGenderStats`·`AGE_GENDER_BUCKETS`가 `storage.js`에 있어 인플루언서 앱 번들에도 포함됨(개인정보 노출 0·집계 함수일 뿐). 기존 `computePrefectureStats`도 동일 위치라 일관적. 정리하려면 `admin-dashboard.js`/`admin-core.js`로 이동(별도 리팩터링, `computePrefectureStats`와 함께).
+- 데이터 누적 후(7/22 시행 이후) 분포·교차표가 의미를 가짐. 현재는 수집률·빈 상태 중심.

--- a/index.html
+++ b/index.html
@@ -4840,6 +4840,53 @@ function computePrefectureStats(users, limit) {
   return { top, unregistered, overseas, total: rows.length };
 }
 
+// 연령·성별 분포 집계 — 대시보드 카드용 (computePrefectureStats 패턴: 추가 쿼리 없이 배열만 집계).
+// 연령대=마케팅 구간(18-24/25-29/30-34/35-39/40-49/50+) + 미등록 + 이상치(생년월일 있으나 18세 미만/비현실).
+// 성별=male/female/other/undisclosed + unregistered(미등록). 연령×성별 교차표 cross 포함.
+// 만 나이는 shared.js calcAgeFromBirthdate(KST) 재사용. 감사용 격리는 호출부(statsUsers)에서 선처리.
+const AGE_GENDER_BUCKETS = ['18-24', '25-29', '30-34', '35-39', '40-49', '50+'];
+function computeAgeGenderStats(users) {
+  const rows = Array.isArray(users) ? users : [];
+  const genders = ['male', 'female', 'other', 'undisclosed'];
+  const bucketOf = (age) => {
+    if (age == null || age < 18 || age > 120) return null; // 미등록/이상치
+    if (age <= 24) return '18-24';
+    if (age <= 29) return '25-29';
+    if (age <= 34) return '30-34';
+    if (age <= 39) return '35-39';
+    if (age <= 49) return '40-49';
+    return '50+';
+  };
+
+  const ageCounts = {}; AGE_GENDER_BUCKETS.forEach(l => { ageCounts[l] = 0; });
+  let ageUnregistered = 0, ageInvalid = 0;
+  const gender = { male: 0, female: 0, other: 0, undisclosed: 0, unregistered: 0 };
+  const cross = {}; [...AGE_GENDER_BUCKETS, '미등록'].forEach(l => { cross[l] = { male: 0, female: 0, other: 0, undisclosed: 0, unregistered: 0 }; });
+
+  let ageRegistered = 0, genderRegistered = 0;
+  for (const row of rows) {
+    const bd = row && row.birthdate ? String(row.birthdate) : '';
+    const age = (typeof calcAgeFromBirthdate === 'function') ? calcAgeFromBirthdate(bd) : null;
+    const bucket = bucketOf(age);
+    const g = genders.includes(row && row.gender) ? row.gender : 'unregistered';
+
+    if (bucket) { ageCounts[bucket]++; ageRegistered++; }
+    else if (bd && age != null) { ageInvalid++; }   // 생년월일 있으나 18세 미만/비현실값 = 이상치
+    else { ageUnregistered++; }                       // 생년월일 미입력/파싱 실패 = 미등록
+
+    gender[g]++;
+    if (g !== 'unregistered') genderRegistered++;
+
+    cross[bucket || '미등록'][g]++;
+  }
+
+  const ageBuckets = AGE_GENDER_BUCKETS.map(l => ({ label: l, count: ageCounts[l] }));
+  ageBuckets.push({ label: '미등록', count: ageUnregistered });
+  if (ageInvalid > 0) ageBuckets.push({ label: '이상치', count: ageInvalid });
+
+  return { total: rows.length, ageRegistered, genderRegistered, ageBuckets, gender, cross, ageInvalid };
+}
+
 // ── 인플루언서 인증/블랙리스트 (관리자 전용, migration 059) ──
 async function setInfluencerVerified(targetId, verify, note = null) {
   if (!db) throw new Error('DB 미연결');


### PR DESCRIPTION
## 변경 요약
- 관리자 대시보드에 회원 연령·성별 분포 카드(수집률·연령대 막대·성별 도넛·연령×성별 교차표).
- 클라 in-memory 집계(statsUsers 재사용·감사용 격리)·**DB 변경 없음**. 데이터 0건 대비 빈 상태·소표본 캡션.

## 요청 외 추가 변경
- 없음

## 관련 사양서
- docs/specs/2026-06-22-age-gender-dashboard.md (구현 결과 기록)

[via planner] 설계 / [via reviewer] GO / qa 권장 light (데이터 0건이라 dev에서 빈 상태·콘솔 확인 수준)