### PR TITLE
feat(orient): 발급 메일 수신자 선택 + 신규 담당자 저장

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -12,7 +12,7 @@
 // 회귀(2026-05-12 PR #182 머지 직후 발생)를 방지하기 위한 자동 reload 가드.
 // sessionStorage 차단 환경(시크릿 모드 일부, 쿠키 차단)에서는 자연스럽게 skip.
 (function(){
-  var CURRENT_BUILD = 'v1782709770';
+  var CURRENT_BUILD = 'v1782719730';
   if (CURRENT_BUILD.indexOf('__') === 0) return; // 빌드 미적용 (dev/ 직접 열기) 시 skip
   try {
     var prev = sessionStorage.getItem('reverb.adminBuild');
@@ -2095,7 +2095,7 @@ tr.audit-row, .audit-row { background: #fff3e0 !important; }
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-06-29 14:09 · 954c088</span>
+          <span class="admin-build-text">2026-06-29 16:55 · cf851a3</span>
         </div>
       </div>
     </aside>
@@ -9675,12 +9675,16 @@ async function createOrientSheet(brandId, applicationId) {
 // 발송 성공 시 연결 신청이 있으면 단계가 'orient_sheet_sent' 로 자동 전진(함수 198, 역행 방지).
 // 반환: { sent:true, recipient, advanced } / { sent:false, reason:'no_recipient'|... } / { sent:false, error }
 // 발송 실패가 발급 자체를 무효화하지 않도록 호출 측에서 결과만 표시(throw 안 함).
-async function sendOrientInviteMail(orientSheetId) {
+async function sendOrientInviteMail(orientSheetId, recipient) {
   if (!db) return { sent: false, reason: 'no_db' };
+  // recipient(선택) 가 있으면 수신자 명시 — 없으면 Edge Function 이 자동 결정(서베이 연결 건 등)
+  const body = { orient_sheet_id: orientSheetId };
+  if (recipient && recipient.email) {
+    body.to_email = recipient.email;
+    if (recipient.name) body.to_name = recipient.name;
+  }
   try {
-    const { data, error } = await db.functions.invoke('notify-orient-sheet', {
-      body: { orient_sheet_id: orientSheetId },
-    });
+    const { data, error } = await db.functions.invoke('notify-orient-sheet', { body });
     if (error) {
       // FunctionsHttpError 는 응답 본문(reason)을 error.context 에 담을 수 있음
       let detail = null;
@@ -11661,6 +11665,9 @@ let _orientSheets = [];
 let _osDetailSheet = null;   // 상세 모달에 열린 시트(카드별 발행에 사용)
 let _osDetailCatMap = {};    // 상세 모달 카테고리 라벨 맵(새창 열기에 재사용)
 let _osLastIssuedId = null;  // 방금 발급한 오리엔시트 id(발급 결과 화면 수동 메일 발송용)
+let _osLastIssuedBrandId = null;  // 방금 발급한 시트의 브랜드 id(수신자 담당자 로드·저장용)
+let _osBrandContacts = [];        // 발급 브랜드의 담당자 배열(드롭다운 소스)
+let _osPendingContact = null;     // 발송 성공 후 저장 대기 중인 신규 담당자 {email, name}
 
 const OS_TYPE_LABEL = { proxy_purchase: '가구매', reviewer: '리뷰어', seeding: '시딩' };
 const OS_TYPE_CHIP = {
@@ -11949,6 +11956,11 @@ async function osSubmitCreate() {
     document.getElementById('osCreateResult').style.display = '';
     btn.style.display = 'none';
     _osLastIssuedId = res.id;   // 발급 결과 화면의 「메일 발송」 버튼이 사용 (자동 발송 안 함 — 수동 선택)
+    _osLastIssuedBrandId = brandId;
+    _osPendingContact = null;
+    // 브랜드만 선택한 건만 수신자 선택 UI 노출 (신청 연결 건은 신청 담당자 이메일 자동)
+    if (!appId) { osLoadRecipients(brandId); }
+    else { const pick = document.getElementById('osRecipientPick'); if (pick) pick.style.display = 'none'; }
     await refreshPane('orient-sheets');
   } catch (e) {
     toast(typeof friendlyError === 'function' ? friendlyError(e) : '발급에 실패했습니다.');
@@ -11970,39 +11982,138 @@ function osCopyResultLink() {
   copyTextToClipboard(document.getElementById('osCreateLink').value, '작성 링크가 복사되었습니다.');
 }
 
+// 발급 브랜드의 담당자 로드 → 수신자 드롭다운 채움 (브랜드만 선택 건). 대표 담당자 기본 선택.
+async function osLoadRecipients(brandId) {
+  const pick = document.getElementById('osRecipientPick');
+  const sel = document.getElementById('osRecipientSelect');
+  if (!pick || !sel) return;
+  _osBrandContacts = [];
+  let brand = null;
+  try { brand = await fetchBrandById(brandId); } catch (_e) { /* 폴백: 직접 입력만 */ }
+  let contacts = (brand && Array.isArray(brand.contacts)) ? brand.contacts.filter(c => c && c.email) : [];
+  // contacts 비었는데 legacy primary_email 있으면 대표 1명으로 폴백
+  if (!contacts.length && brand && brand.primary_email) {
+    contacts = [{ name: brand.primary_contact_name || '', email: brand.primary_email, is_primary: true }];
+  }
+  _osBrandContacts = contacts;
+  const primaryIdx = contacts.findIndex(c => c.is_primary);
+  const defIdx = primaryIdx >= 0 ? primaryIdx : 0;
+  let html = contacts.map((c, i) =>
+    `<option value="${i}">${esc((c.name ? c.name + ' · ' : '') + c.email)}${c.is_primary ? ' (대표)' : ''}</option>`
+  ).join('');
+  html += '<option value="new">+ 직접 입력</option>';
+  sel.innerHTML = html;
+  sel.value = contacts.length ? String(defIdx) : 'new';
+  pick.style.display = '';
+  osOnRecipientChange();
+}
+
+// 드롭다운에서 「직접 입력」 선택 시 이름·이메일 입력칸 표시
+function osOnRecipientChange() {
+  const sel = document.getElementById('osRecipientSelect');
+  const nw = document.getElementById('osRecipientNew');
+  if (!sel || !nw) return;
+  nw.style.display = (sel.value === 'new') ? '' : 'none';
+}
+
 // 발급 결과 화면 「메일 발송」 버튼 — 선택 발송(자동 발송 아님). 발송 중 버튼 비활성.
 async function osSendInviteClick(btn) {
   if (!_osLastIssuedId) return;
+  // 브랜드만 선택 건: 드롭다운/직접입력으로 수신자 명시. 신청 연결 건: recipient 없이 자동 결정.
+  let recipient = null;
+  let isNewContact = false;
+  const pick = document.getElementById('osRecipientPick');
+  if (pick && pick.style.display !== 'none') {
+    const sel = document.getElementById('osRecipientSelect');
+    if (sel && sel.value === 'new') {
+      const email = (document.getElementById('osNewContactEmail').value || '').trim();
+      const name = (document.getElementById('osNewContactName').value || '').trim();
+      if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) { toast('올바른 이메일 주소를 입력해 주세요.'); return; }
+      // 기존 담당자와 중복이면 재사용(신규 저장 안 함)
+      const dup = _osBrandContacts.find(c => (c.email || '').trim().toLowerCase() === email.toLowerCase());
+      recipient = dup ? { email: dup.email, name: dup.name || name } : { email, name };
+      isNewContact = !dup;
+    } else if (sel) {
+      const c = _osBrandContacts[Number(sel.value)];
+      if (c) recipient = { email: c.email, name: c.name || '' };
+    }
+    if (!recipient) { toast('수신자를 선택해 주세요.'); return; }
+  }
   btn.disabled = true;
-  try { await osSendInviteAndShow(_osLastIssuedId); }
+  try { await osSendInviteAndShow(_osLastIssuedId, recipient, isNewContact); }
   finally { btn.disabled = false; }
 }
 
-// 발급 직후 메일 발송 + 발급 결과 화면에 발송 상태 인라인 표시.
-// 발송은 발급과 별개라 실패해도 발급 자체는 유효(링크 수동 복사 안내).
-async function osSendInviteAndShow(orientSheetId) {
+// 메일 발송 + 발급 결과 화면에 상태 인라인 표시. 발송은 발급과 별개라 실패해도 발급은 유효(링크 수동 복사).
+// 신규 담당자(직접 입력·중복 아님)면 발송 성공 후 「브랜드에 저장 + 대표 설정?」 버튼 노출.
+async function osSendInviteAndShow(orientSheetId, recipient, isNewContact) {
   const box = document.getElementById('osCreateMailStatus');
   if (!box) return;
   box.innerHTML = '<span style="color:var(--muted)">메일 발송 중…</span>';
   let r;
   try {
-    r = await sendOrientInviteMail(orientSheetId);
+    r = await sendOrientInviteMail(orientSheetId, recipient);
   } catch (e) {
     r = { sent: false, error: (e && e.message) || 'unknown' };
   }
   if (r && r.sent) {
-    const advNote = r.advanced
-      ? ' · 신청 단계를 「오리엔시트 발송됨」으로 이동했습니다.'
-      : '';
-    box.innerHTML = '<div style="color:#16A34A;font-weight:600">메일을 보냈습니다 — ' +
-      esc(r.recipient || '') + '</div>' +
-      (advNote ? '<div style="color:var(--muted);font-size:12px;margin-top:2px">' + advNote.replace(/^ · /, '') + '</div>' : '');
+    const advNote = r.advanced ? '신청 단계를 「오리엔시트 발송됨」으로 이동했습니다.' : '';
+    let html = '<div style="color:#16A34A;font-weight:600">메일을 보냈습니다 — ' +
+      esc(r.recipient || (recipient && recipient.email) || '') + '</div>' +
+      (advNote ? '<div style="color:var(--muted);font-size:12px;margin-top:2px">' + advNote + '</div>' : '');
+    if (isNewContact && recipient && recipient.email) {
+      _osPendingContact = { email: recipient.email, name: recipient.name || '' };
+      html += '<div style="margin-top:10px;padding:10px;background:#FAFAF7;border-radius:8px">'
+        + '<div style="font-size:13px;margin-bottom:6px">이 담당자를 브랜드에 저장합니다. 대표 담당자로도 설정할까요?</div>'
+        + '<div style="display:flex;gap:6px;flex-wrap:wrap">'
+        + '<button type="button" class="btn btn-primary btn-xs" onclick="osSaveIssuedContact(true,this)">대표 담당자로 저장</button>'
+        + '<button type="button" class="btn btn-ghost btn-xs" onclick="osSaveIssuedContact(false,this)">담당자로만 저장</button>'
+        + '</div></div>';
+    }
+    box.innerHTML = html;
   } else if (r && r.reason === 'no_recipient') {
     box.innerHTML = '<div style="color:#B45309;font-weight:600">수신자 이메일이 없어 메일을 보내지 못했습니다.</div>' +
       '<div style="color:var(--muted);font-size:12px;margin-top:2px">위 링크를 복사해 브랜드에게 직접 전달해 주세요.</div>';
   } else {
     box.innerHTML = '<div style="color:#C41E3A;font-weight:600">메일 발송에 실패했습니다.</div>' +
       '<div style="color:var(--muted);font-size:12px;margin-top:2px">위 링크를 복사해 직접 전달하거나, 잠시 후 다시 시도해 주세요.</div>';
+  }
+}
+
+// 신규 담당자를 브랜드(brands.contacts)에 저장. asPrimary=true 면 대표로 설정 + legacy primary_* 동기화.
+// admin-brand.js 「대표 1개 보장·빈 행 제외」 규칙과 정합. 중복 이메일이면 기존 행 재사용.
+async function osSaveIssuedContact(asPrimary, btn) {
+  if (!_osPendingContact || !_osLastIssuedBrandId) return;
+  if (btn) btn.disabled = true;
+  try {
+    const brand = await fetchBrandById(_osLastIssuedBrandId);   // 최신 contacts (덮어쓰기 최소화)
+    let contacts = (brand && Array.isArray(brand.contacts)) ? brand.contacts.slice() : [];
+    const email = (_osPendingContact.email || '').trim();
+    let row = contacts.find(c => (c.email || '').trim().toLowerCase() === email.toLowerCase());
+    if (!row) {
+      const cid = (typeof _genContactId === 'function') ? _genContactId() : ('c' + contacts.length + '_' + email);
+      row = { id: cid, name: _osPendingContact.name || '', phone: '', email, is_primary: false };
+      contacts.push(row);
+    } else if (_osPendingContact.name && !row.name) {
+      row.name = _osPendingContact.name;
+    }
+    if (asPrimary) contacts.forEach(c => { c.is_primary = (c === row); });
+    else if (!contacts.some(c => c.is_primary) && contacts.length) contacts[0].is_primary = true;
+    const patch = { contacts };
+    const primary = contacts.find(c => c.is_primary);
+    if (primary) {
+      patch.primary_email = primary.email || '';
+      patch.primary_contact_name = primary.name || '';
+      patch.primary_phone = primary.phone || '';
+    }
+    await updateBrand(_osLastIssuedBrandId, patch);
+    const box = document.getElementById('osCreateMailStatus');
+    if (box) box.innerHTML += '<div style="color:#16A34A;font-size:12px;margin-top:6px">담당자를 저장했습니다'
+      + (asPrimary ? ' (대표 담당자로 설정)' : '') + '.</div>';
+    _osPendingContact = null;
+  } catch (e) {
+    toast(typeof friendlyError === 'function' ? friendlyError(e) : '담당자 저장에 실패했습니다.');
+    if (btn) btn.disabled = false;
   }
 }
 
@@ -12416,6 +12527,14 @@ function ensureOrientModals() {
           <p style="font-weight:700;margin-bottom:8px">발급되었습니다. 아래 링크를 브랜드에게 전달하세요.</p>
           <input type="text" id="osCreateLink" class="form-input" readonly onclick="this.select()">
           <div style="font-size:12px;color:var(--muted);margin-top:6px">작성 기한: <span id="osCreateExpire"></span></div>
+          <div id="osRecipientPick" style="display:none;margin-top:12px">
+            <label style="display:block;font-size:12px;font-weight:600;color:var(--muted);margin-bottom:4px">메일 받을 담당자</label>
+            <select id="osRecipientSelect" class="form-input" onchange="osOnRecipientChange()"></select>
+            <div id="osRecipientNew" style="display:none;margin-top:6px">
+              <input id="osNewContactName" class="form-input" placeholder="담당자 이름" style="margin-bottom:6px">
+              <input id="osNewContactEmail" class="form-input" type="email" placeholder="이메일 주소" autocomplete="off">
+            </div>
+          </div>
           <div style="margin-top:10px;display:flex;gap:8px;flex-wrap:wrap">
             <button type="button" class="btn btn-primary btn-sm" onclick="osCopyResultLink()">링크 복사</button>
             <button type="button" class="btn btn-ghost btn-sm" onclick="osSendInviteClick(this)"><span class="material-icons-round notranslate" translate="no" style="font-size:15px;vertical-align:-3px">mail</span> 메일 발송</button>

--- a/dev/js/admin-orient.js
+++ b/dev/js/admin-orient.js
@@ -10,6 +10,9 @@ let _orientSheets = [];
 let _osDetailSheet = null;   // 상세 모달에 열린 시트(카드별 발행에 사용)
 let _osDetailCatMap = {};    // 상세 모달 카테고리 라벨 맵(새창 열기에 재사용)
 let _osLastIssuedId = null;  // 방금 발급한 오리엔시트 id(발급 결과 화면 수동 메일 발송용)
+let _osLastIssuedBrandId = null;  // 방금 발급한 시트의 브랜드 id(수신자 담당자 로드·저장용)
+let _osBrandContacts = [];        // 발급 브랜드의 담당자 배열(드롭다운 소스)
+let _osPendingContact = null;     // 발송 성공 후 저장 대기 중인 신규 담당자 {email, name}
 
 const OS_TYPE_LABEL = { proxy_purchase: '가구매', reviewer: '리뷰어', seeding: '시딩' };
 const OS_TYPE_CHIP = {
@@ -298,6 +301,11 @@ async function osSubmitCreate() {
     document.getElementById('osCreateResult').style.display = '';
     btn.style.display = 'none';
     _osLastIssuedId = res.id;   // 발급 결과 화면의 「메일 발송」 버튼이 사용 (자동 발송 안 함 — 수동 선택)
+    _osLastIssuedBrandId = brandId;
+    _osPendingContact = null;
+    // 브랜드만 선택한 건만 수신자 선택 UI 노출 (신청 연결 건은 신청 담당자 이메일 자동)
+    if (!appId) { osLoadRecipients(brandId); }
+    else { const pick = document.getElementById('osRecipientPick'); if (pick) pick.style.display = 'none'; }
     await refreshPane('orient-sheets');
   } catch (e) {
     toast(typeof friendlyError === 'function' ? friendlyError(e) : '발급에 실패했습니다.');
@@ -319,39 +327,138 @@ function osCopyResultLink() {
   copyTextToClipboard(document.getElementById('osCreateLink').value, '작성 링크가 복사되었습니다.');
 }
 
+// 발급 브랜드의 담당자 로드 → 수신자 드롭다운 채움 (브랜드만 선택 건). 대표 담당자 기본 선택.
+async function osLoadRecipients(brandId) {
+  const pick = document.getElementById('osRecipientPick');
+  const sel = document.getElementById('osRecipientSelect');
+  if (!pick || !sel) return;
+  _osBrandContacts = [];
+  let brand = null;
+  try { brand = await fetchBrandById(brandId); } catch (_e) { /* 폴백: 직접 입력만 */ }
+  let contacts = (brand && Array.isArray(brand.contacts)) ? brand.contacts.filter(c => c && c.email) : [];
+  // contacts 비었는데 legacy primary_email 있으면 대표 1명으로 폴백
+  if (!contacts.length && brand && brand.primary_email) {
+    contacts = [{ name: brand.primary_contact_name || '', email: brand.primary_email, is_primary: true }];
+  }
+  _osBrandContacts = contacts;
+  const primaryIdx = contacts.findIndex(c => c.is_primary);
+  const defIdx = primaryIdx >= 0 ? primaryIdx : 0;
+  let html = contacts.map((c, i) =>
+    `<option value="${i}">${esc((c.name ? c.name + ' · ' : '') + c.email)}${c.is_primary ? ' (대표)' : ''}</option>`
+  ).join('');
+  html += '<option value="new">+ 직접 입력</option>';
+  sel.innerHTML = html;
+  sel.value = contacts.length ? String(defIdx) : 'new';
+  pick.style.display = '';
+  osOnRecipientChange();
+}
+
+// 드롭다운에서 「직접 입력」 선택 시 이름·이메일 입력칸 표시
+function osOnRecipientChange() {
+  const sel = document.getElementById('osRecipientSelect');
+  const nw = document.getElementById('osRecipientNew');
+  if (!sel || !nw) return;
+  nw.style.display = (sel.value === 'new') ? '' : 'none';
+}
+
 // 발급 결과 화면 「메일 발송」 버튼 — 선택 발송(자동 발송 아님). 발송 중 버튼 비활성.
 async function osSendInviteClick(btn) {
   if (!_osLastIssuedId) return;
+  // 브랜드만 선택 건: 드롭다운/직접입력으로 수신자 명시. 신청 연결 건: recipient 없이 자동 결정.
+  let recipient = null;
+  let isNewContact = false;
+  const pick = document.getElementById('osRecipientPick');
+  if (pick && pick.style.display !== 'none') {
+    const sel = document.getElementById('osRecipientSelect');
+    if (sel && sel.value === 'new') {
+      const email = (document.getElementById('osNewContactEmail').value || '').trim();
+      const name = (document.getElementById('osNewContactName').value || '').trim();
+      if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) { toast('올바른 이메일 주소를 입력해 주세요.'); return; }
+      // 기존 담당자와 중복이면 재사용(신규 저장 안 함)
+      const dup = _osBrandContacts.find(c => (c.email || '').trim().toLowerCase() === email.toLowerCase());
+      recipient = dup ? { email: dup.email, name: dup.name || name } : { email, name };
+      isNewContact = !dup;
+    } else if (sel) {
+      const c = _osBrandContacts[Number(sel.value)];
+      if (c) recipient = { email: c.email, name: c.name || '' };
+    }
+    if (!recipient) { toast('수신자를 선택해 주세요.'); return; }
+  }
   btn.disabled = true;
-  try { await osSendInviteAndShow(_osLastIssuedId); }
+  try { await osSendInviteAndShow(_osLastIssuedId, recipient, isNewContact); }
   finally { btn.disabled = false; }
 }
 
-// 발급 직후 메일 발송 + 발급 결과 화면에 발송 상태 인라인 표시.
-// 발송은 발급과 별개라 실패해도 발급 자체는 유효(링크 수동 복사 안내).
-async function osSendInviteAndShow(orientSheetId) {
+// 메일 발송 + 발급 결과 화면에 상태 인라인 표시. 발송은 발급과 별개라 실패해도 발급은 유효(링크 수동 복사).
+// 신규 담당자(직접 입력·중복 아님)면 발송 성공 후 「브랜드에 저장 + 대표 설정?」 버튼 노출.
+async function osSendInviteAndShow(orientSheetId, recipient, isNewContact) {
   const box = document.getElementById('osCreateMailStatus');
   if (!box) return;
   box.innerHTML = '<span style="color:var(--muted)">메일 발송 중…</span>';
   let r;
   try {
-    r = await sendOrientInviteMail(orientSheetId);
+    r = await sendOrientInviteMail(orientSheetId, recipient);
   } catch (e) {
     r = { sent: false, error: (e && e.message) || 'unknown' };
   }
   if (r && r.sent) {
-    const advNote = r.advanced
-      ? ' · 신청 단계를 「오리엔시트 발송됨」으로 이동했습니다.'
-      : '';
-    box.innerHTML = '<div style="color:#16A34A;font-weight:600">메일을 보냈습니다 — ' +
-      esc(r.recipient || '') + '</div>' +
-      (advNote ? '<div style="color:var(--muted);font-size:12px;margin-top:2px">' + advNote.replace(/^ · /, '') + '</div>' : '');
+    const advNote = r.advanced ? '신청 단계를 「오리엔시트 발송됨」으로 이동했습니다.' : '';
+    let html = '<div style="color:#16A34A;font-weight:600">메일을 보냈습니다 — ' +
+      esc(r.recipient || (recipient && recipient.email) || '') + '</div>' +
+      (advNote ? '<div style="color:var(--muted);font-size:12px;margin-top:2px">' + advNote + '</div>' : '');
+    if (isNewContact && recipient && recipient.email) {
+      _osPendingContact = { email: recipient.email, name: recipient.name || '' };
+      html += '<div style="margin-top:10px;padding:10px;background:#FAFAF7;border-radius:8px">'
+        + '<div style="font-size:13px;margin-bottom:6px">이 담당자를 브랜드에 저장합니다. 대표 담당자로도 설정할까요?</div>'
+        + '<div style="display:flex;gap:6px;flex-wrap:wrap">'
+        + '<button type="button" class="btn btn-primary btn-xs" onclick="osSaveIssuedContact(true,this)">대표 담당자로 저장</button>'
+        + '<button type="button" class="btn btn-ghost btn-xs" onclick="osSaveIssuedContact(false,this)">담당자로만 저장</button>'
+        + '</div></div>';
+    }
+    box.innerHTML = html;
   } else if (r && r.reason === 'no_recipient') {
     box.innerHTML = '<div style="color:#B45309;font-weight:600">수신자 이메일이 없어 메일을 보내지 못했습니다.</div>' +
       '<div style="color:var(--muted);font-size:12px;margin-top:2px">위 링크를 복사해 브랜드에게 직접 전달해 주세요.</div>';
   } else {
     box.innerHTML = '<div style="color:#C41E3A;font-weight:600">메일 발송에 실패했습니다.</div>' +
       '<div style="color:var(--muted);font-size:12px;margin-top:2px">위 링크를 복사해 직접 전달하거나, 잠시 후 다시 시도해 주세요.</div>';
+  }
+}
+
+// 신규 담당자를 브랜드(brands.contacts)에 저장. asPrimary=true 면 대표로 설정 + legacy primary_* 동기화.
+// admin-brand.js 「대표 1개 보장·빈 행 제외」 규칙과 정합. 중복 이메일이면 기존 행 재사용.
+async function osSaveIssuedContact(asPrimary, btn) {
+  if (!_osPendingContact || !_osLastIssuedBrandId) return;
+  if (btn) btn.disabled = true;
+  try {
+    const brand = await fetchBrandById(_osLastIssuedBrandId);   // 최신 contacts (덮어쓰기 최소화)
+    let contacts = (brand && Array.isArray(brand.contacts)) ? brand.contacts.slice() : [];
+    const email = (_osPendingContact.email || '').trim();
+    let row = contacts.find(c => (c.email || '').trim().toLowerCase() === email.toLowerCase());
+    if (!row) {
+      const cid = (typeof _genContactId === 'function') ? _genContactId() : ('c' + contacts.length + '_' + email);
+      row = { id: cid, name: _osPendingContact.name || '', phone: '', email, is_primary: false };
+      contacts.push(row);
+    } else if (_osPendingContact.name && !row.name) {
+      row.name = _osPendingContact.name;
+    }
+    if (asPrimary) contacts.forEach(c => { c.is_primary = (c === row); });
+    else if (!contacts.some(c => c.is_primary) && contacts.length) contacts[0].is_primary = true;
+    const patch = { contacts };
+    const primary = contacts.find(c => c.is_primary);
+    if (primary) {
+      patch.primary_email = primary.email || '';
+      patch.primary_contact_name = primary.name || '';
+      patch.primary_phone = primary.phone || '';
+    }
+    await updateBrand(_osLastIssuedBrandId, patch);
+    const box = document.getElementById('osCreateMailStatus');
+    if (box) box.innerHTML += '<div style="color:#16A34A;font-size:12px;margin-top:6px">담당자를 저장했습니다'
+      + (asPrimary ? ' (대표 담당자로 설정)' : '') + '.</div>';
+    _osPendingContact = null;
+  } catch (e) {
+    toast(typeof friendlyError === 'function' ? friendlyError(e) : '담당자 저장에 실패했습니다.');
+    if (btn) btn.disabled = false;
   }
 }
 
@@ -765,6 +872,14 @@ function ensureOrientModals() {
           <p style="font-weight:700;margin-bottom:8px">발급되었습니다. 아래 링크를 브랜드에게 전달하세요.</p>
           <input type="text" id="osCreateLink" class="form-input" readonly onclick="this.select()">
           <div style="font-size:12px;color:var(--muted);margin-top:6px">작성 기한: <span id="osCreateExpire"></span></div>
+          <div id="osRecipientPick" style="display:none;margin-top:12px">
+            <label style="display:block;font-size:12px;font-weight:600;color:var(--muted);margin-bottom:4px">메일 받을 담당자</label>
+            <select id="osRecipientSelect" class="form-input" onchange="osOnRecipientChange()"></select>
+            <div id="osRecipientNew" style="display:none;margin-top:6px">
+              <input id="osNewContactName" class="form-input" placeholder="담당자 이름" style="margin-bottom:6px">
+              <input id="osNewContactEmail" class="form-input" type="email" placeholder="이메일 주소" autocomplete="off">
+            </div>
+          </div>
           <div style="margin-top:10px;display:flex;gap:8px;flex-wrap:wrap">
             <button type="button" class="btn btn-primary btn-sm" onclick="osCopyResultLink()">링크 복사</button>
             <button type="button" class="btn btn-ghost btn-sm" onclick="osSendInviteClick(this)"><span class="material-icons-round notranslate" translate="no" style="font-size:15px;vertical-align:-3px">mail</span> 메일 발송</button>

--- a/dev/lib/storage.js
+++ b/dev/lib/storage.js
@@ -3497,12 +3497,16 @@ async function createOrientSheet(brandId, applicationId) {
 // 발송 성공 시 연결 신청이 있으면 단계가 'orient_sheet_sent' 로 자동 전진(함수 198, 역행 방지).
 // 반환: { sent:true, recipient, advanced } / { sent:false, reason:'no_recipient'|... } / { sent:false, error }
 // 발송 실패가 발급 자체를 무효화하지 않도록 호출 측에서 결과만 표시(throw 안 함).
-async function sendOrientInviteMail(orientSheetId) {
+async function sendOrientInviteMail(orientSheetId, recipient) {
   if (!db) return { sent: false, reason: 'no_db' };
+  // recipient(선택) 가 있으면 수신자 명시 — 없으면 Edge Function 이 자동 결정(서베이 연결 건 등)
+  const body = { orient_sheet_id: orientSheetId };
+  if (recipient && recipient.email) {
+    body.to_email = recipient.email;
+    if (recipient.name) body.to_name = recipient.name;
+  }
   try {
-    const { data, error } = await db.functions.invoke('notify-orient-sheet', {
-      body: { orient_sheet_id: orientSheetId },
-    });
+    const { data, error } = await db.functions.invoke('notify-orient-sheet', { body });
     if (error) {
       // FunctionsHttpError 는 응답 본문(reason)을 error.context 에 담을 수 있음
       let detail = null;

--- a/index.html
+++ b/index.html
@@ -8033,12 +8033,16 @@ async function createOrientSheet(brandId, applicationId) {
 // 발송 성공 시 연결 신청이 있으면 단계가 'orient_sheet_sent' 로 자동 전진(함수 198, 역행 방지).
 // 반환: { sent:true, recipient, advanced } / { sent:false, reason:'no_recipient'|... } / { sent:false, error }
 // 발송 실패가 발급 자체를 무효화하지 않도록 호출 측에서 결과만 표시(throw 안 함).
-async function sendOrientInviteMail(orientSheetId) {
+async function sendOrientInviteMail(orientSheetId, recipient) {
   if (!db) return { sent: false, reason: 'no_db' };
+  // recipient(선택) 가 있으면 수신자 명시 — 없으면 Edge Function 이 자동 결정(서베이 연결 건 등)
+  const body = { orient_sheet_id: orientSheetId };
+  if (recipient && recipient.email) {
+    body.to_email = recipient.email;
+    if (recipient.name) body.to_name = recipient.name;
+  }
   try {
-    const { data, error } = await db.functions.invoke('notify-orient-sheet', {
-      body: { orient_sheet_id: orientSheetId },
-    });
+    const { data, error } = await db.functions.invoke('notify-orient-sheet', { body });
     if (error) {
       // FunctionsHttpError 는 응답 본문(reason)을 error.context 에 담을 수 있음
       let detail = null;

--- a/supabase/functions/notify-orient-sheet/index.ts
+++ b/supabase/functions/notify-orient-sheet/index.ts
@@ -146,7 +146,7 @@ Deno.serve(async (req: Request) => {
   }
 
   try {
-    const { orient_sheet_id } = await req.json();
+    const { orient_sheet_id, to_email, to_name } = await req.json();
     if (!orient_sheet_id) {
       return new Response(JSON.stringify({ error: "orient_sheet_id required" }), {
         status: 400,
@@ -158,6 +158,34 @@ Deno.serve(async (req: Request) => {
     const serviceKey = env("SUPABASE_SERVICE_ROLE_KEY");
     if (!supaUrl || !serviceKey) throw new Error("Supabase service credentials not configured");
     const sb = createClient(supaUrl, serviceKey, { auth: { persistSession: false } });
+
+    // 0) 호출자 인증 — 관리자(admins)만 발송 허용.
+    //    to_email 오버라이드로 임의 수신자에게 발송하는 스팸 악용을 차단(anon 키는 공개되므로 JWT 검증 필수).
+    const authHeader = req.headers.get("Authorization") ?? "";
+    const anonKey = env("SUPABASE_ANON_KEY");
+    const userSb = createClient(supaUrl, anonKey, {
+      global: { headers: { Authorization: authHeader } },
+      auth: { persistSession: false },
+    });
+    const { data: authData } = await userSb.auth.getUser();
+    const caller = authData?.user;
+    if (!caller) {
+      return new Response(JSON.stringify({ error: "Unauthorized" }), {
+        status: 401,
+        headers: { "content-type": "application/json" },
+      });
+    }
+    const { data: adminRow } = await sb
+      .from("admins")
+      .select("id")
+      .eq("auth_id", caller.id)
+      .maybeSingle();
+    if (!adminRow) {
+      return new Response(JSON.stringify({ error: "Forbidden" }), {
+        status: 403,
+        headers: { "content-type": "application/json" },
+      });
+    }
 
     // 1) 시트 조회 (브랜드 마스터명 join — 메일 제목·본문 브랜드명을 확실히 채움)
     const { data: sheet, error: sheetErr } = await sb
@@ -173,8 +201,14 @@ Deno.serve(async (req: Request) => {
       });
     }
 
-    // 2) 수신자 결정
-    const recipient = await resolveRecipient(sb, sheet.application_id, sheet.brand_id);
+    // 2) 수신자 결정 — 클라가 to_email 명시(브랜드만 선택 발급 시 수신자 선택) 우선, 없으면 기존 자동 결정 폴백
+    let recipient: { email: string; name: string } | null = null;
+    const overrideEmail = (typeof to_email === "string" ? to_email : "").trim();
+    if (overrideEmail && /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(overrideEmail)) {
+      recipient = { email: overrideEmail, name: (typeof to_name === "string" ? to_name : "").trim() };
+    } else {
+      recipient = await resolveRecipient(sb, sheet.application_id, sheet.brand_id);
+    }
     if (!recipient) {
       // 3) 수신자 없음 — 발송·단계전이 건너뜀(발급 자체는 이미 성공). 단계 전이 안 함.
       console.warn("[notify-orient-sheet] no recipient email", { orient_sheet_id });


### PR DESCRIPTION
## 변경 요약
오리엔시트 발급 메일에 수신자 선택 기능 추가(브랜드만 선택 건 한정).
- 대표 담당자 기본 + 드롭다운으로 다른 담당자 선택 + 직접 입력
- 직접 입력 이메일은 발송 성공 후 brands.contacts에 저장, 대표 설정 여부 확인
- Edge Function: to_email/to_name 수신자 지정(폴백 유지) + **호출자 관리자 인증 추가**(임의 수신자 스팸 차단) + 이메일 정규식 강화

## 요청 외 추가 변경
- 무관 파일 templates.ts(sync 부수효과) 원복

## 관련 사양서
docs/specs/2026-06-18-brand-self-orient-sheet.md