### PR TITLE
feat(orient-admin): 오리엔시트 현황 상태별 탭

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -12,7 +12,7 @@
 // 회귀(2026-05-12 PR #182 머지 직후 발생)를 방지하기 위한 자동 reload 가드.
 // sessionStorage 차단 환경(시크릿 모드 일부, 쿠키 차단)에서는 자연스럽게 skip.
 (function(){
-  var CURRENT_BUILD = 'v1782700120';
+  var CURRENT_BUILD = 'v1782701770';
   if (CURRENT_BUILD.indexOf('__') === 0) return; // 빌드 미적용 (dev/ 직접 열기) 시 skip
   try {
     var prev = sessionStorage.getItem('reverb.adminBuild');
@@ -2091,7 +2091,7 @@ tr.audit-row, .audit-row { background: #fff3e0 !important; }
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-06-29 11:28 · a89a695</span>
+          <span class="admin-build-text">2026-06-29 11:56 · 71993bf</span>
         </div>
       </div>
     </aside>
@@ -3763,6 +3763,7 @@ tr.audit-row, .audit-row { background: #fff3e0 !important; }
                 <input type="search" id="orientSearch" class="admin-filter-search" autocomplete="off" data-lpignore="true" placeholder="브랜드명 검색" oninput="renderOrientSheets()">
               </div>
             </div>
+            <div id="orientStatusTabBar" class="status-tab-bar" style="margin-top:14px;margin-bottom:0"></div>
           </div>
           <div class="admin-card">
             <div class="admin-card-header">
@@ -11675,6 +11676,15 @@ const OS_STATUS = {
   consumed:  { label: '발행됨', color: '#5B4B9E', bg: '#ECEAF6' },
   expired:   { label: '만료',   color: '#8A8A90', bg: '#F0F0F0' },
 };
+// 상태별 탭 (전체 + 4상태). code=null 은 전체
+const OS_STATUS_TABS = [
+  { code: null, label: '전체' },
+  { code: 'draft', label: '작성 중' },
+  { code: 'submitted', label: '제출됨' },
+  { code: 'consumed', label: '발행됨' },
+  { code: 'expired', label: '만료' },
+];
+let _orientActiveStatusTab = null;
 const OS_CH_LABEL = { instagram: '인스타그램', x: 'X', tiktok: '틱톡', youtube: '유튜브', qoo10: 'Qoo10', lips: 'LIPS', atcosme: '@cosme' };
 
 // 운영/개발 sales 도메인 분기 (orient.html SUPABASE_ENV 규칙과 동일)
@@ -11693,6 +11703,10 @@ function osIsExpired(s) {
 }
 function osStatusOf(s) {
   return (osIsExpired(s) && s.status !== 'consumed') ? OS_STATUS.expired : (OS_STATUS[s.status] || OS_STATUS.draft);
+}
+// 상태 코드(만료 클라 판정 포함) — 탭 필터·건수용
+function osStatusKey(s) {
+  return (osIsExpired(s) && s.status !== 'consumed') ? 'expired' : (OS_STATUS[s.status] ? s.status : 'draft');
 }
 function osBrandName(s) { return s.brands ? (s.brands.name || s.brands.name_ja || '-') : '-'; }
 function osBadge(st) {
@@ -11742,16 +11756,47 @@ function renderOrientSheets() {
   const tbody = document.getElementById('orientTableBody');
   if (!tbody) return;
   const q = (document.getElementById('orientSearch')?.value || '').trim().toLowerCase();
-  const list = _orientSheets.filter(s => !q || osBrandName(s).toLowerCase().includes(q));
+  // 검색 적용 후 base → 상태별 건수 계산 → 탭 렌더
+  const base = _orientSheets.filter(s => !q || osBrandName(s).toLowerCase().includes(q));
+  const counts = {};
+  base.forEach(s => { const k = osStatusKey(s); counts[k] = (counts[k] || 0) + 1; });
+  renderOrientStatusTabs(counts);
+
+  // 선택된 상태 탭으로 필터
+  const list = _orientActiveStatusTab ? base.filter(s => osStatusKey(s) === _orientActiveStatusTab) : base;
 
   const cnt = document.getElementById('orientTotalCount');
   if (cnt) cnt.textContent = list.length ? `${list.length}건` : '';
 
   if (!list.length) {
-    tbody.innerHTML = osMsgRow(q ? '검색 결과가 없습니다.' : '발급된 오리엔시트가 없습니다. 「신규 발급」으로 링크를 만들어 주세요.');
+    const emptyMsg = (q && !base.length) ? '검색 결과가 없습니다.'
+      : (_orientActiveStatusTab ? '해당 상태의 오리엔시트가 없습니다.'
+        : '발급된 오리엔시트가 없습니다. 「신규 발급」으로 링크를 만들어 주세요.');
+    tbody.innerHTML = osMsgRow(emptyMsg);
     return;
   }
   tbody.innerHTML = list.map(osRowHtml).join('');
+}
+
+// 상태 탭 바 렌더 (counts: 검색 적용 후 상태별 건수)
+function renderOrientStatusTabs(counts) {
+  const bar = document.getElementById('orientStatusTabBar');
+  if (!bar) return;
+  counts = counts || {};
+  const totalAll = Object.values(counts).reduce((sum, n) => sum + n, 0);
+  bar.innerHTML = OS_STATUS_TABS.map(tab => {
+    const n = tab.code === null ? totalAll : (counts[tab.code] || 0);
+    const isOn = tab.code === _orientActiveStatusTab;
+    const cls = 'status-tab-btn' + (isOn ? ' on' : '') + (n === 0 && tab.code !== null ? ' zero-count' : '');
+    return `<button type="button" class="${cls}" data-status="${tab.code || ''}" onclick="setOrientStatusTab(this)">`
+      + `${esc(tab.label)}<span class="tab-count">(${n})</span></button>`;
+  }).join('');
+}
+
+// 상태 탭 클릭
+function setOrientStatusTab(btn) {
+  _orientActiveStatusTab = btn.dataset.status || null;   // 빈 문자열(전체)이면 null
+  renderOrientSheets();
 }
 
 function osRowHtml(s) {

--- a/dev/admin/index.html
+++ b/dev/admin/index.html
@@ -1806,6 +1806,7 @@
                 <input type="search" id="orientSearch" class="admin-filter-search" autocomplete="off" data-lpignore="true" placeholder="브랜드명 검색" oninput="renderOrientSheets()">
               </div>
             </div>
+            <div id="orientStatusTabBar" class="status-tab-bar" style="margin-top:14px;margin-bottom:0"></div>
           </div>
           <div class="admin-card">
             <div class="admin-card-header">

--- a/dev/js/admin-orient.js
+++ b/dev/js/admin-orient.js
@@ -24,6 +24,15 @@ const OS_STATUS = {
   consumed:  { label: '발행됨', color: '#5B4B9E', bg: '#ECEAF6' },
   expired:   { label: '만료',   color: '#8A8A90', bg: '#F0F0F0' },
 };
+// 상태별 탭 (전체 + 4상태). code=null 은 전체
+const OS_STATUS_TABS = [
+  { code: null, label: '전체' },
+  { code: 'draft', label: '작성 중' },
+  { code: 'submitted', label: '제출됨' },
+  { code: 'consumed', label: '발행됨' },
+  { code: 'expired', label: '만료' },
+];
+let _orientActiveStatusTab = null;
 const OS_CH_LABEL = { instagram: '인스타그램', x: 'X', tiktok: '틱톡', youtube: '유튜브', qoo10: 'Qoo10', lips: 'LIPS', atcosme: '@cosme' };
 
 // 운영/개발 sales 도메인 분기 (orient.html SUPABASE_ENV 규칙과 동일)
@@ -42,6 +51,10 @@ function osIsExpired(s) {
 }
 function osStatusOf(s) {
   return (osIsExpired(s) && s.status !== 'consumed') ? OS_STATUS.expired : (OS_STATUS[s.status] || OS_STATUS.draft);
+}
+// 상태 코드(만료 클라 판정 포함) — 탭 필터·건수용
+function osStatusKey(s) {
+  return (osIsExpired(s) && s.status !== 'consumed') ? 'expired' : (OS_STATUS[s.status] ? s.status : 'draft');
 }
 function osBrandName(s) { return s.brands ? (s.brands.name || s.brands.name_ja || '-') : '-'; }
 function osBadge(st) {
@@ -91,16 +104,47 @@ function renderOrientSheets() {
   const tbody = document.getElementById('orientTableBody');
   if (!tbody) return;
   const q = (document.getElementById('orientSearch')?.value || '').trim().toLowerCase();
-  const list = _orientSheets.filter(s => !q || osBrandName(s).toLowerCase().includes(q));
+  // 검색 적용 후 base → 상태별 건수 계산 → 탭 렌더
+  const base = _orientSheets.filter(s => !q || osBrandName(s).toLowerCase().includes(q));
+  const counts = {};
+  base.forEach(s => { const k = osStatusKey(s); counts[k] = (counts[k] || 0) + 1; });
+  renderOrientStatusTabs(counts);
+
+  // 선택된 상태 탭으로 필터
+  const list = _orientActiveStatusTab ? base.filter(s => osStatusKey(s) === _orientActiveStatusTab) : base;
 
   const cnt = document.getElementById('orientTotalCount');
   if (cnt) cnt.textContent = list.length ? `${list.length}건` : '';
 
   if (!list.length) {
-    tbody.innerHTML = osMsgRow(q ? '검색 결과가 없습니다.' : '발급된 오리엔시트가 없습니다. 「신규 발급」으로 링크를 만들어 주세요.');
+    const emptyMsg = (q && !base.length) ? '검색 결과가 없습니다.'
+      : (_orientActiveStatusTab ? '해당 상태의 오리엔시트가 없습니다.'
+        : '발급된 오리엔시트가 없습니다. 「신규 발급」으로 링크를 만들어 주세요.');
+    tbody.innerHTML = osMsgRow(emptyMsg);
     return;
   }
   tbody.innerHTML = list.map(osRowHtml).join('');
+}
+
+// 상태 탭 바 렌더 (counts: 검색 적용 후 상태별 건수)
+function renderOrientStatusTabs(counts) {
+  const bar = document.getElementById('orientStatusTabBar');
+  if (!bar) return;
+  counts = counts || {};
+  const totalAll = Object.values(counts).reduce((sum, n) => sum + n, 0);
+  bar.innerHTML = OS_STATUS_TABS.map(tab => {
+    const n = tab.code === null ? totalAll : (counts[tab.code] || 0);
+    const isOn = tab.code === _orientActiveStatusTab;
+    const cls = 'status-tab-btn' + (isOn ? ' on' : '') + (n === 0 && tab.code !== null ? ' zero-count' : '');
+    return `<button type="button" class="${cls}" data-status="${tab.code || ''}" onclick="setOrientStatusTab(this)">`
+      + `${esc(tab.label)}<span class="tab-count">(${n})</span></button>`;
+  }).join('');
+}
+
+// 상태 탭 클릭
+function setOrientStatusTab(btn) {
+  _orientActiveStatusTab = btn.dataset.status || null;   // 빈 문자열(전체)이면 null
+  renderOrientSheets();
 }
 
 function osRowHtml(s) {


### PR DESCRIPTION
## 변경 요약
관리자 오리엔시트 현황 발급 목록에 상태별 탭(전체·작성 중·제출됨·발행됨·만료) 추가. 각 탭에 건수 표시, 검색어와 함께 적용.

- 기존 브랜드 신청 페인의 status-tab 패턴 재사용(CSS 그대로)
- osStatusKey()로 상태 배지(osStatusOf)와 동일한 만료 판정 → 탭/배지 분류 일치
- 검색 적용 후 상태별 건수 계산 → 선택 탭으로 추가 필터

## 요청 외 추가 변경
없음

## 관련 사양서
docs/specs/2026-06-18-brand-self-orient-sheet.md