### PR TITLE
fix: 인플 캠페인 상세에 최소 팔로워수 표시

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -12,7 +12,7 @@
 // 회귀(2026-05-12 PR #182 머지 직후 발생)를 방지하기 위한 자동 reload 가드.
 // sessionStorage 차단 환경(시크릿 모드 일부, 쿠키 차단)에서는 자연스럽게 skip.
 (function(){
-  var CURRENT_BUILD = 'v1782360762';
+  var CURRENT_BUILD = 'v1782378972';
   if (CURRENT_BUILD.indexOf('__') === 0) return; // 빌드 미적용 (dev/ 직접 열기) 시 skip
   try {
     var prev = sessionStorage.getItem('reverb.adminBuild');
@@ -2091,7 +2091,7 @@ tr.audit-row, .audit-row { background: #fff3e0 !important; }
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-06-25 13:12 · 5477a1f</span>
+          <span class="admin-build-text">2026-06-25 18:16 · 52b1668</span>
         </div>
       </div>
     </aside>

--- a/dev/js/application.js
+++ b/dev/js/application.js
@@ -125,6 +125,10 @@ async function openCampaign(id) {
             rows.push(`<div style="${ROW}"><div style="${KEY}">${t('detail.submissionEnd')}</div><div style="${VAL};font-weight:600;color:var(--ink)">${formatDate(camp.submission_end)}</div></div>`);
           }
           rows.push(`<div style="${ROW}"><div style="${KEY}">${t('detail.recruitSlots')}</div><div style="${VAL}">${camp.slots}${t('detail.peopleUnit')}</div></div>`);
+          // 최소 팔로워수 — 시딩·방문형만(리뷰어는 저장 시 0이라 자연 제외). 미리보기와 정합
+          if (camp.min_followers) {
+            rows.push(`<div style="${ROW}"><div style="${KEY}">${t('detail.minFollowers')}</div><div style="${VAL}">${camp.min_followers.toLocaleString()}${t('detail.minFollowersSuffix')}</div></div>`);
+          }
           // 리뷰어(monitor) 캠페인은 당선 발표·리워드 행 제외
           if (!isMonitor) {
             rows.push(`<div style="${ROW}"><div style="${KEY}">${t('detail.winnerAnnounce')}</div><div style="${VAL}">${esc(camp.winner_announce || t('detail.winnerAnnounceValue'))}</div></div>`);

--- a/dev/lib/i18n/ja.js
+++ b/dev/lib/i18n/ja.js
@@ -368,6 +368,8 @@ window.I18N_JA = {
     recruitType: '募集タイプ',
     recruitPeriod: '募集期間',
     recruitSlots: '募集人数',
+    minFollowers: '最小フォロワー数',
+    minFollowersSuffix: '人以上',
     winnerAnnounce: '当選発表',
     winnerAnnounceValue: '選考後、LINEにてご連絡',
     postDeadline: '投稿締切日',

--- a/dev/lib/i18n/ko.js
+++ b/dev/lib/i18n/ko.js
@@ -355,6 +355,8 @@ window.I18N_KO = {
     recruitType: '모집 타입',
     recruitPeriod: '모집 기간',
     recruitSlots: '모집 인원',
+    minFollowers: '최소 팔로워수',
+    minFollowersSuffix: '명 이상',
     winnerAnnounce: '당선 발표',
     winnerAnnounceValue: '선정 후 LINE으로 연락',
     postDeadline: '게시 마감일',

--- a/index.html
+++ b/index.html
@@ -3172,6 +3172,8 @@ window.I18N_JA = {
     recruitType: '募集タイプ',
     recruitPeriod: '募集期間',
     recruitSlots: '募集人数',
+    minFollowers: '最小フォロワー数',
+    minFollowersSuffix: '人以上',
     winnerAnnounce: '当選発表',
     winnerAnnounceValue: '選考後、LINEにてご連絡',
     postDeadline: '投稿締切日',
@@ -3871,6 +3873,8 @@ window.I18N_KO = {
     recruitType: '모집 타입',
     recruitPeriod: '모집 기간',
     recruitSlots: '모집 인원',
+    minFollowers: '최소 팔로워수',
+    minFollowersSuffix: '명 이상',
     winnerAnnounce: '당선 발표',
     winnerAnnounceValue: '선정 후 LINE으로 연락',
     postDeadline: '게시 마감일',
@@ -10060,6 +10064,10 @@ async function openCampaign(id) {
             rows.push(`<div style="${ROW}"><div style="${KEY}">${t('detail.submissionEnd')}</div><div style="${VAL};font-weight:600;color:var(--ink)">${formatDate(camp.submission_end)}</div></div>`);
           }
           rows.push(`<div style="${ROW}"><div style="${KEY}">${t('detail.recruitSlots')}</div><div style="${VAL}">${camp.slots}${t('detail.peopleUnit')}</div></div>`);
+          // 최소 팔로워수 — 시딩·방문형만(리뷰어는 저장 시 0이라 자연 제외). 미리보기와 정합
+          if (camp.min_followers) {
+            rows.push(`<div style="${ROW}"><div style="${KEY}">${t('detail.minFollowers')}</div><div style="${VAL}">${camp.min_followers.toLocaleString()}${t('detail.minFollowersSuffix')}</div></div>`);
+          }
           // 리뷰어(monitor) 캠페인은 당선 발표·리워드 행 제외
           if (!isMonitor) {
             rows.push(`<div style="${ROW}"><div style="${KEY}">${t('detail.winnerAnnounce')}</div><div style="${VAL}">${esc(camp.winner_announce || t('detail.winnerAnnounceValue'))}</div></div>`);


### PR DESCRIPTION
## 변경 요약
- 인플루언서 캠페인 상세 표에 최소 팔로워수 행 추가(시딩·방문형). 미리보기엔 있으나 인플 화면에 없던 버그
- i18n ja/ko 키 추가

## 요청 외 추가 변경
- 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)