### PR TITLE
feat(orient): 예시 이미지 「파일 업로드 / URL 공유」 버튼 분리 + 확인 칩

### DIFF
--- a/dev/sales/orient.html
+++ b/dev/sales/orient.html
@@ -255,7 +255,21 @@ input[type="date"] { min-height: 44px; }
 .img-status.uploading { color: var(--ink-soft); }
 .img-status.done { color: var(--success); }
 .img-status.error { color: var(--brand); }
-.rep-item .img-url-input { margin-top: 8px; }
+/* 선택(버튼 2개) / URL 입력+확인 */
+.img-choose { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
+.img-url-entry { display: flex; align-items: center; gap: 8px; }
+.img-url-entry .img-url-input { flex: 1; min-width: 0; }
+.img-url-confirm {
+  background: var(--brand); color: #fff; border: none; border-radius: 9px;
+  padding: 10px 16px; font-size: 13.5px; font-weight: 800;
+  font-family: inherit; cursor: pointer; flex-shrink: 0;
+}
+.img-url-cancel {
+  background: none; color: var(--ink-mute); border: none;
+  padding: 10px 6px; font-size: 13px; font-weight: 700;
+  font-family: inherit; cursor: pointer; flex-shrink: 0;
+}
+.img-url-cancel:hover { color: var(--brand); }
 /* 업로드된 파일 칩 (URL 입력칸 대체) */
 .img-file-chip {
   display: flex; align-items: center; gap: 8px;
@@ -774,34 +788,42 @@ function uploadDisplayName(name, value) {
   } catch (e) { return '업로드된 파일'; }
 }
 
-// 한 행 = 「올린 파일」 또는 「링크(URL)」 둘 중 하나. 업로드 시 URL 입력칸 대신 파일 칩 표시.
-//   .img-value(hidden) = 수집용 단일 값 / .img-url-input = URL 모드 표시·입력칸(값을 .img-value 로 미러)
+// 한 행 = 「올린 파일」 또는 「공유 링크(URL)」. 3상태: ①선택(버튼2개) ②URL 입력+확인 ③칩(결과).
+//   .img-value(hidden) = 수집용 단일 값. 칩은 업로드·URL확인 공용(둘 다 「제거」로 선택 상태 복귀).
 function imageRowHtml(value, type, name) {
   const isUpload = type === 'upload';
-  const dispName = isUpload ? uploadDisplayName(name, value) : '';
-  const safeHref = (isUpload && /^https:\/\//i.test(value)) ? value : '';   // https만 링크(스킴 주입 방어)
+  const hasValue = !!value;
+  const chipIcon = isUpload ? 'attachment' : 'link';
+  const chipLabel = isUpload ? uploadDisplayName(name, value) : value;
+  const chipHref = isUpload
+    ? (/^https:\/\//i.test(value) ? value : '')           // 업로드 파일은 https만
+    : (/^https?:\/\//i.test(value) ? value : '');          // 공유 링크는 http/https
   return `<div class="rep-item" data-img data-img-type="${isUpload ? 'upload' : 'url'}"${isUpload && name ? ` data-img-name="${escAttr(name)}"` : ''}>
     <div class="rep-head"><span class="rep-num">이미지·파일</span>
       <button type="button" class="rep-remove" onclick="removeRepRow(this)"><span class="material-icons-outlined notranslate" translate="no">close</span>삭제</button></div>
     <div class="field">
       <label>파일 첨부 또는 공유 링크</label>
       <input type="hidden" class="img-value" value="${escAttr(value)}">
-      <!-- 업로드 모드: 파일 칩 -->
-      <div class="img-file-chip${isUpload ? '' : ' hidden'}">
-        <span class="material-icons-outlined notranslate" translate="no">attachment</span>
-        <a class="img-file-name" href="${escAttr(safeHref)}" target="_blank" rel="noopener">${escAttr(dispName)}</a>
+      <!-- ③ 칩(파일 업로드 결과 또는 URL 확인 결과) -->
+      <div class="img-file-chip${hasValue ? '' : ' hidden'}">
+        <span class="img-chip-icon material-icons-outlined notranslate" translate="no">${chipIcon}</span>
+        <a class="img-file-name" href="${escAttr(chipHref)}" target="_blank" rel="noopener">${escAttr(chipLabel)}</a>
         <button type="button" class="img-file-clear" onclick="clearImageUpload(this)"><span class="material-icons-outlined notranslate" translate="no">close</span>제거</button>
       </div>
-      <!-- 선택 모드: 파일 선택 버튼 + URL 입력 -->
-      <div class="img-pick${isUpload ? ' hidden' : ''}">
-        <div class="img-upload">
-          <button type="button" class="img-upload-btn" onclick="pickImageFile(this)"><span class="material-icons-outlined notranslate" translate="no">upload_file</span>파일 선택</button>
-          <input type="file" class="img-file" accept=".jpg,.jpeg,.png,.webp,.pdf,.docx,.xlsx,.pptx,image/jpeg,image/png,image/webp,application/pdf" hidden onchange="onImageFilePick(this)">
-          <span class="img-status"></span>
-        </div>
-        <div class="field-hint" style="margin-top:8px">이미지·PDF·문서(워드·엑셀·PPT)를 올리거나, 아래에 공유 링크(URL)를 직접 붙여넣어도 됩니다.</div>
-        <input type="url" class="img-url-input" placeholder="https://..." value="${isUpload ? '' : escAttr(value)}" oninput="onImgUrlInput(this)">
+      <!-- ① 선택: 파일 업로드 / URL 공유 -->
+      <div class="img-choose${hasValue ? ' hidden' : ''}">
+        <button type="button" class="img-upload-btn" onclick="pickImageFile(this)"><span class="material-icons-outlined notranslate" translate="no">upload_file</span>파일 업로드</button>
+        <button type="button" class="img-upload-btn" onclick="showUrlEntry(this)"><span class="material-icons-outlined notranslate" translate="no">link</span>URL 공유</button>
+        <input type="file" class="img-file" accept=".jpg,.jpeg,.png,.webp,.pdf,.docx,.xlsx,.pptx,image/jpeg,image/png,image/webp,application/pdf" hidden onchange="onImageFilePick(this)">
+        <span class="img-status"></span>
       </div>
+      <!-- ② URL 입력 + 확인 -->
+      <div class="img-url-entry hidden">
+        <input type="url" class="img-url-input" placeholder="https://..." onkeydown="if(event.key==='Enter'){event.preventDefault();confirmUrlEntry(this);}">
+        <button type="button" class="img-url-confirm" onclick="confirmUrlEntry(this)">확인</button>
+        <button type="button" class="img-url-cancel" onclick="cancelUrlEntry(this)">취소</button>
+      </div>
+      <div class="field-hint img-choose-hint${hasValue ? ' hidden' : ''}" style="margin-top:8px">이미지·PDF·문서(워드·엑셀·PPT)는 「파일 업로드」, 외부 링크는 「URL 공유」를 눌러 주세요.</div>
     </div>
   </div>`;
 }
@@ -1190,16 +1212,12 @@ async function onImageFilePick(input) {
     if (!url) throw new Error('no_url');
 
     if (!row.isConnected) return;     // 업로드 중 행이 삭제됐으면 무시
-    // 값 저장 + 업로드 모드로 전환(URL 입력칸 숨기고 파일 칩 표시 → URL이 바뀐 듯 보이지 않게)
+    // 값 저장 + 칩으로 전환(파일명 표시 → URL이 바뀐 듯 보이지 않게)
     row.querySelector('.img-value').value = url;
     row.dataset.imgType = 'upload';
     row.dataset.imgName = file.name;
-    const nameEl = row.querySelector('.img-file-name');
-    nameEl.textContent = file.name;
-    nameEl.setAttribute('href', url);
-    row.querySelector('.img-file-chip').classList.remove('hidden');
-    row.querySelector('.img-pick').classList.add('hidden');
     setUploadStatus(row, '', '');
+    renderImgChip(row, 'attachment', file.name, /^https:\/\//i.test(url) ? url : '');
     onInput();                        // 성공 후에만 저장 트리거(빈값 중간저장 방지)
   } catch (e) {
     console.error('[orient upload]', e);
@@ -1212,29 +1230,64 @@ async function onImageFilePick(input) {
   }
 }
 
-// URL 직접 입력 시: 입력값을 수집용 .img-value 로 미러 + 종류를 url로 표시
-function onImgUrlInput(inp) {
-  const row = inp.closest('[data-img]');
-  if (row) {
-    row.querySelector('.img-value').value = inp.value;
-    row.dataset.imgType = 'url';
-    setUploadStatus(row, '', '');
-  }
+// 칩(결과) 표시 + 선택·URL입력 영역 숨김. 업로드·URL확인 공용
+function renderImgChip(row, icon, label, href) {
+  row.querySelector('.img-chip-icon').textContent = icon;
+  const a = row.querySelector('.img-file-name');
+  a.textContent = label;
+  a.setAttribute('href', href || '');
+  row.querySelector('.img-file-chip').classList.remove('hidden');
+  row.querySelector('.img-choose').classList.add('hidden');
+  row.querySelector('.img-url-entry').classList.add('hidden');
+  row.querySelector('.img-choose-hint').classList.add('hidden');
+}
+// 선택 상태(버튼 2개)로 복귀
+function showChooseState(row) {
+  row.querySelector('.img-file-chip').classList.add('hidden');
+  row.querySelector('.img-url-entry').classList.add('hidden');
+  row.querySelector('.img-choose').classList.remove('hidden');
+  row.querySelector('.img-choose-hint').classList.remove('hidden');
+}
+
+// 「URL 공유」 클릭 → URL 입력칸 노출
+function showUrlEntry(btn) {
+  const row = btn.closest('[data-img]');
+  row.querySelector('.img-choose').classList.add('hidden');
+  row.querySelector('.img-choose-hint').classList.add('hidden');
+  const entry = row.querySelector('.img-url-entry');
+  entry.classList.remove('hidden');
+  const inp = entry.querySelector('.img-url-input');
+  inp.focus();
+}
+// URL 입력 취소 → 선택 상태로
+function cancelUrlEntry(btn) {
+  const row = btn.closest('[data-img]');
+  row.querySelector('.img-url-input').value = '';
+  showChooseState(row);
+}
+// URL 확인 → 칩으로 전환(파일 업로드처럼 「제거」 가능)
+function confirmUrlEntry(btn) {
+  const row = btn.closest('[data-img]');
+  const raw = row.querySelector('.img-url-input').value;
+  const url = normalizeUrl(raw);
+  if (!url) { showToast('공유 링크(URL)를 입력해 주세요.'); return; }
+  row.querySelector('.img-value').value = url;
+  row.dataset.imgType = 'url';
+  delete row.dataset.imgName;
+  renderImgChip(row, 'link', url, /^https?:\/\//i.test(url) ? url : '');
   onInput();
 }
 
-// 업로드한 파일 제거 → 선택 모드(파일 선택 + URL 입력)로 복귀. 행은 유지
+// 칩 「제거」 → 값 비우고 선택 상태(버튼 2개)로 복귀. 행은 유지
 function clearImageUpload(btn) {
   const row = btn.closest('[data-img]');
   if (!row) return;
   row.querySelector('.img-value').value = '';
   row.dataset.imgType = 'url';
   delete row.dataset.imgName;
-  const urlInput = row.querySelector('.img-url-input');
-  if (urlInput) urlInput.value = '';
-  row.querySelector('.img-file-chip').classList.add('hidden');
-  row.querySelector('.img-pick').classList.remove('hidden');
+  row.querySelector('.img-url-input').value = '';
   setUploadStatus(row, '', '');
+  showChooseState(row);
   onInput();
 }
 
@@ -1393,6 +1446,10 @@ function findInvalidField() {
       return { message: `${n}번째 카드의 제품명을 입력해 주세요.`, card: el, target: el.querySelector('.f-product-name') };
     if ((c.form_type === 'reviewer' || c.form_type === 'proxy_purchase') && !c.sale.price_regular)
       return { message: `${n}번째 카드의 상시가를 입력해 주세요.`, card: el, target: el.querySelector('.f-price-regular') };
+    // URL을 입력하고 「확인」을 누르지 않아 값이 저장되지 않은 행 방지
+    const pendingUrl = el.querySelector('.img-url-entry:not(.hidden) .img-url-input');
+    if (pendingUrl && pendingUrl.value.trim())
+      return { message: `${n}번째 카드의 공유 링크를 「확인」 버튼으로 확정해 주세요.`, card: el, target: pendingUrl };
   }
   return null;
 }

--- a/sales/orient.html
+++ b/sales/orient.html
@@ -255,7 +255,21 @@ input[type="date"] { min-height: 44px; }
 .img-status.uploading { color: var(--ink-soft); }
 .img-status.done { color: var(--success); }
 .img-status.error { color: var(--brand); }
-.rep-item .img-url-input { margin-top: 8px; }
+/* 선택(버튼 2개) / URL 입력+확인 */
+.img-choose { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
+.img-url-entry { display: flex; align-items: center; gap: 8px; }
+.img-url-entry .img-url-input { flex: 1; min-width: 0; }
+.img-url-confirm {
+  background: var(--brand); color: #fff; border: none; border-radius: 9px;
+  padding: 10px 16px; font-size: 13.5px; font-weight: 800;
+  font-family: inherit; cursor: pointer; flex-shrink: 0;
+}
+.img-url-cancel {
+  background: none; color: var(--ink-mute); border: none;
+  padding: 10px 6px; font-size: 13px; font-weight: 700;
+  font-family: inherit; cursor: pointer; flex-shrink: 0;
+}
+.img-url-cancel:hover { color: var(--brand); }
 /* 업로드된 파일 칩 (URL 입력칸 대체) */
 .img-file-chip {
   display: flex; align-items: center; gap: 8px;
@@ -774,34 +788,42 @@ function uploadDisplayName(name, value) {
   } catch (e) { return '업로드된 파일'; }
 }
 
-// 한 행 = 「올린 파일」 또는 「링크(URL)」 둘 중 하나. 업로드 시 URL 입력칸 대신 파일 칩 표시.
-//   .img-value(hidden) = 수집용 단일 값 / .img-url-input = URL 모드 표시·입력칸(값을 .img-value 로 미러)
+// 한 행 = 「올린 파일」 또는 「공유 링크(URL)」. 3상태: ①선택(버튼2개) ②URL 입력+확인 ③칩(결과).
+//   .img-value(hidden) = 수집용 단일 값. 칩은 업로드·URL확인 공용(둘 다 「제거」로 선택 상태 복귀).
 function imageRowHtml(value, type, name) {
   const isUpload = type === 'upload';
-  const dispName = isUpload ? uploadDisplayName(name, value) : '';
-  const safeHref = (isUpload && /^https:\/\//i.test(value)) ? value : '';   // https만 링크(스킴 주입 방어)
+  const hasValue = !!value;
+  const chipIcon = isUpload ? 'attachment' : 'link';
+  const chipLabel = isUpload ? uploadDisplayName(name, value) : value;
+  const chipHref = isUpload
+    ? (/^https:\/\//i.test(value) ? value : '')           // 업로드 파일은 https만
+    : (/^https?:\/\//i.test(value) ? value : '');          // 공유 링크는 http/https
   return `<div class="rep-item" data-img data-img-type="${isUpload ? 'upload' : 'url'}"${isUpload && name ? ` data-img-name="${escAttr(name)}"` : ''}>
     <div class="rep-head"><span class="rep-num">이미지·파일</span>
       <button type="button" class="rep-remove" onclick="removeRepRow(this)"><span class="material-icons-outlined notranslate" translate="no">close</span>삭제</button></div>
     <div class="field">
       <label>파일 첨부 또는 공유 링크</label>
       <input type="hidden" class="img-value" value="${escAttr(value)}">
-      <!-- 업로드 모드: 파일 칩 -->
-      <div class="img-file-chip${isUpload ? '' : ' hidden'}">
-        <span class="material-icons-outlined notranslate" translate="no">attachment</span>
-        <a class="img-file-name" href="${escAttr(safeHref)}" target="_blank" rel="noopener">${escAttr(dispName)}</a>
+      <!-- ③ 칩(파일 업로드 결과 또는 URL 확인 결과) -->
+      <div class="img-file-chip${hasValue ? '' : ' hidden'}">
+        <span class="img-chip-icon material-icons-outlined notranslate" translate="no">${chipIcon}</span>
+        <a class="img-file-name" href="${escAttr(chipHref)}" target="_blank" rel="noopener">${escAttr(chipLabel)}</a>
         <button type="button" class="img-file-clear" onclick="clearImageUpload(this)"><span class="material-icons-outlined notranslate" translate="no">close</span>제거</button>
       </div>
-      <!-- 선택 모드: 파일 선택 버튼 + URL 입력 -->
-      <div class="img-pick${isUpload ? ' hidden' : ''}">
-        <div class="img-upload">
-          <button type="button" class="img-upload-btn" onclick="pickImageFile(this)"><span class="material-icons-outlined notranslate" translate="no">upload_file</span>파일 선택</button>
-          <input type="file" class="img-file" accept=".jpg,.jpeg,.png,.webp,.pdf,.docx,.xlsx,.pptx,image/jpeg,image/png,image/webp,application/pdf" hidden onchange="onImageFilePick(this)">
-          <span class="img-status"></span>
-        </div>
-        <div class="field-hint" style="margin-top:8px">이미지·PDF·문서(워드·엑셀·PPT)를 올리거나, 아래에 공유 링크(URL)를 직접 붙여넣어도 됩니다.</div>
-        <input type="url" class="img-url-input" placeholder="https://..." value="${isUpload ? '' : escAttr(value)}" oninput="onImgUrlInput(this)">
+      <!-- ① 선택: 파일 업로드 / URL 공유 -->
+      <div class="img-choose${hasValue ? ' hidden' : ''}">
+        <button type="button" class="img-upload-btn" onclick="pickImageFile(this)"><span class="material-icons-outlined notranslate" translate="no">upload_file</span>파일 업로드</button>
+        <button type="button" class="img-upload-btn" onclick="showUrlEntry(this)"><span class="material-icons-outlined notranslate" translate="no">link</span>URL 공유</button>
+        <input type="file" class="img-file" accept=".jpg,.jpeg,.png,.webp,.pdf,.docx,.xlsx,.pptx,image/jpeg,image/png,image/webp,application/pdf" hidden onchange="onImageFilePick(this)">
+        <span class="img-status"></span>
       </div>
+      <!-- ② URL 입력 + 확인 -->
+      <div class="img-url-entry hidden">
+        <input type="url" class="img-url-input" placeholder="https://..." onkeydown="if(event.key==='Enter'){event.preventDefault();confirmUrlEntry(this);}">
+        <button type="button" class="img-url-confirm" onclick="confirmUrlEntry(this)">확인</button>
+        <button type="button" class="img-url-cancel" onclick="cancelUrlEntry(this)">취소</button>
+      </div>
+      <div class="field-hint img-choose-hint${hasValue ? ' hidden' : ''}" style="margin-top:8px">이미지·PDF·문서(워드·엑셀·PPT)는 「파일 업로드」, 외부 링크는 「URL 공유」를 눌러 주세요.</div>
     </div>
   </div>`;
 }
@@ -1190,16 +1212,12 @@ async function onImageFilePick(input) {
     if (!url) throw new Error('no_url');
 
     if (!row.isConnected) return;     // 업로드 중 행이 삭제됐으면 무시
-    // 값 저장 + 업로드 모드로 전환(URL 입력칸 숨기고 파일 칩 표시 → URL이 바뀐 듯 보이지 않게)
+    // 값 저장 + 칩으로 전환(파일명 표시 → URL이 바뀐 듯 보이지 않게)
     row.querySelector('.img-value').value = url;
     row.dataset.imgType = 'upload';
     row.dataset.imgName = file.name;
-    const nameEl = row.querySelector('.img-file-name');
-    nameEl.textContent = file.name;
-    nameEl.setAttribute('href', url);
-    row.querySelector('.img-file-chip').classList.remove('hidden');
-    row.querySelector('.img-pick').classList.add('hidden');
     setUploadStatus(row, '', '');
+    renderImgChip(row, 'attachment', file.name, /^https:\/\//i.test(url) ? url : '');
     onInput();                        // 성공 후에만 저장 트리거(빈값 중간저장 방지)
   } catch (e) {
     console.error('[orient upload]', e);
@@ -1212,29 +1230,64 @@ async function onImageFilePick(input) {
   }
 }
 
-// URL 직접 입력 시: 입력값을 수집용 .img-value 로 미러 + 종류를 url로 표시
-function onImgUrlInput(inp) {
-  const row = inp.closest('[data-img]');
-  if (row) {
-    row.querySelector('.img-value').value = inp.value;
-    row.dataset.imgType = 'url';
-    setUploadStatus(row, '', '');
-  }
+// 칩(결과) 표시 + 선택·URL입력 영역 숨김. 업로드·URL확인 공용
+function renderImgChip(row, icon, label, href) {
+  row.querySelector('.img-chip-icon').textContent = icon;
+  const a = row.querySelector('.img-file-name');
+  a.textContent = label;
+  a.setAttribute('href', href || '');
+  row.querySelector('.img-file-chip').classList.remove('hidden');
+  row.querySelector('.img-choose').classList.add('hidden');
+  row.querySelector('.img-url-entry').classList.add('hidden');
+  row.querySelector('.img-choose-hint').classList.add('hidden');
+}
+// 선택 상태(버튼 2개)로 복귀
+function showChooseState(row) {
+  row.querySelector('.img-file-chip').classList.add('hidden');
+  row.querySelector('.img-url-entry').classList.add('hidden');
+  row.querySelector('.img-choose').classList.remove('hidden');
+  row.querySelector('.img-choose-hint').classList.remove('hidden');
+}
+
+// 「URL 공유」 클릭 → URL 입력칸 노출
+function showUrlEntry(btn) {
+  const row = btn.closest('[data-img]');
+  row.querySelector('.img-choose').classList.add('hidden');
+  row.querySelector('.img-choose-hint').classList.add('hidden');
+  const entry = row.querySelector('.img-url-entry');
+  entry.classList.remove('hidden');
+  const inp = entry.querySelector('.img-url-input');
+  inp.focus();
+}
+// URL 입력 취소 → 선택 상태로
+function cancelUrlEntry(btn) {
+  const row = btn.closest('[data-img]');
+  row.querySelector('.img-url-input').value = '';
+  showChooseState(row);
+}
+// URL 확인 → 칩으로 전환(파일 업로드처럼 「제거」 가능)
+function confirmUrlEntry(btn) {
+  const row = btn.closest('[data-img]');
+  const raw = row.querySelector('.img-url-input').value;
+  const url = normalizeUrl(raw);
+  if (!url) { showToast('공유 링크(URL)를 입력해 주세요.'); return; }
+  row.querySelector('.img-value').value = url;
+  row.dataset.imgType = 'url';
+  delete row.dataset.imgName;
+  renderImgChip(row, 'link', url, /^https?:\/\//i.test(url) ? url : '');
   onInput();
 }
 
-// 업로드한 파일 제거 → 선택 모드(파일 선택 + URL 입력)로 복귀. 행은 유지
+// 칩 「제거」 → 값 비우고 선택 상태(버튼 2개)로 복귀. 행은 유지
 function clearImageUpload(btn) {
   const row = btn.closest('[data-img]');
   if (!row) return;
   row.querySelector('.img-value').value = '';
   row.dataset.imgType = 'url';
   delete row.dataset.imgName;
-  const urlInput = row.querySelector('.img-url-input');
-  if (urlInput) urlInput.value = '';
-  row.querySelector('.img-file-chip').classList.add('hidden');
-  row.querySelector('.img-pick').classList.remove('hidden');
+  row.querySelector('.img-url-input').value = '';
   setUploadStatus(row, '', '');
+  showChooseState(row);
   onInput();
 }
 
@@ -1393,6 +1446,10 @@ function findInvalidField() {
       return { message: `${n}번째 카드의 제품명을 입력해 주세요.`, card: el, target: el.querySelector('.f-product-name') };
     if ((c.form_type === 'reviewer' || c.form_type === 'proxy_purchase') && !c.sale.price_regular)
       return { message: `${n}번째 카드의 상시가를 입력해 주세요.`, card: el, target: el.querySelector('.f-price-regular') };
+    // URL을 입력하고 「확인」을 누르지 않아 값이 저장되지 않은 행 방지
+    const pendingUrl = el.querySelector('.img-url-entry:not(.hidden) .img-url-input');
+    if (pendingUrl && pendingUrl.value.trim())
+      return { message: `${n}번째 카드의 공유 링크를 「확인」 버튼으로 확정해 주세요.`, card: el, target: pendingUrl };
   }
   return null;
 }


### PR DESCRIPTION
## 변경 요약
- 예시 이미지 행을 「파일 업로드」/「URL 공유」 버튼 2개로 시작
- 파일 업로드는 탐색기 열기(기존), URL 공유는 입력칸+「확인」 → 확인 시 파일처럼 칩으로 바뀌어 「제거」 가능(Enter도 확인)
- 제출 시 「확인」 안 한 URL이 있으면 그 위치로 이동·강조해 누락 방지

## 요청 외 추가 변경
- 없음

## 관련 사양서
- docs/specs/2026-06-18-brand-self-orient-sheet.md