### PR TITLE
feat(admin): 서베이 신청 목록 URL복사·신규등록 버튼 비활성

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -12,7 +12,7 @@
 // 회귀(2026-05-12 PR #182 머지 직후 발생)를 방지하기 위한 자동 reload 가드.
 // sessionStorage 차단 환경(시크릿 모드 일부, 쿠키 차단)에서는 자연스럽게 skip.
 (function(){
-  var CURRENT_BUILD = 'v1782870486';
+  var CURRENT_BUILD = 'v1782871578';
   if (CURRENT_BUILD.indexOf('__') === 0) return; // 빌드 미적용 (dev/ 직접 열기) 시 skip
   try {
     var prev = sessionStorage.getItem('reverb.adminBuild');
@@ -2138,7 +2138,7 @@ tr.audit-row, .audit-row { background: #fff3e0 !important; }
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-07-01 10:48 · caa6246</span>
+          <span class="admin-build-text">2026-07-01 11:06 · d8c99e3</span>
         </div>
       </div>
     </aside>
@@ -3706,11 +3706,11 @@ tr.audit-row, .audit-row { background: #fff3e0 !important; }
                   <span class="material-icons-round notranslate" translate="no" style="font-size:15px">open_in_new</span>
                   설문조사 바로가기
                 </a>
-                <button type="button" class="btn btn-ghost btn-sm" onclick="copyBrandSalesUrl()" style="display:inline-flex;align-items:center;gap:4px" title="광고주에게 공유할 URL을 클립보드에 복사">
+                <button type="button" class="btn btn-ghost btn-sm" onclick="copyBrandSalesUrl()" disabled style="display:inline-flex;align-items:center;gap:4px" title="브랜드 서베이 공개 접수 중단으로 비활성화됨">
                   <span class="material-icons-round notranslate" translate="no" style="font-size:15px">content_copy</span>
                   URL 복사
                 </button>
-                <button type="button" class="btn btn-primary btn-sm" onclick="openNewBrandAppModal()" style="display:inline-flex;align-items:center;gap:4px" title="영업팀이 받은 신청을 직접 등록">
+                <button type="button" class="btn btn-primary btn-sm" onclick="openNewBrandAppModal()" disabled style="display:inline-flex;align-items:center;gap:4px" title="브랜드 서베이 공개 접수 중단으로 비활성화됨">
                   <span class="material-icons-round notranslate" translate="no" style="font-size:15px">add</span>
                   신규 등록
                 </button>

--- a/dev/admin/index.html
+++ b/dev/admin/index.html
@@ -1702,11 +1702,11 @@
                   <span class="material-icons-round notranslate" translate="no" style="font-size:15px">open_in_new</span>
                   설문조사 바로가기
                 </a>
-                <button type="button" class="btn btn-ghost btn-sm" onclick="copyBrandSalesUrl()" style="display:inline-flex;align-items:center;gap:4px" title="광고주에게 공유할 URL을 클립보드에 복사">
+                <button type="button" class="btn btn-ghost btn-sm" onclick="copyBrandSalesUrl()" disabled style="display:inline-flex;align-items:center;gap:4px" title="브랜드 서베이 공개 접수 중단으로 비활성화됨">
                   <span class="material-icons-round notranslate" translate="no" style="font-size:15px">content_copy</span>
                   URL 복사
                 </button>
-                <button type="button" class="btn btn-primary btn-sm" onclick="openNewBrandAppModal()" style="display:inline-flex;align-items:center;gap:4px" title="영업팀이 받은 신청을 직접 등록">
+                <button type="button" class="btn btn-primary btn-sm" onclick="openNewBrandAppModal()" disabled style="display:inline-flex;align-items:center;gap:4px" title="브랜드 서베이 공개 접수 중단으로 비활성화됨">
                   <span class="material-icons-round notranslate" translate="no" style="font-size:15px">add</span>
                   신규 등록
                 </button>


### PR DESCRIPTION
## 변경 요약
브랜드 서베이 공개 접수 중단으로 서베이 신청 목록 헤더의 「URL 복사」·「신규 등록」 버튼 비활성화(disabled + 안내 title). 설문조사 바로가기 링크는 유지.

## 요청 외 추가 변경
- 없음

## 비고
- 신규 등록(관리자 수동 등록)도 UI 차단 — 사용자 확정. 필요 시 SQL로만 가능.

## 리뷰
- reverb-reviewer GO · qa skip