### PR TITLE
feat(admin): 오리엔 상세 모달 브랜드명 중복 생략

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -12,7 +12,7 @@
 // 회귀(2026-05-12 PR #182 머지 직후 발생)를 방지하기 위한 자동 reload 가드.
 // sessionStorage 차단 환경(시크릿 모드 일부, 쿠키 차단)에서는 자연스럽게 skip.
 (function(){
-  var CURRENT_BUILD = 'v1782709165';
+  var CURRENT_BUILD = 'v1782709770';
   if (CURRENT_BUILD.indexOf('__') === 0) return; // 빌드 미적용 (dev/ 직접 열기) 시 skip
   try {
     var prev = sessionStorage.getItem('reverb.adminBuild');
@@ -2095,7 +2095,7 @@ tr.audit-row, .audit-row { background: #fff3e0 !important; }
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-06-29 13:59 · c4a3636</span>
+          <span class="admin-build-text">2026-06-29 14:09 · 954c088</span>
         </div>
       </div>
     </aside>
@@ -12138,7 +12138,7 @@ function osDetailHtml(s, catMap, readonly) {
   // 상태 배지 + 모집 건수 줄 — 브랜드 정보 카드와 제품(모집 건) 카드 사이에 배치
   const statusLine = `<div style="margin:16px 0 10px">${osBadge(osStatusOf(s))}`
     + `<span style="margin-left:6px;color:var(--muted);font-size:12px">${cards.length ? cards.length + '개 모집 건' : ''}</span></div>`;
-  const brandCard = osBrandCard(d.brand);
+  const brandCard = osBrandCard(d.brand, osBrandName(s));
   let bodyHtml;
   if (!cards.length) {
     const msg = (s.status === 'draft')
@@ -12165,10 +12165,12 @@ function osFieldHtml(label, htmlVal, wide) {
 }
 function osRange(a, b) { return (a || b) ? `${a || '?'} ~ ${b || '?'}` : ''; }
 
-// 공통 브랜드 카드 (1회)
-function osBrandCard(brand) {
+// 공통 브랜드 카드 (1회). headerName: 모달 헤더의 발급 브랜드 마스터명 — 작성 브랜드명과 같으면 중복이라 생략
+function osBrandCard(brand, headerName) {
   const b = brand || {};
-  const inner = osField('브랜드명', b.name) + osField('소개·어필', b.intro, true) + osField('공식 계정', b.official_accounts, true);
+  // 작성된 브랜드명이 헤더와 동일하면 생략(중복), 다르거나 미입력이면 표시
+  const nameField = (b.name && b.name.trim() === String(headerName || '').trim()) ? '' : osField('브랜드명', b.name);
+  const inner = nameField + osField('소개·어필', b.intro, true) + osField('공식 계정', b.official_accounts, true);
   return `<div class="os-card">
     <div class="os-card-title">브랜드 정보</div>
     <div class="os-fields">${inner}</div></div>`;

--- a/dev/js/admin-orient.js
+++ b/dev/js/admin-orient.js
@@ -487,7 +487,7 @@ function osDetailHtml(s, catMap, readonly) {
   // 상태 배지 + 모집 건수 줄 — 브랜드 정보 카드와 제품(모집 건) 카드 사이에 배치
   const statusLine = `<div style="margin:16px 0 10px">${osBadge(osStatusOf(s))}`
     + `<span style="margin-left:6px;color:var(--muted);font-size:12px">${cards.length ? cards.length + '개 모집 건' : ''}</span></div>`;
-  const brandCard = osBrandCard(d.brand);
+  const brandCard = osBrandCard(d.brand, osBrandName(s));
   let bodyHtml;
   if (!cards.length) {
     const msg = (s.status === 'draft')
@@ -514,10 +514,12 @@ function osFieldHtml(label, htmlVal, wide) {
 }
 function osRange(a, b) { return (a || b) ? `${a || '?'} ~ ${b || '?'}` : ''; }
 
-// 공통 브랜드 카드 (1회)
-function osBrandCard(brand) {
+// 공통 브랜드 카드 (1회). headerName: 모달 헤더의 발급 브랜드 마스터명 — 작성 브랜드명과 같으면 중복이라 생략
+function osBrandCard(brand, headerName) {
   const b = brand || {};
-  const inner = osField('브랜드명', b.name) + osField('소개·어필', b.intro, true) + osField('공식 계정', b.official_accounts, true);
+  // 작성된 브랜드명이 헤더와 동일하면 생략(중복), 다르거나 미입력이면 표시
+  const nameField = (b.name && b.name.trim() === String(headerName || '').trim()) ? '' : osField('브랜드명', b.name);
+  const inner = nameField + osField('소개·어필', b.intro, true) + osField('공식 계정', b.official_accounts, true);
   return `<div class="os-card">
     <div class="os-card-title">브랜드 정보</div>
     <div class="os-fields">${inner}</div></div>`;


### PR DESCRIPTION
## 변경 요약
상세 모달 「브랜드 정보」 카드의 브랜드명이 헤더 회사명(발급 브랜드 마스터)과 같으면 생략, 다르거나 미입력이면 표시. 헤더=brands.name, 카드=data.brand.name(작성 입력)으로 출처가 달라 같을 때만 중복 제거.

## 요청 외 추가 변경
없음

## 관련 사양서
docs/specs/2026-06-18-brand-self-orient-sheet.md