### PR TITLE
feat(admin): 오리엔시트 발급 모달 브랜드 검색 드롭다운

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -12,7 +12,7 @@
 // 회귀(2026-05-12 PR #182 머지 직후 발생)를 방지하기 위한 자동 reload 가드.
 // sessionStorage 차단 환경(시크릿 모드 일부, 쿠키 차단)에서는 자연스럽게 skip.
 (function(){
-  var CURRENT_BUILD = 'v1782731919';
+  var CURRENT_BUILD = 'v1782780696';
   if (CURRENT_BUILD.indexOf('__') === 0) return; // 빌드 미적용 (dev/ 직접 열기) 시 skip
   try {
     var prev = sessionStorage.getItem('reverb.adminBuild');
@@ -2138,7 +2138,7 @@ tr.audit-row, .audit-row { background: #fff3e0 !important; }
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-06-29 20:18 · 4ba4b99</span>
+          <span class="admin-build-text">2026-06-30 09:51 · 82ace13</span>
         </div>
       </div>
     </aside>
@@ -11706,6 +11706,7 @@ function initDraggableModals() {
 // ============================================================
 
 let _orientSheets = [];
+let _orientBrands = [];      // 발급 모달 브랜드 검색 드롭다운 후보 (osOpenCreate 에서 적재)
 let _osDetailSheet = null;   // 상세 모달에 열린 시트(카드별 발행에 사용)
 let _osDetailCatMap = {};    // 상세 모달 카테고리 라벨 맵(새창 열기에 재사용)
 let _osLastIssuedId = null;  // 방금 발급한 오리엔시트 id(발급 결과 화면 수동 메일 발송용)
@@ -11967,20 +11968,24 @@ async function osOpenCreate(opts) {
   document.getElementById('osCreateSubmitBtn').style.display = '';
   const title = document.getElementById('osCreateTitle'); if (title) title.textContent = '오리엔시트 링크 발급';
   document.getElementById('orientCreateModal').classList.add('open');
-  const sel = document.getElementById('osCreateBrand');
-  sel.disabled = false;
-  sel.innerHTML = '<option value="">불러오는 중…</option>';
+  // 브랜드 검색 드롭다운 초기화 (검색형 combobox — hidden #osCreateBrand 가 선택 brand_id 보관)
+  const brandInput = document.getElementById('osCreateBrandInput');
+  document.getElementById('osCreateBrand').value = '';
+  document.getElementById('osCreateBrandList').classList.remove('open');
+  brandInput.value = '';
+  brandInput.disabled = false;
+  brandInput.placeholder = '불러오는 중…';
   try {
-    const brands = await fetchBrands();
-    sel.innerHTML = '<option value="">브랜드 선택</option>' +
-      (brands || []).map(b => `<option value="${b.id}">${esc(b.name || b.name_ja || '-')}</option>`).join('');
+    _orientBrands = await fetchBrands() || [];
+    brandInput.placeholder = '브랜드명 검색 후 선택';
   } catch (e) {
-    sel.innerHTML = '<option value="">브랜드 조회 실패</option>';
+    _orientBrands = [];
+    brandInput.placeholder = '브랜드 조회 실패';
   }
   // 진입점 ②③ 컨텍스트 주입: 브랜드 고정 + (있으면) 신청 연결 선택
   if (opts.brandId) {
-    sel.value = opts.brandId;
-    if (opts.lockBrand) sel.disabled = true;
+    osSelectBrand(opts.brandId, { silent: true });   // silent: 신청 연결 로드는 아래에서 직접 제어
+    if (opts.lockBrand) brandInput.disabled = true;
     if (opts.appId) {
       await osOnBrandChange();
       document.getElementById('osCreateApp').value = opts.appId;
@@ -12015,6 +12020,57 @@ function osAppLabel(a) {
   const t = a.form_type ? OS_TYPE_LABEL[a.form_type] : '';
   const d = a.created_at ? formatDate(a.created_at) : '';
   return [d, t].filter(Boolean).join(' · ') || '신청';
+}
+
+// ── 브랜드 검색 드롭다운 (combobox) — .admin-proxy-combobox 패턴 재사용 ──
+function osBrandShowList() {
+  const input = document.getElementById('osCreateBrandInput');
+  if (!input || input.disabled) return;   // 진입점 ②③ 잠긴 브랜드면 열지 않음
+  document.getElementById('osCreateBrandList').classList.add('open');
+  _osRenderBrandList(input.value);
+}
+
+function osBrandInput() {
+  // 검색어 입력 = 선택 확정 전 상태. 선택 brand_id 비우고 신청 연결도 초기화.
+  document.getElementById('osCreateBrand').value = '';
+  const appSel = document.getElementById('osCreateApp');
+  if (appSel) appSel.innerHTML = '<option value="">연결 안 함</option>';
+  _osRenderBrandList(document.getElementById('osCreateBrandInput').value);
+  document.getElementById('osCreateBrandList').classList.add('open');
+}
+
+function _osRenderBrandList(query) {
+  const list = document.getElementById('osCreateBrandList');
+  if (!list) return;
+  const q = (query || '').trim().toLowerCase();
+  const matched = (_orientBrands || []).filter(b =>
+    (typeof matchSearchTokens === 'function')
+      ? matchSearchTokens(q, [b.name, b.name_ja, b.name_en])
+      : (!q || (b.name || '').toLowerCase().includes(q)));
+  if (!matched.length) {
+    list.innerHTML = '<div class="empty">일치하는 브랜드가 없습니다</div>';
+    return;
+  }
+  list.innerHTML = matched.slice(0, 100).map(b => {
+    const name = esc(b.name || b.name_ja || b.name_en || '-');
+    const sub = [(b.name_ja && b.name_ja !== b.name) ? b.name_ja : '', b.company_name || '']
+      .filter(Boolean).join(' · ');
+    return `<div class="item" onmousedown="osSelectBrand('${esc(b.id)}')">
+      <div>${name}</div>${sub ? `<div class="item-meta">${esc(sub)}</div>` : ''}</div>`;
+  }).join('');
+}
+
+// 항목 선택: hidden #osCreateBrand 에 id, 입력칸에 브랜드명 표기, 리스트 닫기.
+// silent=true 면 신청 연결 로드(osOnBrandChange)를 호출부가 직접 제어(진입점 ②③).
+function osSelectBrand(id, opts2) {
+  opts2 = opts2 || {};
+  const b = (_orientBrands || []).find(x => String(x.id) === String(id));
+  document.getElementById('osCreateBrand').value = id || '';
+  const input = document.getElementById('osCreateBrandInput');
+  if (input) input.value = b ? (b.name || b.name_ja || b.name_en || '-') : '';
+  const list = document.getElementById('osCreateBrandList');
+  if (list) list.classList.remove('open');
+  if (!opts2.silent) osOnBrandChange();
 }
 
 async function osSubmitCreate() {
@@ -12627,7 +12683,11 @@ function ensureOrientModals() {
       <div class="modal-body" style="padding:20px;overflow-y:auto;flex:1">
         <div id="osCreateForm">
           <div class="form-group"><label class="form-label">브랜드 <span style="color:var(--pink,#E8344E)">*</span></label>
-            <select id="osCreateBrand" class="form-input" onchange="osOnBrandChange()"></select></div>
+            <div class="admin-proxy-combobox" id="osCreateBrandCombobox">
+              <input type="text" id="osCreateBrandInput" class="admin-proxy-combobox-input" placeholder="브랜드명 검색 후 선택" autocomplete="off" oninput="osBrandInput()" onfocus="osBrandShowList()">
+              <input type="hidden" id="osCreateBrand">
+              <div class="admin-proxy-combobox-list" id="osCreateBrandList"></div>
+            </div></div>
           <div class="form-group"><label class="form-label">광고주 신청 연결 (선택)</label>
             <select id="osCreateApp" class="form-input"><option value="">연결 안 함</option></select>
             <div style="font-size:11px;color:var(--muted);margin-top:4px">신청을 연결하면 그 신청의 모집 희망값을 작성 폼 첫 카드에 미리 채웁니다.</div></div>
@@ -12694,6 +12754,15 @@ function ensureOrientModals() {
   // 동적 생성된 오리엔 모달에 드래그·리사이즈 옵저버 부착(부트 시점엔 없던 overlay라 재등록 필요. 멱등)
   if (typeof initDraggableModals === 'function') initDraggableModals();
 }
+
+// 발급 모달 브랜드 검색 드롭다운 — 바깥 클릭 시 리스트 닫기 (combobox 표준 동작)
+document.addEventListener('click', function(e) {
+  const combo = document.getElementById('osCreateBrandCombobox');
+  if (combo && !combo.contains(e.target)) {
+    const list = document.getElementById('osCreateBrandList');
+    if (list) list.classList.remove('open');
+  }
+});
 
 // ══════════════════════════════════════
 // REVERB JP — Admin Brand Survey 영역

--- a/dev/js/admin-orient.js
+++ b/dev/js/admin-orient.js
@@ -7,6 +7,7 @@
 // ============================================================
 
 let _orientSheets = [];
+let _orientBrands = [];      // 발급 모달 브랜드 검색 드롭다운 후보 (osOpenCreate 에서 적재)
 let _osDetailSheet = null;   // 상세 모달에 열린 시트(카드별 발행에 사용)
 let _osDetailCatMap = {};    // 상세 모달 카테고리 라벨 맵(새창 열기에 재사용)
 let _osLastIssuedId = null;  // 방금 발급한 오리엔시트 id(발급 결과 화면 수동 메일 발송용)
@@ -268,20 +269,24 @@ async function osOpenCreate(opts) {
   document.getElementById('osCreateSubmitBtn').style.display = '';
   const title = document.getElementById('osCreateTitle'); if (title) title.textContent = '오리엔시트 링크 발급';
   document.getElementById('orientCreateModal').classList.add('open');
-  const sel = document.getElementById('osCreateBrand');
-  sel.disabled = false;
-  sel.innerHTML = '<option value="">불러오는 중…</option>';
+  // 브랜드 검색 드롭다운 초기화 (검색형 combobox — hidden #osCreateBrand 가 선택 brand_id 보관)
+  const brandInput = document.getElementById('osCreateBrandInput');
+  document.getElementById('osCreateBrand').value = '';
+  document.getElementById('osCreateBrandList').classList.remove('open');
+  brandInput.value = '';
+  brandInput.disabled = false;
+  brandInput.placeholder = '불러오는 중…';
   try {
-    const brands = await fetchBrands();
-    sel.innerHTML = '<option value="">브랜드 선택</option>' +
-      (brands || []).map(b => `<option value="${b.id}">${esc(b.name || b.name_ja || '-')}</option>`).join('');
+    _orientBrands = await fetchBrands() || [];
+    brandInput.placeholder = '브랜드명 검색 후 선택';
   } catch (e) {
-    sel.innerHTML = '<option value="">브랜드 조회 실패</option>';
+    _orientBrands = [];
+    brandInput.placeholder = '브랜드 조회 실패';
   }
   // 진입점 ②③ 컨텍스트 주입: 브랜드 고정 + (있으면) 신청 연결 선택
   if (opts.brandId) {
-    sel.value = opts.brandId;
-    if (opts.lockBrand) sel.disabled = true;
+    osSelectBrand(opts.brandId, { silent: true });   // silent: 신청 연결 로드는 아래에서 직접 제어
+    if (opts.lockBrand) brandInput.disabled = true;
     if (opts.appId) {
       await osOnBrandChange();
       document.getElementById('osCreateApp').value = opts.appId;
@@ -316,6 +321,57 @@ function osAppLabel(a) {
   const t = a.form_type ? OS_TYPE_LABEL[a.form_type] : '';
   const d = a.created_at ? formatDate(a.created_at) : '';
   return [d, t].filter(Boolean).join(' · ') || '신청';
+}
+
+// ── 브랜드 검색 드롭다운 (combobox) — .admin-proxy-combobox 패턴 재사용 ──
+function osBrandShowList() {
+  const input = document.getElementById('osCreateBrandInput');
+  if (!input || input.disabled) return;   // 진입점 ②③ 잠긴 브랜드면 열지 않음
+  document.getElementById('osCreateBrandList').classList.add('open');
+  _osRenderBrandList(input.value);
+}
+
+function osBrandInput() {
+  // 검색어 입력 = 선택 확정 전 상태. 선택 brand_id 비우고 신청 연결도 초기화.
+  document.getElementById('osCreateBrand').value = '';
+  const appSel = document.getElementById('osCreateApp');
+  if (appSel) appSel.innerHTML = '<option value="">연결 안 함</option>';
+  _osRenderBrandList(document.getElementById('osCreateBrandInput').value);
+  document.getElementById('osCreateBrandList').classList.add('open');
+}
+
+function _osRenderBrandList(query) {
+  const list = document.getElementById('osCreateBrandList');
+  if (!list) return;
+  const q = (query || '').trim().toLowerCase();
+  const matched = (_orientBrands || []).filter(b =>
+    (typeof matchSearchTokens === 'function')
+      ? matchSearchTokens(q, [b.name, b.name_ja, b.name_en])
+      : (!q || (b.name || '').toLowerCase().includes(q)));
+  if (!matched.length) {
+    list.innerHTML = '<div class="empty">일치하는 브랜드가 없습니다</div>';
+    return;
+  }
+  list.innerHTML = matched.slice(0, 100).map(b => {
+    const name = esc(b.name || b.name_ja || b.name_en || '-');
+    const sub = [(b.name_ja && b.name_ja !== b.name) ? b.name_ja : '', b.company_name || '']
+      .filter(Boolean).join(' · ');
+    return `<div class="item" onmousedown="osSelectBrand('${esc(b.id)}')">
+      <div>${name}</div>${sub ? `<div class="item-meta">${esc(sub)}</div>` : ''}</div>`;
+  }).join('');
+}
+
+// 항목 선택: hidden #osCreateBrand 에 id, 입력칸에 브랜드명 표기, 리스트 닫기.
+// silent=true 면 신청 연결 로드(osOnBrandChange)를 호출부가 직접 제어(진입점 ②③).
+function osSelectBrand(id, opts2) {
+  opts2 = opts2 || {};
+  const b = (_orientBrands || []).find(x => String(x.id) === String(id));
+  document.getElementById('osCreateBrand').value = id || '';
+  const input = document.getElementById('osCreateBrandInput');
+  if (input) input.value = b ? (b.name || b.name_ja || b.name_en || '-') : '';
+  const list = document.getElementById('osCreateBrandList');
+  if (list) list.classList.remove('open');
+  if (!opts2.silent) osOnBrandChange();
 }
 
 async function osSubmitCreate() {
@@ -928,7 +984,11 @@ function ensureOrientModals() {
       <div class="modal-body" style="padding:20px;overflow-y:auto;flex:1">
         <div id="osCreateForm">
           <div class="form-group"><label class="form-label">브랜드 <span style="color:var(--pink,#E8344E)">*</span></label>
-            <select id="osCreateBrand" class="form-input" onchange="osOnBrandChange()"></select></div>
+            <div class="admin-proxy-combobox" id="osCreateBrandCombobox">
+              <input type="text" id="osCreateBrandInput" class="admin-proxy-combobox-input" placeholder="브랜드명 검색 후 선택" autocomplete="off" oninput="osBrandInput()" onfocus="osBrandShowList()">
+              <input type="hidden" id="osCreateBrand">
+              <div class="admin-proxy-combobox-list" id="osCreateBrandList"></div>
+            </div></div>
           <div class="form-group"><label class="form-label">광고주 신청 연결 (선택)</label>
             <select id="osCreateApp" class="form-input"><option value="">연결 안 함</option></select>
             <div style="font-size:11px;color:var(--muted);margin-top:4px">신청을 연결하면 그 신청의 모집 희망값을 작성 폼 첫 카드에 미리 채웁니다.</div></div>
@@ -995,3 +1055,12 @@ function ensureOrientModals() {
   // 동적 생성된 오리엔 모달에 드래그·리사이즈 옵저버 부착(부트 시점엔 없던 overlay라 재등록 필요. 멱등)
   if (typeof initDraggableModals === 'function') initDraggableModals();
 }
+
+// 발급 모달 브랜드 검색 드롭다운 — 바깥 클릭 시 리스트 닫기 (combobox 표준 동작)
+document.addEventListener('click', function(e) {
+  const combo = document.getElementById('osCreateBrandCombobox');
+  if (combo && !combo.contains(e.target)) {
+    const list = document.getElementById('osCreateBrandList');
+    if (list) list.classList.remove('open');
+  }
+});


### PR DESCRIPTION
## 변경 요약
오리엔시트 발급 모달의 브랜드 선택을 일반 드롭다운에서 검색형 드롭다운(combobox)으로 교체. 브랜드명(한·일·영) 타이핑으로 필터·선택. 기존 대리등록 모달 검색 드롭다운 패턴·CSS 재사용(새 CSS 0). 선택 brand_id 는 기존 hidden(#osCreateBrand) 유지로 발급·cascade 로직 무변경. 오리엔시트는 운영 보류라 dev 까지만.

## 요청 외 추가 변경
- 없음

## 리뷰
- reverb-reviewer GO · qa-tester light