### PR TITLE
feat(orient-admin): 상세 모달 드래그·리사이즈 + 너비별 2/1열 + 새창 열기

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -12,7 +12,7 @@
 // 회귀(2026-05-12 PR #182 머지 직후 발생)를 방지하기 위한 자동 reload 가드.
 // sessionStorage 차단 환경(시크릿 모드 일부, 쿠키 차단)에서는 자연스럽게 skip.
 (function(){
-  var CURRENT_BUILD = 'v1782462963';
+  var CURRENT_BUILD = 'v1782463842';
   if (CURRENT_BUILD.indexOf('__') === 0) return; // 빌드 미적용 (dev/ 직접 열기) 시 skip
   try {
     var prev = sessionStorage.getItem('reverb.adminBuild');
@@ -2091,7 +2091,7 @@ tr.audit-row, .audit-row { background: #fff3e0 !important; }
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-06-26 17:36 · eca095a</span>
+          <span class="admin-build-text">2026-06-26 17:50 · d19229a</span>
         </div>
       </div>
     </aside>
@@ -11515,6 +11515,8 @@ const DRAGGABLE_ADMIN_MODALS = new Set([
   'companyModal', 'brandAssignModal', 'brandDetailModal', 'newBrandAppModal', 'brandAppMemoModal', 'brandAppHistoryModal', 'linkCampaignModal', 'brandAppOrientListModal',
   // 공지·기준데이터·계정
   'adminNoticeEditModal', 'adminNoticeViewModal', 'lookupEditModal', 'faqEditModal', 'addAdminModal', 'adminEmailSubsModal',
+  // 오리엔시트 (동적 생성 — ensureOrientModals 가 initDraggableModals 재호출로 옵저버 부착)
+  'orientDetailModal', 'orientCreateModal',
   // 메시지
   'admMsgModal', 'admHideModal',
   // 일괄 발송 (PR 3) — 대상 선택·발송 상세는 내용이 길어 드래그·리사이즈 유용
@@ -11657,6 +11659,7 @@ function initDraggableModals() {
 
 let _orientSheets = [];
 let _osDetailSheet = null;   // 상세 모달에 열린 시트(카드별 발행에 사용)
+let _osDetailCatMap = {};    // 상세 모달 카테고리 라벨 맵(새창 열기에 재사용)
 
 const OS_TYPE_LABEL = { proxy_purchase: '가구매', reviewer: '리뷰어', seeding: '시딩' };
 const OS_TYPE_CHIP = {
@@ -11996,66 +11999,90 @@ async function osOpenDetail(id) {
   // 카테고리는 code 로 저장되므로 한국어 라벨로 변환해 표시 (캠페인 폼과 동일 기준 데이터)
   let catMap = {};
   try { const cats = await fetchLookups('category'); catMap = Object.fromEntries((cats || []).map(c => [c.code, c.name_ko])); } catch (_) {}
+  _osDetailCatMap = catMap;
   body.innerHTML = osDetailHtml(s, catMap);
+}
+
+// 상세 내용을 브라우저 새창에 읽기 전용으로 출력 (인쇄·나란히 보기 용)
+function osOpenDetailNewWindow() {
+  const s = _osDetailSheet;
+  if (!s) return;
+  const inner = osDetailHtml(s, _osDetailCatMap || {}, true);   // readonly=true → 발행 버튼 제외
+  const w = window.open('', '_blank');
+  if (!w) { toast('팝업이 차단되었습니다. 브라우저에서 팝업을 허용한 뒤 다시 시도해 주세요.'); return; }
+  w.document.write('<!DOCTYPE html><html lang="ko"><head><meta charset="utf-8">'
+    + '<meta name="viewport" content="width=device-width,initial-scale=1">'
+    + '<title>오리엔시트 — ' + esc(osBrandName(s)) + '</title>'
+    + '<style>body{font-family:-apple-system,BlinkMacSystemFont,"Apple SD Gothic Neo","Malgun Gothic",sans-serif;'
+    + 'margin:0;padding:24px;background:#f5f5f7;color:#161618;max-width:1000px}</style>'
+    + '</head><body>' + inner + '</body></html>');
+  w.document.close();
 }
 
 // 상세 모달 전용 스코프 스타일 (가독성: 항목 구분선 + 라벨/값 위계 + 카드 제목)
 const OS_DETAIL_STYLE = `<style>
+  .os-detail{container-type:inline-size}
   .os-card{border:1px solid #ececf0;border-radius:12px;padding:14px 16px;margin-bottom:14px;background:#fff}
-  .os-card-title{font-weight:800;font-size:14px;color:#161618;margin-bottom:4px}
-  .os-card-head{display:flex;align-items:center;gap:8px;margin-bottom:6px;padding-bottom:10px;border-bottom:1px solid #ececf0}
+  .os-card-title{font-weight:800;font-size:14px;color:#161618;margin-bottom:2px}
+  .os-card-head{display:flex;align-items:center;gap:8px;margin-bottom:2px;padding-bottom:8px}
   .os-card-head .os-name{font-weight:800;font-size:14.5px;color:#161618;flex:1;min-width:0}
-  .os-fields .os-field{padding:9px 0;border-top:1px solid #f2f2f2}
-  .os-fields .os-field:first-child{border-top:0;padding-top:2px}
+  /* 모달(컨테이너) 너비에 따라 2열/1열 — 브랜드 입력 폼과 동일 반응형 */
+  .os-fields{display:grid;grid-template-columns:1fr;gap:0 20px}
+  @container (min-width:480px){.os-fields{grid-template-columns:1fr 1fr}}
+  .os-fields .os-field{padding:9px 0;border-top:1px solid #f2f2f2;min-width:0}
+  .os-field-wide{grid-column:1/-1}
   .os-field-label{color:var(--muted,#8a8a90);font-size:11px;font-weight:700;letter-spacing:.02em;margin-bottom:3px}
   .os-field-val{font-size:13.5px;line-height:1.65;color:#161618;word-break:break-word}
   .os-field-val a{color:var(--pink,#E8344E);text-decoration:underline}
   .os-empty{color:#bbb;font-weight:400}
 </style>`;
 
-function osDetailHtml(s, catMap) {
+function osDetailHtml(s, catMap, readonly) {
   const d = s.data || {};
   const cards = Array.isArray(d.cards) ? d.cards : [];
-  const header = OS_DETAIL_STYLE + `<div style="margin-bottom:14px">
+  const headerHtml = `<div style="margin-bottom:14px">
     <div style="font-size:16px;font-weight:800;color:#161618">${esc(osBrandName(s))}</div>
     <div style="margin-top:6px">${osBadge(osStatusOf(s))}
       <span style="margin-left:6px;color:var(--muted);font-size:12px">${cards.length ? cards.length + '개 모집 건' : ''}</span></div>
   </div>`;
   const brandCard = osBrandCard(d.brand);
+  let bodyHtml;
   if (!cards.length) {
     const msg = (s.status === 'draft')
       ? '아직 작성 전입니다. 브랜드가 작성하면 여기에 표시됩니다.'
       : '작성된 모집 건이 없습니다.';
-    return header + brandCard + `<p style="color:var(--muted)">${msg}</p>`;
+    bodyHtml = brandCard + `<p style="color:var(--muted)">${msg}</p>`;
+  } else {
+    bodyHtml = brandCard + cards.map((c, i) => osCardDetail(c, i, catMap, readonly)).join('');
   }
-  return header + brandCard + cards.map((c, i) => osCardDetail(c, i, catMap)).join('');
+  return OS_DETAIL_STYLE + `<div class="os-detail">${headerHtml}${bodyHtml}</div>`;
 }
 
-function osFieldRow(label, valHtml) {
-  return `<div class="os-field"><div class="os-field-label">${label}</div><div class="os-field-val">${valHtml}</div></div>`;
+function osFieldRow(label, valHtml, wide) {
+  return `<div class="os-field${wide ? ' os-field-wide' : ''}"><div class="os-field-label">${label}</div><div class="os-field-val">${valHtml}</div></div>`;
 }
-function osField(label, val) {
+function osField(label, val, wide) {
   const v = (val == null || val === '') ? '<span class="os-empty">미입력</span>' : esc(String(val));
-  return osFieldRow(label, v);
+  return osFieldRow(label, v, wide);
 }
 // 값이 이미 안전한 HTML(링크 등 — 호출부가 esc·화이트리스트 보장)일 때. esc 미적용.
-function osFieldHtml(label, htmlVal) {
+function osFieldHtml(label, htmlVal, wide) {
   const v = htmlVal ? htmlVal : '<span class="os-empty">미입력</span>';
-  return osFieldRow(label, v);
+  return osFieldRow(label, v, wide);
 }
 function osRange(a, b) { return (a || b) ? `${a || '?'} ~ ${b || '?'}` : ''; }
 
 // 공통 브랜드 카드 (1회)
 function osBrandCard(brand) {
   const b = brand || {};
-  const inner = osField('브랜드명', b.name) + osField('소개·어필', b.intro) + osField('공식 계정', b.official_accounts);
+  const inner = osField('브랜드명', b.name) + osField('소개·어필', b.intro, true) + osField('공식 계정', b.official_accounts, true);
   return `<div class="os-card">
     <div class="os-card-title">브랜드 정보</div>
     <div class="os-fields">${inner}</div></div>`;
 }
 
 // 카드(모집 건) 1개 상세 — 형식별 항목 분기(§15-12)
-function osCardDetail(c, idx, catMap) {
+function osCardDetail(c, idx, catMap, readonly) {
   const ft = (c && c.form_type) || '';
   const p = c.product || {};
   const r = c.recruit || {};
@@ -12067,34 +12094,35 @@ function osCardDetail(c, idx, catMap) {
     + osField('희망 모집 기간', osRange(r.recruit_start, r.recruit_end));
 
   if (ft === 'proxy_purchase' || ft === 'reviewer') {
-    inner += osField('판매처', sale.market || 'Qoo10') + osFieldHtml('판매 URL', osLinkOrText(sale.url))
+    inner += osField('판매처', sale.market || 'Qoo10') + osFieldHtml('판매 URL', osLinkOrText(sale.url), true)
       + osField('상시가', sale.price_regular);
   }
-  if (ft === 'reviewer') inner += osFieldHtml('리뷰 가이드', sanitizeCautionHtml(c.review_guide));
+  if (ft === 'reviewer') inner += osFieldHtml('리뷰 가이드', sanitizeCautionHtml(c.review_guide), true);
   if (ft === 'seeding') {
     inner += osField('등급', OS_GRADE_LABEL[sd.grade] || sd.grade);
     const guides = Array.isArray(sd.guides) ? sd.guides.filter(g => g && (g.channel || g.guide)) : [];
     inner += guides.length
-      ? guides.map(g => osField('채널 — ' + osChLabel(g.channel), g.guide)).join('')
-      : osField('채널별 가이드', '');
-    inner += osField('소구 키워드', sd.appeal)
+      ? guides.map(g => osField('채널 — ' + osChLabel(g.channel), g.guide, true)).join('')
+      : osField('채널별 가이드', '', true);
+    inner += osField('소구 키워드', sd.appeal, true)
       + osField('해시태그', Array.isArray(sd.hashtags) ? sd.hashtags.join(' ') : (sd.hashtags || ''))
       + osField('계정 태그', sd.account_tags);
     if (sd.grade === 'middle_mega') {
-      inner += osField('촬영 가이드', sd.shooting_guide) + osField('필수 내용', sd.required_content) + osField('증정품', sd.gift);
+      inner += osField('촬영 가이드', sd.shooting_guide, true) + osField('필수 내용', sd.required_content, true) + osField('증정품', sd.gift);
     }
-    inner += osField('배송 안내', sd.shipping_note);
+    inner += osField('배송 안내', sd.shipping_note, true);
   }
-  inner += osFieldHtml('금지 표현(NG)', sanitizeCautionHtml(c.ng)) + osFieldHtml('추가 안내', sanitizeCautionHtml(c.cautions)) + osImagesInline(c.images);
+  inner += osFieldHtml('금지 표현(NG)', sanitizeCautionHtml(c.ng), true) + osFieldHtml('추가 안내', sanitizeCautionHtml(c.cautions), true) + osImagesInline(c.images);
   if (!ft) inner = '<div style="color:var(--muted);font-size:12px;margin-bottom:8px">브랜드가 아직 형식을 고르지 않았습니다.</div>' + inner;
 
   const head = `<div class="os-card-head">
-    ${osTypeChip(ft)}<span class="os-name">${esc(p.name || ('제품 ' + (idx + 1)))}</span>${osCardPublishControl(c, idx)}</div>`;
+    ${osTypeChip(ft)}<span class="os-name">${esc(p.name || ('제품 ' + (idx + 1)))}</span>${osCardPublishControl(c, idx, readonly)}</div>`;
   return `<div class="os-card">${head}<div class="os-fields">${inner}</div></div>`;
 }
 
 // 카드 헤더 우측 — 발행 버튼(제출됨·미발행·형식 선택) / 발행됨 배지 / 형식 미선택 안내
-function osCardPublishControl(c, idx) {
+function osCardPublishControl(c, idx, readonly) {
+  if (readonly) return '';   // 새창(읽기 전용)에서는 발행 버튼 숨김
   const s = _osDetailSheet;
   if (c && c.campaign_id) {
     return '<span style="flex-shrink:0;display:inline-block;padding:2px 8px;border-radius:999px;font-size:11px;font-weight:700;color:#16A34A;background:#E8F5E9">발행됨</span>';
@@ -12125,7 +12153,7 @@ function osImagesInline(images) {
       ? `<div style="margin-bottom:4px"><a href="${disp}" target="_blank" rel="noopener">${disp}</a></div>`
       : `<div style="margin-bottom:4px;color:var(--muted)">${disp} <span style="font-size:10px">(링크 차단)</span></div>`;
   }).join('');
-  return osFieldRow('예시 이미지·자료', inner);
+  return osFieldRow('예시 이미지·자료', inner, true);
 }
 
 // ── 카드 → 캠페인 발행 (자동 채움) ──
@@ -12302,7 +12330,9 @@ function ensureOrientModals() {
       <div class="modal-header"><h2>오리엔시트 내용</h2>
         <button type="button" class="modal-close-btn" onclick="osCloseModal('orientDetailModal')"><span class="material-icons-round notranslate" translate="no">close</span></button></div>
       <div class="modal-body" style="padding:20px;overflow-y:auto;flex:1" id="osDetailBody"></div>
-      <div class="modal-footer"><button type="button" class="btn btn-ghost" onclick="osCloseModal('orientDetailModal')">닫기</button></div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-ghost" onclick="osOpenDetailNewWindow()"><span class="material-icons-round notranslate" translate="no" style="font-size:16px;vertical-align:-3px">open_in_new</span> 새창으로 열기</button>
+        <button type="button" class="btn btn-ghost" onclick="osCloseModal('orientDetailModal')">닫기</button></div>
     </div>
   </div>
   <div class="modal-overlay" id="orientDeleteModal">
@@ -12323,6 +12353,8 @@ function ensureOrientModals() {
     </div>
   </div>`;
   document.body.insertAdjacentHTML('beforeend', html);
+  // 동적 생성된 오리엔 모달에 드래그·리사이즈 옵저버 부착(부트 시점엔 없던 overlay라 재등록 필요. 멱등)
+  if (typeof initDraggableModals === 'function') initDraggableModals();
 }
 
 // ══════════════════════════════════════

--- a/dev/js/admin-core.js
+++ b/dev/js/admin-core.js
@@ -694,6 +694,8 @@ const DRAGGABLE_ADMIN_MODALS = new Set([
   'companyModal', 'brandAssignModal', 'brandDetailModal', 'newBrandAppModal', 'brandAppMemoModal', 'brandAppHistoryModal', 'linkCampaignModal', 'brandAppOrientListModal',
   // 공지·기준데이터·계정
   'adminNoticeEditModal', 'adminNoticeViewModal', 'lookupEditModal', 'faqEditModal', 'addAdminModal', 'adminEmailSubsModal',
+  // 오리엔시트 (동적 생성 — ensureOrientModals 가 initDraggableModals 재호출로 옵저버 부착)
+  'orientDetailModal', 'orientCreateModal',
   // 메시지
   'admMsgModal', 'admHideModal',
   // 일괄 발송 (PR 3) — 대상 선택·발송 상세는 내용이 길어 드래그·리사이즈 유용

--- a/dev/js/admin-orient.js
+++ b/dev/js/admin-orient.js
@@ -8,6 +8,7 @@
 
 let _orientSheets = [];
 let _osDetailSheet = null;   // 상세 모달에 열린 시트(카드별 발행에 사용)
+let _osDetailCatMap = {};    // 상세 모달 카테고리 라벨 맵(새창 열기에 재사용)
 
 const OS_TYPE_LABEL = { proxy_purchase: '가구매', reviewer: '리뷰어', seeding: '시딩' };
 const OS_TYPE_CHIP = {
@@ -347,66 +348,90 @@ async function osOpenDetail(id) {
   // 카테고리는 code 로 저장되므로 한국어 라벨로 변환해 표시 (캠페인 폼과 동일 기준 데이터)
   let catMap = {};
   try { const cats = await fetchLookups('category'); catMap = Object.fromEntries((cats || []).map(c => [c.code, c.name_ko])); } catch (_) {}
+  _osDetailCatMap = catMap;
   body.innerHTML = osDetailHtml(s, catMap);
+}
+
+// 상세 내용을 브라우저 새창에 읽기 전용으로 출력 (인쇄·나란히 보기 용)
+function osOpenDetailNewWindow() {
+  const s = _osDetailSheet;
+  if (!s) return;
+  const inner = osDetailHtml(s, _osDetailCatMap || {}, true);   // readonly=true → 발행 버튼 제외
+  const w = window.open('', '_blank');
+  if (!w) { toast('팝업이 차단되었습니다. 브라우저에서 팝업을 허용한 뒤 다시 시도해 주세요.'); return; }
+  w.document.write('<!DOCTYPE html><html lang="ko"><head><meta charset="utf-8">'
+    + '<meta name="viewport" content="width=device-width,initial-scale=1">'
+    + '<title>오리엔시트 — ' + esc(osBrandName(s)) + '</title>'
+    + '<style>body{font-family:-apple-system,BlinkMacSystemFont,"Apple SD Gothic Neo","Malgun Gothic",sans-serif;'
+    + 'margin:0;padding:24px;background:#f5f5f7;color:#161618;max-width:1000px}</style>'
+    + '</head><body>' + inner + '</body></html>');
+  w.document.close();
 }
 
 // 상세 모달 전용 스코프 스타일 (가독성: 항목 구분선 + 라벨/값 위계 + 카드 제목)
 const OS_DETAIL_STYLE = `<style>
+  .os-detail{container-type:inline-size}
   .os-card{border:1px solid #ececf0;border-radius:12px;padding:14px 16px;margin-bottom:14px;background:#fff}
-  .os-card-title{font-weight:800;font-size:14px;color:#161618;margin-bottom:4px}
-  .os-card-head{display:flex;align-items:center;gap:8px;margin-bottom:6px;padding-bottom:10px;border-bottom:1px solid #ececf0}
+  .os-card-title{font-weight:800;font-size:14px;color:#161618;margin-bottom:2px}
+  .os-card-head{display:flex;align-items:center;gap:8px;margin-bottom:2px;padding-bottom:8px}
   .os-card-head .os-name{font-weight:800;font-size:14.5px;color:#161618;flex:1;min-width:0}
-  .os-fields .os-field{padding:9px 0;border-top:1px solid #f2f2f2}
-  .os-fields .os-field:first-child{border-top:0;padding-top:2px}
+  /* 모달(컨테이너) 너비에 따라 2열/1열 — 브랜드 입력 폼과 동일 반응형 */
+  .os-fields{display:grid;grid-template-columns:1fr;gap:0 20px}
+  @container (min-width:480px){.os-fields{grid-template-columns:1fr 1fr}}
+  .os-fields .os-field{padding:9px 0;border-top:1px solid #f2f2f2;min-width:0}
+  .os-field-wide{grid-column:1/-1}
   .os-field-label{color:var(--muted,#8a8a90);font-size:11px;font-weight:700;letter-spacing:.02em;margin-bottom:3px}
   .os-field-val{font-size:13.5px;line-height:1.65;color:#161618;word-break:break-word}
   .os-field-val a{color:var(--pink,#E8344E);text-decoration:underline}
   .os-empty{color:#bbb;font-weight:400}
 </style>`;
 
-function osDetailHtml(s, catMap) {
+function osDetailHtml(s, catMap, readonly) {
   const d = s.data || {};
   const cards = Array.isArray(d.cards) ? d.cards : [];
-  const header = OS_DETAIL_STYLE + `<div style="margin-bottom:14px">
+  const headerHtml = `<div style="margin-bottom:14px">
     <div style="font-size:16px;font-weight:800;color:#161618">${esc(osBrandName(s))}</div>
     <div style="margin-top:6px">${osBadge(osStatusOf(s))}
       <span style="margin-left:6px;color:var(--muted);font-size:12px">${cards.length ? cards.length + '개 모집 건' : ''}</span></div>
   </div>`;
   const brandCard = osBrandCard(d.brand);
+  let bodyHtml;
   if (!cards.length) {
     const msg = (s.status === 'draft')
       ? '아직 작성 전입니다. 브랜드가 작성하면 여기에 표시됩니다.'
       : '작성된 모집 건이 없습니다.';
-    return header + brandCard + `<p style="color:var(--muted)">${msg}</p>`;
+    bodyHtml = brandCard + `<p style="color:var(--muted)">${msg}</p>`;
+  } else {
+    bodyHtml = brandCard + cards.map((c, i) => osCardDetail(c, i, catMap, readonly)).join('');
   }
-  return header + brandCard + cards.map((c, i) => osCardDetail(c, i, catMap)).join('');
+  return OS_DETAIL_STYLE + `<div class="os-detail">${headerHtml}${bodyHtml}</div>`;
 }
 
-function osFieldRow(label, valHtml) {
-  return `<div class="os-field"><div class="os-field-label">${label}</div><div class="os-field-val">${valHtml}</div></div>`;
+function osFieldRow(label, valHtml, wide) {
+  return `<div class="os-field${wide ? ' os-field-wide' : ''}"><div class="os-field-label">${label}</div><div class="os-field-val">${valHtml}</div></div>`;
 }
-function osField(label, val) {
+function osField(label, val, wide) {
   const v = (val == null || val === '') ? '<span class="os-empty">미입력</span>' : esc(String(val));
-  return osFieldRow(label, v);
+  return osFieldRow(label, v, wide);
 }
 // 값이 이미 안전한 HTML(링크 등 — 호출부가 esc·화이트리스트 보장)일 때. esc 미적용.
-function osFieldHtml(label, htmlVal) {
+function osFieldHtml(label, htmlVal, wide) {
   const v = htmlVal ? htmlVal : '<span class="os-empty">미입력</span>';
-  return osFieldRow(label, v);
+  return osFieldRow(label, v, wide);
 }
 function osRange(a, b) { return (a || b) ? `${a || '?'} ~ ${b || '?'}` : ''; }
 
 // 공통 브랜드 카드 (1회)
 function osBrandCard(brand) {
   const b = brand || {};
-  const inner = osField('브랜드명', b.name) + osField('소개·어필', b.intro) + osField('공식 계정', b.official_accounts);
+  const inner = osField('브랜드명', b.name) + osField('소개·어필', b.intro, true) + osField('공식 계정', b.official_accounts, true);
   return `<div class="os-card">
     <div class="os-card-title">브랜드 정보</div>
     <div class="os-fields">${inner}</div></div>`;
 }
 
 // 카드(모집 건) 1개 상세 — 형식별 항목 분기(§15-12)
-function osCardDetail(c, idx, catMap) {
+function osCardDetail(c, idx, catMap, readonly) {
   const ft = (c && c.form_type) || '';
   const p = c.product || {};
   const r = c.recruit || {};
@@ -418,34 +443,35 @@ function osCardDetail(c, idx, catMap) {
     + osField('희망 모집 기간', osRange(r.recruit_start, r.recruit_end));
 
   if (ft === 'proxy_purchase' || ft === 'reviewer') {
-    inner += osField('판매처', sale.market || 'Qoo10') + osFieldHtml('판매 URL', osLinkOrText(sale.url))
+    inner += osField('판매처', sale.market || 'Qoo10') + osFieldHtml('판매 URL', osLinkOrText(sale.url), true)
       + osField('상시가', sale.price_regular);
   }
-  if (ft === 'reviewer') inner += osFieldHtml('리뷰 가이드', sanitizeCautionHtml(c.review_guide));
+  if (ft === 'reviewer') inner += osFieldHtml('리뷰 가이드', sanitizeCautionHtml(c.review_guide), true);
   if (ft === 'seeding') {
     inner += osField('등급', OS_GRADE_LABEL[sd.grade] || sd.grade);
     const guides = Array.isArray(sd.guides) ? sd.guides.filter(g => g && (g.channel || g.guide)) : [];
     inner += guides.length
-      ? guides.map(g => osField('채널 — ' + osChLabel(g.channel), g.guide)).join('')
-      : osField('채널별 가이드', '');
-    inner += osField('소구 키워드', sd.appeal)
+      ? guides.map(g => osField('채널 — ' + osChLabel(g.channel), g.guide, true)).join('')
+      : osField('채널별 가이드', '', true);
+    inner += osField('소구 키워드', sd.appeal, true)
       + osField('해시태그', Array.isArray(sd.hashtags) ? sd.hashtags.join(' ') : (sd.hashtags || ''))
       + osField('계정 태그', sd.account_tags);
     if (sd.grade === 'middle_mega') {
-      inner += osField('촬영 가이드', sd.shooting_guide) + osField('필수 내용', sd.required_content) + osField('증정품', sd.gift);
+      inner += osField('촬영 가이드', sd.shooting_guide, true) + osField('필수 내용', sd.required_content, true) + osField('증정품', sd.gift);
     }
-    inner += osField('배송 안내', sd.shipping_note);
+    inner += osField('배송 안내', sd.shipping_note, true);
   }
-  inner += osFieldHtml('금지 표현(NG)', sanitizeCautionHtml(c.ng)) + osFieldHtml('추가 안내', sanitizeCautionHtml(c.cautions)) + osImagesInline(c.images);
+  inner += osFieldHtml('금지 표현(NG)', sanitizeCautionHtml(c.ng), true) + osFieldHtml('추가 안내', sanitizeCautionHtml(c.cautions), true) + osImagesInline(c.images);
   if (!ft) inner = '<div style="color:var(--muted);font-size:12px;margin-bottom:8px">브랜드가 아직 형식을 고르지 않았습니다.</div>' + inner;
 
   const head = `<div class="os-card-head">
-    ${osTypeChip(ft)}<span class="os-name">${esc(p.name || ('제품 ' + (idx + 1)))}</span>${osCardPublishControl(c, idx)}</div>`;
+    ${osTypeChip(ft)}<span class="os-name">${esc(p.name || ('제품 ' + (idx + 1)))}</span>${osCardPublishControl(c, idx, readonly)}</div>`;
   return `<div class="os-card">${head}<div class="os-fields">${inner}</div></div>`;
 }
 
 // 카드 헤더 우측 — 발행 버튼(제출됨·미발행·형식 선택) / 발행됨 배지 / 형식 미선택 안내
-function osCardPublishControl(c, idx) {
+function osCardPublishControl(c, idx, readonly) {
+  if (readonly) return '';   // 새창(읽기 전용)에서는 발행 버튼 숨김
   const s = _osDetailSheet;
   if (c && c.campaign_id) {
     return '<span style="flex-shrink:0;display:inline-block;padding:2px 8px;border-radius:999px;font-size:11px;font-weight:700;color:#16A34A;background:#E8F5E9">발행됨</span>';
@@ -476,7 +502,7 @@ function osImagesInline(images) {
       ? `<div style="margin-bottom:4px"><a href="${disp}" target="_blank" rel="noopener">${disp}</a></div>`
       : `<div style="margin-bottom:4px;color:var(--muted)">${disp} <span style="font-size:10px">(링크 차단)</span></div>`;
   }).join('');
-  return osFieldRow('예시 이미지·자료', inner);
+  return osFieldRow('예시 이미지·자료', inner, true);
 }
 
 // ── 카드 → 캠페인 발행 (자동 채움) ──
@@ -653,7 +679,9 @@ function ensureOrientModals() {
       <div class="modal-header"><h2>오리엔시트 내용</h2>
         <button type="button" class="modal-close-btn" onclick="osCloseModal('orientDetailModal')"><span class="material-icons-round notranslate" translate="no">close</span></button></div>
       <div class="modal-body" style="padding:20px;overflow-y:auto;flex:1" id="osDetailBody"></div>
-      <div class="modal-footer"><button type="button" class="btn btn-ghost" onclick="osCloseModal('orientDetailModal')">닫기</button></div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-ghost" onclick="osOpenDetailNewWindow()"><span class="material-icons-round notranslate" translate="no" style="font-size:16px;vertical-align:-3px">open_in_new</span> 새창으로 열기</button>
+        <button type="button" class="btn btn-ghost" onclick="osCloseModal('orientDetailModal')">닫기</button></div>
     </div>
   </div>
   <div class="modal-overlay" id="orientDeleteModal">
@@ -674,4 +702,6 @@ function ensureOrientModals() {
     </div>
   </div>`;
   document.body.insertAdjacentHTML('beforeend', html);
+  // 동적 생성된 오리엔 모달에 드래그·리사이즈 옵저버 부착(부트 시점엔 없던 overlay라 재등록 필요. 멱등)
+  if (typeof initDraggableModals === 'function') initDraggableModals();
 }


### PR DESCRIPTION
## 변경 요약
- 오리엔시트 상세 모달을 다른 관리자 모달처럼 드래그·크기조절 가능하게(헤더 드래그). 동적 생성 모달이라 ensureOrientModals에서 옵저버 재등록
- 모달 너비에 따라 2열/1열 반응형(컨테이너 쿼리, 브랜드 입력 폼과 동일). 긴 항목(가이드·NG·추가안내·이미지 등)은 전체 폭
- 상세 모달에 「새창으로 열기」 버튼 — 클릭 시 브라우저 새창에 읽기 전용으로 출력(발행 버튼 숨김)

## 요청 외 추가 변경
- 없음