### PR TITLE
fix: 발급 메일 LINE 제거 + 템플릿 주석 누출 수정

### DIFF
--- a/docs/email-templates/orient-sheet-invite.html
+++ b/docs/email-templates/orient-sheet-invite.html
@@ -13,7 +13,7 @@
     {{deadline}}     작성 기한(YYYY. M. D. 한국어 표기, 발급+30일)
 
   Note:
-    문의처(LINE/카톡/TEL)는 brand-ack-reviewer 와 동일 하드코딩.
+    문의처(카톡/TEL)는 하드코딩. 브랜드 발송 메일은 LINE 제외(2026-06-24 사용자 요청).
     브랜드 대상 메일이라 인플루언서 4줄 푸터 의무 없음.
 -->
 <div style="font-family:'Manrope','Pretendard Variable','Noto Sans KR',Arial,sans-serif;color:#222;max-width:560px">
@@ -35,8 +35,7 @@
   <div style="border-top:1px solid #EAEAE4;margin-top:26px;padding-top:18px">
     <h3 style="font-size:11px;color:#161618;letter-spacing:0.15em;margin-bottom:12px;text-transform:uppercase;font-weight:700">문의</h3>
     <table style="border-collapse:collapse;width:100%;font-size:13px">
-      <tr><td style="padding:6px 0;color:#888;font-size:10px;letter-spacing:0.12em;text-transform:uppercase;font-weight:700;width:100px">LINE</td><td style="padding:6px 0"><a href="https://line.me/R/ti/p/@reverb.jp" style="color:#E8344E;text-decoration:none;font-weight:600">@reverb.jp</a></td></tr>
-      <tr><td style="padding:6px 0;color:#888;font-size:10px;letter-spacing:0.12em;text-transform:uppercase;font-weight:700">KakaoTalk</td><td style="padding:6px 0;font-weight:600">byhyunho7</td></tr>
+      <tr><td style="padding:6px 0;color:#888;font-size:10px;letter-spacing:0.12em;text-transform:uppercase;font-weight:700;width:100px">KakaoTalk</td><td style="padding:6px 0;font-weight:600">byhyunho7</td></tr>
       <tr><td style="padding:6px 0;color:#888;font-size:10px;letter-spacing:0.12em;text-transform:uppercase;font-weight:700">TEL</td><td style="padding:6px 0;font-family:monospace;font-weight:600">010-2550-1511</td></tr>
     </table>
   </div>

--- a/docs/email-templates/orient-sheet-invite.preview.html
+++ b/docs/email-templates/orient-sheet-invite.preview.html
@@ -70,8 +70,7 @@
       <div style="border-top:1px solid #EAEAE4;margin-top:26px;padding-top:18px">
         <h3 style="font-size:11px;color:#161618;letter-spacing:0.15em;margin-bottom:12px;text-transform:uppercase;font-weight:700">문의</h3>
         <table style="border-collapse:collapse;width:100%;font-size:13px">
-          <tr><td style="padding:6px 0;color:#888;font-size:10px;letter-spacing:0.12em;text-transform:uppercase;font-weight:700;width:100px">LINE</td><td style="padding:6px 0"><a href="https://line.me/R/ti/p/@reverb.jp" style="color:#E8344E;text-decoration:none;font-weight:600">@reverb.jp</a></td></tr>
-          <tr><td style="padding:6px 0;color:#888;font-size:10px;letter-spacing:0.12em;text-transform:uppercase;font-weight:700">KakaoTalk</td><td style="padding:6px 0;font-weight:600">byhyunho7</td></tr>
+          <tr><td style="padding:6px 0;color:#888;font-size:10px;letter-spacing:0.12em;text-transform:uppercase;font-weight:700;width:100px">KakaoTalk</td><td style="padding:6px 0;font-weight:600">byhyunho7</td></tr>
           <tr><td style="padding:6px 0;color:#888;font-size:10px;letter-spacing:0.12em;text-transform:uppercase;font-weight:700">TEL</td><td style="padding:6px 0;font-family:monospace;font-weight:600">010-2550-1511</td></tr>
         </table>
       </div>

--- a/supabase/functions/notify-orient-sheet/_templates/orient-sheet-invite.html
+++ b/supabase/functions/notify-orient-sheet/_templates/orient-sheet-invite.html
@@ -13,7 +13,7 @@
     {{deadline}}     작성 기한(YYYY. M. D. 한국어 표기, 발급+30일)
 
   Note:
-    문의처(LINE/카톡/TEL)는 brand-ack-reviewer 와 동일 하드코딩.
+    문의처(카톡/TEL)는 하드코딩. 브랜드 발송 메일은 LINE 제외(2026-06-24 사용자 요청).
     브랜드 대상 메일이라 인플루언서 4줄 푸터 의무 없음.
 -->
 <div style="font-family:'Manrope','Pretendard Variable','Noto Sans KR',Arial,sans-serif;color:#222;max-width:560px">
@@ -35,8 +35,7 @@
   <div style="border-top:1px solid #EAEAE4;margin-top:26px;padding-top:18px">
     <h3 style="font-size:11px;color:#161618;letter-spacing:0.15em;margin-bottom:12px;text-transform:uppercase;font-weight:700">문의</h3>
     <table style="border-collapse:collapse;width:100%;font-size:13px">
