### PR TITLE
feat: searchable multi-filter '이 검색 결과만 선택' (prod hotfix)

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -12,7 +12,7 @@
 // 회귀(2026-05-12 PR #182 머지 직후 발생)를 방지하기 위한 자동 reload 가드.
 // sessionStorage 차단 환경(시크릿 모드 일부, 쿠키 차단)에서는 자연스럽게 skip.
 (function(){
-  var CURRENT_BUILD = 'v1782097745';
+  var CURRENT_BUILD = 'v1782291271';
   if (CURRENT_BUILD.indexOf('__') === 0) return; // 빌드 미적용 (dev/ 직접 열기) 시 skip
   try {
     var prev = sessionStorage.getItem('reverb.adminBuild');
@@ -2076,7 +2076,7 @@ tr.audit-row, .audit-row { background: #fff3e0 !important; }
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-06-22 12:09 · 4efb529</span>
+          <span class="admin-build-text">2026-06-24 17:54 · 4280533</span>
         </div>
       </div>
     </aside>
@@ -11005,6 +11005,7 @@ function createMultiFilter(containerId, allLabel, options, onChange, opts = {}) 
   // 검색형(opt-in) — 옵션이 많은 드롭다운(캠페인 등)에서만 사용. 기본 false → 기존 전 페인 무영향
   const searchHtml = opts.searchable
     ? `<div class="mf-search-box"><input type="search" class="mf-search" autocomplete="off" data-lpignore="true" data-1p-ignore="true" placeholder="${esc(opts.searchPlaceholder || '検索')}"></div>`
+      + `<button type="button" class="mf-search-only" style="display:none;width:calc(100% - 16px);margin:0 8px 4px;font-size:12px;font-weight:700;color:var(--pink,#E8344E);background:var(--light-pink,#FDEEF4);border:1px solid var(--pink,#E8344E);border-radius:6px;padding:5px 8px;cursor:pointer">이 검색 결과만 선택</button>`
     : '';
   const emptyHtml = opts.searchable ? `<div class="mf-search-empty" style="display:none">일치하는 항목이 없습니다</div>` : '';
   // 드롭다운 아이템 생성 — 초기 상태: 모두 비체크 = 필터 없음 (전체 표시)
@@ -11066,6 +11067,8 @@ function createMultiFilter(containerId, allLabel, options, onChange, opts = {}) 
   if (opts.searchable) {
     const si = drop.querySelector('.mf-search');
     const emptyEl = drop.querySelector('.mf-search-empty');
+    const onlyBtn = drop.querySelector('.mf-search-only');
+    const allItem = drop.querySelector('.all-item');
     const optItems = [...drop.querySelectorAll('.mf-item:not(.all-item)')];
     if (si) si.oninput = () => {
       const q = (si.value || '').trim().toLowerCase();
@@ -11078,6 +11081,16 @@ function createMultiFilter(containerId, allLabel, options, onChange, opts = {}) 
         if (show) visible++;
       });
       if (emptyEl) emptyEl.style.display = visible === 0 ? '' : 'none';
+      // 검색 중엔 「전체」 항목을 숨기고 「이 검색 결과만 선택」 버튼으로 대체(검색어 지우면 「전체」 복귀).
+      if (allItem) allItem.style.display = q ? 'none' : '';
+      if (onlyBtn) onlyBtn.style.display = (q && visible > 0) ? '' : 'none';
+    };
+    // 검색에 보이는 항목만 선택(나머지 해제) → 그 캠페인들만 필터링. 「전체」 체크 상태도 자동 해제(부분 선택).
+    // itemCbs는 createMultiFilter 시점 스냅샷 — reorderSelectedFirst 로 DOM 순서가 바뀌어도 display 기준 판정이라 정합성 무영향.
+    if (onlyBtn) onlyBtn.onclick = (e) => {
+      e.stopPropagation();
+      itemCbs.forEach(c => { c.checked = (c.closest('.mf-item')?.style.display !== 'none'); });
+      update();
     };
   }
   // 외부에서 prev 복원 후 다시 호출할 수 있도록 노출

--- a/dev/js/admin-core.js
+++ b/dev/js/admin-core.js
@@ -461,6 +461,7 @@ function createMultiFilter(containerId, allLabel, options, onChange, opts = {}) 
   // 검색형(opt-in) — 옵션이 많은 드롭다운(캠페인 등)에서만 사용. 기본 false → 기존 전 페인 무영향
   const searchHtml = opts.searchable
     ? `<div class="mf-search-box"><input type="search" class="mf-search" autocomplete="off" data-lpignore="true" data-1p-ignore="true" placeholder="${esc(opts.searchPlaceholder || '検索')}"></div>`
+      + `<button type="button" class="mf-search-only" style="display:none;width:calc(100% - 16px);margin:0 8px 4px;font-size:12px;font-weight:700;color:var(--pink,#E8344E);background:var(--light-pink,#FDEEF4);border:1px solid var(--pink,#E8344E);border-radius:6px;padding:5px 8px;cursor:pointer">이 검색 결과만 선택</button>`
     : '';
   const emptyHtml = opts.searchable ? `<div class="mf-search-empty" style="display:none">일치하는 항목이 없습니다</div>` : '';
   // 드롭다운 아이템 생성 — 초기 상태: 모두 비체크 = 필터 없음 (전체 표시)
@@ -522,6 +523,8 @@ function createMultiFilter(containerId, allLabel, options, onChange, opts = {}) 
   if (opts.searchable) {
     const si = drop.querySelector('.mf-search');
     const emptyEl = drop.querySelector('.mf-search-empty');
+    const onlyBtn = drop.querySelector('.mf-search-only');
+    const allItem = drop.querySelector('.all-item');
     const optItems = [...drop.querySelectorAll('.mf-item:not(.all-item)')];
     if (si) si.oninput = () => {
       const q = (si.value || '').trim().toLowerCase();
@@ -534,6 +537,16 @@ function createMultiFilter(containerId, allLabel, options, onChange, opts = {}) 
         if (show) visible++;
       });
       if (emptyEl) emptyEl.style.display = visible === 0 ? '' : 'none';
+      // 검색 중엔 「전체」 항목을 숨기고 「이 검색 결과만 선택」 버튼으로 대체(검색어 지우면 「전체」 복귀).
+      if (allItem) allItem.style.display = q ? 'none' : '';
+      if (onlyBtn) onlyBtn.style.display = (q && visible > 0) ? '' : 'none';
+    };
+    // 검색에 보이는 항목만 선택(나머지 해제) → 그 캠페인들만 필터링. 「전체」 체크 상태도 자동 해제(부분 선택).
+    // itemCbs는 createMultiFilter 시점 스냅샷 — reorderSelectedFirst 로 DOM 순서가 바뀌어도 display 기준 판정이라 정합성 무영향.
+    if (onlyBtn) onlyBtn.onclick = (e) => {
+      e.stopPropagation();
+      itemCbs.forEach(c => { c.checked = (c.closest('.mf-item')?.style.display !== 'none'); });
+      update();
     };
   }
   // 외부에서 prev 복원 후 다시 호출할 수 있도록 노출


### PR DESCRIPTION
## 변경 요약
- 검색형 다중필터에 「이 검색 결과만 선택」 버튼 + 검색 중 「전체」 항목 숨김
- 결과물 관리 캠페인 필터에서 브랜드 검색 후 그 브랜드만 필터링 가능

## 운영 적용 범위
- dev 검증·reviewer GO 완료된 admin-core.js 변경만 운영 적용
- 오리엔시트 재설계 등 dev 보류 기능 미포함 (소스 패치 후 main 재빌드)
- dev 원본 커밋: 760fea6(버튼) + 55df706(전체 숨김)

🤖 Generated with [Claude Code](https://claude.com/claude-code)