### PR TITLE
feat(orient): 자체번호 표시 PR2 — 메일·관리자 화면, 신청번호 제거

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -12,7 +12,7 @@
 // 회귀(2026-05-12 PR #182 머지 직후 발생)를 방지하기 위한 자동 reload 가드.
 // sessionStorage 차단 환경(시크릿 모드 일부, 쿠키 차단)에서는 자연스럽게 skip.
 (function(){
-  var CURRENT_BUILD = 'v1782780696';
+  var CURRENT_BUILD = 'v1782814217';
   if (CURRENT_BUILD.indexOf('__') === 0) return; // 빌드 미적용 (dev/ 직접 열기) 시 skip
   try {
     var prev = sessionStorage.getItem('reverb.adminBuild');
@@ -2138,7 +2138,7 @@ tr.audit-row, .audit-row { background: #fff3e0 !important; }
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-06-30 09:51 · 82ace13</span>
+          <span class="admin-build-text">2026-06-30 19:10 · 96b3bc3</span>
         </div>
       </div>
     </aside>
@@ -3817,6 +3817,7 @@ tr.audit-row, .audit-row { background: #fff3e0 !important; }
             <div class="admin-table-wrap">
               <table class="data-table">
                 <thead><tr>
+                  <th style="width:120px">오리엔 번호</th>
                   <th>브랜드</th>
                   <th style="width:140px">모집 형식</th>
                   <th style="width:140px">상태</th>
@@ -3825,7 +3826,7 @@ tr.audit-row, .audit-row { background: #fff3e0 !important; }
                   <th style="width:140px">제출일시</th>
                   <th style="width:170px">관리</th>
                 </tr></thead>
-                <tbody id="orientTableBody"><tr><td colspan="7" style="text-align:center;color:var(--muted);padding:24px">불러오는 중…</td></tr></tbody>
+                <tbody id="orientTableBody"><tr><td colspan="8" style="text-align:center;color:var(--muted);padding:24px">불러오는 중…</td></tr></tbody>
               </table>
             </div>
           </div>
@@ -9773,7 +9774,7 @@ async function fetchOrientSheets() {
   if (!db) return [];
   return await retryWithRefresh(async () =>
     fetchAllPaged(() => db.from('orient_sheets')
-      .select('id, brand_id, application_id, form_type, data, status, token, token_expires_at, submitted_at, created_at, campaign_id, mail_sent_at, mail_sent_to, brands(name, name_ja)')
+      .select('id, brand_id, application_id, orient_no, form_type, data, status, token, token_expires_at, submitted_at, created_at, campaign_id, mail_sent_at, mail_sent_to, brands(name, name_ja)')
       .order('created_at', { ascending: false }))
   );
 }
@@ -11840,7 +11841,7 @@ async function refreshOrientBadge(cached) {
 }
 
 function osMsgRow(msg) {
-  return `<tr><td colspan="7" style="text-align:center;color:var(--muted);padding:24px">${esc(msg)}</td></tr>`;
+  return `<tr><td colspan="8" style="text-align:center;color:var(--muted);padding:24px">${esc(msg)}</td></tr>`;
 }
 
 function renderOrientSheets() {
@@ -11895,6 +11896,7 @@ function osRowHtml(s) {
   const linkBadge = s.application_id
     ? ' <span style="display:inline-block;padding:1px 6px;border-radius:999px;font-size:10px;color:#8A8A90;background:#F0F0F0">신청연결</span>' : '';
   return `<tr>
+    <td style="font-weight:700;color:var(--ink);white-space:nowrap">${s.orient_no ? esc(s.orient_no) : '-'}</td>
     <td>${esc(osBrandName(s))}${linkBadge}</td>
     <td>${osCardsSummary(s.data)}</td>
     <td>${osBadge(osStatusOf(s))}</td>
@@ -12084,6 +12086,7 @@ async function osSubmitCreate() {
     if (!res || res.success !== true) { toast('발급 실패: ' + osReasonText(res?.reason)); return; }
     document.getElementById('osCreateLink').value = osBuildLink(res.token);
     document.getElementById('osCreateExpire').textContent = res.token_expires_at ? formatDate(res.token_expires_at) : '';
+    const onEl = document.getElementById('osCreateOrientNo'); if (onEl) onEl.textContent = res.orient_no || '-';
     document.getElementById('osCreateForm').style.display = 'none';
     document.getElementById('osCreateResult').style.display = '';
     btn.style.display = 'none';
@@ -12105,6 +12108,7 @@ async function osSubmitCreate() {
 function osReasonText(r) {
   return ({
     brand_not_found: '브랜드를 찾을 수 없습니다',
+    brand_seq_missing: '브랜드 식별번호가 없습니다 (관리자에게 문의)',
     application_not_found: '신청을 찾을 수 없습니다',
     brand_mismatch: '신청과 브랜드가 일치하지 않습니다',
     no_db: '연결 오류',
@@ -12411,6 +12415,7 @@ function osDetailHtml(s, catMap, readonly) {
   const d = s.data || {};
   const cards = Array.isArray(d.cards) ? d.cards : [];
   const headerHtml = `<div style="margin-bottom:14px">
+    ${s.orient_no ? `<div style="font-size:12px;font-weight:700;color:var(--muted);margin-bottom:2px">${esc(s.orient_no)}</div>` : ''}
     <div style="font-size:16px;font-weight:800;color:#161618">${esc(osBrandName(s))}</div>
   </div>`;
   // 상태 배지 + 모집 건수 줄 — 브랜드 정보 카드와 제품(모집 건) 카드 사이에 배치
@@ -12695,7 +12700,8 @@ function ensureOrientModals() {
             모집 형식(가구매·리뷰어·시딩)과 제품은 브랜드가 작성 폼에서 카드마다 직접 추가·선택합니다.</div>
         </div>
         <div id="osCreateResult" style="display:none">
-          <p style="font-weight:700;margin-bottom:8px">발급되었습니다. 아래 링크를 브랜드에게 전달하세요.</p>
+          <p style="font-weight:700;margin-bottom:6px">발급되었습니다. 아래 링크를 브랜드에게 전달하세요.</p>
+          <p style="margin:0 0 10px;font-size:13px;color:var(--muted)">오리엔시트 번호 <span id="osCreateOrientNo" style="font-weight:800;color:var(--ink)"></span></p>
           <div style="position:relative">
             <input type="text" id="osCreateLink" class="form-input" readonly onclick="this.select()" style="padding-right:48px">
             <button type="button" class="os-copy-btn" onclick="osCopyResultLink()" title="링크 복사" style="position:absolute;right:1px;top:1px;bottom:1px;background:none;border:none;border-left:1px solid var(--line);cursor:pointer;padding:0 10px;display:flex;align-items:center"><span class="material-icons-round notranslate" translate="no" style="font-size:18px;color:var(--muted);transition:transform .1s">content_copy</span></button>

--- a/dev/admin/index.html
+++ b/dev/admin/index.html
@@ -1813,6 +1813,7 @@
             <div class="admin-table-wrap">
               <table class="data-table">
                 <thead><tr>
+                  <th style="width:120px">오리엔 번호</th>
                   <th>브랜드</th>
                   <th style="width:140px">모집 형식</th>
                   <th style="width:140px">상태</th>
@@ -1821,7 +1822,7 @@
                   <th style="width:140px">제출일시</th>
                   <th style="width:170px">관리</th>
                 </tr></thead>
-                <tbody id="orientTableBody"><tr><td colspan="7" style="text-align:center;color:var(--muted);padding:24px">불러오는 중…</td></tr></tbody>
+                <tbody id="orientTableBody"><tr><td colspan="8" style="text-align:center;color:var(--muted);padding:24px">불러오는 중…</td></tr></tbody>
               </table>
             </div>
           </div>

--- a/dev/js/admin-orient.js
+++ b/dev/js/admin-orient.js
@@ -141,7 +141,7 @@ async function refreshOrientBadge(cached) {
 }
 
 function osMsgRow(msg) {
-  return `<tr><td colspan="7" style="text-align:center;color:var(--muted);padding:24px">${esc(msg)}</td></tr>`;
+  return `<tr><td colspan="8" style="text-align:center;color:var(--muted);padding:24px">${esc(msg)}</td></tr>`;
 }
 
 function renderOrientSheets() {
@@ -196,6 +196,7 @@ function osRowHtml(s) {
   const linkBadge = s.application_id
     ? ' <span style="display:inline-block;padding:1px 6px;border-radius:999px;font-size:10px;color:#8A8A90;background:#F0F0F0">신청연결</span>' : '';
   return `<tr>
+    <td style="font-weight:700;color:var(--ink);white-space:nowrap">${s.orient_no ? esc(s.orient_no) : '-'}</td>
     <td>${esc(osBrandName(s))}${linkBadge}</td>
     <td>${osCardsSummary(s.data)}</td>
     <td>${osBadge(osStatusOf(s))}</td>
@@ -385,6 +386,7 @@ async function osSubmitCreate() {
     if (!res || res.success !== true) { toast('발급 실패: ' + osReasonText(res?.reason)); return; }
     document.getElementById('osCreateLink').value = osBuildLink(res.token);
     document.getElementById('osCreateExpire').textContent = res.token_expires_at ? formatDate(res.token_expires_at) : '';
+    const onEl = document.getElementById('osCreateOrientNo'); if (onEl) onEl.textContent = res.orient_no || '-';
     document.getElementById('osCreateForm').style.display = 'none';
     document.getElementById('osCreateResult').style.display = '';
     btn.style.display = 'none';
@@ -406,6 +408,7 @@ async function osSubmitCreate() {
 function osReasonText(r) {
   return ({
     brand_not_found: '브랜드를 찾을 수 없습니다',
+    brand_seq_missing: '브랜드 식별번호가 없습니다 (관리자에게 문의)',
     application_not_found: '신청을 찾을 수 없습니다',
     brand_mismatch: '신청과 브랜드가 일치하지 않습니다',
     no_db: '연결 오류',
@@ -712,6 +715,7 @@ function osDetailHtml(s, catMap, readonly) {
   const d = s.data || {};
   const cards = Array.isArray(d.cards) ? d.cards : [];
   const headerHtml = `<div style="margin-bottom:14px">
+    ${s.orient_no ? `<div style="font-size:12px;font-weight:700;color:var(--muted);margin-bottom:2px">${esc(s.orient_no)}</div>` : ''}
     <div style="font-size:16px;font-weight:800;color:#161618">${esc(osBrandName(s))}</div>
   </div>`;
   // 상태 배지 + 모집 건수 줄 — 브랜드 정보 카드와 제품(모집 건) 카드 사이에 배치
@@ -996,7 +1000,8 @@ function ensureOrientModals() {
             모집 형식(가구매·리뷰어·시딩)과 제품은 브랜드가 작성 폼에서 카드마다 직접 추가·선택합니다.</div>
         </div>
         <div id="osCreateResult" style="display:none">
-          <p style="font-weight:700;margin-bottom:8px">발급되었습니다. 아래 링크를 브랜드에게 전달하세요.</p>
+          <p style="font-weight:700;margin-bottom:6px">발급되었습니다. 아래 링크를 브랜드에게 전달하세요.</p>
+          <p style="margin:0 0 10px;font-size:13px;color:var(--muted)">오리엔시트 번호 <span id="osCreateOrientNo" style="font-weight:800;color:var(--ink)"></span></p>
           <div style="position:relative">
             <input type="text" id="osCreateLink" class="form-input" readonly onclick="this.select()" style="padding-right:48px">
             <button type="button" class="os-copy-btn" onclick="osCopyResultLink()" title="링크 복사" style="position:absolute;right:1px;top:1px;bottom:1px;background:none;border:none;border-left:1px solid var(--line);cursor:pointer;padding:0 10px;display:flex;align-items:center"><span class="material-icons-round notranslate" translate="no" style="font-size:18px;color:var(--muted);transition:transform .1s">content_copy</span></button>

--- a/dev/lib/storage.js
+++ b/dev/lib/storage.js
@@ -3551,7 +3551,7 @@ async function fetchOrientSheets() {
   if (!db) return [];
   return await retryWithRefresh(async () =>
     fetchAllPaged(() => db.from('orient_sheets')
-      .select('id, brand_id, application_id, form_type, data, status, token, token_expires_at, submitted_at, created_at, campaign_id, mail_sent_at, mail_sent_to, brands(name, name_ja)')
+      .select('id, brand_id, application_id, orient_no, form_type, data, status, token, token_expires_at, submitted_at, created_at, campaign_id, mail_sent_at, mail_sent_to, brands(name, name_ja)')
       .order('created_at', { ascending: false }))
   );
 }

--- a/docs/email-templates/orient-submitted-notify.html
+++ b/docs/email-templates/orient-submitted-notify.html
@@ -9,10 +9,10 @@
 
   Placeholders:
     {{submit_kind}}       "신규 제출" 또는 "수정 재제출"
+    {{orient_no}}         오리엔시트 자체 식별번호 (B0001-O001, 마이그205)
     {{brand_name}}        브랜드명
     {{form_type_label}}   "리뷰어" 또는 "시딩"
     {{submitted_at}}      제출 시각 (KST, 예: 2026. 06. 30. 14:32)
-    {{application_no}}    연결 신청 번호 (없으면 "-")
     {{deep_link}}         관리자 오리엔시트 조회 페인 링크
 
   Note:
@@ -26,7 +26,11 @@
   <div style="background:#F7F4EE;border:1px solid #EAEAE4;border-radius:12px;padding:16px 18px;margin-bottom:20px">
     <table style="border-collapse:collapse;width:100%;font-size:13px">
       <tr>
-        <td style="padding:6px 0;color:#888;font-weight:700;width:100px;vertical-align:top">브랜드</td>
+        <td style="padding:6px 0;color:#888;font-weight:700;width:100px;vertical-align:top">오리엔시트 번호</td>
+        <td style="padding:6px 0;font-weight:700">{{orient_no}}</td>
+      </tr>
+      <tr>
+        <td style="padding:6px 0;color:#888;font-weight:700;vertical-align:top">브랜드</td>
         <td style="padding:6px 0;font-weight:700;color:#E8344E">{{brand_name}}</td>
       </tr>
       <tr>
@@ -36,10 +40,6 @@
       <tr>
         <td style="padding:6px 0;color:#888;font-weight:700;vertical-align:top">제출 시각</td>
         <td style="padding:6px 0">{{submitted_at}}</td>
-      </tr>
-      <tr>
-        <td style="padding:6px 0;color:#888;font-weight:700;vertical-align:top">연결 신청</td>
-        <td style="padding:6px 0">{{application_no}}</td>
       </tr>
     </table>
   </div>

--- a/index.html
+++ b/index.html
@@ -8087,7 +8087,7 @@ async function fetchOrientSheets() {
   if (!db) return [];
   return await retryWithRefresh(async () =>
     fetchAllPaged(() => db.from('orient_sheets')
-      .select('id, brand_id, application_id, form_type, data, status, token, token_expires_at, submitted_at, created_at, campaign_id, mail_sent_at, mail_sent_to, brands(name, name_ja)')
+      .select('id, brand_id, application_id, orient_no, form_type, data, status, token, token_expires_at, submitted_at, created_at, campaign_id, mail_sent_at, mail_sent_to, brands(name, name_ja)')
       .order('created_at', { ascending: false }))
   );
 }

--- a/supabase/functions/notify-brand-daily-digest/index.ts
+++ b/supabase/functions/notify-brand-daily-digest/index.ts
@@ -183,6 +183,7 @@ async function sendBrevoEmail(params: {
 interface OrientSheetRow {
   id: string;
   brand_id: string;
+  orient_no: string | null;     // 자체 식별번호 B0001-O001 (마이그205)
   form_type: string | null;
   submitted_at: string;         // 최초 제출 (불변)
   last_submitted_at: string;    // 마지막 제출 (매 제출 갱신)
@@ -222,9 +223,11 @@ function renderNewSection(args: {
   const tableRows = args.rows.map((r) => {
     const brand = args.brandMap.get(r.brand_id);
     const brandName = escapeHtml(brand?.name || "-");
+    const orientNo = escapeHtml(r.orient_no || "-");
     const formType = escapeHtml(formTypeKo(r.form_type));
     const submittedAt = escapeHtml(formatKstFull(r.submitted_at));
     return `<tr>
+      <td style="padding:6px 8px;vertical-align:top;color:#5B6BBF;border-bottom:1px solid #F0F2F8;font-weight:700;white-space:nowrap">${orientNo}</td>
       <td style="padding:6px 8px;vertical-align:top;border-bottom:1px solid #F0F2F8;font-weight:600">${brandName}</td>
       <td style="padding:6px 8px;vertical-align:top;color:#555;border-bottom:1px solid #F0F2F8">${formType}</td>
       <td style="padding:6px 8px;vertical-align:top;color:#666;border-bottom:1px solid #F0F2F8;white-space:nowrap">${submittedAt}</td>
@@ -234,6 +237,7 @@ function renderNewSection(args: {
   const bodyHtml = `<table style="width:100%;border-collapse:collapse;font-size:12px">
     <thead>
       <tr style="background:#F5F7FC">
+        <th style="padding:6px 8px;text-align:left;color:#555;font-weight:600">오리엔 번호</th>
         <th style="padding:6px 8px;text-align:left;color:#555;font-weight:600">브랜드</th>
         <th style="padding:6px 8px;text-align:left;color:#555;font-weight:600">형식</th>
         <th style="padding:6px 8px;text-align:left;color:#555;font-weight:600">제출 시각</th>
@@ -262,10 +266,12 @@ function renderResubmitSection(args: {
   const tableRows = args.rows.map((r) => {
     const brand = args.brandMap.get(r.brand_id);
     const brandName = escapeHtml(brand?.name || "-");
+    const orientNo = escapeHtml(r.orient_no || "-");
     const formType = escapeHtml(formTypeKo(r.form_type));
     const resubmittedAt = escapeHtml(formatKstFull(r.last_submitted_at));
     const firstAt = escapeHtml(formatKstFull(r.submitted_at));
     return `<tr>
+      <td style="padding:6px 8px;vertical-align:top;color:#5B6BBF;border-bottom:1px solid #F0F2F8;font-weight:700;white-space:nowrap">${orientNo}</td>
       <td style="padding:6px 8px;vertical-align:top;border-bottom:1px solid #F0F2F8;font-weight:600">${brandName}</td>
       <td style="padding:6px 8px;vertical-align:top;color:#555;border-bottom:1px solid #F0F2F8">${formType}</td>
       <td style="padding:6px 8px;vertical-align:top;color:#666;border-bottom:1px solid #F0F2F8;white-space:nowrap">${resubmittedAt}</td>
@@ -276,6 +282,7 @@ function renderResubmitSection(args: {
   const bodyHtml = `<table style="width:100%;border-collapse:collapse;font-size:12px">
     <thead>
       <tr style="background:#F5F7FC">
+        <th style="padding:6px 8px;text-align:left;color:#555;font-weight:600">오리엔 번호</th>
         <th style="padding:6px 8px;text-align:left;color:#555;font-weight:600">브랜드</th>
         <th style="padding:6px 8px;text-align:left;color:#555;font-weight:600">형식</th>
         <th style="padding:6px 8px;text-align:left;color:#555;font-weight:600">재제출 시각</th>
@@ -381,13 +388,13 @@ Deno.serve(async (req: Request) => {
     const [newRes, resubmitRes] = await Promise.all([
       // 섹션 1: 신규 제출
       sb.from("orient_sheets")
-        .select("id, brand_id, form_type, submitted_at, last_submitted_at")
+        .select("id, brand_id, orient_no, form_type, submitted_at, last_submitted_at")
         .gte("submitted_at", startIso)
         .lt("submitted_at", endIso)
         .order("submitted_at", { ascending: true }),
       // 섹션 2: 수정 재제출 (마지막 제출이 어제 AND 최초 제출은 그 이전)
       sb.from("orient_sheets")
-        .select("id, brand_id, form_type, submitted_at, last_submitted_at")
+        .select("id, brand_id, orient_no, form_type, submitted_at, last_submitted_at")
         .gte("last_submitted_at", startIso)
         .lt("last_submitted_at", endIso)
         .lt("submitted_at", startIso)

--- a/supabase/functions/notify-orient-submitted/_templates/orient-submitted-notify.html
+++ b/supabase/functions/notify-orient-submitted/_templates/orient-submitted-notify.html
@@ -9,10 +9,10 @@
 
   Placeholders:
     {{submit_kind}}       "신규 제출" 또는 "수정 재제출"
+    {{orient_no}}         오리엔시트 자체 식별번호 (B0001-O001, 마이그205)
     {{brand_name}}        브랜드명
     {{form_type_label}}   "리뷰어" 또는 "시딩"
     {{submitted_at}}      제출 시각 (KST, 예: 2026. 06. 30. 14:32)
-    {{application_no}}    연결 신청 번호 (없으면 "-")
     {{deep_link}}         관리자 오리엔시트 조회 페인 링크
 
   Note:
@@ -26,7 +26,11 @@
   <div style="background:#F7F4EE;border:1px solid #EAEAE4;border-radius:12px;padding:16px 18px;margin-bottom:20px">
     <table style="border-collapse:collapse;width:100%;font-size:13px">
       <tr>
-        <td style="padding:6px 0;color:#888;font-weight:700;width:100px;vertical-align:top">브랜드</td>
+        <td style="padding:6px 0;color:#888;font-weight:700;width:100px;vertical-align:top">오리엔시트 번호</td>
+        <td style="padding:6px 0;font-weight:700">{{orient_no}}</td>
+      </tr>
+      <tr>
+        <td style="padding:6px 0;color:#888;font-weight:700;vertical-align:top">브랜드</td>
         <td style="padding:6px 0;font-weight:700;color:#E8344E">{{brand_name}}</td>
       </tr>
       <tr>
@@ -36,10 +40,6 @@
       <tr>
         <td style="padding:6px 0;color:#888;font-weight:700;vertical-align:top">제출 시각</td>
         <td style="padding:6px 0">{{submitted_at}}</td>
-      </tr>
-      <tr>
-        <td style="padding:6px 0;color:#888;font-weight:700;vertical-align:top">연결 신청</td>
-        <td style="padding:6px 0">{{application_no}}</td>
       </tr>
     </table>
   </div>

--- a/supabase/functions/notify-orient-submitted/index.ts
+++ b/supabase/functions/notify-orient-submitted/index.ts
@@ -53,6 +53,7 @@ interface OrientSheetRecord {
   id: string;
   brand_id: string;
   application_id: string | null;
+  orient_no: string | null;        // 자체 식별번호 B0001-O001 (마이그205)
   form_type: "reviewer" | "seeding" | null;
   status: string;
   submitted_at: string | null;
@@ -227,17 +228,9 @@ Deno.serve(async (req: Request) => {
       if (brandRow?.name) brandName = brandRow.name as string;
     }
 
-    // 연결 신청 번호 (있으면)
-    let applicationNo = "-";
-    if (record.application_id) {
-      const { data: appRow, error: appErr } = await sb
-        .from("brand_applications")
-        .select("application_no")
-        .eq("id", record.application_id)
-        .maybeSingle();
-      if (appErr) console.error("[notify-orient-submitted] app fetch error", appErr.message);
-      if (appRow?.application_no) applicationNo = appRow.application_no as string;
-    }
+    // 오리엔시트 자체 식별번호 (웹훅 record 에 포함 — 별도 조회 불필요)
+    // 신청 번호(application_no) 표시는 제거(자체 번호로 일원화 — "서베이 경유" 오해 차단, 사양 §3⑦)
+    const orientNo = (record.orient_no as string | null) || "-";
 
     // 제출 시각 (last_submitted_at 우선, 없으면 submitted_at)
     const submittedIso = (record.last_submitted_at || record.submitted_at) ?? null;
@@ -270,16 +263,16 @@ Deno.serve(async (req: Request) => {
       brand_name:       escapeHtml(brandName),
       form_type_label:  escapeHtml(formTypeLabel(record.form_type)),
       submitted_at:     escapeHtml(submittedAt),
-      application_no:   escapeHtml(applicationNo),
+      orient_no:        escapeHtml(orientNo),
       deep_link:        escapeHtml(deepLink),
     });
 
     const text =
       `[${submitKind}] 오리엔시트 알림\n\n` +
+      `오리엔시트 번호: ${orientNo}\n` +
       `브랜드: ${brandName}\n` +
       `폼 종류: ${formTypeLabel(record.form_type)}\n` +
-      `제출 시각: ${submittedAt}\n` +
-      `연결 신청: ${applicationNo}\n\n` +
+      `제출 시각: ${submittedAt}\n\n` +
       `관리자 페이지: ${deepLink}\n`;
 
     // 관리자 1인 1통 분리 발송 (To 헤더 노출 차단)

--- a/supabase/functions/notify-orient-submitted/templates.ts
+++ b/supabase/functions/notify-orient-submitted/templates.ts
@@ -15,10 +15,10 @@ export const TEMPLATES: Record<string, string> = {
 
   Placeholders:
     {{submit_kind}}       "신규 제출" 또는 "수정 재제출"
+    {{orient_no}}         오리엔시트 자체 식별번호 (B0001-O001, 마이그205)
     {{brand_name}}        브랜드명
     {{form_type_label}}   "리뷰어" 또는 "시딩"
     {{submitted_at}}      제출 시각 (KST, 예: 2026. 06. 30. 14:32)
-    {{application_no}}    연결 신청 번호 (없으면 "-")
     {{deep_link}}         관리자 오리엔시트 조회 페인 링크
 
   Note:
@@ -32,7 +32,11 @@ export const TEMPLATES: Record<string, string> = {
   <div style="background:#F7F4EE;border:1px solid #EAEAE4;border-radius:12px;padding:16px 18px;margin-bottom:20px">
     <table style="border-collapse:collapse;width:100%;font-size:13px">
       <tr>
-        <td style="padding:6px 0;color:#888;font-weight:700;width:100px;vertical-align:top">브랜드</td>
+        <td style="padding:6px 0;color:#888;font-weight:700;width:100px;vertical-align:top">오리엔시트 번호</td>
+        <td style="padding:6px 0;font-weight:700">{{orient_no}}</td>
+      </tr>
+      <tr>
+        <td style="padding:6px 0;color:#888;font-weight:700;vertical-align:top">브랜드</td>
         <td style="padding:6px 0;font-weight:700;color:#E8344E">{{brand_name}}</td>
       </tr>
       <tr>
@@ -42,10 +46,6 @@ export const TEMPLATES: Record<string, string> = {
       <tr>
         <td style="padding:6px 0;color:#888;font-weight:700;vertical-align:top">제출 시각</td>
         <td style="padding:6px 0">{{submitted_at}}</td>
-      </tr>
-      <tr>
-        <td style="padding:6px 0;color:#888;font-weight:700;vertical-align:top">연결 신청</td>
-        <td style="padding:6px 0">{{application_no}}</td>
       </tr>
     </table>
   </div>


### PR DESCRIPTION
## 변경 요약
오리엔 알림 메일 2개·관리자 화면에서 신청번호 표시 제거하고 자체번호(orient_no, B0001-O001) 표시. 사양서 docs/specs/2026-06-30-orient-self-numbering.md PR2.
- notify-orient-submitted: 웹훅 record.orient_no 사용(application_no 조회 제거), 템플릿 「연결 신청」→「오리엔시트 번호」
- notify-brand-daily-digest: 2섹션에 「오리엔 번호」 열 추가
- admin-orient.js: 목록 맨 앞 열·상세 헤더·발급 결과 표시 + osReasonText brand_seq_missing
- storage.js fetchOrientSheets orient_no select

## 요청 외 추가 변경
- osReasonText brand_seq_missing 라벨(PR1 reviewer 경고)

## 비고
- application_id 연결은 유지(표시만 제거). 메일 함수 운영 가동 중 → 운영 재배포는 사용자 확인 후.

## 리뷰
- reverb-reviewer GO · qa light 권장