-      <tr><td style="padding:6px 0;color:#888;font-size:10px;letter-spacing:0.12em;text-transform:uppercase;font-weight:700;width:100px">LINE</td><td style="padding:6px 0"><a href="https://line.me/R/ti/p/@reverb.jp" style="color:#E8344E;text-decoration:none;font-weight:600">@reverb.jp</a></td></tr>
-      <tr><td style="padding:6px 0;color:#888;font-size:10px;letter-spacing:0.12em;text-transform:uppercase;font-weight:700">KakaoTalk</td><td style="padding:6px 0;font-weight:600">byhyunho7</td></tr>
+      <tr><td style="padding:6px 0;color:#888;font-size:10px;letter-spacing:0.12em;text-transform:uppercase;font-weight:700;width:100px">KakaoTalk</td><td style="padding:6px 0;font-weight:600">byhyunho7</td></tr>
       <tr><td style="padding:6px 0;color:#888;font-size:10px;letter-spacing:0.12em;text-transform:uppercase;font-weight:700">TEL</td><td style="padding:6px 0;font-family:monospace;font-weight:600">010-2550-1511</td></tr>
     </table>
   </div>

--- a/supabase/functions/notify-orient-sheet/index.ts
+++ b/supabase/functions/notify-orient-sheet/index.ts
@@ -195,7 +195,10 @@ Deno.serve(async (req: Request) => {
 
     // 5) 메일 발송
     const subject = `[REVERB JP] 캠페인 오리엔시트 작성 요청 — ${brandName}`;
-    const html = render(TEMPLATES["orient-sheet-invite"], {
+    // HTML 주석 strip — templates.ts 인라인 원본 주석이 메일 본문에 누출되는 것 차단
+    // (notify-deliverable-decision 동일 패턴, 메모리 mail_template_comment_leak)
+    const tpl = TEMPLATES["orient-sheet-invite"].replace(/<!--[\s\S]*?-->/g, "");
+    const html = render(tpl, {
       brand_name: escapeHtml(brandName),
       link: escapeHtml(link),
       deadline: escapeHtml(deadline),
@@ -207,7 +210,6 @@ Deno.serve(async (req: Request) => {
       `작성 링크: ${link}\n` +
       `작성 기한: ${deadline}\n\n` +
       `[문의]\n` +
-      `· LINE @reverb.jp — https://line.me/R/ti/p/@reverb.jp\n` +
       `· 카카오톡 byhyunho7\n` +
       `· 연락처 010-2550-1511\n`;
 

--- a/supabase/functions/notify-orient-sheet/templates.ts
+++ b/supabase/functions/notify-orient-sheet/templates.ts
@@ -19,7 +19,7 @@ export const TEMPLATES: Record<string, string> = {
     {{deadline}}     작성 기한(YYYY. M. D. 한국어 표기, 발급+30일)
 
   Note:
-    문의처(LINE/카톡/TEL)는 brand-ack-reviewer 와 동일 하드코딩.
+    문의처(카톡/TEL)는 하드코딩. 브랜드 발송 메일은 LINE 제외(2026-06-24 사용자 요청).
     브랜드 대상 메일이라 인플루언서 4줄 푸터 의무 없음.
 -->
 <div style="font-family:'Manrope','Pretendard Variable','Noto Sans KR',Arial,sans-serif;color:#222;max-width:560px">
@@ -41,8 +41,7 @@ export const TEMPLATES: Record<string, string> = {
   <div style="border-top:1px solid #EAEAE4;margin-top:26px;padding-top:18px">
     <h3 style="font-size:11px;color:#161618;letter-spacing:0.15em;margin-bottom:12px;text-transform:uppercase;font-weight:700">문의</h3>
     <table style="border-collapse:collapse;width:100%;font-size:13px">
-      <tr><td style="padding:6px 0;color:#888;font-size:10px;letter-spacing:0.12em;text-transform:uppercase;font-weight:700;width:100px">LINE</td><td style="padding:6px 0"><a href="https://line.me/R/ti/p/@reverb.jp" style="color:#E8344E;text-decoration:none;font-weight:600">@reverb.jp</a></td></tr>
-      <tr><td style="padding:6px 0;color:#888;font-size:10px;letter-spacing:0.12em;text-transform:uppercase;font-weight:700">KakaoTalk</td><td style="padding:6px 0;font-weight:600">byhyunho7</td></tr>
+      <tr><td style="padding:6px 0;color:#888;font-size:10px;letter-spacing:0.12em;text-transform:uppercase;font-weight:700;width:100px">KakaoTalk</td><td style="padding:6px 0;font-weight:600">byhyunho7</td></tr>
       <tr><td style="padding:6px 0;color:#888;font-size:10px;letter-spacing:0.12em;text-transform:uppercase;font-weight:700">TEL</td><td style="padding:6px 0;font-family:monospace;font-weight:600">010-2550-1511</td></tr>
     </table>
   </div>


### PR DESCRIPTION
## 변경 요약
- 브랜드 발송 오리엔시트 발급 메일 문의처에서 LINE 제거(카톡·TEL만)
- Edge Function이 템플릿 인라인 주석을 메일 본문에 누출하던 버그 수정(주석 strip)

## 요청 외 추가 변경
- 주석 누출 방지(LINE 제거 검증 중 발견, notify-deliverable-decision 동일 패턴)

🤖 Generated with [Claude Code](https://claude.com/claude-code)