### PR TITLE
feat(admin): 캠페인 관리 목록 상태별 탭 (운영 핫픽스)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,7 +122,7 @@
 - **캠페인 등록/편집 폼**: 4개 섹션 그룹핑 (기본정보/제품정보/모집조건/콘텐츠가이드). 모집타입 라디오버튼 UI, 채널은 복수 선택 체크박스(Instagram/X/Qoo10/TikTok/YouTube/LIPS/@cosme, 콤마 구분 저장 `"instagram,x"`. LIPS·@cosme는 리뷰어형 전용 — `lookup_values.recruit_types=['monitor']`). 채널 2개+ 선택 시 `or`/`&` 라디오 노출 → `campaigns.channel_match`. 자격 검증은 `primary_channel` 단일 기준
 - **콘텐츠 가이드 리치 텍스트** (Quill v2, 3개 필드): Notion 복사·붙여넣기 서식 유지. 이미지 태그는 저장 시 제거. XSS 방어 DOMPurify 저장+렌더 이중 sanitize. 헬퍼는 `dev/lib/shared.js`
 - **참여방법·주의사항·NG 미니 에디터**: 굵게/기울이기/링크/이미지 첨부 가능. 이미지는 `campaign-images/content/` 업로드 (5MB / jpg·png·webp) → `<img class="rich-img">` 삽입. 클릭 팝오버로 Small/Medium/Large/Original 크기 조정. XSS 방어는 src 화이트리스트 (https + `*.supabase.co`)
-- **캠페인 목록**: 썸네일+이미지수, 상태/타입 드롭다운 필터, 검색(캠페인명+브랜드+제품+campaign_no), 헤더 정렬(조회/신청/등록일/수정일 ▲▼), D-day 라벨, 승인수/모집수 표시 + 대기 배지
+- **캠페인 목록**: 썸네일+이미지수, 상태별 탭(전체/준비/모집예정/모집중/모집마감/종료/노출종료, 각 건수 표시·단일 선택) + 타입 드롭다운 필터, 검색(캠페인명+브랜드+제품+campaign_no), 헤더 정렬(조회/신청/등록일/수정일 ▲▼), D-day 라벨, 승인수/모집수 표시 + 대기 배지
 - **캠페인 미리보기**: 캠페인 제목 클릭 시 모바일 크기 프리뷰 모달 (편집 버튼 포함)
 - **캠페인 상태 6단계**: `draft` → `scheduled` → `active` → `closed`(모집마감) → `ended`(종료), `expired`(노출마감). 자동 전이 3종: `scheduled→active`(recruit_start 도래), `active→closed`(deadline 경과), `closed→ended`(submission_end 경과 — `autoEndCampaigns`, 마이그레이션 156). `expired` 는 운영자 「캠페인 노출」 토글 OFF 로만 진입. `closed`(모집마감)·`ended`(종료) 는 운영자 OFF 까지 인플 화면에 노출(closed=募集締切, ended=終了 오버레이). 노출 그룹(scheduled/active/closed/ended) 컬러 배지(closed=핑크, ended=남보라 `badge-done`), 비노출 그룹(draft/expired) 회색·점선
 - **캠페인 노출 토글**: 등록/편집 폼 최상단 + 목록 「상태」 컬럼 빠른 토글. OFF 시 확인 모달 후 status=expired, ON 시 자연 상태 재계산. draft 는 비활성. `toggleCampaignVisibility` + `computeCampaignStatus`

