### PR TITLE
fix: 오리엔시트 관리자 모달 레이아웃 + 작성 폼 하단바 가림 수정

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -12,7 +12,7 @@
 // 회귀(2026-05-12 PR #182 머지 직후 발생)를 방지하기 위한 자동 reload 가드.
 // sessionStorage 차단 환경(시크릿 모드 일부, 쿠키 차단)에서는 자연스럽게 skip.
 (function(){
-  var CURRENT_BUILD = 'v1782096755';
+  var CURRENT_BUILD = 'v1782104388';
   if (CURRENT_BUILD.indexOf('__') === 0) return; // 빌드 미적용 (dev/ 직접 열기) 시 skip
   try {
     var prev = sessionStorage.getItem('reverb.adminBuild');
@@ -2091,7 +2091,7 @@ tr.audit-row, .audit-row { background: #fff3e0 !important; }
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-06-22 11:52 · ed34036</span>
+          <span class="admin-build-text">2026-06-22 13:59 · 5ea3326</span>
         </div>
       </div>
     </aside>
@@ -15711,27 +15711,29 @@ function ensureOrientModals() {
   if (document.getElementById('orientCreateModal')) return;
   const html = `
   <div class="modal-overlay" id="orientCreateModal">
-    <div class="modal-body" style="max-width:480px">
+    <div class="modal" style="max-width:480px;width:94vw;border-radius:16px;margin:auto;max-height:88vh;display:flex;flex-direction:column">
       <div class="modal-header"><h2>오리엔시트 링크 발급</h2>
         <button type="button" class="modal-close-btn" onclick="osCloseModal('orientCreateModal')"><span class="material-icons-round notranslate" translate="no">close</span></button></div>
-      <div class="modal-content" id="osCreateForm">
-        <div class="form-group"><label class="form-label">브랜드 <span style="color:var(--pink,#E8344E)">*</span></label>
-          <select id="osCreateBrand" class="form-input" onchange="osOnBrandChange()"></select></div>
-        <div class="form-group"><label class="form-label">광고주 신청 연결 (선택)</label>
-          <select id="osCreateApp" class="form-input"><option value="">연결 안 함</option></select>
-          <div style="font-size:11px;color:var(--muted);margin-top:4px">신청을 연결하면 그 신청의 타입을 자동 승계합니다.</div></div>
-        <div class="form-group"><label class="form-label">모집 타입 (선택)</label>
-          <select id="osCreateType" class="form-input">
-            <option value="">브랜드가 작성 시 선택</option>
-            <option value="reviewer">리뷰어형</option>
-            <option value="seeding">시딩형</option></select>
-          <div style="font-size:11px;color:var(--muted);margin-top:4px">비워두면 브랜드가 작성 첫 화면에서 직접 고릅니다.</div></div>
-      </div>
-      <div class="modal-content hidden" id="osCreateResult">
-        <p style="font-weight:700;margin-bottom:8px">발급되었습니다. 아래 링크를 브랜드에게 전달하세요.</p>
-        <input type="text" id="osCreateLink" class="form-input" readonly onclick="this.select()">
-        <div style="font-size:12px;color:var(--muted);margin-top:6px">작성 기한: <span id="osCreateExpire"></span></div>
-        <button type="button" class="btn btn-primary btn-sm" style="margin-top:10px" onclick="osCopyResultLink()">링크 복사</button>
+      <div class="modal-body" style="padding:20px;overflow-y:auto;flex:1">
+        <div id="osCreateForm">
+          <div class="form-group"><label class="form-label">브랜드 <span style="color:var(--pink,#E8344E)">*</span></label>
+            <select id="osCreateBrand" class="form-input" onchange="osOnBrandChange()"></select></div>
+          <div class="form-group"><label class="form-label">광고주 신청 연결 (선택)</label>
+            <select id="osCreateApp" class="form-input"><option value="">연결 안 함</option></select>
+            <div style="font-size:11px;color:var(--muted);margin-top:4px">신청을 연결하면 그 신청의 타입을 자동 승계합니다.</div></div>
+          <div class="form-group"><label class="form-label">모집 타입 (선택)</label>
+            <select id="osCreateType" class="form-input">
+              <option value="">브랜드가 작성 시 선택</option>
+              <option value="reviewer">리뷰어형</option>
+              <option value="seeding">시딩형</option></select>
+            <div style="font-size:11px;color:var(--muted);margin-top:4px">비워두면 브랜드가 작성 첫 화면에서 직접 고릅니다.</div></div>
+        </div>
+        <div class="hidden" id="osCreateResult">
+          <p style="font-weight:700;margin-bottom:8px">발급되었습니다. 아래 링크를 브랜드에게 전달하세요.</p>
+          <input type="text" id="osCreateLink" class="form-input" readonly onclick="this.select()">
+          <div style="font-size:12px;color:var(--muted);margin-top:6px">작성 기한: <span id="osCreateExpire"></span></div>
+          <button type="button" class="btn btn-primary btn-sm" style="margin-top:10px" onclick="osCopyResultLink()">링크 복사</button>
+        </div>
       </div>
       <div class="modal-footer">
         <button type="button" class="btn btn-ghost" onclick="osCloseModal('orientCreateModal')">닫기</button>
@@ -15740,10 +15742,10 @@ function ensureOrientModals() {
     </div>
   </div>
   <div class="modal-overlay" id="orientDetailModal">
-    <div class="modal-body" style="max-width:560px">
+    <div class="modal" style="max-width:560px;width:94vw;border-radius:16px;margin:auto;max-height:88vh;display:flex;flex-direction:column">
       <div class="modal-header"><h2>오리엔시트 내용</h2>
         <button type="button" class="modal-close-btn" onclick="osCloseModal('orientDetailModal')"><span class="material-icons-round notranslate" translate="no">close</span></button></div>
-      <div class="modal-content" id="osDetailBody"></div>
+      <div class="modal-body" style="padding:20px;overflow-y:auto;flex:1" id="osDetailBody"></div>
       <div class="modal-footer"><button type="button" class="btn btn-ghost" onclick="osCloseModal('orientDetailModal')">닫기</button></div>
     </div>
   </div>`;

--- a/dev/js/admin-orient.js
+++ b/dev/js/admin-orient.js
@@ -269,27 +269,29 @@ function ensureOrientModals() {
   if (document.getElementById('orientCreateModal')) return;
   const html = `
   <div class="modal-overlay" id="orientCreateModal">
-    <div class="modal-body" style="max-width:480px">
+    <div class="modal" style="max-width:480px;width:94vw;border-radius:16px;margin:auto;max-height:88vh;display:flex;flex-direction:column">
       <div class="modal-header"><h2>오리엔시트 링크 발급</h2>
         <button type="button" class="modal-close-btn" onclick="osCloseModal('orientCreateModal')"><span class="material-icons-round notranslate" translate="no">close</span></button></div>
-      <div class="modal-content" id="osCreateForm">
-        <div class="form-group"><label class="form-label">브랜드 <span style="color:var(--pink,#E8344E)">*</span></label>
-          <select id="osCreateBrand" class="form-input" onchange="osOnBrandChange()"></select></div>
-        <div class="form-group"><label class="form-label">광고주 신청 연결 (선택)</label>
-          <select id="osCreateApp" class="form-input"><option value="">연결 안 함</option></select>
-          <div style="font-size:11px;color:var(--muted);margin-top:4px">신청을 연결하면 그 신청의 타입을 자동 승계합니다.</div></div>
-        <div class="form-group"><label class="form-label">모집 타입 (선택)</label>
-          <select id="osCreateType" class="form-input">
-            <option value="">브랜드가 작성 시 선택</option>
-            <option value="reviewer">리뷰어형</option>
-            <option value="seeding">시딩형</option></select>
-          <div style="font-size:11px;color:var(--muted);margin-top:4px">비워두면 브랜드가 작성 첫 화면에서 직접 고릅니다.</div></div>
-      </div>
-      <div class="modal-content hidden" id="osCreateResult">
-        <p style="font-weight:700;margin-bottom:8px">발급되었습니다. 아래 링크를 브랜드에게 전달하세요.</p>
-        <input type="text" id="osCreateLink" class="form-input" readonly onclick="this.select()">
-        <div style="font-size:12px;color:var(--muted);margin-top:6px">작성 기한: <span id="osCreateExpire"></span></div>
-        <button type="button" class="btn btn-primary btn-sm" style="margin-top:10px" onclick="osCopyResultLink()">링크 복사</button>
+      <div class="modal-body" style="padding:20px;overflow-y:auto;flex:1">
+        <div id="osCreateForm">
+          <div class="form-group"><label class="form-label">브랜드 <span style="color:var(--pink,#E8344E)">*</span></label>
+            <select id="osCreateBrand" class="form-input" onchange="osOnBrandChange()"></select></div>
+          <div class="form-group"><label class="form-label">광고주 신청 연결 (선택)</label>
+            <select id="osCreateApp" class="form-input"><option value="">연결 안 함</option></select>
+            <div style="font-size:11px;color:var(--muted);margin-top:4px">신청을 연결하면 그 신청의 타입을 자동 승계합니다.</div></div>
+          <div class="form-group"><label class="form-label">모집 타입 (선택)</label>
+            <select id="osCreateType" class="form-input">
+              <option value="">브랜드가 작성 시 선택</option>
+              <option value="reviewer">리뷰어형</option>
+              <option value="seeding">시딩형</option></select>
+            <div style="font-size:11px;color:var(--muted);margin-top:4px">비워두면 브랜드가 작성 첫 화면에서 직접 고릅니다.</div></div>
+        </div>
+        <div class="hidden" id="osCreateResult">
+          <p style="font-weight:700;margin-bottom:8px">발급되었습니다. 아래 링크를 브랜드에게 전달하세요.</p>
+          <input type="text" id="osCreateLink" class="form-input" readonly onclick="this.select()">
+          <div style="font-size:12px;color:var(--muted);margin-top:6px">작성 기한: <span id="osCreateExpire"></span></div>
+          <button type="button" class="btn btn-primary btn-sm" style="margin-top:10px" onclick="osCopyResultLink()">링크 복사</button>
+        </div>
       </div>
       <div class="modal-footer">
         <button type="button" class="btn btn-ghost" onclick="osCloseModal('orientCreateModal')">닫기</button>
@@ -298,10 +300,10 @@ function ensureOrientModals() {
     </div>
   </div>
   <div class="modal-overlay" id="orientDetailModal">
-    <div class="modal-body" style="max-width:560px">
+    <div class="modal" style="max-width:560px;width:94vw;border-radius:16px;margin:auto;max-height:88vh;display:flex;flex-direction:column">
       <div class="modal-header"><h2>오리엔시트 내용</h2>
         <button type="button" class="modal-close-btn" onclick="osCloseModal('orientDetailModal')"><span class="material-icons-round notranslate" translate="no">close</span></button></div>
-      <div class="modal-content" id="osDetailBody"></div>
+      <div class="modal-body" style="padding:20px;overflow-y:auto;flex:1" id="osDetailBody"></div>
       <div class="modal-footer"><button type="button" class="btn btn-ghost" onclick="osCloseModal('orientDetailModal')">닫기</button></div>
     </div>
   </div>`;

--- a/dev/sales/orient.html
+++ b/dev/sales/orient.html
@@ -46,7 +46,8 @@ body {
   min-height: 100vh;
   background: var(--paper);
   position: relative;
-  padding-bottom: 96px;
+  /* 하단 고정바(footbar) + 모바일 홈 인디케이터(safe-area)에 마지막 입력칸이 가리지 않도록 여백 확보 */
+  padding-bottom: calc(120px + env(safe-area-inset-bottom));
 }
 
 /* ============ HEADER ============ */
@@ -283,7 +284,7 @@ input[type="date"] { min-height: 44px; }
   background: rgba(255,255,255,0.94);
   backdrop-filter: blur(10px); -webkit-backdrop-filter: blur(10px);
   border-top: 1px solid var(--border);
-  padding: 12px 20px;
+  padding: 12px 20px calc(12px + env(safe-area-inset-bottom));
   display: flex; align-items: center; gap: 10px;
   z-index: 90;
 }

--- a/sales/orient.html
+++ b/sales/orient.html
@@ -46,7 +46,8 @@ body {
   min-height: 100vh;
   background: var(--paper);
   position: relative;
-  padding-bottom: 96px;
+  /* 하단 고정바(footbar) + 모바일 홈 인디케이터(safe-area)에 마지막 입력칸이 가리지 않도록 여백 확보 */
+  padding-bottom: calc(120px + env(safe-area-inset-bottom));
 }
 
 /* ============ HEADER ============ */
@@ -283,7 +284,7 @@ input[type="date"] { min-height: 44px; }
   background: rgba(255,255,255,0.94);
   backdrop-filter: blur(10px); -webkit-backdrop-filter: blur(10px);
   border-top: 1px solid var(--border);
-  padding: 12px 20px;
+  padding: 12px 20px calc(12px + env(safe-area-inset-bottom));
   display: flex; align-items: center; gap: 10px;
   z-index: 90;
 }


### PR DESCRIPTION
## 변경 요약
- 관리자 오리엔시트 발급·상세 모달이 화면 우측에 좁게 치우쳐 뜨던 버그 수정 (표준 `.modal` 구조로 교체, 중앙 정렬·본문 스크롤 복구)
- 브랜드 작성 폼 하단 고정바가 마지막 입력칸을 가리던 문제 수정 (하단 여백 확대 + 모바일 안전영역 반영)

## 요청 외 추가 변경
- 없음

## 관련 사양서
- docs/specs/2026-06-18-brand-self-orient-sheet.md (개선 1·2)

[via planner] 원인 분석 · [via reviewer] GO (qa: skip)