### PR TITLE
fix: orient detail sale URL renders as link

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -12,7 +12,7 @@
 // 회귀(2026-05-12 PR #182 머지 직후 발생)를 방지하기 위한 자동 reload 가드.
 // sessionStorage 차단 환경(시크릿 모드 일부, 쿠키 차단)에서는 자연스럽게 skip.
 (function(){
-  var CURRENT_BUILD = 'v1782199088';
+  var CURRENT_BUILD = 'v1782200479';
   if (CURRENT_BUILD.indexOf('__') === 0) return; // 빌드 미적용 (dev/ 직접 열기) 시 skip
   try {
     var prev = sessionStorage.getItem('reverb.adminBuild');
@@ -2091,7 +2091,7 @@ tr.audit-row, .audit-row { background: #fff3e0 !important; }
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-06-23 16:18 · 01a0e55</span>
+          <span class="admin-build-text">2026-06-23 16:41 · 48c1213</span>
         </div>
       </div>
     </aside>
@@ -15802,6 +15802,11 @@ function osField(label, val) {
   const v = (val == null || val === '') ? '<span style="color:var(--muted)">미입력</span>' : esc(String(val));
   return `<div style="margin-bottom:6px"><span style="color:var(--muted);font-size:12px">${label}</span><br>${v}</div>`;
 }
+// 값이 이미 안전한 HTML(링크 등 — 호출부가 esc·화이트리스트 보장)일 때. esc 미적용.
+function osFieldHtml(label, htmlVal) {
+  const v = htmlVal ? htmlVal : '<span style="color:var(--muted)">미입력</span>';
+  return `<div style="margin-bottom:6px"><span style="color:var(--muted);font-size:12px">${label}</span><br>${v}</div>`;
+}
 function osRange(a, b) { return (a || b) ? `${a || '?'} ~ ${b || '?'}` : ''; }
 
 // 공통 브랜드 카드 (1회)
@@ -15825,7 +15830,7 @@ function osCardDetail(c, idx, catMap) {
     + osField('희망 모집 기간', osRange(r.recruit_start, r.recruit_end));
 
   if (ft === 'proxy_purchase' || ft === 'reviewer') {
-    inner += osField('판매처', sale.market) + osField('판매 URL', osLinkOrText(sale.url))
+    inner += osField('판매처', sale.market) + osFieldHtml('판매 URL', osLinkOrText(sale.url))
       + osField('상시가', sale.price_regular) + osField('세일가', sale.price_sale)
       + osField('대형할인', [sale.event, sale.price_event].filter(Boolean).join(' '));
   }

--- a/dev/js/admin-orient.js
+++ b/dev/js/admin-orient.js
@@ -261,6 +261,11 @@ function osField(label, val) {
   const v = (val == null || val === '') ? '<span style="color:var(--muted)">미입력</span>' : esc(String(val));
   return `<div style="margin-bottom:6px"><span style="color:var(--muted);font-size:12px">${label}</span><br>${v}</div>`;
 }
+// 값이 이미 안전한 HTML(링크 등 — 호출부가 esc·화이트리스트 보장)일 때. esc 미적용.
+function osFieldHtml(label, htmlVal) {
+  const v = htmlVal ? htmlVal : '<span style="color:var(--muted)">미입력</span>';
+  return `<div style="margin-bottom:6px"><span style="color:var(--muted);font-size:12px">${label}</span><br>${v}</div>`;
+}
 function osRange(a, b) { return (a || b) ? `${a || '?'} ~ ${b || '?'}` : ''; }
 
 // 공통 브랜드 카드 (1회)
@@ -284,7 +289,7 @@ function osCardDetail(c, idx, catMap) {
     + osField('희망 모집 기간', osRange(r.recruit_start, r.recruit_end));
 
   if (ft === 'proxy_purchase' || ft === 'reviewer') {
-    inner += osField('판매처', sale.market) + osField('판매 URL', osLinkOrText(sale.url))
+    inner += osField('판매처', sale.market) + osFieldHtml('판매 URL', osLinkOrText(sale.url))
       + osField('상시가', sale.price_regular) + osField('세일가', sale.price_sale)
       + osField('대형할인', [sale.event, sale.price_event].filter(Boolean).join(' '));
   }


### PR DESCRIPTION
## 변경 요약
- 오리엔시트 상세 모달의 판매 URL이 `osField`(esc 적용)로 들어가 `osLinkOrText`의 `<a>` 태그가 이중 이스케이프되어 원문 텍스트로 표시되던 버그 수정
- `osFieldHtml`(esc 미적용) 헬퍼 분리. URL 텍스트는 `osLinkOrText` 내부에서 esc + http/https 화이트리스트라 XSS 안전

## 요청 외 추가 변경
- 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)