### PR TITLE
fix(orient): 엣코스메 체크박스 정렬 수정

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -12,7 +12,7 @@
 // 회귀(2026-05-12 PR #182 머지 직후 발생)를 방지하기 위한 자동 reload 가드.
 // sessionStorage 차단 환경(시크릿 모드 일부, 쿠키 차단)에서는 자연스럽게 skip.
 (function(){
-  var CURRENT_BUILD = 'v1782699368';
+  var CURRENT_BUILD = 'v1782700120';
   if (CURRENT_BUILD.indexOf('__') === 0) return; // 빌드 미적용 (dev/ 직접 열기) 시 skip
   try {
     var prev = sessionStorage.getItem('reverb.adminBuild');
@@ -2091,7 +2091,7 @@ tr.audit-row, .audit-row { background: #fff3e0 !important; }
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-06-29 11:16 · 21f78fa</span>
+          <span class="admin-build-text">2026-06-29 11:28 · a89a695</span>
         </div>
       </div>
     </aside>

--- a/dev/sales/orient.html
+++ b/dev/sales/orient.html
@@ -385,8 +385,8 @@ input[type="date"] { min-height: 44px; }
 .ocard:not([data-ctype]) .card-gated { display: none; }
 .ocard[data-ctype] .needtype-hint { display: none; }
 .ocard .only-rp, .ocard .only-reviewer, .ocard .only-seeding { display: none; }
-.check-row { display: flex; align-items: center; gap: 8px; font-weight: 700; cursor: pointer; margin: 0; }
-.check-row input[type="checkbox"] { width: 18px; height: 18px; accent-color: var(--brand); cursor: pointer; }
+.field label.check-row { display: flex; align-items: center; gap: 8px; font-weight: 700; cursor: pointer; margin: 0; }
+.check-row input[type="checkbox"] { width: 18px; height: 18px; margin: 0; flex: none; accent-color: var(--brand); cursor: pointer; }
 .ocard[data-ctype="proxy_purchase"] .only-rp { display: block; }
 .ocard[data-ctype="reviewer"] .only-rp,
 .ocard[data-ctype="reviewer"] .only-reviewer { display: block; }

--- a/sales/orient.html
+++ b/sales/orient.html
@@ -385,8 +385,8 @@ input[type="date"] { min-height: 44px; }
 .ocard:not([data-ctype]) .card-gated { display: none; }
 .ocard[data-ctype] .needtype-hint { display: none; }
 .ocard .only-rp, .ocard .only-reviewer, .ocard .only-seeding { display: none; }
-.check-row { display: flex; align-items: center; gap: 8px; font-weight: 700; cursor: pointer; margin: 0; }
-.check-row input[type="checkbox"] { width: 18px; height: 18px; accent-color: var(--brand); cursor: pointer; }
+.field label.check-row { display: flex; align-items: center; gap: 8px; font-weight: 700; cursor: pointer; margin: 0; }
+.check-row input[type="checkbox"] { width: 18px; height: 18px; margin: 0; flex: none; accent-color: var(--brand); cursor: pointer; }
 .ocard[data-ctype="proxy_purchase"] .only-rp { display: block; }
 .ocard[data-ctype="reviewer"] .only-rp,
 .ocard[data-ctype="reviewer"] .only-reviewer { display: block; }


### PR DESCRIPTION
## 변경 요약
엣코스메 희망 체크박스와 라벨 텍스트가 세로로 어긋나던 문제 수정. `.field label`의 우선순위가 `.check-row`의 flex 정렬을 덮어써서, `.field label.check-row`로 범위를 좁혀 한 줄 정렬되게 함.

## 요청 외 추가 변경
없음 (빌드 산출물 admin/index.html 빌드정보 갱신 포함)

## 관련 사양서
docs/specs/2026-06-18-brand-self-orient-sheet.md