### PR TITLE
style(orient-admin): 복사 아이콘 구분선·이름폭 축소·모달 확대

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -12,7 +12,7 @@
 // 회귀(2026-05-12 PR #182 머지 직후 발생)를 방지하기 위한 자동 reload 가드.
 // sessionStorage 차단 환경(시크릿 모드 일부, 쿠키 차단)에서는 자연스럽게 skip.
 (function(){
-  var CURRENT_BUILD = 'v1782720715';
+  var CURRENT_BUILD = 'v1782720975';
   if (CURRENT_BUILD.indexOf('__') === 0) return; // 빌드 미적용 (dev/ 직접 열기) 시 skip
   try {
     var prev = sessionStorage.getItem('reverb.adminBuild');
@@ -2095,7 +2095,7 @@ tr.audit-row, .audit-row { background: #fff3e0 !important; }
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-06-29 17:11 · 8b35c71</span>
+          <span class="admin-build-text">2026-06-29 17:16 · 0e7fdc2</span>
         </div>
       </div>
     </aside>
@@ -12510,7 +12510,7 @@ function ensureOrientModals() {
   if (document.getElementById('orientCreateModal')) return;
   const html = `
   <div class="modal-overlay" id="orientCreateModal">
-    <div class="modal" style="max-width:480px;width:94vw;border-radius:16px;margin:auto;max-height:88vh;display:flex;flex-direction:column">
+    <div class="modal" style="max-width:600px;width:94vw;border-radius:16px;margin:auto;max-height:88vh;display:flex;flex-direction:column">
       <div class="modal-header"><h2>오리엔시트 링크 발급</h2>
         <button type="button" class="modal-close-btn" onclick="osCloseModal('orientCreateModal')"><span class="material-icons-round notranslate" translate="no">close</span></button></div>
       <div class="modal-body" style="padding:20px;overflow-y:auto;flex:1">
@@ -12526,8 +12526,8 @@ function ensureOrientModals() {
         <div id="osCreateResult" style="display:none">
           <p style="font-weight:700;margin-bottom:8px">발급되었습니다. 아래 링크를 브랜드에게 전달하세요.</p>
           <div style="position:relative">
-            <input type="text" id="osCreateLink" class="form-input" readonly onclick="this.select()" style="padding-right:42px">
-            <button type="button" onclick="osCopyResultLink()" title="링크 복사" style="position:absolute;right:6px;top:50%;transform:translateY(-50%);background:none;border:none;cursor:pointer;padding:4px;display:flex;align-items:center"><span class="material-icons-round notranslate" translate="no" style="font-size:18px;color:var(--muted)">content_copy</span></button>
+            <input type="text" id="osCreateLink" class="form-input" readonly onclick="this.select()" style="padding-right:48px">
+            <button type="button" onclick="osCopyResultLink()" title="링크 복사" style="position:absolute;right:1px;top:1px;bottom:1px;background:none;border:none;border-left:1px solid var(--line);cursor:pointer;padding:0 10px;display:flex;align-items:center"><span class="material-icons-round notranslate" translate="no" style="font-size:18px;color:var(--muted)">content_copy</span></button>
           </div>
           <div style="font-size:15px;color:var(--ink);margin-top:8px;font-weight:700">작성 기한: <span id="osCreateExpire" style="color:var(--pink)"></span></div>
           <hr style="border:none;border-top:1px solid var(--line);margin:16px 0">
@@ -12535,7 +12535,7 @@ function ensureOrientModals() {
             <label style="display:block;font-size:12px;font-weight:600;color:var(--muted);margin-bottom:4px">메일 받을 담당자</label>
             <select id="osRecipientSelect" class="form-input" onchange="osOnRecipientChange()"></select>
             <div id="osRecipientNew" style="display:none;margin-top:6px;gap:6px">
-              <input id="osNewContactName" class="form-input" placeholder="담당자 이름" style="flex:1;min-width:0">
+              <input id="osNewContactName" class="form-input" placeholder="담당자 이름" style="width:120px;flex-shrink:0">
               <input id="osNewContactEmail" class="form-input" type="email" placeholder="이메일 주소" autocomplete="off" style="flex:1;min-width:0">
             </div>
           </div>

--- a/dev/js/admin-orient.js
+++ b/dev/js/admin-orient.js
@@ -855,7 +855,7 @@ function ensureOrientModals() {
   if (document.getElementById('orientCreateModal')) return;
   const html = `
   <div class="modal-overlay" id="orientCreateModal">
-    <div class="modal" style="max-width:480px;width:94vw;border-radius:16px;margin:auto;max-height:88vh;display:flex;flex-direction:column">
+    <div class="modal" style="max-width:600px;width:94vw;border-radius:16px;margin:auto;max-height:88vh;display:flex;flex-direction:column">
       <div class="modal-header"><h2>오리엔시트 링크 발급</h2>
         <button type="button" class="modal-close-btn" onclick="osCloseModal('orientCreateModal')"><span class="material-icons-round notranslate" translate="no">close</span></button></div>
       <div class="modal-body" style="padding:20px;overflow-y:auto;flex:1">
@@ -871,8 +871,8 @@ function ensureOrientModals() {
         <div id="osCreateResult" style="display:none">
           <p style="font-weight:700;margin-bottom:8px">발급되었습니다. 아래 링크를 브랜드에게 전달하세요.</p>
           <div style="position:relative">
-            <input type="text" id="osCreateLink" class="form-input" readonly onclick="this.select()" style="padding-right:42px">
-            <button type="button" onclick="osCopyResultLink()" title="링크 복사" style="position:absolute;right:6px;top:50%;transform:translateY(-50%);background:none;border:none;cursor:pointer;padding:4px;display:flex;align-items:center"><span class="material-icons-round notranslate" translate="no" style="font-size:18px;color:var(--muted)">content_copy</span></button>
+            <input type="text" id="osCreateLink" class="form-input" readonly onclick="this.select()" style="padding-right:48px">
+            <button type="button" onclick="osCopyResultLink()" title="링크 복사" style="position:absolute;right:1px;top:1px;bottom:1px;background:none;border:none;border-left:1px solid var(--line);cursor:pointer;padding:0 10px;display:flex;align-items:center"><span class="material-icons-round notranslate" translate="no" style="font-size:18px;color:var(--muted)">content_copy</span></button>
           </div>
           <div style="font-size:15px;color:var(--ink);margin-top:8px;font-weight:700">작성 기한: <span id="osCreateExpire" style="color:var(--pink)"></span></div>
           <hr style="border:none;border-top:1px solid var(--line);margin:16px 0">
@@ -880,7 +880,7 @@ function ensureOrientModals() {
             <label style="display:block;font-size:12px;font-weight:600;color:var(--muted);margin-bottom:4px">메일 받을 담당자</label>
             <select id="osRecipientSelect" class="form-input" onchange="osOnRecipientChange()"></select>
             <div id="osRecipientNew" style="display:none;margin-top:6px;gap:6px">
-              <input id="osNewContactName" class="form-input" placeholder="담당자 이름" style="flex:1;min-width:0">
+              <input id="osNewContactName" class="form-input" placeholder="담당자 이름" style="width:120px;flex-shrink:0">
               <input id="osNewContactEmail" class="form-input" type="email" placeholder="이메일 주소" autocomplete="off" style="flex:1;min-width:0">
             </div>
           </div>


### PR DESCRIPTION
## 변경 요약
- 복사 아이콘 좌측 세로 구분선(URL과 분리)
- 신규 담당자 이름 입력 폭 축소(이메일이 나머지 차지)
- 발급 모달 너비 480→600px

## 요청 외 추가 변경
없음