### PR TITLE
docs: 오리엔시트 발급 메일 미리보기 카탈로그 등록

### DIFF
--- a/docs/email-templates/index.html
+++ b/docs/email-templates/index.html
@@ -172,6 +172,27 @@
     </div>
   </div>
 
+  <!-- ⑤-2 오리엔시트 작성 요청 -->
+  <div class="card">
+    <div class="card-tag tag-brand">Brand</div>
+    <div class="card-title">오리엔시트 작성 요청</div>
+    <div class="card-desc">관리자가 작성 링크를 발급하면 브랜드 담당자에게 작성 링크 자동 발송.</div>
+    <div class="card-condition">
+      <div class="cc-label">언제 보내요?</div>
+      <div class="cc-text">관리자가 「오리엔시트 발급」을 누르면 브랜드 담당자에게 「캠페인 정보를 여기서 작성해 주세요」 링크를 보냅니다.</div>
+      <div class="cc-timing"><strong>발송 시점:</strong> 오리엔시트 발급 즉시 (수신자 이메일 없으면 발송 건너뜀)</div>
+    </div>
+    <div class="card-meta">
+      <div><b>트리거:</b> create_orient_sheet 발급 직후 notify-orient-sheet invoke</div>
+      <div><b>수신자:</b> 서베이=applicant_email / 비-서베이=brands 대표 담당자</div>
+      <div><b>언어:</b> KO</div>
+    </div>
+    <div class="card-actions">
+      <a class="btn btn-primary" href="orient-sheet-invite.preview.html">미리보기</a>
+      <a class="btn btn-ghost" href="orient-sheet-invite.html">원본</a>
+    </div>
+  </div>
+
   <!-- ⑥ 결과물 — 영수증 승인 -->
   <div class="card">
     <div class="card-tag tag-infl">Influencer</div>