--- a/admin/index.html
+++ b/admin/index.html
@@ -12,7 +12,7 @@
 // 회귀(2026-05-12 PR #182 머지 직후 발생)를 방지하기 위한 자동 reload 가드.
 // sessionStorage 차단 환경(시크릿 모드 일부, 쿠키 차단)에서는 자연스럽게 skip.
 (function(){
-  var CURRENT_BUILD = 'v1782379384';
+  var CURRENT_BUILD = 'v1782704358';
   if (CURRENT_BUILD.indexOf('__') === 0) return; // 빌드 미적용 (dev/ 직접 열기) 시 skip
   try {
     var prev = sessionStorage.getItem('reverb.adminBuild');
@@ -2076,7 +2076,7 @@ tr.audit-row, .audit-row { background: #fff3e0 !important; }
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-06-25 18:23 · d55c4c5</span>
+          <span class="admin-build-text">2026-06-29 12:39 · 7e91e52</span>
         </div>
       </div>
     </aside>
@@ -2200,10 +2200,6 @@ tr.audit-row, .audit-row { background: #fff3e0 !important; }
                 <label>캠페인 타입</label>
                 <div id="campTypeMulti" class="mf-wrap"><button type="button" class="mf-btn">전체 타입</button><div class="mf-drop"></div></div>
               </div>
-              <div class="admin-filter-group">
-                <label>캠페인 상태</label>
-                <div id="campStatusMulti" class="mf-wrap"><button type="button" class="mf-btn">전체 상태</button><div class="mf-drop"></div></div>
-              </div>
               <div class="admin-filter-group" style="flex:1;min-width:200px;margin-left:auto">
                 <label>검색</label>
                 <div style="display:flex;gap:6px;align-items:center">
@@ -2215,10 +2211,11 @@ tr.audit-row, .audit-row { background: #fff3e0 !important; }
                 </div>
               </div>
             </div>
+            <div id="campStatusTabBar" class="status-tab-bar" style="margin-top:14px;margin-bottom:0"></div>
           </div>
           <div class="admin-card">
             <div class="admin-card-header">
-              <div style="display:flex;align-items:center;gap:8px"><span class="admin-card-title">캠페인 목록</span><span id="adminCampStatusCounts" style="font-size:12px;color:var(--muted)"></span><span id="adminCampSelectedCount" style="font-size:12px;color:var(--pink);font-weight:600;display:none"></span></div>
+              <div style="display:flex;align-items:center;gap:8px"><span class="admin-card-title">캠페인 목록</span><span id="adminCampSelectedCount" style="font-size:12px;color:var(--pink);font-weight:600;display:none"></span></div>
               <div style="display:flex;align-items:center;gap:6px">
                 <button class="btn btn-ghost btn-xs" id="btnCampSelectClear" onclick="clearCampSelection()" style="display:none">선택 초기화</button>
                 <button class="btn btn-ghost btn-xs" id="btnCampSelectApplicants" onclick="exportSelectedCampaignsApplicants()" disabled title="캠페인을 1개 이상 선택하세요"><span class="material-icons-round notranslate" translate="no" style="font-size:14px;vertical-align:middle">download</span> 신청자 엑셀</button>
@@ -10810,9 +10807,7 @@ function initMultiFilters() {
   createMultiFilter('campTypeMulti', '전체 타입', [
     {value:'monitor',label:'리뷰어'},{value:'gifting',label:'기프팅'},{value:'visit',label:'방문형'}
   ], () => filterAdminCampaigns());
-  createMultiFilter('campStatusMulti', '전체 상태', [
-    {value:'draft',label:'준비'},{value:'scheduled',label:'모집예정'},{value:'active',label:'모집중'},{value:'closed',label:'모집마감'},{value:'ended',label:'종료'},{value:'expired',label:'노출종료'}
-  ], () => filterAdminCampaigns());
+  // 캠페인 상태 필터는 다중선택 드롭다운 → 상태별 탭(admin.js CAMP_STATUS_TABS)으로 교체됨
   // 신청관리
   createMultiFilter('appTypeMulti', '전체 타입', [
     {value:'monitor',label:'리뷰어'},{value:'gifting',label:'기프팅'},{value:'visit',label:'방문형'}
@@ -24529,7 +24524,7 @@ async function renderAppCampList() {
   syncMultiFilter('appTypeMulti', '전체 타입',
     availableTypes.map(t => ({value:t, label:RECRUIT_TYPE_LABEL_KO[t] || t, count: appTypeCounts[t] || 0})),
     () => renderAppCampList());
-  // 캠페인 상태 필터 — 캠페인 관리 페인과 동일 6단계 (admin.js campStatusMulti 와 라벨·순서 통일)
+  // 캠페인 상태 필터 — 캠페인 관리 페인과 동일 6단계 (admin.js CAMP_STATUS_TABS 와 라벨·순서 통일)
   syncMultiFilter('appCampStatusMulti', '전체 상태', [
     {value:'draft',     label:'준비',     count: appCampStatusCounts.draft     || 0},
     {value:'scheduled', label:'모집예정', count: appCampStatusCounts.scheduled || 0},
@@ -26518,7 +26513,7 @@ const debouncedFilterAdminCampaigns = debounce(filterAdminCampaigns, 300);
 
 // 보기 초기화 버튼 노출 — 필터·검색·정렬 중 하나라도 비기본이면 표시
 function updateCampViewResetBtn() {
-  const hasFilter = ['campTypeMulti','campStatusMulti'].some(id => getMultiFilterValues(id).length > 0);
+  const hasFilter = getMultiFilterValues('campTypeMulti').length > 0 || _campActiveStatusTab !== null;
   const hasSearch = !!(($('adminCampSearch')?.value || '').trim());
   const hasSort = !!adminCampSortKey;
   const btn = $('btnCampViewReset');
@@ -26527,14 +26522,14 @@ function updateCampViewResetBtn() {
 
 function resetCampFilters() {
   resetMultiFilter('campTypeMulti', '전체 타입');
-  resetMultiFilter('campStatusMulti', '전체 상태');
+  _campActiveStatusTab = null;
   const s = $('adminCampSearch'); if (s) s.value = '';
   filterAdminCampaigns();
 }
 // 보기 초기화 — 필터·검색·정렬을 한 번에 기본값으로
 function resetCampView() {
   resetMultiFilter('campTypeMulti', '전체 타입');
-  resetMultiFilter('campStatusMulti', '전체 상태');
+  _campActiveStatusTab = null;
   const s = $('adminCampSearch'); if (s) s.value = '';
   adminCampSortKey = ''; adminCampSortDir = '';
   updateSortArrows(); updateCampTableHead();
@@ -26607,6 +26602,41 @@ var adminReorderMode = false;
 // 캠페인 상태별 클라이언트 노출 도움말 모달 노출
 function openCampStatusHelp() {
   if (typeof openModal === 'function') openModal('campStatusHelpModal');
+}
+
+// ── 캠페인 상태별 탭 (campStatusMulti 드롭다운·adminCampStatusCounts 텍스트를 대체)
+//    오리엔시트·브랜드 신청 페인의 status-tab 패턴 재사용. 단일 선택(한 번에 1개 상태)
+const CAMP_STATUS_TABS = [
+  { code: null,        label: '전체' },
+  { code: 'draft',     label: '준비' },
+  { code: 'scheduled', label: '모집예정' },
+  { code: 'active',    label: '모집중' },
+  { code: 'closed',    label: '모집마감' },
+  { code: 'ended',     label: '종료' },
+  { code: 'expired',   label: '노출종료' },
+];
+var _campActiveStatusTab = null;
+
+// 상태 탭 바 렌더 (counts: 필터 전 전체 기준 상태별 건수)
+function renderCampStatusTabs(counts) {
+  const bar = $('campStatusTabBar');
+  if (!bar) return;
+  counts = counts || {};
+  const totalAll = Object.values(counts).reduce((sum, n) => sum + n, 0);
+  bar.innerHTML = CAMP_STATUS_TABS.map(tab => {
+    const n = tab.code === null ? totalAll : (counts[tab.code] || 0);
+    const isOn = tab.code === _campActiveStatusTab;
+    const cls = 'status-tab-btn' + (isOn ? ' on' : '') + (n === 0 && tab.code !== null ? ' zero-count' : '');
+    return `<button type="button" class="${cls}" data-status="${tab.code || ''}" onclick="setCampStatusTab(this)">`
+      + `${esc(tab.label)}<span class="tab-count">(${n})</span></button>`;
+  }).join('');
+}
+
+// 상태 탭 클릭 → 단일 상태 필터로 목록 재조회 (필터 경로라 sentinel 리셋은 loadAdminCampaigns 가 처리)
+function setCampStatusTab(btn) {
+  _campActiveStatusTab = btn.dataset.status || null;   // 빈 문자열(전체)이면 null
+  updateCampViewResetBtn();
+  filterAdminCampaigns();
 }
 
 function updateCampTableHead() {
@@ -26705,30 +26735,15 @@ async function loadAdminCampaigns(useCache) {
     {value:'gifting', label:'기프팅',  count: rtCounts.gifting || 0},
     {value:'visit',   label:'방문형',  count: rtCounts.visit || 0},
   ], () => filterAdminCampaigns());
-  syncMultiFilter('campStatusMulti', '전체 상태', [
-    {value:'draft',     label:'준비',     count: stCounts.draft || 0},
-    {value:'scheduled', label:'모집예정', count: stCounts.scheduled || 0},
-    {value:'active',    label:'모집중',   count: stCounts.active || 0},
-    {value:'closed',    label:'모집마감', count: stCounts.closed || 0},
-    {value:'ended',     label:'종료',     count: stCounts.ended || 0},
-    {value:'expired',   label:'노출종료', count: stCounts.expired || 0},
-  ], () => filterAdminCampaigns());
-  // closed(모집마감)·ended(종료)는 실제 DB 상태(마이그레이션 156)라 필터·요약·배지 모두 분리.
-  const stLabels = {active:'모집중',scheduled:'모집예정',draft:'준비',closed:'모집마감',ended:'종료',expired:'노출종료'};
-  // 노출 그룹(scheduled/active/closed/ended)은 컬러, 비노출(draft/expired)은 회색·점선으로 시각 구분
-  const stColors = {active:'var(--green)',scheduled:'#5B7CFF',draft:'var(--muted)',closed:'#B91C5C',ended:'#5E35B1',expired:'#666666'};
-  const el = $('adminCampStatusCounts');
-  if (el) el.innerHTML = Object.keys(stLabels).filter(k=>stCounts[k]).map(k =>
-    `<span style="color:${stColors[k]};font-weight:600">${stLabels[k]} ${stCounts[k]}</span>`
-  ).join('<span style="margin:0 4px;color:var(--line)">·</span>');
+  // 상태 필터는 다중 선택 드롭다운 대신 상태별 탭으로 표시 (건수 포함). closed·ended 는 실제 DB 상태(마이그레이션 156)라 탭에서도 분리.
+  renderCampStatusTabs(stCounts);
 
   // 타입 필터 (다중 선택)
   const typeVals = getMultiFilterValues('campTypeMulti');
   if (typeVals.length) camps = camps.filter(c => typeVals.includes(c.recruit_type));
 
-  // 상태 필터 (다중 선택)
-  const statusVals = getMultiFilterValues('campStatusMulti');
-  if (statusVals.length) camps = camps.filter(c => statusVals.includes(c.status));
+  // 상태 필터 (탭 단일 선택)
+  if (_campActiveStatusTab) camps = camps.filter(c => c.status === _campActiveStatusTab);
 
   // 검색 필터 — 단어 단위 AND 매칭 (matchSearchTokens, 전각/반각 공백 무관)
   const searchVal = ($('adminCampSearch')?.value || '').trim().toLowerCase();
@@ -26767,7 +26782,7 @@ async function loadAdminCampaigns(useCache) {
   }
 
   // 필터/검색/정렬 중에는 순서 변경 비활성화
-  const isFiltered = searchVal || typeVals.length > 0 || statusVals.length > 0 || !!adminCampSortKey;
+  const isFiltered = searchVal || typeVals.length > 0 || _campActiveStatusTab !== null || !!adminCampSortKey;
 
   const typeLabel = t => getRecruitTypeBadgeKoSm(t);
   // 상태 배지 — closed 는 submission_end 경과 여부로 「모집마감」/「종료」 자동 구분 (shared.js campaignStatusLabelKey)

--- a/dev/admin/index.html
+++ b/dev/admin/index.html
@@ -256,10 +256,6 @@
                 <label>캠페인 타입</label>
                 <div id="campTypeMulti" class="mf-wrap"><button type="button" class="mf-btn">전체 타입</button><div class="mf-drop"></div></div>
               </div>
-              <div class="admin-filter-group">
-                <label>캠페인 상태</label>
-                <div id="campStatusMulti" class="mf-wrap"><button type="button" class="mf-btn">전체 상태</button><div class="mf-drop"></div></div>
-              </div>
               <div class="admin-filter-group" style="flex:1;min-width:200px;margin-left:auto">
                 <label>검색</label>
                 <div style="display:flex;gap:6px;align-items:center">
@@ -271,10 +267,11 @@
                 </div>
               </div>
             </div>
+            <div id="campStatusTabBar" class="status-tab-bar" style="margin-top:14px;margin-bottom:0"></div>
           </div>
           <div class="admin-card">
             <div class="admin-card-header">
-              <div style="display:flex;align-items:center;gap:8px"><span class="admin-card-title">캠페인 목록</span><span id="adminCampStatusCounts" style="font-size:12px;color:var(--muted)"></span><span id="adminCampSelectedCount" style="font-size:12px;color:var(--pink);font-weight:600;display:none"></span></div>
+              <div style="display:flex;align-items:center;gap:8px"><span class="admin-card-title">캠페인 목록</span><span id="adminCampSelectedCount" style="font-size:12px;color:var(--pink);font-weight:600;display:none"></span></div>
               <div style="display:flex;align-items:center;gap:6px">
                 <button class="btn btn-ghost btn-xs" id="btnCampSelectClear" onclick="clearCampSelection()" style="display:none">선택 초기화</button>
                 <button class="btn btn-ghost btn-xs" id="btnCampSelectApplicants" onclick="exportSelectedCampaignsApplicants()" disabled title="캠페인을 1개 이상 선택하세요"><span class="material-icons-round notranslate" translate="no" style="font-size:14px;vertical-align:middle">download</span> 신청자 엑셀</button>

--- a/dev/js/admin-applications.js
+++ b/dev/js/admin-applications.js
@@ -454,7 +454,7 @@ async function renderAppCampList() {
   syncMultiFilter('appTypeMulti', '전체 타입',
     availableTypes.map(t => ({value:t, label:RECRUIT_TYPE_LABEL_KO[t] || t, count: appTypeCounts[t] || 0})),
     () => renderAppCampList());
-  // 캠페인 상태 필터 — 캠페인 관리 페인과 동일 6단계 (admin.js campStatusMulti 와 라벨·순서 통일)
+  // 캠페인 상태 필터 — 캠페인 관리 페인과 동일 6단계 (admin.js CAMP_STATUS_TABS 와 라벨·순서 통일)
   syncMultiFilter('appCampStatusMulti', '전체 상태', [
     {value:'draft',     label:'준비',     count: appCampStatusCounts.draft     || 0},
     {value:'scheduled', label:'모집예정', count: appCampStatusCounts.scheduled || 0},

--- a/dev/js/admin-core.js
+++ b/dev/js/admin-core.js
@@ -266,9 +266,7 @@ function initMultiFilters() {
   createMultiFilter('campTypeMulti', '전체 타입', [
     {value:'monitor',label:'리뷰어'},{value:'gifting',label:'기프팅'},{value:'visit',label:'방문형'}
   ], () => filterAdminCampaigns());
-  createMultiFilter('campStatusMulti', '전체 상태', [
-    {value:'draft',label:'준비'},{value:'scheduled',label:'모집예정'},{value:'active',label:'모집중'},{value:'closed',label:'모집마감'},{value:'ended',label:'종료'},{value:'expired',label:'노출종료'}
-  ], () => filterAdminCampaigns());
+  // 캠페인 상태 필터는 다중선택 드롭다운 → 상태별 탭(admin.js CAMP_STATUS_TABS)으로 교체됨
   // 신청관리
   createMultiFilter('appTypeMulti', '전체 타입', [
     {value:'monitor',label:'리뷰어'},{value:'gifting',label:'기프팅'},{value:'visit',label:'방문형'}

--- a/dev/js/admin.js
+++ b/dev/js/admin.js
@@ -62,7 +62,7 @@ const debouncedFilterAdminCampaigns = debounce(filterAdminCampaigns, 300);
 
 // 보기 초기화 버튼 노출 — 필터·검색·정렬 중 하나라도 비기본이면 표시
 function updateCampViewResetBtn() {
-  const hasFilter = ['campTypeMulti','campStatusMulti'].some(id => getMultiFilterValues(id).length > 0);
+  const hasFilter = getMultiFilterValues('campTypeMulti').length > 0 || _campActiveStatusTab !== null;
   const hasSearch = !!(($('adminCampSearch')?.value || '').trim());
   const hasSort = !!adminCampSortKey;
   const btn = $('btnCampViewReset');
@@ -71,14 +71,14 @@ function updateCampViewResetBtn() {
 
 function resetCampFilters() {
   resetMultiFilter('campTypeMulti', '전체 타입');
-  resetMultiFilter('campStatusMulti', '전체 상태');
+  _campActiveStatusTab = null;
   const s = $('adminCampSearch'); if (s) s.value = '';
   filterAdminCampaigns();
 }
 // 보기 초기화 — 필터·검색·정렬을 한 번에 기본값으로
 function resetCampView() {
   resetMultiFilter('campTypeMulti', '전체 타입');
-  resetMultiFilter('campStatusMulti', '전체 상태');
+  _campActiveStatusTab = null;
   const s = $('adminCampSearch'); if (s) s.value = '';
   adminCampSortKey = ''; adminCampSortDir = '';
   updateSortArrows(); updateCampTableHead();
@@ -151,6 +151,41 @@ var adminReorderMode = false;
 // 캠페인 상태별 클라이언트 노출 도움말 모달 노출
 function openCampStatusHelp() {
   if (typeof openModal === 'function') openModal('campStatusHelpModal');
+}
+
+// ── 캠페인 상태별 탭 (campStatusMulti 드롭다운·adminCampStatusCounts 텍스트를 대체)
+//    오리엔시트·브랜드 신청 페인의 status-tab 패턴 재사용. 단일 선택(한 번에 1개 상태)
+const CAMP_STATUS_TABS = [
+  { code: null,        label: '전체' },
+  { code: 'draft',     label: '준비' },
+  { code: 'scheduled', label: '모집예정' },
+  { code: 'active',    label: '모집중' },
+  { code: 'closed',    label: '모집마감' },
+  { code: 'ended',     label: '종료' },
+  { code: 'expired',   label: '노출종료' },
+];
+var _campActiveStatusTab = null;
+
+// 상태 탭 바 렌더 (counts: 필터 전 전체 기준 상태별 건수)
+function renderCampStatusTabs(counts) {
+  const bar = $('campStatusTabBar');
+  if (!bar) return;
+  counts = counts || {};
+  const totalAll = Object.values(counts).reduce((sum, n) => sum + n, 0);
+  bar.innerHTML = CAMP_STATUS_TABS.map(tab => {
+    const n = tab.code === null ? totalAll : (counts[tab.code] || 0);
+    const isOn = tab.code === _campActiveStatusTab;
+    const cls = 'status-tab-btn' + (isOn ? ' on' : '') + (n === 0 && tab.code !== null ? ' zero-count' : '');
+    return `<button type="button" class="${cls}" data-status="${tab.code || ''}" onclick="setCampStatusTab(this)">`
+      + `${esc(tab.label)}<span class="tab-count">(${n})</span></button>`;
+  }).join('');
+}
+
+// 상태 탭 클릭 → 단일 상태 필터로 목록 재조회 (필터 경로라 sentinel 리셋은 loadAdminCampaigns 가 처리)
+function setCampStatusTab(btn) {
+  _campActiveStatusTab = btn.dataset.status || null;   // 빈 문자열(전체)이면 null
+  updateCampViewResetBtn();
+  filterAdminCampaigns();
 }
 
 function updateCampTableHead() {
@@ -249,30 +284,15 @@ async function loadAdminCampaigns(useCache) {
     {value:'gifting', label:'기프팅',  count: rtCounts.gifting || 0},
     {value:'visit',   label:'방문형',  count: rtCounts.visit || 0},
   ], () => filterAdminCampaigns());
-  syncMultiFilter('campStatusMulti', '전체 상태', [
-    {value:'draft',     label:'준비',     count: stCounts.draft || 0},
-    {value:'scheduled', label:'모집예정', count: stCounts.scheduled || 0},
-    {value:'active',    label:'모집중',   count: stCounts.active || 0},
-    {value:'closed',    label:'모집마감', count: stCounts.closed || 0},
-    {value:'ended',     label:'종료',     count: stCounts.ended || 0},
-    {value:'expired',   label:'노출종료', count: stCounts.expired || 0},
-  ], () => filterAdminCampaigns());
-  // closed(모집마감)·ended(종료)는 실제 DB 상태(마이그레이션 156)라 필터·요약·배지 모두 분리.
-  const stLabels = {active:'모집중',scheduled:'모집예정',draft:'준비',closed:'모집마감',ended:'종료',expired:'노출종료'};
-  // 노출 그룹(scheduled/active/closed/ended)은 컬러, 비노출(draft/expired)은 회색·점선으로 시각 구분
-  const stColors = {active:'var(--green)',scheduled:'#5B7CFF',draft:'var(--muted)',closed:'#B91C5C',ended:'#5E35B1',expired:'#666666'};
-  const el = $('adminCampStatusCounts');
-  if (el) el.innerHTML = Object.keys(stLabels).filter(k=>stCounts[k]).map(k =>
-    `<span style="color:${stColors[k]};font-weight:600">${stLabels[k]} ${stCounts[k]}</span>`
-  ).join('<span style="margin:0 4px;color:var(--line)">·</span>');
+  // 상태 필터는 다중 선택 드롭다운 대신 상태별 탭으로 표시 (건수 포함). closed·ended 는 실제 DB 상태(마이그레이션 156)라 탭에서도 분리.
+  renderCampStatusTabs(stCounts);
 
   // 타입 필터 (다중 선택)
   const typeVals = getMultiFilterValues('campTypeMulti');
   if (typeVals.length) camps = camps.filter(c => typeVals.includes(c.recruit_type));
 
-  // 상태 필터 (다중 선택)
-  const statusVals = getMultiFilterValues('campStatusMulti');
-  if (statusVals.length) camps = camps.filter(c => statusVals.includes(c.status));
+  // 상태 필터 (탭 단일 선택)
+  if (_campActiveStatusTab) camps = camps.filter(c => c.status === _campActiveStatusTab);
 
   // 검색 필터 — 단어 단위 AND 매칭 (matchSearchTokens, 전각/반각 공백 무관)
   const searchVal = ($('adminCampSearch')?.value || '').trim().toLowerCase();
@@ -311,7 +331,7 @@ async function loadAdminCampaigns(useCache) {
   }
 
   // 필터/검색/정렬 중에는 순서 변경 비활성화
-  const isFiltered = searchVal || typeVals.length > 0 || statusVals.length > 0 || !!adminCampSortKey;
+  const isFiltered = searchVal || typeVals.length > 0 || _campActiveStatusTab !== null || !!adminCampSortKey;
 
   const typeLabel = t => getRecruitTypeBadgeKoSm(t);
   // 상태 배지 — closed 는 submission_end 경과 여부로 「모집마감」/「종료」 자동 구분 (shared.js campaignStatusLabelKey)


### PR DESCRIPTION
## 변경 요약
캠페인 관리 목록의 상태 필터를 다중 선택 드롭다운 → 상태별 탭(전체/준비/모집예정/모집중/모집마감/종료/노출종료, 각 건수)으로 교체. 개발서버(PR #608·#609)에서 검증 완료.

dev 브랜치엔 운영 보류 중인 오리엔시트가 섞여 있어, 캠페인 탭 커밋(1aa5ede·303ef16)의 소스 변경분만 main에 적용 + 재빌드(핫픽스 방식). 오리엔시트는 운영에 포함되지 않음.

## 요청 외 추가 변경
- CLAUDE.md 캠페인 목록 필터 설명 갱신

## 관련
- 개발서버 PR #608, #609