### PR TITLE
feat(orient-admin): 발급 시 메일 자동발송 → 「메일 발송」 버튼 수동 발송

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -12,7 +12,7 @@
 // 회귀(2026-05-12 PR #182 머지 직후 발생)를 방지하기 위한 자동 reload 가드.
 // sessionStorage 차단 환경(시크릿 모드 일부, 쿠키 차단)에서는 자연스럽게 skip.
 (function(){
-  var CURRENT_BUILD = 'v1782463842';
+  var CURRENT_BUILD = 'v1782464687';
   if (CURRENT_BUILD.indexOf('__') === 0) return; // 빌드 미적용 (dev/ 직접 열기) 시 skip
   try {
     var prev = sessionStorage.getItem('reverb.adminBuild');
@@ -2091,7 +2091,7 @@ tr.audit-row, .audit-row { background: #fff3e0 !important; }
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-06-26 17:50 · d19229a</span>
+          <span class="admin-build-text">2026-06-26 18:04 · 7b0aec9</span>
         </div>
       </div>
     </aside>
@@ -11660,6 +11660,7 @@ function initDraggableModals() {
 let _orientSheets = [];
 let _osDetailSheet = null;   // 상세 모달에 열린 시트(카드별 발행에 사용)
 let _osDetailCatMap = {};    // 상세 모달 카테고리 라벨 맵(새창 열기에 재사용)
+let _osLastIssuedId = null;  // 방금 발급한 오리엔시트 id(발급 결과 화면 수동 메일 발송용)
 
 const OS_TYPE_LABEL = { proxy_purchase: '가구매', reviewer: '리뷰어', seeding: '시딩' };
 const OS_TYPE_CHIP = {
@@ -11863,9 +11864,8 @@ async function osSubmitCreate() {
     document.getElementById('osCreateForm').style.display = 'none';
     document.getElementById('osCreateResult').style.display = '';
     btn.style.display = 'none';
+    _osLastIssuedId = res.id;   // 발급 결과 화면의 「메일 발송」 버튼이 사용 (자동 발송 안 함 — 수동 선택)
     await refreshPane('orient-sheets');
-    // 발급 직후 브랜드 담당자에게 작성 링크 메일 자동 발송 (실패해도 발급은 유효 — 결과만 표시)
-    osSendInviteAndShow(res.id);
   } catch (e) {
     toast(typeof friendlyError === 'function' ? friendlyError(e) : '발급에 실패했습니다.');
   } finally {
@@ -11884,6 +11884,14 @@ function osReasonText(r) {
 
 function osCopyResultLink() {
   copyTextToClipboard(document.getElementById('osCreateLink').value, '작성 링크가 복사되었습니다.');
+}
+
+// 발급 결과 화면 「메일 발송」 버튼 — 선택 발송(자동 발송 아님). 발송 중 버튼 비활성.
+async function osSendInviteClick(btn) {
+  if (!_osLastIssuedId) return;
+  btn.disabled = true;
+  try { await osSendInviteAndShow(_osLastIssuedId); }
+  finally { btn.disabled = false; }
 }
 
 // 발급 직후 메일 발송 + 발급 결과 화면에 발송 상태 인라인 표시.
@@ -12315,7 +12323,11 @@ function ensureOrientModals() {
           <p style="font-weight:700;margin-bottom:8px">발급되었습니다. 아래 링크를 브랜드에게 전달하세요.</p>
           <input type="text" id="osCreateLink" class="form-input" readonly onclick="this.select()">
           <div style="font-size:12px;color:var(--muted);margin-top:6px">작성 기한: <span id="osCreateExpire"></span></div>
-          <button type="button" class="btn btn-primary btn-sm" style="margin-top:10px" onclick="osCopyResultLink()">링크 복사</button>
+          <div style="margin-top:10px;display:flex;gap:8px;flex-wrap:wrap">
+            <button type="button" class="btn btn-primary btn-sm" onclick="osCopyResultLink()">링크 복사</button>
+            <button type="button" class="btn btn-ghost btn-sm" onclick="osSendInviteClick(this)"><span class="material-icons-round notranslate" translate="no" style="font-size:15px;vertical-align:-3px">mail</span> 메일 발송</button>
+          </div>
+          <div style="font-size:12px;color:var(--muted);margin-top:6px">메일은 자동 발송되지 않습니다. 필요하면 「메일 발송」을 눌러 브랜드 담당자에게 작성 링크를 보내세요.</div>
           <div id="osCreateMailStatus" style="margin-top:12px;font-size:13px;line-height:1.6"></div>
         </div>
       </div>

--- a/dev/js/admin-orient.js
+++ b/dev/js/admin-orient.js
@@ -9,6 +9,7 @@
 let _orientSheets = [];
 let _osDetailSheet = null;   // 상세 모달에 열린 시트(카드별 발행에 사용)
 let _osDetailCatMap = {};    // 상세 모달 카테고리 라벨 맵(새창 열기에 재사용)
+let _osLastIssuedId = null;  // 방금 발급한 오리엔시트 id(발급 결과 화면 수동 메일 발송용)
 
 const OS_TYPE_LABEL = { proxy_purchase: '가구매', reviewer: '리뷰어', seeding: '시딩' };
 const OS_TYPE_CHIP = {
@@ -212,9 +213,8 @@ async function osSubmitCreate() {
     document.getElementById('osCreateForm').style.display = 'none';
     document.getElementById('osCreateResult').style.display = '';
     btn.style.display = 'none';
+    _osLastIssuedId = res.id;   // 발급 결과 화면의 「메일 발송」 버튼이 사용 (자동 발송 안 함 — 수동 선택)
     await refreshPane('orient-sheets');
-    // 발급 직후 브랜드 담당자에게 작성 링크 메일 자동 발송 (실패해도 발급은 유효 — 결과만 표시)
-    osSendInviteAndShow(res.id);
   } catch (e) {
     toast(typeof friendlyError === 'function' ? friendlyError(e) : '발급에 실패했습니다.');
   } finally {
@@ -233,6 +233,14 @@ function osReasonText(r) {
 
 function osCopyResultLink() {
   copyTextToClipboard(document.getElementById('osCreateLink').value, '작성 링크가 복사되었습니다.');
+}
+
+// 발급 결과 화면 「메일 발송」 버튼 — 선택 발송(자동 발송 아님). 발송 중 버튼 비활성.
+async function osSendInviteClick(btn) {
+  if (!_osLastIssuedId) return;
+  btn.disabled = true;
+  try { await osSendInviteAndShow(_osLastIssuedId); }
+  finally { btn.disabled = false; }
 }
 
 // 발급 직후 메일 발송 + 발급 결과 화면에 발송 상태 인라인 표시.
@@ -664,7 +672,11 @@ function ensureOrientModals() {
           <p style="font-weight:700;margin-bottom:8px">발급되었습니다. 아래 링크를 브랜드에게 전달하세요.</p>
           <input type="text" id="osCreateLink" class="form-input" readonly onclick="this.select()">
           <div style="font-size:12px;color:var(--muted);margin-top:6px">작성 기한: <span id="osCreateExpire"></span></div>
-          <button type="button" class="btn btn-primary btn-sm" style="margin-top:10px" onclick="osCopyResultLink()">링크 복사</button>
+          <div style="margin-top:10px;display:flex;gap:8px;flex-wrap:wrap">
+            <button type="button" class="btn btn-primary btn-sm" onclick="osCopyResultLink()">링크 복사</button>
+            <button type="button" class="btn btn-ghost btn-sm" onclick="osSendInviteClick(this)"><span class="material-icons-round notranslate" translate="no" style="font-size:15px;vertical-align:-3px">mail</span> 메일 발송</button>
+          </div>
+          <div style="font-size:12px;color:var(--muted);margin-top:6px">메일은 자동 발송되지 않습니다. 필요하면 「메일 발송」을 눌러 브랜드 담당자에게 작성 링크를 보내세요.</div>
           <div id="osCreateMailStatus" style="margin-top:12px;font-size:13px;line-height:1.6"></div>
         </div>
       </div>


### PR DESCRIPTION
## 변경 요약
- 오리엔시트 링크 발급 시 메일 자동 발송 제거. 발급 결과 화면에 「메일 발송」 버튼 추가해 필요할 때만 발송(자동 발송 안 된다는 안내문 포함)

## 요청 외 추가 변경
- 없음