### PR TITLE
fix: brand-app 신규 badge clears when processing

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -12,7 +12,7 @@
 // 회귀(2026-05-12 PR #182 머지 직후 발생)를 방지하기 위한 자동 reload 가드.
 // sessionStorage 차단 환경(시크릿 모드 일부, 쿠키 차단)에서는 자연스럽게 skip.
 (function(){
-  var CURRENT_BUILD = 'v1782280923';
+  var CURRENT_BUILD = 'v1782286186';
   if (CURRENT_BUILD.indexOf('__') === 0) return; // 빌드 미적용 (dev/ 직접 열기) 시 skip
   try {
     var prev = sessionStorage.getItem('reverb.adminBuild');
@@ -2091,7 +2091,7 @@ tr.audit-row, .audit-row { background: #fff3e0 !important; }
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-06-24 15:02 · 27b0a54</span>
+          <span class="admin-build-text">2026-06-24 16:29 · 2dc506a</span>
         </div>
       </div>
     </aside>
@@ -12337,8 +12337,16 @@ async function quickChangeBrandAppProductStatus(id, idx, newStatus) {
     copy.status = newStatus;
     return copy;
   });
+  var patch = {products: nextProducts};
+  // 첫 검수 진입: 신청 전체 상태가 아직 '신규'인데 제품을 '신규' 밖으로 올리면
+  // 신청 전체 상태도 함께 전이 → 사이드바 「신규」 배지가 줄어들도록 (배지는 신청 단위 status='new' 카운트).
+  if (cur.status === 'new' && newStatus !== 'new') {
+    patch.status = newStatus;
+    patch.reviewed_by = currentUser?.id || null;
+    patch.reviewed_at = new Date().toISOString();
+  }
   var expectedVersion = cur.version;
-  var result = await updateBrandApplication(id, {products: nextProducts}, expectedVersion);
+  var result = await updateBrandApplication(id, patch, expectedVersion);
   if (result.conflict) {
     toast('다른 관리자가 먼저 처리했습니다. 목록을 새로고침합니다.', 'warn');
     await loadBrandApplications();
@@ -12350,8 +12358,10 @@ async function quickChangeBrandAppProductStatus(id, idx, newStatus) {
     return;
   }
   cur.products = nextProducts;
+  if (patch.status) cur.status = patch.status;   // 신청 전체 상태 전이 캐시 동기화
   _syncBrandAppCur(cur, result, expectedVersion);
   _refreshBrandAppHistoryButton(id);
+  if (patch.status && typeof refreshBrandAppBadge === 'function') refreshBrandAppBadge();   // 신규 배지 즉시 갱신
   // 상태 변경은 필터 (NN)건 카운트와 매칭 행 노출에 즉시 영향 — 목록 전체 재렌더
   // 일정 인라인 편집과는 다른 흐름이라 의도적으로 셀-only 재렌더 미사용
   renderBrandApplicationsList();

--- a/dev/js/admin-brand.js
+++ b/dev/js/admin-brand.js
@@ -209,8 +209,16 @@ async function quickChangeBrandAppProductStatus(id, idx, newStatus) {
     copy.status = newStatus;
     return copy;
   });
+  var patch = {products: nextProducts};
+  // 첫 검수 진입: 신청 전체 상태가 아직 '신규'인데 제품을 '신규' 밖으로 올리면
+  // 신청 전체 상태도 함께 전이 → 사이드바 「신규」 배지가 줄어들도록 (배지는 신청 단위 status='new' 카운트).
+  if (cur.status === 'new' && newStatus !== 'new') {
+    patch.status = newStatus;
+    patch.reviewed_by = currentUser?.id || null;
+    patch.reviewed_at = new Date().toISOString();
+  }
   var expectedVersion = cur.version;
-  var result = await updateBrandApplication(id, {products: nextProducts}, expectedVersion);
+  var result = await updateBrandApplication(id, patch, expectedVersion);
   if (result.conflict) {
     toast('다른 관리자가 먼저 처리했습니다. 목록을 새로고침합니다.', 'warn');
     await loadBrandApplications();
@@ -222,8 +230,10 @@ async function quickChangeBrandAppProductStatus(id, idx, newStatus) {
     return;
   }
   cur.products = nextProducts;
+  if (patch.status) cur.status = patch.status;   // 신청 전체 상태 전이 캐시 동기화
   _syncBrandAppCur(cur, result, expectedVersion);
   _refreshBrandAppHistoryButton(id);
+  if (patch.status && typeof refreshBrandAppBadge === 'function') refreshBrandAppBadge();   // 신규 배지 즉시 갱신
   // 상태 변경은 필터 (NN)건 카운트와 매칭 행 노출에 즉시 영향 — 목록 전체 재렌더
   // 일정 인라인 편집과는 다른 흐름이라 의도적으로 셀-only 재렌더 미사용
   renderBrandApplicationsList();


### PR DESCRIPTION
사이드바 「신규」 배지가 처리 시 줄어들도록 — 제품 상태를 '신규' 밖으로 올릴 때 신청 전체 상태도 함께 전이.

🤖 Generated with [Claude Code](https://claude.com/claude-code)