### PR TITLE
fix: @cosme 채널 한국어 라벨 엣코스메로

### DIFF
--- a/supabase/migrations/193_merge_cosme_channel_duplicate.sql
+++ b/supabase/migrations/193_merge_cosme_channel_duplicate.sql
@@ -56,7 +56,7 @@ WHERE primary_channel = 'channel-96r9y3';
 UPDATE lookup_values
 SET active        = true,
     sort_order    = 60,
-    name_ko       = '@cosme',
+    name_ko       = '엣코스메',
     name_ja       = '@cosme',
     recruit_types = ARRAY['monitor']
 WHERE kind = 'channel'

--- a/supabase/seed/lookup_values.sql
+++ b/supabase/seed/lookup_values.sql
@@ -19,7 +19,7 @@ INSERT INTO lookup_values (kind, code, name_ko, name_ja, sort_order, active, rec
   ('channel',  'tiktok',           'TikTok',                                     'TikTok',                               30, true, '{gifting,visit}'),
   ('channel',  'youtube',          'YouTube',                                    'YouTube',                              40, true, '{gifting,visit}'),
   ('channel',  'qoo10',            'Qoo10',                                      'Qoo10',                                50, true, '{monitor}'),
-  ('channel',  'cosme',            '@cosme',                                     '@cosme',                               60, true, '{monitor}'),
+  ('channel',  'cosme',            '엣코스메',                                     '@cosme',                               60, true, '{monitor}'),
 
   -- content_type
   ('content_type', 'feed',         '피드',                                        'フィード',                              10, true, '{}'),


### PR DESCRIPTION
통합된 @cosme 채널의 한국어 이름(name_ko)을 '엣코스메'로 설정 (관리자 한국어 화면 표시용). 일본어 이름은 '@cosme' 유지. 마이그레이션 193 + 초기데이터 파일 동기화.