### PR TITLE
fix(admin): 공지 보기 화면 빈 줄 높이를 편집기와 일치

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -12,7 +12,7 @@
 // 회귀(2026-05-12 PR #182 머지 직후 발생)를 방지하기 위한 자동 reload 가드.
 // sessionStorage 차단 환경(시크릿 모드 일부, 쿠키 차단)에서는 자연스럽게 skip.
 (function(){
-  var CURRENT_BUILD = 'v1782726909';
+  var CURRENT_BUILD = 'v1782728976';
   if (CURRENT_BUILD.indexOf('__') === 0) return; // 빌드 미적용 (dev/ 직접 열기) 시 skip
   try {
     var prev = sessionStorage.getItem('reverb.adminBuild');
@@ -1082,6 +1082,13 @@ input[type="date"].form-input::-webkit-calendar-picker-indicator{margin-left:aut
 #anEditBodyQuill .ql-editor li{margin:2px 0}
 #anEditBodyQuill .ql-editor blockquote{border-left:3px solid var(--pink);padding:4px 10px;margin:8px 0;background:var(--light-pink);color:var(--ink)}
 #anEditBodyQuill .ql-editor a{color:var(--pink);text-decoration:underline}
+/* 공지 보기 화면 빈 줄 높이 정합.
+   Quill 편집기는 빈 줄(빈 단락)을 한 줄 높이로 보여주지만, 저장 후 보기 화면의
+   빈 <p></p> 는 높이 0 으로 접혀 편집기보다 섹션 간격이 좁아 보인다.
+   보기 모달·미읽음 팝업의 빈 단락을 편집기와 같은 한 줄 높이로 맞춰 "편집 = 보기" 완성.
+   (각 컨테이너의 line-height 와 동일한 em 값 사용) */
+#adminNoticeViewBody p:empty{min-height:1.7em}
+#adminNoticeUnreadModal [data-notice-body] p:empty{min-height:1.6em}
 
 /* 캠페인 폼 참여방법/주의사항 요약 카드 (편집은 모달로 분리) */
 .bundle-summary-card{
@@ -2117,7 +2124,7 @@ tr.audit-row, .audit-row { background: #fff3e0 !important; }
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-06-29 18:55 · e9659cb</span>
+          <span class="admin-build-text">2026-06-29 19:29 · 8d74a0f</span>
         </div>
       </div>
     </aside>

--- a/dev/css/admin.css
+++ b/dev/css/admin.css
@@ -624,6 +624,13 @@
 #anEditBodyQuill .ql-editor li{margin:2px 0}
 #anEditBodyQuill .ql-editor blockquote{border-left:3px solid var(--pink);padding:4px 10px;margin:8px 0;background:var(--light-pink);color:var(--ink)}
 #anEditBodyQuill .ql-editor a{color:var(--pink);text-decoration:underline}
+/* 공지 보기 화면 빈 줄 높이 정합.
+   Quill 편집기는 빈 줄(빈 단락)을 한 줄 높이로 보여주지만, 저장 후 보기 화면의
+   빈 <p></p> 는 높이 0 으로 접혀 편집기보다 섹션 간격이 좁아 보인다.
+   보기 모달·미읽음 팝업의 빈 단락을 편집기와 같은 한 줄 높이로 맞춰 "편집 = 보기" 완성.
+   (각 컨테이너의 line-height 와 동일한 em 값 사용) */
+#adminNoticeViewBody p:empty{min-height:1.7em}
+#adminNoticeUnreadModal [data-notice-body] p:empty{min-height:1.6em}
 
 /* 캠페인 폼 참여방법/주의사항 요약 카드 (편집은 모달로 분리) */
 .bundle-summary-card{


### PR DESCRIPTION
## 변경 요약
공지 편집기(Quill)는 빈 줄을 한 줄 높이로 보여주나 저장 후 보기 화면의 빈 <p></p> 는 높이 0 으로 접혀 섹션 간격이 좁아 보임. 보기 모달·미읽음 팝업의 빈 단락에 한 줄 min-height 부여로 편집=보기 일치 완성. 관리자 전용 CSS 2줄.

## 요청 외 추가 변경
- 없음

## 리뷰
- reverb-reviewer GO · qa-tester skip