### PR TITLE
style(orient-admin): 발급 링크 복사 아이콘 인라인화

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -12,7 +12,7 @@
 // 회귀(2026-05-12 PR #182 머지 직후 발생)를 방지하기 위한 자동 reload 가드.
 // sessionStorage 차단 환경(시크릿 모드 일부, 쿠키 차단)에서는 자연스럽게 skip.
 (function(){
-  var CURRENT_BUILD = 'v1782719730';
+  var CURRENT_BUILD = 'v1782720345';
   if (CURRENT_BUILD.indexOf('__') === 0) return; // 빌드 미적용 (dev/ 직접 열기) 시 skip
   try {
     var prev = sessionStorage.getItem('reverb.adminBuild');
@@ -2095,7 +2095,7 @@ tr.audit-row, .audit-row { background: #fff3e0 !important; }
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-06-29 16:55 · cf851a3</span>
+          <span class="admin-build-text">2026-06-29 17:05 · c35caa1</span>
         </div>
       </div>
     </aside>
@@ -12525,7 +12525,10 @@ function ensureOrientModals() {
         </div>
         <div id="osCreateResult" style="display:none">
           <p style="font-weight:700;margin-bottom:8px">발급되었습니다. 아래 링크를 브랜드에게 전달하세요.</p>
-          <input type="text" id="osCreateLink" class="form-input" readonly onclick="this.select()">
+          <div style="display:flex;gap:6px;align-items:center">
+            <input type="text" id="osCreateLink" class="form-input" readonly onclick="this.select()" style="flex:1;min-width:0">
+            <button type="button" class="btn btn-ghost btn-sm" onclick="osCopyResultLink()" title="링크 복사" style="flex-shrink:0;padding:8px"><span class="material-icons-round notranslate" translate="no" style="font-size:18px;vertical-align:middle">content_copy</span></button>
+          </div>
           <div style="font-size:12px;color:var(--muted);margin-top:6px">작성 기한: <span id="osCreateExpire"></span></div>
           <div id="osRecipientPick" style="display:none;margin-top:12px">
             <label style="display:block;font-size:12px;font-weight:600;color:var(--muted);margin-bottom:4px">메일 받을 담당자</label>
@@ -12536,8 +12539,7 @@ function ensureOrientModals() {
             </div>
           </div>
           <div style="margin-top:10px;display:flex;gap:8px;flex-wrap:wrap">
-            <button type="button" class="btn btn-primary btn-sm" onclick="osCopyResultLink()">링크 복사</button>
-            <button type="button" class="btn btn-ghost btn-sm" onclick="osSendInviteClick(this)"><span class="material-icons-round notranslate" translate="no" style="font-size:15px;vertical-align:-3px">mail</span> 메일 발송</button>
+            <button type="button" class="btn btn-primary btn-sm" onclick="osSendInviteClick(this)"><span class="material-icons-round notranslate" translate="no" style="font-size:15px;vertical-align:-3px">mail</span> 메일 발송</button>
           </div>
           <div style="font-size:12px;color:var(--muted);margin-top:6px">메일은 자동 발송되지 않습니다. 필요하면 「메일 발송」을 눌러 브랜드 담당자에게 작성 링크를 보내세요.</div>
           <div id="osCreateMailStatus" style="margin-top:12px;font-size:13px;line-height:1.6"></div>

--- a/dev/js/admin-orient.js
+++ b/dev/js/admin-orient.js
@@ -870,7 +870,10 @@ function ensureOrientModals() {
         </div>
         <div id="osCreateResult" style="display:none">
           <p style="font-weight:700;margin-bottom:8px">발급되었습니다. 아래 링크를 브랜드에게 전달하세요.</p>
-          <input type="text" id="osCreateLink" class="form-input" readonly onclick="this.select()">
+          <div style="display:flex;gap:6px;align-items:center">
+            <input type="text" id="osCreateLink" class="form-input" readonly onclick="this.select()" style="flex:1;min-width:0">
+            <button type="button" class="btn btn-ghost btn-sm" onclick="osCopyResultLink()" title="링크 복사" style="flex-shrink:0;padding:8px"><span class="material-icons-round notranslate" translate="no" style="font-size:18px;vertical-align:middle">content_copy</span></button>
+          </div>
           <div style="font-size:12px;color:var(--muted);margin-top:6px">작성 기한: <span id="osCreateExpire"></span></div>
           <div id="osRecipientPick" style="display:none;margin-top:12px">
             <label style="display:block;font-size:12px;font-weight:600;color:var(--muted);margin-bottom:4px">메일 받을 담당자</label>
@@ -881,8 +884,7 @@ function ensureOrientModals() {
             </div>
           </div>
           <div style="margin-top:10px;display:flex;gap:8px;flex-wrap:wrap">
-            <button type="button" class="btn btn-primary btn-sm" onclick="osCopyResultLink()">링크 복사</button>
-            <button type="button" class="btn btn-ghost btn-sm" onclick="osSendInviteClick(this)"><span class="material-icons-round notranslate" translate="no" style="font-size:15px;vertical-align:-3px">mail</span> 메일 발송</button>
+            <button type="button" class="btn btn-primary btn-sm" onclick="osSendInviteClick(this)"><span class="material-icons-round notranslate" translate="no" style="font-size:15px;vertical-align:-3px">mail</span> 메일 발송</button>
           </div>
           <div style="font-size:12px;color:var(--muted);margin-top:6px">메일은 자동 발송되지 않습니다. 필요하면 「메일 발송」을 눌러 브랜드 담당자에게 작성 링크를 보내세요.</div>
           <div id="osCreateMailStatus" style="margin-top:12px;font-size:13px;line-height:1.6"></div>


### PR DESCRIPTION
## 변경 요약
발급 결과 화면 「링크 복사」 텍스트 버튼 → URL 인풋박스 우측 복사 아이콘(content_copy)으로 변경. 메일 발송 버튼만 별도 유지.

## 요청 외 추가 변경
없음