### PR TITLE
docs(orient): 예시 이미지 안내문구·라벨을 파일 업로드 지원에 맞게 갱신

### DIFF
--- a/dev/sales/orient.html
+++ b/dev/sales/orient.html
@@ -922,8 +922,8 @@ function cardHtml(id, card) {
           <textarea class="f-ng" placeholder="콘텐츠에 사용하면 안 되는 표현·내용을 적어 주세요." oninput="onInput()">${escAttr(card.ng)}</textarea></div>
         <div class="field"><label>추가 안내 · 필독 사항</label>
           <textarea class="f-cautions" placeholder="인플루언서가 꼭 알아야 할 안내사항을 적어 주세요." oninput="onInput()">${escAttr(card.cautions)}</textarea></div>
-        <div class="field"><label>예시 이미지 링크</label>
-          <div class="field-hint" style="margin-top:0;margin-bottom:8px">참고용 이미지가 있으면 링크(URL)를 넣어 주세요. (파일 직접 첨부는 추후 지원 예정)</div>
+        <div class="field"><label>예시 이미지·자료</label>
+          <div class="field-hint" style="margin-top:0;margin-bottom:8px">참고용 이미지·자료가 있으면 「파일 업로드」로 올리거나 「URL 공유」로 링크를 넣어 주세요. (이미지·PDF·문서, 최대 5개)</div>
           <div class="img-list">${imgRows}</div>
           <button type="button" class="add-btn" onclick="addImageRow(this)"><span class="material-icons-outlined notranslate" translate="no">add</span>이미지·파일 추가</button></div>
       </div>

--- a/sales/orient.html
+++ b/sales/orient.html
@@ -922,8 +922,8 @@ function cardHtml(id, card) {
           <textarea class="f-ng" placeholder="콘텐츠에 사용하면 안 되는 표현·내용을 적어 주세요." oninput="onInput()">${escAttr(card.ng)}</textarea></div>
         <div class="field"><label>추가 안내 · 필독 사항</label>
           <textarea class="f-cautions" placeholder="인플루언서가 꼭 알아야 할 안내사항을 적어 주세요." oninput="onInput()">${escAttr(card.cautions)}</textarea></div>
-        <div class="field"><label>예시 이미지 링크</label>
-          <div class="field-hint" style="margin-top:0;margin-bottom:8px">참고용 이미지가 있으면 링크(URL)를 넣어 주세요. (파일 직접 첨부는 추후 지원 예정)</div>
+        <div class="field"><label>예시 이미지·자료</label>
+          <div class="field-hint" style="margin-top:0;margin-bottom:8px">참고용 이미지·자료가 있으면 「파일 업로드」로 올리거나 「URL 공유」로 링크를 넣어 주세요. (이미지·PDF·문서, 최대 5개)</div>
           <div class="img-list">${imgRows}</div>
           <button type="button" class="add-btn" onclick="addImageRow(this)"><span class="material-icons-outlined notranslate" translate="no">add</span>이미지·파일 추가</button></div>
       </div>


### PR DESCRIPTION
## 변경 요약
- 예시 이미지 라벨 '예시 이미지 링크' → '예시 이미지·자료', 안내문구를 파일 업로드+URL 공유 둘 다 안내하도록 갱신(추후 지원 예정 문구 제거)

## 요청 외 추가 변경
- 없음