--- a/docs/email-templates/orient-sheet-invite.preview.html
+++ b/docs/email-templates/orient-sheet-invite.preview.html
@@ -1,0 +1,96 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+<meta charset="UTF-8">
+<title>REVERB JP · 오리엔시트 작성 요청 미리보기</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link rel="stylesheet" as="style" crossorigin href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable.min.css">
+<link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700;800&family=Noto+Sans+JP:wght@400;500;700&family=Noto+Sans+KR:wght@400;500;700&display=swap" rel="stylesheet">
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { font-family: 'Manrope','Pretendard Variable',Pretendard,'Noto Sans JP',sans-serif; background:#EEECE6; color:#161618; padding:40px 20px 80px; min-height:100vh; }
+  .head { max-width:640px; margin:0 auto 28px; }
+  .back-link { display:inline-block; font-size:12px; color:#666; text-decoration:none; margin-bottom:14px; letter-spacing:0.04em; }
+  .back-link:hover { color:#161618; }
+  h1 { font-size:22px; font-weight:800; letter-spacing:-0.02em; margin-bottom:6px; }
+  .sub { font-size:13px; color:#666; }
+  .mail-card { max-width:640px; margin:0 auto; background:#fff; border-radius:14px; box-shadow:0 4px 20px rgba(0,0,0,0.06); overflow:hidden; }
+  .mail-head { background:#F7F4EE; border-bottom:1px solid #EAEAE4; padding:18px 22px; }
+  .mail-from { font-size:11px; color:#888; letter-spacing:0.08em; text-transform:uppercase; margin-bottom:6px; font-weight:700; }
+  .mail-meta { font-size:12px; color:#555; line-height:1.7; }
+  .mail-meta b { color:#161618; font-weight:600; }
+  .mail-subject { font-size:16px; font-weight:700; color:#161618; margin-top:8px; letter-spacing:-0.01em; }
+  .mail-body { padding:32px 28px; background:#fff; }
+  details.meta { max-width:640px; margin:18px auto 0; background:#fff; border-radius:10px; padding:14px 18px; box-shadow:0 2px 8px rgba(0,0,0,0.04); font-size:12px; color:#444; }
+  details.meta summary { cursor:pointer; font-weight:700; color:#161618; }
+  details.meta dl { margin-top:10px; display:grid; grid-template-columns:120px 1fr; gap:6px 12px; }
+  details.meta dt { color:#888; font-size:11px; text-transform:uppercase; letter-spacing:0.06em; }
+  details.meta code { font-family:monospace; background:#F7F4EE; padding:1px 6px; border-radius:4px; font-size:11px; }
+  .sample-note { max-width:640px; margin:0 auto 12px; padding:10px 14px; background:#FFF6E5; border:1px solid #F0D6A0; border-radius:8px; font-size:11px; color:#8A6A2A; }
+</style>
+</head>
+<body>
+
+<div class="head">
+  <a href="index.html" class="back-link">← 메일 목록</a>
+  <h1>오리엔시트 작성 요청</h1>
+  <p class="sub">관리자가 오리엔시트 작성 링크를 발급하면 Edge Function이 브랜드 담당자에게 자동 발송</p>
+</div>
+
+<p class="sample-note">📌 본문은 샘플 데이터로 placeholder 치환된 결과입니다. 템플릿 수정 시 본 미리보기도 같이 갱신해주세요.</p>
+
+<div class="mail-card">
+  <div class="mail-head">
+    <div class="mail-from">Preview · Orient Sheet Invite</div>
+    <div class="mail-meta">
+      <div><b>From:</b> REVERB JP &lt;noreply@globalreverb.com&gt;</div>
+      <div><b>To:</b> brand@test.com (서베이 연결 건 applicant_email / 비-서베이 건 brands 대표 담당자)</div>
+    </div>
+    <div class="mail-subject">[REVERB JP] 캠페인 오리엔시트 작성 요청 — REVERB 코스메틱</div>
+  </div>
+  <div class="mail-body">
+    <!-- ── orient-sheet-invite.html (샘플 데이터 적용) ── -->
+    <div style="font-family:'Manrope','Pretendard Variable','Noto Sans KR',Arial,sans-serif;color:#222;max-width:560px">
+      <h2 style="color:#E8344E;margin:0 0 8px;font-size:20px;font-weight:800;letter-spacing:-0.02em">캠페인 오리엔시트 작성을 요청드립니다</h2>
+      <p style="margin:0 0 18px;color:#666;font-size:13px">REVERB 코스메틱 담당자님</p>
+      <p style="margin:0 0 20px;font-size:13px;color:#444;line-height:1.7">
+        캠페인 진행에 필요한 제품·콘텐츠 정보를 아래 링크에서 작성해 주세요.
+        별도 로그인 없이 바로 작성하실 수 있으며, 작성 중 자동 저장됩니다.
+      </p>
+      <div style="text-align:center;margin:0 0 22px">
+        <a href="https://sales-dev.globalreverb.com/orient?token=8f3a1c20-7b4e-49d2-9a11-6c2f0e5d8a77" style="display:inline-block;background:#E8344E;color:#fff;text-decoration:none;font-weight:700;font-size:14px;padding:13px 28px;border-radius:10px">오리엔시트 작성하기</a>
+      </div>
+      <div style="background:#F7F4EE;border:1px solid #EAEAE4;border-radius:12px;padding:16px 18px;margin-bottom:20px;font-size:13px">
+        <div style="color:#888;font-size:11px;letter-spacing:0.08em;margin-bottom:4px;text-transform:uppercase;font-weight:700">작성 기한</div>
+        <div style="font-weight:700;color:#E8344E">2026년 7월 24일</div>
+        <div style="color:#888;font-size:12px;margin-top:10px;line-height:1.6">버튼이 눌리지 않으면 아래 주소를 복사해 브라우저에 붙여넣어 주세요.</div>
+        <div style="font-family:monospace;font-size:12px;color:#555;word-break:break-all;margin-top:4px">https://sales-dev.globalreverb.com/orient?token=8f3a1c20-7b4e-49d2-9a11-6c2f0e5d8a77</div>
+      </div>
+      <div style="border-top:1px solid #EAEAE4;margin-top:26px;padding-top:18px">
+        <h3 style="font-size:11px;color:#161618;letter-spacing:0.15em;margin-bottom:12px;text-transform:uppercase;font-weight:700">문의</h3>
+        <table style="border-collapse:collapse;width:100%;font-size:13px">
+          <tr><td style="padding:6px 0;color:#888;font-size:10px;letter-spacing:0.12em;text-transform:uppercase;font-weight:700;width:100px">LINE</td><td style="padding:6px 0"><a href="https://line.me/R/ti/p/@reverb.jp" style="color:#E8344E;text-decoration:none;font-weight:600">@reverb.jp</a></td></tr>
+          <tr><td style="padding:6px 0;color:#888;font-size:10px;letter-spacing:0.12em;text-transform:uppercase;font-weight:700">KakaoTalk</td><td style="padding:6px 0;font-weight:600">byhyunho7</td></tr>
+          <tr><td style="padding:6px 0;color:#888;font-size:10px;letter-spacing:0.12em;text-transform:uppercase;font-weight:700">TEL</td><td style="padding:6px 0;font-family:monospace;font-weight:600">010-2550-1511</td></tr>
+        </table>
+      </div>
+      <p style="margin-top:24px;font-size:11px;color:#999;letter-spacing:0.02em">© JFUN Corp. · 株式会社ジェイファン</p>
+    </div>
+  </div>
+</div>
+
+<details class="meta">
+  <summary>발송 메타 / Placeholder 매핑</summary>
+  <dl>
+    <dt>트리거</dt><dd>관리자 발급(create_orient_sheet) 직후 admin-orient.js 가 notify-orient-sheet 를 invoke</dd>
+    <dt>수신자</dt><dd>서베이 연결 건: brand_applications.applicant_email(없으면 email) / 비-서베이 건: brands 대표 담당자(contacts is_primary → primary_email)</dd>
+    <dt>원본</dt><dd><a href="orient-sheet-invite.html">orient-sheet-invite.html</a></dd>
+    <dt>Subject</dt><dd><code>[REVERB JP] 캠페인 오리엔시트 작성 요청 — {brand_name}</code></dd>
+    <dt>주요 placeholder</dt><dd><code>{{brand_name}}</code> <code>{{link}}</code> <code>{{deadline}}</code></dd>
+    <dt>발송 후 동작</dt><dd>발송 성공 + 연결 신청 있으면 신청 단계를 orient_sheet_sent 로 자동 전진(역행 방지·연결 건만, 함수 advance_to_orient_sheet_sent)</dd>
+  </dl>
+</details>
+
+</body>
+</html>


### PR DESCRIPTION
## 변경 요약
- `docs/email-templates/` 카탈로그에 「오리엔시트 작성 요청」 메일 카드 + 미리보기(`orient-sheet-invite.preview.html`) 추가
- docs-only (코드·DB·메일 발송 동작 무관)

## 요청 외 추가 변경
- 없음

## 관련
- 발급 메일 기능 PR #582 후속