### PR TITLE
fix(orient): 모집 기간 안내 문구를 모집 필드 밑으로 원위치

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -12,7 +12,7 @@
 // 회귀(2026-05-12 PR #182 머지 직후 발생)를 방지하기 위한 자동 reload 가드.
 // sessionStorage 차단 환경(시크릿 모드 일부, 쿠키 차단)에서는 자연스럽게 skip.
 (function(){
-  var CURRENT_BUILD = 'v1782904593';
+  var CURRENT_BUILD = 'v1782904931';
   if (CURRENT_BUILD.indexOf('__') === 0) return; // 빌드 미적용 (dev/ 직접 열기) 시 skip
   try {
     var prev = sessionStorage.getItem('reverb.adminBuild');
@@ -2138,7 +2138,7 @@ tr.audit-row, .audit-row { background: #fff3e0 !important; }
         <!-- 빌드 버전 표시 — build.sh가 BUILD_DATETIME_KST·GIT_SHA_SHORT를 빌드 시점에 치환 -->
         <div class="admin-build-info" title="배포된 빌드의 일시·커밋. 운영팀이 어느 시점 빌드인지 식별할 때 사용">
           <span class="material-icons-round notranslate" translate="no" style="font-size:12px;vertical-align:middle;margin-right:3px">history</span>
-          <span class="admin-build-text">2026-07-01 20:16 · 6cbac4a</span>
+          <span class="admin-build-text">2026-07-01 20:22 · 0057ee5</span>
         </div>
       </div>
     </aside>

--- a/dev/sales/orient.html
+++ b/dev/sales/orient.html
@@ -987,13 +987,13 @@ function cardHtml(id, card) {
           <div class="field"><label>희망 모집 마감일</label>
             <input type="date" class="f-recruit-end" value="${escAttr(r.recruit_end)}" onchange="onInput()"></div>
         </div>
+        <div class="field-hint" style="margin:-6px 0 14px">원하시는 모집 기간을 적어 주세요. 모집 시작일로부터 +30~40일로 권장 드립니다. (단기간 일정이 필요할 경우 레버브 담당자분께 소통 부탁드립니다.)</div>
         <div class="row2">
           <div class="field"><label>희망 업로드 시작일</label>
             <input type="date" class="f-upload-start" value="${escAttr(r.upload_start)}" onchange="onInput()"></div>
           <div class="field"><label>희망 업로드 마감일</label>
             <input type="date" class="f-upload-end" value="${escAttr(r.upload_end)}" onchange="onInput()"></div>
         </div>
-        <div class="field-hint" style="margin:-6px 0 14px">원하시는 모집 기간을 적어 주세요. 모집 시작일로부터 +30~40일로 권장 드립니다. (단기간 일정이 필요할 경우 레버브 담당자분께 소통 부탁드립니다.)</div>
 
         <!-- 리뷰 가이드 (리뷰어) -->
         <div class="field only-reviewer"><label>리뷰 가이드</label>

--- a/sales/orient.html
+++ b/sales/orient.html
@@ -987,13 +987,13 @@ function cardHtml(id, card) {
           <div class="field"><label>희망 모집 마감일</label>
             <input type="date" class="f-recruit-end" value="${escAttr(r.recruit_end)}" onchange="onInput()"></div>
         </div>
+        <div class="field-hint" style="margin:-6px 0 14px">원하시는 모집 기간을 적어 주세요. 모집 시작일로부터 +30~40일로 권장 드립니다. (단기간 일정이 필요할 경우 레버브 담당자분께 소통 부탁드립니다.)</div>
         <div class="row2">
           <div class="field"><label>희망 업로드 시작일</label>
             <input type="date" class="f-upload-start" value="${escAttr(r.upload_start)}" onchange="onInput()"></div>
           <div class="field"><label>희망 업로드 마감일</label>
             <input type="date" class="f-upload-end" value="${escAttr(r.upload_end)}" onchange="onInput()"></div>
         </div>
-        <div class="field-hint" style="margin:-6px 0 14px">원하시는 모집 기간을 적어 주세요. 모집 시작일로부터 +30~40일로 권장 드립니다. (단기간 일정이 필요할 경우 레버브 담당자분께 소통 부탁드립니다.)</div>
 
         <!-- 리뷰 가이드 (리뷰어) -->
         <div class="field only-reviewer"><label>리뷰 가이드</label>


### PR DESCRIPTION
## 변경 요약
- 희망 업로드 필드 아래로 옮겼던 「원하시는 모집 기간을... +30~40일 권장」 안내 문구를 모집 시작/마감일 필드 밑(원위치)으로 되돌림
- 업로드 필드는 안내 없이 입력란만 유지

## 요청 외 추가 변경
- 없음

## DB 변경
- 없음

## 리뷰
- 문구 div 위치 조정만(로직·필드·데이터 무변경). 직전 PR #656 에서 전체 리뷰 GO 받은 파일

🤖 Generated with [Claude Code](https://claude.com/claude-code)