### PR TITLE
feat(orient): 알림 메일 자체번호 표시 운영 기록 (PR2 메일분)

### DIFF
--- a/docs/email-templates/orient-submitted-notify.html
+++ b/docs/email-templates/orient-submitted-notify.html
@@ -9,10 +9,10 @@
 
   Placeholders:
     {{submit_kind}}       "신규 제출" 또는 "수정 재제출"
+    {{orient_no}}         오리엔시트 자체 식별번호 (B0001-O001, 마이그205)
     {{brand_name}}        브랜드명
     {{form_type_label}}   "리뷰어" 또는 "시딩"
     {{submitted_at}}      제출 시각 (KST, 예: 2026. 06. 30. 14:32)
-    {{application_no}}    연결 신청 번호 (없으면 "-")
     {{deep_link}}         관리자 오리엔시트 조회 페인 링크
 
   Note:
@@ -26,7 +26,11 @@
   <div style="background:#F7F4EE;border:1px solid #EAEAE4;border-radius:12px;padding:16px 18px;margin-bottom:20px">
     <table style="border-collapse:collapse;width:100%;font-size:13px">
       <tr>
-        <td style="padding:6px 0;color:#888;font-weight:700;width:100px;vertical-align:top">브랜드</td>
+        <td style="padding:6px 0;color:#888;font-weight:700;width:100px;vertical-align:top">오리엔시트 번호</td>
+        <td style="padding:6px 0;font-weight:700">{{orient_no}}</td>
+      </tr>
+      <tr>
+        <td style="padding:6px 0;color:#888;font-weight:700;vertical-align:top">브랜드</td>
         <td style="padding:6px 0;font-weight:700;color:#E8344E">{{brand_name}}</td>
       </tr>
       <tr>
@@ -36,10 +40,6 @@
       <tr>
         <td style="padding:6px 0;color:#888;font-weight:700;vertical-align:top">제출 시각</td>
         <td style="padding:6px 0">{{submitted_at}}</td>
-      </tr>
-      <tr>
-        <td style="padding:6px 0;color:#888;font-weight:700;vertical-align:top">연결 신청</td>
-        <td style="padding:6px 0">{{application_no}}</td>
       </tr>
     </table>
   </div>

