### PR TITLE
fix(admin): 공지 보기·편집 모달 하단 버튼 고정(스크롤 분리)

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -12,7 +12,7 @@
 // 회귀(2026-05-12 PR #182 머지 직후 발생)를 방지하기 위한 자동 reload 가드.
 // sessionStorage 차단 환경(시크릿 모드 일부, 쿠키 차단)에서는 자연스럽게 skip.
 (function(){
-  var CURRENT_BUILD = 'v1782729950';
+  var CURRENT_BUILD = 'v1782730549';
   if (CURRENT_BUILD.indexOf('__') === 0) return; // 빌드 미적용 (dev/ 직접 열기) 시 skip
   try {
     var prev = sessionStorage.getItem('reverb.adminBuild');
@@ -2130,7 +2130,7 @@ tr.audit-row, .audit-row { background: #fff3e0 !important; }
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-06-29 19:45 · 36101dc</span>
+          <span class="admin-build-text">2026-06-29 19:55 · f1d4587</span>
         </div>
       </div>
     </aside>
@@ -4257,15 +4257,15 @@ tr.audit-row, .audit-row { background: #fff3e0 !important; }
       <div style="font-size:11px;color:var(--muted);margin-bottom:6px">노션·문서에서 복사해 그대로 붙여넣으면 제목·굵게·목록·링크 서식이 유지됩니다. 편집 중 보이는 모습이 게시 후와 동일합니다(HTML 소스 입력 불필요).</div>
       <div id="anEditBodyQuill" style="min-height:220px;background:#fff"></div>
       <textarea id="anEditBodyRaw" style="display:none;width:100%;min-height:220px;font-family:ui-monospace,Menlo,monospace;font-size:12px;padding:10px;border:1px solid var(--line);border-radius:6px;resize:vertical" placeholder="HTML 코드를 직접 입력하세요. 예) <p>안녕하세요</p><ul><li>항목</li></ul>"></textarea>
-      <div id="adminNoticeEditFooter" style="display:flex;gap:8px;margin-top:14px;justify-content:flex-end;align-items:center">
-        <span id="adminNoticeEditStatusPill" style="margin-right:auto"></span>
-        <button class="btn btn-ghost btn-xs" id="btnDeleteAdminNotice" onclick="onDeleteAdminNotice()" style="color:#C62828;display:none">삭제</button>
-        <button class="btn btn-ghost btn-xs" onclick="closeModal('adminNoticeEditModal')">취소</button>
-        <button class="btn btn-ghost btn-xs" id="btnSaveAdminNoticeKeepPublished" onclick="onSaveAdminNotice('keep_published')" style="display:none">게시 유지하며 저장</button>
-        <button class="btn btn-ghost btn-xs" id="btnSaveAdminNoticeDraft" onclick="onSaveAdminNotice('draft')" style="display:none">초안 저장</button>
-        <button class="btn btn-primary btn-xs" id="btnPublishAdminNotice" onclick="onSaveAdminNotice('publish')" style="display:none">게시하기</button>
-        <button class="btn btn-primary btn-xs" id="btnSaveAdminNoticeRevertDraft" onclick="onSaveAdminNotice('revert_draft')" style="display:none">초안으로 되돌리고 저장</button>
-      </div>
+    </div>
+    <div id="adminNoticeEditFooter" style="display:flex;gap:8px;padding:14px 20px;border-top:1px solid var(--line);justify-content:flex-end;align-items:center;flex-shrink:0">
+      <span id="adminNoticeEditStatusPill" style="margin-right:auto"></span>
+      <button class="btn btn-ghost btn-xs" id="btnDeleteAdminNotice" onclick="onDeleteAdminNotice()" style="color:#C62828;display:none">삭제</button>
+      <button class="btn btn-ghost btn-xs" onclick="closeModal('adminNoticeEditModal')">취소</button>
+      <button class="btn btn-ghost btn-xs" id="btnSaveAdminNoticeKeepPublished" onclick="onSaveAdminNotice('keep_published')" style="display:none">게시 유지하며 저장</button>
+      <button class="btn btn-ghost btn-xs" id="btnSaveAdminNoticeDraft" onclick="onSaveAdminNotice('draft')" style="display:none">초안 저장</button>
+      <button class="btn btn-primary btn-xs" id="btnPublishAdminNotice" onclick="onSaveAdminNotice('publish')" style="display:none">게시하기</button>
+      <button class="btn btn-primary btn-xs" id="btnSaveAdminNoticeRevertDraft" onclick="onSaveAdminNotice('revert_draft')" style="display:none">초안으로 되돌리고 저장</button>
     </div>
   </div>
 </div>
@@ -4280,11 +4280,11 @@ tr.audit-row, .audit-row { background: #fff3e0 !important; }
     <div class="modal-body" style="padding:20px;overflow-y:auto;flex:1;min-height:0">
       <div id="adminNoticeViewMeta" style="font-size:12px;color:var(--muted);margin-bottom:12px;display:flex;gap:10px;flex-wrap:wrap;align-items:center"></div>
       <div id="adminNoticeViewBody" class="rich-content" style="font-size:13px;line-height:1.7;color:var(--ink)"></div>
-      <div id="adminNoticeViewFooter" style="display:none;gap:8px;margin-top:18px;padding-top:14px;border-top:1px solid var(--line);justify-content:flex-end">
-        <button class="btn btn-ghost btn-xs" id="btnEditAdminNoticeFromView" onclick="onEditAdminNoticeFromView()"><span class="material-icons-round notranslate" translate="no" style="font-size:13px;vertical-align:-2px">edit</span> 수정</button>
-        <button class="btn btn-ghost btn-xs" id="btnUnpublishAdminNoticeFromView" onclick="onUnpublishFromView()" style="display:none">게시 회수</button>
-        <button class="btn btn-primary btn-xs" id="btnPublishAdminNoticeFromView" onclick="onPublishFromView()" style="display:none"><span class="material-icons-round notranslate" translate="no" style="font-size:13px;vertical-align:-2px">campaign</span> 지금 게시</button>
-      </div>
+    </div>
+    <div id="adminNoticeViewFooter" style="display:none;gap:8px;padding:14px 20px;border-top:1px solid var(--line);justify-content:flex-end;flex-shrink:0">
+      <button class="btn btn-ghost btn-xs" id="btnEditAdminNoticeFromView" onclick="onEditAdminNoticeFromView()"><span class="material-icons-round notranslate" translate="no" style="font-size:13px;vertical-align:-2px">edit</span> 수정</button>
+      <button class="btn btn-ghost btn-xs" id="btnUnpublishAdminNoticeFromView" onclick="onUnpublishFromView()" style="display:none">게시 회수</button>
+      <button class="btn btn-primary btn-xs" id="btnPublishAdminNoticeFromView" onclick="onPublishFromView()" style="display:none"><span class="material-icons-round notranslate" translate="no" style="font-size:13px;vertical-align:-2px">campaign</span> 지금 게시</button>
     </div>
   </div>
 </div>

--- a/dev/admin/index.html
+++ b/dev/admin/index.html
@@ -2263,15 +2263,15 @@
       <div style="font-size:11px;color:var(--muted);margin-bottom:6px">노션·문서에서 복사해 그대로 붙여넣으면 제목·굵게·목록·링크 서식이 유지됩니다. 편집 중 보이는 모습이 게시 후와 동일합니다(HTML 소스 입력 불필요).</div>
       <div id="anEditBodyQuill" style="min-height:220px;background:#fff"></div>
       <textarea id="anEditBodyRaw" style="display:none;width:100%;min-height:220px;font-family:ui-monospace,Menlo,monospace;font-size:12px;padding:10px;border:1px solid var(--line);border-radius:6px;resize:vertical" placeholder="HTML 코드를 직접 입력하세요. 예) <p>안녕하세요</p><ul><li>항목</li></ul>"></textarea>
-      <div id="adminNoticeEditFooter" style="display:flex;gap:8px;margin-top:14px;justify-content:flex-end;align-items:center">
-        <span id="adminNoticeEditStatusPill" style="margin-right:auto"></span>
-        <button class="btn btn-ghost btn-xs" id="btnDeleteAdminNotice" onclick="onDeleteAdminNotice()" style="color:#C62828;display:none">삭제</button>
-        <button class="btn btn-ghost btn-xs" onclick="closeModal('adminNoticeEditModal')">취소</button>
-        <button class="btn btn-ghost btn-xs" id="btnSaveAdminNoticeKeepPublished" onclick="onSaveAdminNotice('keep_published')" style="display:none">게시 유지하며 저장</button>
-        <button class="btn btn-ghost btn-xs" id="btnSaveAdminNoticeDraft" onclick="onSaveAdminNotice('draft')" style="display:none">초안 저장</button>
-        <button class="btn btn-primary btn-xs" id="btnPublishAdminNotice" onclick="onSaveAdminNotice('publish')" style="display:none">게시하기</button>
-        <button class="btn btn-primary btn-xs" id="btnSaveAdminNoticeRevertDraft" onclick="onSaveAdminNotice('revert_draft')" style="display:none">초안으로 되돌리고 저장</button>
-      </div>
+    </div>
+    <div id="adminNoticeEditFooter" style="display:flex;gap:8px;padding:14px 20px;border-top:1px solid var(--line);justify-content:flex-end;align-items:center;flex-shrink:0">
+      <span id="adminNoticeEditStatusPill" style="margin-right:auto"></span>
+      <button class="btn btn-ghost btn-xs" id="btnDeleteAdminNotice" onclick="onDeleteAdminNotice()" style="color:#C62828;display:none">삭제</button>
+      <button class="btn btn-ghost btn-xs" onclick="closeModal('adminNoticeEditModal')">취소</button>
+      <button class="btn btn-ghost btn-xs" id="btnSaveAdminNoticeKeepPublished" onclick="onSaveAdminNotice('keep_published')" style="display:none">게시 유지하며 저장</button>
+      <button class="btn btn-ghost btn-xs" id="btnSaveAdminNoticeDraft" onclick="onSaveAdminNotice('draft')" style="display:none">초안 저장</button>
+      <button class="btn btn-primary btn-xs" id="btnPublishAdminNotice" onclick="onSaveAdminNotice('publish')" style="display:none">게시하기</button>
+      <button class="btn btn-primary btn-xs" id="btnSaveAdminNoticeRevertDraft" onclick="onSaveAdminNotice('revert_draft')" style="display:none">초안으로 되돌리고 저장</button>
     </div>
   </div>
 </div>
@@ -2286,11 +2286,11 @@
     <div class="modal-body" style="padding:20px;overflow-y:auto;flex:1;min-height:0">
       <div id="adminNoticeViewMeta" style="font-size:12px;color:var(--muted);margin-bottom:12px;display:flex;gap:10px;flex-wrap:wrap;align-items:center"></div>
       <div id="adminNoticeViewBody" class="rich-content" style="font-size:13px;line-height:1.7;color:var(--ink)"></div>
-      <div id="adminNoticeViewFooter" style="display:none;gap:8px;margin-top:18px;padding-top:14px;border-top:1px solid var(--line);justify-content:flex-end">
-        <button class="btn btn-ghost btn-xs" id="btnEditAdminNoticeFromView" onclick="onEditAdminNoticeFromView()"><span class="material-icons-round notranslate" translate="no" style="font-size:13px;vertical-align:-2px">edit</span> 수정</button>
-        <button class="btn btn-ghost btn-xs" id="btnUnpublishAdminNoticeFromView" onclick="onUnpublishFromView()" style="display:none">게시 회수</button>
-        <button class="btn btn-primary btn-xs" id="btnPublishAdminNoticeFromView" onclick="onPublishFromView()" style="display:none"><span class="material-icons-round notranslate" translate="no" style="font-size:13px;vertical-align:-2px">campaign</span> 지금 게시</button>
-      </div>
+    </div>
+    <div id="adminNoticeViewFooter" style="display:none;gap:8px;padding:14px 20px;border-top:1px solid var(--line);justify-content:flex-end;flex-shrink:0">
+      <button class="btn btn-ghost btn-xs" id="btnEditAdminNoticeFromView" onclick="onEditAdminNoticeFromView()"><span class="material-icons-round notranslate" translate="no" style="font-size:13px;vertical-align:-2px">edit</span> 수정</button>
+      <button class="btn btn-ghost btn-xs" id="btnUnpublishAdminNoticeFromView" onclick="onUnpublishFromView()" style="display:none">게시 회수</button>
+      <button class="btn btn-primary btn-xs" id="btnPublishAdminNoticeFromView" onclick="onPublishFromView()" style="display:none"><span class="material-icons-round notranslate" translate="no" style="font-size:13px;vertical-align:-2px">campaign</span> 지금 게시</button>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## 변경 요약
공지 보기·편집 모달의 하단 버튼이 스크롤 본문 안에 있어 긴 공지에서 스크롤해야 보였음. footer 를 본문 밖 형제로 옮겨 본문만 스크롤되고 버튼은 하단 고정. 기존 다른 모달(linkCampaign/company 등)과 동일 구조. HTML 단독 변경.

## 요청 외 추가 변경
- 편집 모달 footer 도 동일 고정(요청은 보기 모달이나 같은 문제라 함께)

## 리뷰
- reverb-reviewer GO · qa-tester light