### PR TITLE
fix(admin): 공지 보기 모달 상단 정보(상태·작성자·게시일) 고정

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -12,7 +12,7 @@
 // 회귀(2026-05-12 PR #182 머지 직후 발생)를 방지하기 위한 자동 reload 가드.
 // sessionStorage 차단 환경(시크릿 모드 일부, 쿠키 차단)에서는 자연스럽게 skip.
 (function(){
-  var CURRENT_BUILD = 'v1782730549';
+  var CURRENT_BUILD = 'v1782730887';
   if (CURRENT_BUILD.indexOf('__') === 0) return; // 빌드 미적용 (dev/ 직접 열기) 시 skip
   try {
     var prev = sessionStorage.getItem('reverb.adminBuild');
@@ -2130,7 +2130,7 @@ tr.audit-row, .audit-row { background: #fff3e0 !important; }
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-06-29 19:55 · f1d4587</span>
+          <span class="admin-build-text">2026-06-29 20:01 · 818c9bd</span>
         </div>
       </div>
     </aside>
@@ -4273,12 +4273,12 @@ tr.audit-row, .audit-row { background: #fff3e0 !important; }
 <!-- 공지 상세 보기 모달 -->
 <div class="modal-overlay" id="adminNoticeViewModal" style="z-index:550">
   <div class="modal" style="max-width:720px;border-radius:16px;margin:auto;max-height:90vh;overflow:hidden;display:flex;flex-direction:column">
-    <div class="modal-header">
+    <div class="modal-header" style="border-bottom:none;padding-bottom:8px">
       <div class="modal-title" id="adminNoticeViewTitle">공지</div>
       <div class="modal-close" onclick="closeModal('adminNoticeViewModal')"><span class="material-icons-round notranslate" translate="no" style="font-size:18px">close</span></div>
     </div>
+    <div id="adminNoticeViewMeta" style="font-size:12px;color:var(--muted);padding:0 22px 14px;border-bottom:1px solid var(--line);display:flex;gap:10px;flex-wrap:wrap;align-items:center;flex-shrink:0"></div>
     <div class="modal-body" style="padding:20px;overflow-y:auto;flex:1;min-height:0">
-      <div id="adminNoticeViewMeta" style="font-size:12px;color:var(--muted);margin-bottom:12px;display:flex;gap:10px;flex-wrap:wrap;align-items:center"></div>
       <div id="adminNoticeViewBody" class="rich-content" style="font-size:13px;line-height:1.7;color:var(--ink)"></div>
     </div>
     <div id="adminNoticeViewFooter" style="display:none;gap:8px;padding:14px 20px;border-top:1px solid var(--line);justify-content:flex-end;flex-shrink:0">

--- a/dev/admin/index.html
+++ b/dev/admin/index.html
@@ -2279,12 +2279,12 @@
 <!-- 공지 상세 보기 모달 -->
 <div class="modal-overlay" id="adminNoticeViewModal" style="z-index:550">
   <div class="modal" style="max-width:720px;border-radius:16px;margin:auto;max-height:90vh;overflow:hidden;display:flex;flex-direction:column">
-    <div class="modal-header">
+    <div class="modal-header" style="border-bottom:none;padding-bottom:8px">
       <div class="modal-title" id="adminNoticeViewTitle">공지</div>
       <div class="modal-close" onclick="closeModal('adminNoticeViewModal')"><span class="material-icons-round notranslate" translate="no" style="font-size:18px">close</span></div>
     </div>
+    <div id="adminNoticeViewMeta" style="font-size:12px;color:var(--muted);padding:0 22px 14px;border-bottom:1px solid var(--line);display:flex;gap:10px;flex-wrap:wrap;align-items:center;flex-shrink:0"></div>
     <div class="modal-body" style="padding:20px;overflow-y:auto;flex:1;min-height:0">
-      <div id="adminNoticeViewMeta" style="font-size:12px;color:var(--muted);margin-bottom:12px;display:flex;gap:10px;flex-wrap:wrap;align-items:center"></div>
       <div id="adminNoticeViewBody" class="rich-content" style="font-size:13px;line-height:1.7;color:var(--ink)"></div>
     </div>
     <div id="adminNoticeViewFooter" style="display:none;gap:8px;padding:14px 20px;border-top:1px solid var(--line);justify-content:flex-end;flex-shrink:0">


### PR DESCRIPTION
## 변경 요약
공지 보기 모달의 상단 메타(게시 상태·카테고리·작성자·게시일)가 본문과 함께 스크롤돼 사라졌음. 제목 헤더 아래 고정 밴드로 옮겨 본문만 스크롤되고 메타는 상단 고정. 제목+메타가 한 묶음(하단 구분선 하나)으로 보임.

## 요청 외 추가 변경
- 없음

## 리뷰
- reverb-reviewer GO · qa-tester skip