### PR TITLE
feat(admin): 캠페인 상태 변경 드롭다운 전이 규칙 비활성

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -12,7 +12,7 @@
 // 회귀(2026-05-12 PR #182 머지 직후 발생)를 방지하기 위한 자동 reload 가드.
 // sessionStorage 차단 환경(시크릿 모드 일부, 쿠키 차단)에서는 자연스럽게 skip.
 (function(){
-  var CURRENT_BUILD = 'v1782703868';
+  var CURRENT_BUILD = 'v1782705400';
   if (CURRENT_BUILD.indexOf('__') === 0) return; // 빌드 미적용 (dev/ 직접 열기) 시 skip
   try {
     var prev = sessionStorage.getItem('reverb.adminBuild');
@@ -743,6 +743,10 @@ input[type="date"].form-input::-webkit-calendar-picker-indicator{margin-left:aut
 .status-dropdown{position:absolute;top:100%;left:0;margin-top:4px;background:#fff;border-radius:10px;box-shadow:0 4px 16px rgba(0,0,0,.15);padding:4px;z-index:999;min-width:110px}
 .status-dropdown-item{padding:6px 10px;border-radius:6px;cursor:pointer;transition:background .12s}
 .status-dropdown-item:hover{background:var(--surface-dim)}
+.status-dropdown-item.disabled{cursor:not-allowed;opacity:.4}
+.status-dropdown-item.disabled:hover{background:none}
+.status-dropdown-item.disabled .badge{filter:grayscale(.7)}
+.status-dropdown-note{padding:8px 10px;font-size:12px;line-height:1.5;color:var(--muted);text-align:center;white-space:nowrap}
 .data-table{width:100%;border-collapse:collapse;font-size:13px}
 .data-table th{padding:10px 10px;background:var(--surface-dim);font-size:11px;font-weight:600;letter-spacing:.04em;text-transform:uppercase;color:var(--on-surface-variant);text-align:left;border-bottom:1px solid var(--outline)}
 .admin-table-wrap{overflow-y:auto}
@@ -2091,7 +2095,7 @@ tr.audit-row, .audit-row { background: #fff3e0 !important; }
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-06-29 12:31 · 4bc43ba</span>
+          <span class="admin-build-text">2026-06-29 12:56 · f0cb683</span>
         </div>
       </div>
     </aside>
@@ -30197,6 +30201,39 @@ async function purgeCampaignAuditData(campId) {
   }
 }
 
+// 캠페인 상태 수동 전이 규칙 — 진행 흐름(준비→모집예정→모집중→모집마감→종료) + 한 칸 되돌리기 허용.
+// 노출종료(expired)는 노출 토글 OFF 로만 진입하므로 어떤 상태에서도 드롭다운 전이 대상이 아니다(빈 배열).
+// 자기 자신은 목록에 없으므로 자동 비활성. 마감일 지난 건의 active/scheduled 추가 차단은 toggleStatusDropdown 에서 적용.
+const CAMP_STATUS_TRANSITIONS = {
+  draft:     ['scheduled', 'active'],
+  scheduled: ['draft', 'active', 'closed'],
+  active:    ['scheduled', 'closed'],
+  closed:    ['active', 'ended'],
+  ended:     ['closed'],
+  expired:   [],
+};
+
+const CAMP_STATUS_ITEMS = [
+  {val:'draft',     label:'준비',     cls:'badge-gray'},
+  {val:'scheduled', label:'모집예정', cls:'badge-blue'},
+  {val:'active',    label:'모집중',   cls:'badge-green'},
+  {val:'closed',    label:'모집마감', cls:'badge-pink'},
+  {val:'ended',     label:'종료',     cls:'badge-done'},
+  {val:'expired',   label:'노출종료', cls:'badge-expired'}
+];
+
+// 드롭다운 항목 1개 렌더 — enabled 면 클릭 가능, 아니면 회색 비활성(onclick 없음)
+function buildStatusDropdownItem(campId, it, enabled) {
+  if (!enabled) {
+    return `<div class="status-dropdown-item disabled" aria-disabled="true">
+      <span class="badge ${it.cls}" style="pointer-events:none">${it.label}</span>
+    </div>`;
+  }
+  return `<div class="status-dropdown-item" onclick="changeCampStatus('${campId}','${it.val}')">
+    <span class="badge ${it.cls}" style="pointer-events:none">${it.label}</span>
+  </div>`;
+}
+
 function toggleStatusDropdown(badgeEl) {
   // 기존 드롭다운 닫기
   document.querySelectorAll('.status-dropdown').forEach(d => d.remove());
@@ -30205,22 +30242,28 @@ function toggleStatusDropdown(badgeEl) {
   const campId = tr?.dataset.campId;
   if (!campId) return;
 
-  const items = [
-    {val:'draft',     label:'준비',     cls:'badge-gray'},
-    {val:'scheduled', label:'모집예정', cls:'badge-blue'},
-    {val:'active',    label:'모집중',   cls:'badge-green'},
-    {val:'closed',    label:'모집마감', cls:'badge-pink'},
-    {val:'ended',     label:'종료',     cls:'badge-done'},
-    {val:'expired',   label:'노출종료', cls:'badge-expired'}
-  ];
+  const camp = allCampaigns.find(c => c.id === campId);
+  const curStatus = camp?.status;
+  const allowed = CAMP_STATUS_TRANSITIONS[curStatus] || [];
+  // 마감일 지난 캠페인은 모집중·모집예정으로 되돌릴 수 없음 (changeCampStatus 차단과 동일 기준)
+  let deadlinePassed = false;
+  if (camp?.deadline) {
+    const dl = new Date(camp.deadline); dl.setHours(23,59,59,999);
+    deadlinePassed = new Date() > dl;
+  }
 
   const dd = document.createElement('div');
   dd.className = 'status-dropdown';
-  dd.innerHTML = items.map(it =>
-    `<div class="status-dropdown-item" onclick="changeCampStatus('${campId}','${it.val}')">
-      <span class="badge ${it.cls}" style="pointer-events:none">${it.label}</span>
-    </div>`
-  ).join('');
+  if (curStatus === 'expired') {
+    // 노출종료는 「노출」 토글로만 복귀 — 드롭다운 전이 대상 없음. 빈 회색 목록 대신 안내 표시
+    dd.innerHTML = `<div class="status-dropdown-note">「노출」 토글로만<br>상태를 변경할 수 있습니다</div>`;
+  } else {
+    dd.innerHTML = CAMP_STATUS_ITEMS.map(it => {
+      let enabled = allowed.includes(it.val);
+      if (enabled && deadlinePassed && (it.val === 'active' || it.val === 'scheduled')) enabled = false;
+      return buildStatusDropdownItem(campId, it, enabled);
+    }).join('');
+  }
   // body에 붙여 부모의 overflow:hidden 클리핑 회피
   document.body.appendChild(dd);
   const rect = badgeEl.getBoundingClientRect();

--- a/dev/css/admin.css
+++ b/dev/css/admin.css
@@ -285,6 +285,10 @@
 .status-dropdown{position:absolute;top:100%;left:0;margin-top:4px;background:#fff;border-radius:10px;box-shadow:0 4px 16px rgba(0,0,0,.15);padding:4px;z-index:999;min-width:110px}
 .status-dropdown-item{padding:6px 10px;border-radius:6px;cursor:pointer;transition:background .12s}
 .status-dropdown-item:hover{background:var(--surface-dim)}
+.status-dropdown-item.disabled{cursor:not-allowed;opacity:.4}
+.status-dropdown-item.disabled:hover{background:none}
+.status-dropdown-item.disabled .badge{filter:grayscale(.7)}
+.status-dropdown-note{padding:8px 10px;font-size:12px;line-height:1.5;color:var(--muted);text-align:center;white-space:nowrap}
 .data-table{width:100%;border-collapse:collapse;font-size:13px}
 .data-table th{padding:10px 10px;background:var(--surface-dim);font-size:11px;font-weight:600;letter-spacing:.04em;text-transform:uppercase;color:var(--on-surface-variant);text-align:left;border-bottom:1px solid var(--outline)}
 .admin-table-wrap{overflow-y:auto}

--- a/dev/js/admin.js
+++ b/dev/js/admin.js
@@ -2368,6 +2368,39 @@ async function purgeCampaignAuditData(campId) {
   }
 }
 
+// 캠페인 상태 수동 전이 규칙 — 진행 흐름(준비→모집예정→모집중→모집마감→종료) + 한 칸 되돌리기 허용.
+// 노출종료(expired)는 노출 토글 OFF 로만 진입하므로 어떤 상태에서도 드롭다운 전이 대상이 아니다(빈 배열).
+// 자기 자신은 목록에 없으므로 자동 비활성. 마감일 지난 건의 active/scheduled 추가 차단은 toggleStatusDropdown 에서 적용.
+const CAMP_STATUS_TRANSITIONS = {
+  draft:     ['scheduled', 'active'],
+  scheduled: ['draft', 'active', 'closed'],
+  active:    ['scheduled', 'closed'],
+  closed:    ['active', 'ended'],
+  ended:     ['closed'],
+  expired:   [],
+};
+
+const CAMP_STATUS_ITEMS = [
+  {val:'draft',     label:'준비',     cls:'badge-gray'},
+  {val:'scheduled', label:'모집예정', cls:'badge-blue'},
+  {val:'active',    label:'모집중',   cls:'badge-green'},
+  {val:'closed',    label:'모집마감', cls:'badge-pink'},
+  {val:'ended',     label:'종료',     cls:'badge-done'},
+  {val:'expired',   label:'노출종료', cls:'badge-expired'}
+];
+
+// 드롭다운 항목 1개 렌더 — enabled 면 클릭 가능, 아니면 회색 비활성(onclick 없음)
+function buildStatusDropdownItem(campId, it, enabled) {
+  if (!enabled) {
+    return `<div class="status-dropdown-item disabled" aria-disabled="true">
+      <span class="badge ${it.cls}" style="pointer-events:none">${it.label}</span>
+    </div>`;
+  }
+  return `<div class="status-dropdown-item" onclick="changeCampStatus('${campId}','${it.val}')">
+    <span class="badge ${it.cls}" style="pointer-events:none">${it.label}</span>
+  </div>`;
+}
+
 function toggleStatusDropdown(badgeEl) {
   // 기존 드롭다운 닫기
   document.querySelectorAll('.status-dropdown').forEach(d => d.remove());
@@ -2376,22 +2409,28 @@ function toggleStatusDropdown(badgeEl) {
   const campId = tr?.dataset.campId;
   if (!campId) return;
 
-  const items = [
-    {val:'draft',     label:'준비',     cls:'badge-gray'},
-    {val:'scheduled', label:'모집예정', cls:'badge-blue'},
-    {val:'active',    label:'모집중',   cls:'badge-green'},
-    {val:'closed',    label:'모집마감', cls:'badge-pink'},
-    {val:'ended',     label:'종료',     cls:'badge-done'},
-    {val:'expired',   label:'노출종료', cls:'badge-expired'}
-  ];
+  const camp = allCampaigns.find(c => c.id === campId);
+  const curStatus = camp?.status;
+  const allowed = CAMP_STATUS_TRANSITIONS[curStatus] || [];
+  // 마감일 지난 캠페인은 모집중·모집예정으로 되돌릴 수 없음 (changeCampStatus 차단과 동일 기준)
+  let deadlinePassed = false;
+  if (camp?.deadline) {
+    const dl = new Date(camp.deadline); dl.setHours(23,59,59,999);
+    deadlinePassed = new Date() > dl;
+  }
 
   const dd = document.createElement('div');
   dd.className = 'status-dropdown';
-  dd.innerHTML = items.map(it =>
-    `<div class="status-dropdown-item" onclick="changeCampStatus('${campId}','${it.val}')">
-      <span class="badge ${it.cls}" style="pointer-events:none">${it.label}</span>
-    </div>`
-  ).join('');
+  if (curStatus === 'expired') {
+    // 노출종료는 「노출」 토글로만 복귀 — 드롭다운 전이 대상 없음. 빈 회색 목록 대신 안내 표시
+    dd.innerHTML = `<div class="status-dropdown-note">「노출」 토글로만<br>상태를 변경할 수 있습니다</div>`;
+  } else {
+    dd.innerHTML = CAMP_STATUS_ITEMS.map(it => {
+      let enabled = allowed.includes(it.val);
+      if (enabled && deadlinePassed && (it.val === 'active' || it.val === 'scheduled')) enabled = false;
+      return buildStatusDropdownItem(campId, it, enabled);
+    }).join('');
+  }
   // body에 붙여 부모의 overflow:hidden 클리핑 회피
   document.body.appendChild(dd);
   const rect = badgeEl.getBoundingClientRect();


### PR DESCRIPTION
## 변경 요약
캠페인 목록 「상태」 컬럼의 상태 변경 드롭다운에서 현재 상태로부터 갈 수 없는 상태를 회색 비활성 처리(진행 흐름 전이 규칙).

- 전이 규칙: 준비→모집예정·모집중 / 모집예정→준비·모집중·모집마감 / 모집중→모집예정·모집마감 / 모집마감→모집중·종료 / 종료→모집마감
- 자기 자신·노출종료(노출 토글 전용)·마감일 지난 모집중/모집예정 비활성
- 노출종료 캠페인은 「노출 토글로만 변경」 안내 표시

## 요청 외 추가 변경
없음