### PR TITLE
style(orient-admin): 발급 결과 화면 정리(기한 강조·구분선·입력 한줄)

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -12,7 +12,7 @@
 // 회귀(2026-05-12 PR #182 머지 직후 발생)를 방지하기 위한 자동 reload 가드.
 // sessionStorage 차단 환경(시크릿 모드 일부, 쿠키 차단)에서는 자연스럽게 skip.
 (function(){
-  var CURRENT_BUILD = 'v1782720560';
+  var CURRENT_BUILD = 'v1782720715';
   if (CURRENT_BUILD.indexOf('__') === 0) return; // 빌드 미적용 (dev/ 직접 열기) 시 skip
   try {
     var prev = sessionStorage.getItem('reverb.adminBuild');
@@ -2095,7 +2095,7 @@ tr.audit-row, .audit-row { background: #fff3e0 !important; }
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-06-29 17:09 · 6001ab5</span>
+          <span class="admin-build-text">2026-06-29 17:11 · 8b35c71</span>
         </div>
       </div>
     </aside>
@@ -12013,7 +12013,7 @@ function osOnRecipientChange() {
   const sel = document.getElementById('osRecipientSelect');
   const nw = document.getElementById('osRecipientNew');
   if (!sel || !nw) return;
-  nw.style.display = (sel.value === 'new') ? '' : 'none';
+  nw.style.display = (sel.value === 'new') ? 'flex' : 'none';
 }
 
 // 발급 결과 화면 「메일 발송」 버튼 — 선택 발송(자동 발송 아님). 발송 중 버튼 비활성.
@@ -12529,13 +12529,14 @@ function ensureOrientModals() {
             <input type="text" id="osCreateLink" class="form-input" readonly onclick="this.select()" style="padding-right:42px">
             <button type="button" onclick="osCopyResultLink()" title="링크 복사" style="position:absolute;right:6px;top:50%;transform:translateY(-50%);background:none;border:none;cursor:pointer;padding:4px;display:flex;align-items:center"><span class="material-icons-round notranslate" translate="no" style="font-size:18px;color:var(--muted)">content_copy</span></button>
           </div>
-          <div style="font-size:12px;color:var(--muted);margin-top:6px">작성 기한: <span id="osCreateExpire"></span></div>
+          <div style="font-size:15px;color:var(--ink);margin-top:8px;font-weight:700">작성 기한: <span id="osCreateExpire" style="color:var(--pink)"></span></div>
+          <hr style="border:none;border-top:1px solid var(--line);margin:16px 0">
           <div id="osRecipientPick" style="display:none;margin-top:12px">
             <label style="display:block;font-size:12px;font-weight:600;color:var(--muted);margin-bottom:4px">메일 받을 담당자</label>
             <select id="osRecipientSelect" class="form-input" onchange="osOnRecipientChange()"></select>
-            <div id="osRecipientNew" style="display:none;margin-top:6px">
-              <input id="osNewContactName" class="form-input" placeholder="담당자 이름" style="margin-bottom:6px">
-              <input id="osNewContactEmail" class="form-input" type="email" placeholder="이메일 주소" autocomplete="off">
+            <div id="osRecipientNew" style="display:none;margin-top:6px;gap:6px">
+              <input id="osNewContactName" class="form-input" placeholder="담당자 이름" style="flex:1;min-width:0">
+              <input id="osNewContactEmail" class="form-input" type="email" placeholder="이메일 주소" autocomplete="off" style="flex:1;min-width:0">
             </div>
           </div>
           <div style="margin-top:10px;display:flex;gap:8px;flex-wrap:wrap">

--- a/dev/js/admin-orient.js
+++ b/dev/js/admin-orient.js
@@ -358,7 +358,7 @@ function osOnRecipientChange() {
   const sel = document.getElementById('osRecipientSelect');
   const nw = document.getElementById('osRecipientNew');
   if (!sel || !nw) return;
-  nw.style.display = (sel.value === 'new') ? '' : 'none';
+  nw.style.display = (sel.value === 'new') ? 'flex' : 'none';
 }
 
 // 발급 결과 화면 「메일 발송」 버튼 — 선택 발송(자동 발송 아님). 발송 중 버튼 비활성.
@@ -874,13 +874,14 @@ function ensureOrientModals() {
             <input type="text" id="osCreateLink" class="form-input" readonly onclick="this.select()" style="padding-right:42px">
             <button type="button" onclick="osCopyResultLink()" title="링크 복사" style="position:absolute;right:6px;top:50%;transform:translateY(-50%);background:none;border:none;cursor:pointer;padding:4px;display:flex;align-items:center"><span class="material-icons-round notranslate" translate="no" style="font-size:18px;color:var(--muted)">content_copy</span></button>
           </div>
-          <div style="font-size:12px;color:var(--muted);margin-top:6px">작성 기한: <span id="osCreateExpire"></span></div>
+          <div style="font-size:15px;color:var(--ink);margin-top:8px;font-weight:700">작성 기한: <span id="osCreateExpire" style="color:var(--pink)"></span></div>
+          <hr style="border:none;border-top:1px solid var(--line);margin:16px 0">
           <div id="osRecipientPick" style="display:none;margin-top:12px">
             <label style="display:block;font-size:12px;font-weight:600;color:var(--muted);margin-bottom:4px">메일 받을 담당자</label>
             <select id="osRecipientSelect" class="form-input" onchange="osOnRecipientChange()"></select>
-            <div id="osRecipientNew" style="display:none;margin-top:6px">
-              <input id="osNewContactName" class="form-input" placeholder="담당자 이름" style="margin-bottom:6px">
-              <input id="osNewContactEmail" class="form-input" type="email" placeholder="이메일 주소" autocomplete="off">
+            <div id="osRecipientNew" style="display:none;margin-top:6px;gap:6px">
+              <input id="osNewContactName" class="form-input" placeholder="담당자 이름" style="flex:1;min-width:0">
+              <input id="osNewContactEmail" class="form-input" type="email" placeholder="이메일 주소" autocomplete="off" style="flex:1;min-width:0">
             </div>
           </div>
           <div style="margin-top:10px;display:flex;gap:8px;flex-wrap:wrap">


### PR DESCRIPTION
## 변경 요약
- 작성 기한 글자 크게(15px 볼드)·날짜 핑크 강조
- 발급 링크와 메일 발송 영역 사이 구분선(hr)
- 신규 담당자 이름·이메일 입력을 한 줄(flex)로

## 요청 외 추가 변경
없음