--- a/supabase/functions/notify-brand-daily-digest/index.ts
+++ b/supabase/functions/notify-brand-daily-digest/index.ts
@@ -183,6 +183,7 @@ async function sendBrevoEmail(params: {
 interface OrientSheetRow {
   id: string;
   brand_id: string;
+  orient_no: string | null;     // 자체 식별번호 B0001-O001 (마이그205)
   form_type: string | null;
   submitted_at: string;         // 최초 제출 (불변)
   last_submitted_at: string;    // 마지막 제출 (매 제출 갱신)
@@ -222,9 +223,11 @@ function renderNewSection(args: {
   const tableRows = args.rows.map((r) => {
     const brand = args.brandMap.get(r.brand_id);
     const brandName = escapeHtml(brand?.name || "-");
+    const orientNo = escapeHtml(r.orient_no || "-");
     const formType = escapeHtml(formTypeKo(r.form_type));
     const submittedAt = escapeHtml(formatKstFull(r.submitted_at));
     return `<tr>
+      <td style="padding:6px 8px;vertical-align:top;color:#5B6BBF;border-bottom:1px solid #F0F2F8;font-weight:700;white-space:nowrap">${orientNo}</td>
       <td style="padding:6px 8px;vertical-align:top;border-bottom:1px solid #F0F2F8;font-weight:600">${brandName}</td>
       <td style="padding:6px 8px;vertical-align:top;color:#555;border-bottom:1px solid #F0F2F8">${formType}</td>
       <td style="padding:6px 8px;vertical-align:top;color:#666;border-bottom:1px solid #F0F2F8;white-space:nowrap">${submittedAt}</td>
@@ -234,6 +237,7 @@ function renderNewSection(args: {
   const bodyHtml = `<table style="width:100%;border-collapse:collapse;font-size:12px">
     <thead>
       <tr style="background:#F5F7FC">
+        <th style="padding:6px 8px;text-align:left;color:#555;font-weight:600">오리엔 번호</th>
         <th style="padding:6px 8px;text-align:left;color:#555;font-weight:600">브랜드</th>
         <th style="padding:6px 8px;text-align:left;color:#555;font-weight:600">형식</th>
         <th style="padding:6px 8px;text-align:left;color:#555;font-weight:600">제출 시각</th>
@@ -262,10 +266,12 @@ function renderResubmitSection(args: {
   const tableRows = args.rows.map((r) => {
     const brand = args.brandMap.get(r.brand_id);
     const brandName = escapeHtml(brand?.name || "-");
+    const orientNo = escapeHtml(r.orient_no || "-");
     const formType = escapeHtml(formTypeKo(r.form_type));
     const resubmittedAt = escapeHtml(formatKstFull(r.last_submitted_at));
     const firstAt = escapeHtml(formatKstFull(r.submitted_at));
     return `<tr>
+      <td style="padding:6px 8px;vertical-align:top;color:#5B6BBF;border-bottom:1px solid #F0F2F8;font-weight:700;white-space:nowrap">${orientNo}</td>
       <td style="padding:6px 8px;vertical-align:top;border-bottom:1px solid #F0F2F8;font-weight:600">${brandName}</td>
       <td style="padding:6px 8px;vertical-align:top;color:#555;border-bottom:1px solid #F0F2F8">${formType}</td>
       <td style="padding:6px 8px;vertical-align:top;color:#666;border-bottom:1px solid #F0F2F8;white-space:nowrap">${resubmittedAt}</td>
@@ -276,6 +282,7 @@ function renderResubmitSection(args: {
   const bodyHtml = `<table style="width:100%;border-collapse:collapse;font-size:12px">
     <thead>
       <tr style="background:#F5F7FC">
+        <th style="padding:6px 8px;text-align:left;color:#555;font-weight:600">오리엔 번호</th>
         <th style="padding:6px 8px;text-align:left;color:#555;font-weight:600">브랜드</th>
         <th style="padding:6px 8px;text-align:left;color:#555;font-weight:600">형식</th>
         <th style="padding:6px 8px;text-align:left;color:#555;font-weight:600">재제출 시각</th>
@@ -381,13 +388,13 @@ Deno.serve(async (req: Request) => {
     const [newRes, resubmitRes] = await Promise.all([
       // 섹션 1: 신규 제출
       sb.from("orient_sheets")
-        .select("id, brand_id, form_type, submitted_at, last_submitted_at")
+        .select("id, brand_id, orient_no, form_type, submitted_at, last_submitted_at")
         .gte("submitted_at", startIso)
         .lt("submitted_at", endIso)
         .order("submitted_at", { ascending: true }),
       // 섹션 2: 수정 재제출 (마지막 제출이 어제 AND 최초 제출은 그 이전)
       sb.from("orient_sheets")
-        .select("id, brand_id, form_type, submitted_at, last_submitted_at")
+        .select("id, brand_id, orient_no, form_type, submitted_at, last_submitted_at")
         .gte("last_submitted_at", startIso)
         .lt("last_submitted_at", endIso)
         .lt("submitted_at", startIso)

--- a/supabase/functions/notify-orient-submitted/_templates/orient-submitted-notify.html
+++ b/supabase/functions/notify-orient-submitted/_templates/orient-submitted-notify.html
@@ -9,10 +9,10 @@
 
   Placeholders:
     {{submit_kind}}       "신규 제출" 또는 "수정 재제출"
+    {{orient_no}}         오리엔시트 자체 식별번호 (B0001-O001, 마이그205)
     {{brand_name}}        브랜드명
     {{form_type_label}}   "리뷰어" 또는 "시딩"
     {{submitted_at}}      제출 시각 (KST, 예: 2026. 06. 30. 14:32)
-    {{application_no}}    연결 신청 번호 (없으면 "-")
     {{deep_link}}         관리자 오리엔시트 조회 페인 링크
 
   Note:
@@ -26,7 +26,11 @@
   <div style="background:#F7F4EE;border:1px solid #EAEAE4;border-radius:12px;padding:16px 18px;margin-bottom:20px">
     <table style="border-collapse:collapse;width:100%;font-size:13px">
       <tr>
-        <td style="padding:6px 0;color:#888;font-weight:700;width:100px;vertical-align:top">브랜드</td>
+        <td style="padding:6px 0;color:#888;font-weight:700;width:100px;vertical-align:top">오리엔시트 번호</td>
+        <td style="padding:6px 0;font-weight:700">{{orient_no}}</td>
+      </tr>
+      <tr>
+        <td style="padding:6px 0;color:#888;font-weight:700;vertical-align:top">브랜드</td>
         <td style="padding:6px 0;font-weight:700;color:#E8344E">{{brand_name}}</td>
       </tr>
       <tr>
@@ -36,10 +40,6 @@
       <tr>
         <td style="padding:6px 0;color:#888;font-weight:700;vertical-align:top">제출 시각</td>
         <td style="padding:6px 0">{{submitted_at}}</td>
-      </tr>
-      <tr>
-        <td style="padding:6px 0;color:#888;font-weight:700;vertical-align:top">연결 신청</td>
-        <td style="padding:6px 0">{{application_no}}</td>
       </tr>
     </table>
   </div>

--- a/supabase/functions/notify-orient-submitted/index.ts
+++ b/supabase/functions/notify-orient-submitted/index.ts
@@ -53,6 +53,7 @@ interface OrientSheetRecord {
   id: string;
   brand_id: string;
   application_id: string | null;
+  orient_no: string | null;        // 자체 식별번호 B0001-O001 (마이그205)
   form_type: "reviewer" | "seeding" | null;
   status: string;
   submitted_at: string | null;
@@ -227,17 +228,9 @@ Deno.serve(async (req: Request) => {
       if (brandRow?.name) brandName = brandRow.name as string;
     }
 
-    // 연결 신청 번호 (있으면)
-    let applicationNo = "-";
-    if (record.application_id) {
-      const { data: appRow, error: appErr } = await sb
-        .from("brand_applications")
-        .select("application_no")
-        .eq("id", record.application_id)
-        .maybeSingle();
-      if (appErr) console.error("[notify-orient-submitted] app fetch error", appErr.message);
-      if (appRow?.application_no) applicationNo = appRow.application_no as string;
-    }
+    // 오리엔시트 자체 식별번호 (웹훅 record 에 포함 — 별도 조회 불필요)
+    // 신청 번호(application_no) 표시는 제거(자체 번호로 일원화 — "서베이 경유" 오해 차단, 사양 §3⑦)
+    const orientNo = (record.orient_no as string | null) || "-";
 
     // 제출 시각 (last_submitted_at 우선, 없으면 submitted_at)
     const submittedIso = (record.last_submitted_at || record.submitted_at) ?? null;
@@ -270,16 +263,16 @@ Deno.serve(async (req: Request) => {
       brand_name:       escapeHtml(brandName),
       form_type_label:  escapeHtml(formTypeLabel(record.form_type)),
       submitted_at:     escapeHtml(submittedAt),
-      application_no:   escapeHtml(applicationNo),
+      orient_no:        escapeHtml(orientNo),
       deep_link:        escapeHtml(deepLink),
     });
 
     const text =
       `[${submitKind}] 오리엔시트 알림\n\n` +
+      `오리엔시트 번호: ${orientNo}\n` +
       `브랜드: ${brandName}\n` +
       `폼 종류: ${formTypeLabel(record.form_type)}\n` +
-      `제출 시각: ${submittedAt}\n` +
-      `연결 신청: ${applicationNo}\n\n` +
+      `제출 시각: ${submittedAt}\n\n` +
       `관리자 페이지: ${deepLink}\n`;
 
     // 관리자 1인 1통 분리 발송 (To 헤더 노출 차단)

--- a/supabase/functions/notify-orient-submitted/templates.ts
+++ b/supabase/functions/notify-orient-submitted/templates.ts
@@ -15,10 +15,10 @@ export const TEMPLATES: Record<string, string> = {
 
   Placeholders:
     {{submit_kind}}       "신규 제출" 또는 "수정 재제출"
+    {{orient_no}}         오리엔시트 자체 식별번호 (B0001-O001, 마이그205)
     {{brand_name}}        브랜드명
     {{form_type_label}}   "리뷰어" 또는 "시딩"
     {{submitted_at}}      제출 시각 (KST, 예: 2026. 06. 30. 14:32)
-    {{application_no}}    연결 신청 번호 (없으면 "-")
     {{deep_link}}         관리자 오리엔시트 조회 페인 링크
 
   Note:
@@ -32,7 +32,11 @@ export const TEMPLATES: Record<string, string> = {
   <div style="background:#F7F4EE;border:1px solid #EAEAE4;border-radius:12px;padding:16px 18px;margin-bottom:20px">
     <table style="border-collapse:collapse;width:100%;font-size:13px">
       <tr>
-        <td style="padding:6px 0;color:#888;font-weight:700;width:100px;vertical-align:top">브랜드</td>
+        <td style="padding:6px 0;color:#888;font-weight:700;width:100px;vertical-align:top">오리엔시트 번호</td>
+        <td style="padding:6px 0;font-weight:700">{{orient_no}}</td>
+      </tr>
+      <tr>
+        <td style="padding:6px 0;color:#888;font-weight:700;vertical-align:top">브랜드</td>
         <td style="padding:6px 0;font-weight:700;color:#E8344E">{{brand_name}}</td>
       </tr>
       <tr>
@@ -42,10 +46,6 @@ export const TEMPLATES: Record<string, string> = {
       <tr>
         <td style="padding:6px 0;color:#888;font-weight:700;vertical-align:top">제출 시각</td>
         <td style="padding:6px 0">{{submitted_at}}</td>
-      </tr>
-      <tr>
-        <td style="padding:6px 0;color:#888;font-weight:700;vertical-align:top">연결 신청</td>
-        <td style="padding:6px 0">{{application_no}}</td>
       </tr>
     </table>
   </div>


### PR DESCRIPTION
## 변경 요약
오리엔 알림 메일 2개에서 신청번호→자체번호(orient_no) 표시. 운영 Edge Function 재배포 완료(2026-06-30)분을 main에 기록. 메일 함수·템플릿만(관리자 화면 admin-orient.js 표시는 보류 #638과 얽혀 별도).

## 요청 외 추가 변경
- 없음

## 비고
- 프론트 0·빌드 불필요. dev #645 reviewer GO·운영 배포 완료.

## 리뷰
- reverb-reviewer GO(#645) · 운영 배포 검증(함수 deploy 성공)